### PR TITLE
[codex] add v2 VPM artifact kernel

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,50 @@
+name: Python package
+
+on:
+  pull_request:
+    paths:
+      - "zeromodel/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/workflows/python.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "zeromodel/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/workflows/python.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  v2-contracts:
+    name: v2 contracts / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package and test tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest
+
+      - name: Run v2 contract tests
+        run: pytest tests/v2 -q

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ A VPM is **not** a foundation model, a model's hidden chain of thought, or an ac
 
 ## Rebuild status
 
-This repository currently contains two layers:
+This repository currently contains three layers:
 
 - `zeromodel/` — the original v1 experimental implementation. It is retained for reference while the useful ideas are retested.
-- the v2 rebuild documents and website — the new contract being established before a replacement Python package is written.
+- `zeromodel/v2/` — the first-principles artifact kernel.
+- `site/` and `docs/spec/` — the public website and artifact contract.
 
 Do not treat the current v1 package API as the future v2 API.
 
@@ -40,6 +41,55 @@ The separation matters:
 2. **Layout recipes** explicitly define normalization, ordering, direction, and tie-break behavior.
 3. **VPM artifacts** preserve the resulting view and its mapping back to source evidence.
 4. **Consumers** own any threshold, route, ranking, or action.
+
+## Current v2 artifact kernel
+
+The initial reference implementation is intentionally small:
+
+```python
+from zeromodel.v2 import LayoutRecipe, ScoreTable, build_vpm
+
+score_table = ScoreTable(
+    values=values,
+    row_ids=row_ids,
+    metric_ids=metric_ids,
+)
+
+recipe = LayoutRecipe.from_dict(recipe_data)
+artifact = build_vpm(score_table, recipe)
+
+artifact.validate()
+cell = artifact.cell(view_row=0, view_column=0)
+region = artifact.region(rows=slice(0, 4), columns=slice(0, 4))
+```
+
+Implemented now:
+
+- immutable `ScoreTable`, `LayoutRecipe`, and `VPMArtifact` objects;
+- deterministic artifact IDs;
+- per-metric min-max normalization;
+- source, lexicographic, and weighted row ordering;
+- source and explicit metric ordering;
+- exact cell-to-source mapping;
+- rectangular region inspection;
+- JSON-compatible dictionary round-trip;
+- provenance digests for source and recipe;
+- v2 imports that do not initialize the old v1 runtime.
+
+Not implemented yet:
+
+- bundle serialization;
+- PNG/SVG rendering;
+- artifact diffing;
+- hierarchy;
+- edge consumers;
+- visual composition.
+
+Decision behavior belongs outside the artifact:
+
+```python
+result = TopLeftGate(threshold=0.8).evaluate(artifact)
+```
 
 ## Website
 
@@ -91,33 +141,6 @@ The website uses three evidence labels:
 - **Defined** — required by the artifact specification;
 - **Measured** — reproduced by a benchmark in this repository;
 - **Hypothesis** — proposed research not yet established.
-
-## Target v2 API
-
-The final names may change, but the intended surface is deliberately small:
-
-```python
-score_table = ScoreTable(
-    values=values,
-    row_ids=row_ids,
-    metric_ids=metric_ids,
-)
-
-recipe = LayoutRecipe.from_dict(recipe_data)
-artifact = build_vpm(score_table, recipe)
-
-artifact.validate()
-artifact.cell(view_row=0, view_column=0)
-artifact.region(rows=slice(0, 4), columns=slice(0, 4))
-artifact.to_bundle("artifact.vpm")
-artifact.render_png("artifact.png")
-```
-
-Decision behavior belongs outside the artifact:
-
-```python
-result = TopLeftGate(threshold=0.8).evaluate(artifact)
-```
 
 ## Delivery order
 

--- a/tests/v2/test_artifact_kernel.py
+++ b/tests/v2/test_artifact_kernel.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from zeromodel.v2 import LayoutRecipe, ScoreTable, VPMArtifact, build_vpm
+from zeromodel.v2.artifact import VPMValidationError
+
+
+def quality_recipe() -> LayoutRecipe:
+    return LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "quality-first",
+            "row_order": {
+                "kind": "lexicographic",
+                "keys": [
+                    {"metric_id": "quality", "direction": "desc"},
+                    {"metric_id": "uncertainty", "direction": "asc"},
+                ],
+                "tie_break": "row_id",
+            },
+            "column_order": {
+                "kind": "explicit",
+                "metric_ids": ["quality", "uncertainty"],
+            },
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+
+
+def sample_table() -> ScoreTable:
+    return ScoreTable(
+        values=[
+            [0.9, 0.1],
+            [0.4, 0.9],
+            [0.7, 0.2],
+        ],
+        row_ids=["b", "a", "c"],
+        metric_ids=["quality", "uncertainty"],
+        metadata={"source": "unit-test"},
+    )
+
+
+def test_build_vpm_is_deterministic() -> None:
+    first = build_vpm(sample_table(), quality_recipe())
+    second = build_vpm(sample_table(), quality_recipe())
+
+    assert first.artifact_id == second.artifact_id
+    assert first.compute_artifact_id() == first.artifact_id
+    assert first.normalized_values.flags.writeable is False
+
+
+def test_cell_maps_view_coordinates_to_source_coordinates() -> None:
+    artifact = build_vpm(sample_table(), quality_recipe())
+
+    assert artifact.row_order == (0, 2, 1)
+    assert artifact.column_order == (0, 1)
+
+    cell = artifact.cell(view_row=1, view_column=0)
+    assert cell.row_id == "c"
+    assert cell.metric_id == "quality"
+    assert cell.source_row_index == 2
+    assert cell.source_metric_index == 0
+    assert cell.raw_value == pytest.approx(0.7)
+    assert cell.normalized_value == pytest.approx(0.6)
+
+
+def test_region_summary_uses_view_cells() -> None:
+    artifact = build_vpm(sample_table(), quality_recipe())
+
+    region = artifact.region(rows=slice(0, 2), columns=slice(0, 2))
+
+    assert region.shape == (2, 2)
+    assert [cell.row_id for cell in region.cells] == ["b", "b", "c", "c"]
+    assert region.normalized_mean == pytest.approx(np.mean([1.0, 0.0, 0.6, 0.125]))
+
+
+def test_ties_are_resolved_by_row_id() -> None:
+    table = ScoreTable(
+        values=[[0.5], [0.5], [0.5]],
+        row_ids=["row-c", "row-a", "row-b"],
+        metric_ids=["quality"],
+    )
+    recipe = LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "tie-break",
+            "row_order": {
+                "kind": "lexicographic",
+                "keys": [{"metric_id": "quality", "direction": "desc"}],
+                "tie_break": "row_id",
+            },
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+
+    artifact = build_vpm(table, recipe)
+
+    assert artifact.row_order == (1, 2, 0)
+    assert [artifact.cell(row, 0).row_id for row in range(3)] == ["row-a", "row-b", "row-c"]
+
+
+def test_score_table_rejects_duplicate_row_ids() -> None:
+    with pytest.raises(VPMValidationError, match="Duplicate row"):
+        ScoreTable(values=[[0.1], [0.2]], row_ids=["same", "same"], metric_ids=["quality"])
+
+
+def test_score_table_rejects_non_finite_values_without_policy() -> None:
+    with pytest.raises(VPMValidationError, match="finite"):
+        ScoreTable(values=[[float("nan")]], row_ids=["row"], metric_ids=["quality"])
+
+
+def test_recipe_rejects_unknown_shape_kinds() -> None:
+    with pytest.raises(VPMValidationError, match="Unsupported row_order kind"):
+        LayoutRecipe.from_dict(
+            {
+                "version": "vpm-layout/0",
+                "row_order": {"kind": "magic", "tie_break": "row_id"},
+                "column_order": {"kind": "source"},
+                "normalization": {"kind": "per_metric_minmax", "clip": True},
+            }
+        )
+
+
+def test_build_rejects_unknown_metrics() -> None:
+    recipe = LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "row_order": {
+                "kind": "lexicographic",
+                "keys": [{"metric_id": "missing", "direction": "desc"}],
+                "tie_break": "row_id",
+            },
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+
+    with pytest.raises(VPMValidationError, match="Unknown metric_id"):
+        build_vpm(sample_table(), recipe)
+
+
+def test_artifact_round_trips_through_json_dict() -> None:
+    artifact = build_vpm(sample_table(), quality_recipe())
+    payload = json.loads(json.dumps(artifact.to_dict(), sort_keys=True))
+
+    loaded = VPMArtifact.from_dict(payload)
+
+    assert loaded.artifact_id == artifact.artifact_id
+    assert loaded.row_order == artifact.row_order
+    assert loaded.column_order == artifact.column_order
+    assert loaded.cell(0, 0) == artifact.cell(0, 0)
+
+
+def test_artifact_rejects_tampered_identity() -> None:
+    artifact = build_vpm(sample_table(), quality_recipe())
+    payload = artifact.to_dict()
+    payload["artifact_id"] = "not-the-real-id"
+
+    with pytest.raises(VPMValidationError, match="artifact_id mismatch"):
+        VPMArtifact.from_dict(payload)

--- a/zeromodel/__init__.py
+++ b/zeromodel/__init__.py
@@ -1,32 +1,61 @@
 #  zeromodel/__init__.py
-"""
-Zero-Model Intelligence (zeromodel) - Standalone package for cognitive compression
+"""ZeroModel package.
+
+The package now has two layers:
+
+- v1 experimental symbols, loaded lazily for compatibility;
+- v2 artifact-kernel symbols, loaded lazily for the first-principles rebuild.
+
+Keeping this module lightweight prevents ``import zeromodel`` or
+``import zeromodel.v2`` from initializing the old runtime, global config,
+DuckDB adapters, or image helpers unless those compatibility symbols are
+actually requested.
 """
 from __future__ import annotations
 
-from .config import init_config
-from .core import ZeroModel
-from .edge import EdgeProtocol
-from .hierarchical import HierarchicalVPM
-from .hierarchical_edge import HierarchicalEdgeProtocol
-from .normalizer import DynamicNormalizer
-from .vpm.image import (AGG_MAX, VPMImageReader, VPMImageWriter,
-                        build_parent_level_png)
-from .vpm.transform import get_critical_tile, transform_vpm
-
 __version__ = "1.0.9"
-__all__ = [
-    "ZeroModel",
-    "init_config",
-    "HierarchicalVPM",
-    "DynamicNormalizer",
-    "transform_vpm",
-    "get_critical_tile",
-    "EdgeProtocol",
-    "HierarchicalEdgeProtocol",
-    "VPMImageWriter",
-    "VPMImageReader",
-    "build_parent_level_png",
-    "AGG_MAX",
-]
 
+_V1_EXPORTS = {
+    "init_config": (".config", "init_config"),
+    "ZeroModel": (".core", "ZeroModel"),
+    "EdgeProtocol": (".edge", "EdgeProtocol"),
+    "HierarchicalVPM": (".hierarchical", "HierarchicalVPM"),
+    "HierarchicalEdgeProtocol": (".hierarchical_edge", "HierarchicalEdgeProtocol"),
+    "DynamicNormalizer": (".normalizer", "DynamicNormalizer"),
+    "AGG_MAX": (".vpm.image", "AGG_MAX"),
+    "VPMImageReader": (".vpm.image", "VPMImageReader"),
+    "VPMImageWriter": (".vpm.image", "VPMImageWriter"),
+    "build_parent_level_png": (".vpm.image", "build_parent_level_png"),
+    "get_critical_tile": (".vpm.transform", "get_critical_tile"),
+    "transform_vpm": (".vpm.transform", "transform_vpm"),
+}
+
+_V2_EXPORTS = {
+    "LayoutRecipe": (".v2", "LayoutRecipe"),
+    "ScoreTable": (".v2", "ScoreTable"),
+    "VPMArtifact": (".v2", "VPMArtifact"),
+    "VPMCell": (".v2", "VPMCell"),
+    "VPMRegion": (".v2", "VPMRegion"),
+    "build_vpm": (".v2", "build_vpm"),
+}
+
+_EXPORTS = {**_V1_EXPORTS, **_V2_EXPORTS}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name):
+    if name not in _EXPORTS:
+        raise AttributeError("module 'zeromodel' has no attribute %r" % name)
+
+    module_name, attribute_name = _EXPORTS[name]
+    from importlib import import_module
+
+    module = import_module(module_name, __name__)
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(list(globals()) + __all__)

--- a/zeromodel/v2/__init__.py
+++ b/zeromodel/v2/__init__.py
@@ -1,0 +1,25 @@
+"""ZeroModel v2 artifact kernel.
+
+This package contains the first-principles reference implementation for the
+Visual Policy Map artifact contract. It is intentionally separate from the v1
+experimental package surface.
+"""
+from __future__ import annotations
+
+from .artifact import (
+    LayoutRecipe,
+    ScoreTable,
+    VPMArtifact,
+    VPMCell,
+    VPMRegion,
+    build_vpm,
+)
+
+__all__ = [
+    "LayoutRecipe",
+    "ScoreTable",
+    "VPMArtifact",
+    "VPMCell",
+    "VPMRegion",
+    "build_vpm",
+]

--- a/zeromodel/v2/artifact.py
+++ b/zeromodel/v2/artifact.py
@@ -16,15 +16,15 @@ from functools import cmp_to_key
 import hashlib
 import json
 from types import MappingProxyType
-from typing import Any, Mapping, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
 
 SPEC_VERSION = "vpm-artifact/0"
 LAYOUT_VERSION = "vpm-layout/0"
 
-
 JsonMap = Mapping[str, Any]
+MatrixLike = Union[Sequence[Sequence[float]], np.ndarray]
 
 
 class VPMValidationError(ValueError):
@@ -35,7 +35,7 @@ def _freeze_json(value: Any) -> Any:
     """Return a JSON-like immutable representation for metadata/provenance."""
     if isinstance(value, Mapping):
         return MappingProxyType({str(k): _freeze_json(v) for k, v in value.items()})
-    if isinstance(value, list | tuple):
+    if isinstance(value, (list, tuple)):
         return tuple(_freeze_json(v) for v in value)
     return value
 
@@ -65,15 +65,15 @@ def _sha256_hex(value: Any) -> str:
 
 
 def _validate_unique(values: Sequence[str], kind: str) -> None:
-    seen: set[str] = set()
-    duplicates: list[str] = []
+    seen: Set[str] = set()
+    duplicates: List[str] = []
     for item in values:
         if item in seen:
             duplicates.append(item)
         seen.add(item)
     if duplicates:
         dupes = ", ".join(sorted(set(duplicates)))
-        raise VPMValidationError(f"Duplicate {kind} identifiers: {dupes}")
+        raise VPMValidationError("Duplicate %s identifiers: %s" % (kind, dupes))
 
 
 @dataclass(frozen=True)
@@ -86,16 +86,16 @@ class ScoreTable:
     """
 
     values: np.ndarray
-    row_ids: tuple[str, ...]
-    metric_ids: tuple[str, ...]
+    row_ids: Tuple[str, ...]
+    metric_ids: Tuple[str, ...]
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __init__(
         self,
-        values: Sequence[Sequence[float]] | np.ndarray,
+        values: MatrixLike,
         row_ids: Sequence[str],
         metric_ids: Sequence[str],
-        metadata: Mapping[str, Any] | None = None,
+        metadata: Optional[Mapping[str, Any]] = None,
     ) -> None:
         matrix = np.array(values, dtype=np.float64, copy=True)
         rows = tuple(str(row_id) for row_id in row_ids)
@@ -113,8 +113,8 @@ class ScoreTable:
         if self.values.shape != (len(self.row_ids), len(self.metric_ids)):
             raise VPMValidationError(
                 "ScoreTable shape must match row_ids and metric_ids "
-                f"(shape={self.values.shape}, rows={len(self.row_ids)}, "
-                f"metrics={len(self.metric_ids)})"
+                "(shape=%s, rows=%s, metrics=%s)"
+                % (self.values.shape, len(self.row_ids), len(self.metric_ids))
             )
         if not self.row_ids:
             raise VPMValidationError("ScoreTable must contain at least one row")
@@ -129,7 +129,7 @@ class ScoreTable:
         self.values.flags.writeable = False
 
     @property
-    def shape(self) -> tuple[int, int]:
+    def shape(self) -> Tuple[int, int]:
         return self.values.shape
 
     @property
@@ -140,9 +140,9 @@ class ScoreTable:
         try:
             return self.metric_ids.index(metric_id)
         except ValueError as exc:
-            raise VPMValidationError(f"Unknown metric_id in recipe: {metric_id}") from exc
+            raise VPMValidationError("Unknown metric_id in recipe: %s" % metric_id) from exc
 
-    def to_identity_payload(self) -> dict[str, Any]:
+    def to_identity_payload(self) -> Dict[str, Any]:
         return {
             "values": self.values.tolist(),
             "row_ids": list(self.row_ids),
@@ -150,7 +150,7 @@ class ScoreTable:
             "metadata": _thaw_json(self.metadata),
         }
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         return self.to_identity_payload()
 
     @classmethod
@@ -189,7 +189,8 @@ class LayoutRecipe:
     def validate_shape(self) -> None:
         if self.data.get("version") != LAYOUT_VERSION:
             raise VPMValidationError(
-                f"LayoutRecipe version must be {LAYOUT_VERSION!r}; got {self.data.get('version')!r}"
+                "LayoutRecipe version must be %r; got %r"
+                % (LAYOUT_VERSION, self.data.get("version"))
             )
 
         row_order = self.data.get("row_order")
@@ -204,11 +205,13 @@ class LayoutRecipe:
 
         row_kind = row_order.get("kind")
         if row_kind not in {"source", "lexicographic", "weighted_score"}:
-            raise VPMValidationError(f"Unsupported row_order kind: {row_kind!r}")
+            raise VPMValidationError("Unsupported row_order kind: %r" % row_kind)
         if row_kind in {"lexicographic", "weighted_score"}:
             keys = row_order.get("keys") or row_order.get("metrics")
             if not isinstance(keys, tuple) or len(keys) == 0:
-                raise VPMValidationError(f"row_order kind {row_kind!r} requires non-empty keys/metrics")
+                raise VPMValidationError(
+                    "row_order kind %r requires non-empty keys/metrics" % row_kind
+                )
             for key in keys:
                 if not isinstance(key, Mapping):
                     raise VPMValidationError("row_order keys must be mappings")
@@ -225,7 +228,7 @@ class LayoutRecipe:
 
         column_kind = column_order.get("kind")
         if column_kind not in {"source", "explicit"}:
-            raise VPMValidationError(f"Unsupported column_order kind: {column_kind!r}")
+            raise VPMValidationError("Unsupported column_order kind: %r" % column_kind)
         if column_kind == "explicit":
             metric_ids = column_order.get("metric_ids")
             if not isinstance(metric_ids, tuple) or len(metric_ids) == 0:
@@ -234,9 +237,7 @@ class LayoutRecipe:
 
         normalization_kind = normalization.get("kind")
         if normalization_kind != "per_metric_minmax":
-            raise VPMValidationError(
-                f"Unsupported normalization kind: {normalization_kind!r}"
-            )
+            raise VPMValidationError("Unsupported normalization kind: %r" % normalization_kind)
 
     def validate_against(self, table: ScoreTable) -> None:
         row_order = self.data["row_order"]
@@ -251,7 +252,7 @@ class LayoutRecipe:
             for metric_id in column_order["metric_ids"]:
                 table.metric_index(str(metric_id))
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         return _thaw_json(self.data)
 
 
@@ -273,12 +274,12 @@ class VPMCell:
 class VPMRegion:
     """Resolved region summary for a rectangular view slice."""
 
-    rows: tuple[int, ...]
-    columns: tuple[int, ...]
-    cells: tuple[VPMCell, ...]
+    rows: Tuple[int, ...]
+    columns: Tuple[int, ...]
+    cells: Tuple[VPMCell, ...]
 
     @property
-    def shape(self) -> tuple[int, int]:
+    def shape(self) -> Tuple[int, int]:
         return (len(self.rows), len(self.columns))
 
     @property
@@ -295,8 +296,8 @@ class VPMArtifact:
     source: ScoreTable
     recipe: LayoutRecipe
     normalized_values: np.ndarray
-    row_order: tuple[int, ...]
-    column_order: tuple[int, ...]
+    row_order: Tuple[int, ...]
+    column_order: Tuple[int, ...]
     provenance: Mapping[str, Any]
     artifact_id: str
     spec_version: str = SPEC_VERSION
@@ -305,11 +306,11 @@ class VPMArtifact:
         self,
         source: ScoreTable,
         recipe: LayoutRecipe,
-        normalized_values: Sequence[Sequence[float]] | np.ndarray,
+        normalized_values: MatrixLike,
         row_order: Sequence[int],
         column_order: Sequence[int],
-        provenance: Mapping[str, Any] | None = None,
-        artifact_id: str | None = None,
+        provenance: Optional[Mapping[str, Any]] = None,
+        artifact_id: Optional[str] = None,
         spec_version: str = SPEC_VERSION,
     ) -> None:
         matrix = np.array(normalized_values, dtype=np.float64, copy=True)
@@ -330,13 +331,14 @@ class VPMArtifact:
         self.validate()
 
     @property
-    def shape(self) -> tuple[int, int]:
+    def shape(self) -> Tuple[int, int]:
         return self.normalized_values.shape
 
     def validate(self) -> None:
         if self.spec_version != SPEC_VERSION:
             raise VPMValidationError(
-                f"VPMArtifact spec_version must be {SPEC_VERSION!r}; got {self.spec_version!r}"
+                "VPMArtifact spec_version must be %r; got %r"
+                % (SPEC_VERSION, self.spec_version)
             )
         self.source.validate()
         self.recipe.validate_against(self.source)
@@ -349,7 +351,7 @@ class VPMArtifact:
         if self.normalized_values.shape != (row_count, metric_count):
             raise VPMValidationError(
                 "normalized_values must have source shape after view ordering "
-                f"(shape={self.normalized_values.shape}, source={self.source.shape})"
+                "(shape=%s, source=%s)" % (self.normalized_values.shape, self.source.shape)
             )
         if not np.isfinite(self.normalized_values).all():
             raise VPMValidationError("normalized_values must be finite")
@@ -361,14 +363,14 @@ class VPMArtifact:
         expected_id = self.compute_artifact_id()
         if self.artifact_id != expected_id:
             raise VPMValidationError(
-                f"artifact_id mismatch: expected {expected_id}, got {self.artifact_id}"
+                "artifact_id mismatch: expected %s, got %s" % (expected_id, self.artifact_id)
             )
         self.normalized_values.flags.writeable = False
 
     def compute_artifact_id(self) -> str:
         return _sha256_hex(self.to_identity_payload())
 
-    def to_identity_payload(self) -> dict[str, Any]:
+    def to_identity_payload(self) -> Dict[str, Any]:
         return {
             "spec_version": self.spec_version,
             "source": self.source.to_identity_payload(),
@@ -381,7 +383,7 @@ class VPMArtifact:
             "provenance": _thaw_json(self.provenance),
         }
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         payload = self.to_identity_payload()
         payload["artifact_id"] = self.artifact_id
         return payload
@@ -402,9 +404,9 @@ class VPMArtifact:
 
     def cell(self, view_row: int, view_column: int) -> VPMCell:
         if not (0 <= view_row < len(self.row_order)):
-            raise IndexError(f"view_row out of range: {view_row}")
+            raise IndexError("view_row out of range: %s" % view_row)
         if not (0 <= view_column < len(self.column_order)):
-            raise IndexError(f"view_column out of range: {view_column}")
+            raise IndexError("view_column out of range: %s" % view_column)
 
         source_row_index = self.row_order[view_row]
         source_metric_index = self.column_order[view_column]
@@ -445,7 +447,12 @@ def _normalize_per_metric_minmax(table: ScoreTable, clip: bool) -> np.ndarray:
     return normalized
 
 
-def _compare_lexicographic(table: ScoreTable, keys: Sequence[Mapping[str, Any]], left: int, right: int) -> int:
+def _compare_lexicographic(
+    table: ScoreTable,
+    keys: Sequence[Mapping[str, Any]],
+    left: int,
+    right: int,
+) -> int:
     for key in keys:
         metric_index = table.metric_index(str(key["metric_id"]))
         left_value = float(table.values[left, metric_index])
@@ -468,7 +475,7 @@ def _weighted_score(table: ScoreTable, keys: Sequence[Mapping[str, Any]], row_in
     return total
 
 
-def _compile_row_order(table: ScoreTable, recipe: LayoutRecipe) -> tuple[int, ...]:
+def _compile_row_order(table: ScoreTable, recipe: LayoutRecipe) -> Tuple[int, ...]:
     row_order = recipe.data["row_order"]
     kind = row_order["kind"]
     row_indices = tuple(range(len(table.row_ids)))
@@ -493,23 +500,23 @@ def _compile_row_order(table: ScoreTable, recipe: LayoutRecipe) -> tuple[int, ..
             )
         )
 
-    raise VPMValidationError(f"Unsupported row_order kind: {kind!r}")
+    raise VPMValidationError("Unsupported row_order kind: %r" % kind)
 
 
-def _compile_column_order(table: ScoreTable, recipe: LayoutRecipe) -> tuple[int, ...]:
+def _compile_column_order(table: ScoreTable, recipe: LayoutRecipe) -> Tuple[int, ...]:
     column_order = recipe.data["column_order"]
     kind = column_order["kind"]
     if kind == "source":
         return tuple(range(len(table.metric_ids)))
     if kind == "explicit":
         return tuple(table.metric_index(str(metric_id)) for metric_id in column_order["metric_ids"])
-    raise VPMValidationError(f"Unsupported column_order kind: {kind!r}")
+    raise VPMValidationError("Unsupported column_order kind: %r" % kind)
 
 
 def build_vpm(
     score_table: ScoreTable,
     recipe: LayoutRecipe,
-    provenance: Mapping[str, Any] | None = None,
+    provenance: Optional[Mapping[str, Any]] = None,
 ) -> VPMArtifact:
     """Build an immutable VPM artifact from a score table and layout recipe."""
     score_table.validate()
@@ -525,8 +532,8 @@ def build_vpm(
     normalized_view = normalized_source[np.ix_(row_order, column_order)]
 
     default_provenance = {
-        "source_digest": f"sha256:{score_table.digest}",
-        "recipe_digest": f"sha256:{recipe.digest}",
+        "source_digest": "sha256:%s" % score_table.digest,
+        "recipe_digest": "sha256:%s" % recipe.digest,
         "parents": [],
     }
     if provenance:

--- a/zeromodel/v2/artifact.py
+++ b/zeromodel/v2/artifact.py
@@ -1,0 +1,542 @@
+"""Immutable Visual Policy Map artifact kernel.
+
+This module implements the smallest useful v2 ZeroModel surface:
+
+- ``ScoreTable``: finite numeric values plus stable row and metric identifiers.
+- ``LayoutRecipe``: explicit normalization and ordering instructions.
+- ``VPMArtifact``: deterministic spatial view with cell-to-source mapping.
+
+The artifact is deliberately not a decision policy. Consumers may evaluate a
+region, threshold, router, or ranking rule outside this module.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import cmp_to_key
+import hashlib
+import json
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+SPEC_VERSION = "vpm-artifact/0"
+LAYOUT_VERSION = "vpm-layout/0"
+
+
+JsonMap = Mapping[str, Any]
+
+
+class VPMValidationError(ValueError):
+    """Raised when a VPM source, recipe, or artifact violates the v0 contract."""
+
+
+def _freeze_json(value: Any) -> Any:
+    """Return a JSON-like immutable representation for metadata/provenance."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(k): _freeze_json(v) for k, v in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_json(v) for v in value)
+    return value
+
+
+def _thaw_json(value: Any) -> Any:
+    """Return a normal JSON-serializable structure from a frozen structure."""
+    if isinstance(value, Mapping):
+        return {str(k): _thaw_json(v) for k, v in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(v) for v in value]
+    return value
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    """Serialize semantic content with stable key and separator choices."""
+    return json.dumps(
+        _thaw_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_hex(value: Any) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _validate_unique(values: Sequence[str], kind: str) -> None:
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for item in values:
+        if item in seen:
+            duplicates.append(item)
+        seen.add(item)
+    if duplicates:
+        dupes = ", ".join(sorted(set(duplicates)))
+        raise VPMValidationError(f"Duplicate {kind} identifiers: {dupes}")
+
+
+@dataclass(frozen=True)
+class ScoreTable:
+    """Rectangular source score table with stable identifiers.
+
+    Values are canonicalized to a copied ``float64`` NumPy array. The table is
+    immutable at the object level; callers should treat the exposed array as
+    read-only.
+    """
+
+    values: np.ndarray
+    row_ids: tuple[str, ...]
+    metric_ids: tuple[str, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __init__(
+        self,
+        values: Sequence[Sequence[float]] | np.ndarray,
+        row_ids: Sequence[str],
+        metric_ids: Sequence[str],
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        matrix = np.array(values, dtype=np.float64, copy=True)
+        rows = tuple(str(row_id) for row_id in row_ids)
+        metrics = tuple(str(metric_id) for metric_id in metric_ids)
+
+        object.__setattr__(self, "values", matrix)
+        object.__setattr__(self, "row_ids", rows)
+        object.__setattr__(self, "metric_ids", metrics)
+        object.__setattr__(self, "metadata", _freeze_json(metadata or {}))
+        self.validate()
+
+    def validate(self) -> None:
+        if self.values.ndim != 2:
+            raise VPMValidationError("ScoreTable values must be a two-dimensional matrix")
+        if self.values.shape != (len(self.row_ids), len(self.metric_ids)):
+            raise VPMValidationError(
+                "ScoreTable shape must match row_ids and metric_ids "
+                f"(shape={self.values.shape}, rows={len(self.row_ids)}, "
+                f"metrics={len(self.metric_ids)})"
+            )
+        if not self.row_ids:
+            raise VPMValidationError("ScoreTable must contain at least one row")
+        if not self.metric_ids:
+            raise VPMValidationError("ScoreTable must contain at least one metric")
+        _validate_unique(self.row_ids, "row")
+        _validate_unique(self.metric_ids, "metric")
+        if not np.isfinite(self.values).all():
+            raise VPMValidationError(
+                "ScoreTable values must be finite unless a missing-value policy is declared"
+            )
+        self.values.flags.writeable = False
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self.values.shape
+
+    @property
+    def digest(self) -> str:
+        return _sha256_hex(self.to_identity_payload())
+
+    def metric_index(self, metric_id: str) -> int:
+        try:
+            return self.metric_ids.index(metric_id)
+        except ValueError as exc:
+            raise VPMValidationError(f"Unknown metric_id in recipe: {metric_id}") from exc
+
+    def to_identity_payload(self) -> dict[str, Any]:
+        return {
+            "values": self.values.tolist(),
+            "row_ids": list(self.row_ids),
+            "metric_ids": list(self.metric_ids),
+            "metadata": _thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.to_identity_payload()
+
+    @classmethod
+    def from_dict(cls, data: JsonMap) -> "ScoreTable":
+        return cls(
+            values=data["values"],
+            row_ids=data["row_ids"],
+            metric_ids=data["metric_ids"],
+            metadata=data.get("metadata") or {},
+        )
+
+
+@dataclass(frozen=True)
+class LayoutRecipe:
+    """Explicit recipe for normalizing and spatially ordering a score table."""
+
+    data: Mapping[str, Any]
+
+    def __init__(self, data: Mapping[str, Any]) -> None:
+        frozen = _freeze_json(data)
+        object.__setattr__(self, "data", frozen)
+        self.validate_shape()
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "LayoutRecipe":
+        return cls(data)
+
+    @property
+    def name(self) -> str:
+        return str(self.data.get("name") or "unnamed")
+
+    @property
+    def digest(self) -> str:
+        return _sha256_hex(self.to_dict())
+
+    def validate_shape(self) -> None:
+        if self.data.get("version") != LAYOUT_VERSION:
+            raise VPMValidationError(
+                f"LayoutRecipe version must be {LAYOUT_VERSION!r}; got {self.data.get('version')!r}"
+            )
+
+        row_order = self.data.get("row_order")
+        column_order = self.data.get("column_order")
+        normalization = self.data.get("normalization")
+        if not isinstance(row_order, Mapping):
+            raise VPMValidationError("LayoutRecipe requires row_order mapping")
+        if not isinstance(column_order, Mapping):
+            raise VPMValidationError("LayoutRecipe requires column_order mapping")
+        if not isinstance(normalization, Mapping):
+            raise VPMValidationError("LayoutRecipe requires normalization mapping")
+
+        row_kind = row_order.get("kind")
+        if row_kind not in {"source", "lexicographic", "weighted_score"}:
+            raise VPMValidationError(f"Unsupported row_order kind: {row_kind!r}")
+        if row_kind in {"lexicographic", "weighted_score"}:
+            keys = row_order.get("keys") or row_order.get("metrics")
+            if not isinstance(keys, tuple) or len(keys) == 0:
+                raise VPMValidationError(f"row_order kind {row_kind!r} requires non-empty keys/metrics")
+            for key in keys:
+                if not isinstance(key, Mapping):
+                    raise VPMValidationError("row_order keys must be mappings")
+                if "metric_id" not in key:
+                    raise VPMValidationError("row_order key requires metric_id")
+                if key.get("direction") not in {"asc", "desc"}:
+                    raise VPMValidationError("row_order key direction must be 'asc' or 'desc'")
+                if row_kind == "weighted_score" and "weight" not in key:
+                    raise VPMValidationError("weighted_score row_order keys require weight")
+        if "tie_break" not in row_order:
+            raise VPMValidationError("row_order requires explicit tie_break")
+        if row_order.get("tie_break") != "row_id":
+            raise VPMValidationError("Only tie_break='row_id' is supported in v0")
+
+        column_kind = column_order.get("kind")
+        if column_kind not in {"source", "explicit"}:
+            raise VPMValidationError(f"Unsupported column_order kind: {column_kind!r}")
+        if column_kind == "explicit":
+            metric_ids = column_order.get("metric_ids")
+            if not isinstance(metric_ids, tuple) or len(metric_ids) == 0:
+                raise VPMValidationError("explicit column_order requires non-empty metric_ids")
+            _validate_unique([str(metric_id) for metric_id in metric_ids], "column metric")
+
+        normalization_kind = normalization.get("kind")
+        if normalization_kind != "per_metric_minmax":
+            raise VPMValidationError(
+                f"Unsupported normalization kind: {normalization_kind!r}"
+            )
+
+    def validate_against(self, table: ScoreTable) -> None:
+        row_order = self.data["row_order"]
+        row_kind = row_order["kind"]
+        if row_kind in {"lexicographic", "weighted_score"}:
+            keys = row_order.get("keys") or row_order.get("metrics")
+            for key in keys:
+                table.metric_index(str(key["metric_id"]))
+
+        column_order = self.data["column_order"]
+        if column_order["kind"] == "explicit":
+            for metric_id in column_order["metric_ids"]:
+                table.metric_index(str(metric_id))
+
+    def to_dict(self) -> dict[str, Any]:
+        return _thaw_json(self.data)
+
+
+@dataclass(frozen=True)
+class VPMCell:
+    """Resolved view cell and its source coordinates."""
+
+    view_row: int
+    view_column: int
+    source_row_index: int
+    source_metric_index: int
+    row_id: str
+    metric_id: str
+    raw_value: float
+    normalized_value: float
+
+
+@dataclass(frozen=True)
+class VPMRegion:
+    """Resolved region summary for a rectangular view slice."""
+
+    rows: tuple[int, ...]
+    columns: tuple[int, ...]
+    cells: tuple[VPMCell, ...]
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return (len(self.rows), len(self.columns))
+
+    @property
+    def normalized_mean(self) -> float:
+        if not self.cells:
+            raise VPMValidationError("Cannot summarize an empty region")
+        return float(np.mean([cell.normalized_value for cell in self.cells]))
+
+
+@dataclass(frozen=True)
+class VPMArtifact:
+    """Immutable deterministic Visual Policy Map artifact."""
+
+    source: ScoreTable
+    recipe: LayoutRecipe
+    normalized_values: np.ndarray
+    row_order: tuple[int, ...]
+    column_order: tuple[int, ...]
+    provenance: Mapping[str, Any]
+    artifact_id: str
+    spec_version: str = SPEC_VERSION
+
+    def __init__(
+        self,
+        source: ScoreTable,
+        recipe: LayoutRecipe,
+        normalized_values: Sequence[Sequence[float]] | np.ndarray,
+        row_order: Sequence[int],
+        column_order: Sequence[int],
+        provenance: Mapping[str, Any] | None = None,
+        artifact_id: str | None = None,
+        spec_version: str = SPEC_VERSION,
+    ) -> None:
+        matrix = np.array(normalized_values, dtype=np.float64, copy=True)
+        rows = tuple(int(index) for index in row_order)
+        columns = tuple(int(index) for index in column_order)
+        frozen_provenance = _freeze_json(provenance or {})
+
+        object.__setattr__(self, "source", source)
+        object.__setattr__(self, "recipe", recipe)
+        object.__setattr__(self, "normalized_values", matrix)
+        object.__setattr__(self, "row_order", rows)
+        object.__setattr__(self, "column_order", columns)
+        object.__setattr__(self, "provenance", frozen_provenance)
+        object.__setattr__(self, "spec_version", spec_version)
+
+        computed_id = artifact_id or self.compute_artifact_id()
+        object.__setattr__(self, "artifact_id", computed_id)
+        self.validate()
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self.normalized_values.shape
+
+    def validate(self) -> None:
+        if self.spec_version != SPEC_VERSION:
+            raise VPMValidationError(
+                f"VPMArtifact spec_version must be {SPEC_VERSION!r}; got {self.spec_version!r}"
+            )
+        self.source.validate()
+        self.recipe.validate_against(self.source)
+
+        row_count, metric_count = self.source.shape
+        if sorted(self.row_order) != list(range(row_count)):
+            raise VPMValidationError("row_order must be a full permutation of source rows")
+        if sorted(self.column_order) != list(range(metric_count)):
+            raise VPMValidationError("column_order must be a full permutation of source metrics")
+        if self.normalized_values.shape != (row_count, metric_count):
+            raise VPMValidationError(
+                "normalized_values must have source shape after view ordering "
+                f"(shape={self.normalized_values.shape}, source={self.source.shape})"
+            )
+        if not np.isfinite(self.normalized_values).all():
+            raise VPMValidationError("normalized_values must be finite")
+        if self.normalized_values.size and (
+            self.normalized_values.min() < -1e-12 or self.normalized_values.max() > 1 + 1e-12
+        ):
+            raise VPMValidationError("normalized_values must be in the [0, 1] range")
+
+        expected_id = self.compute_artifact_id()
+        if self.artifact_id != expected_id:
+            raise VPMValidationError(
+                f"artifact_id mismatch: expected {expected_id}, got {self.artifact_id}"
+            )
+        self.normalized_values.flags.writeable = False
+
+    def compute_artifact_id(self) -> str:
+        return _sha256_hex(self.to_identity_payload())
+
+    def to_identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "source": self.source.to_identity_payload(),
+            "layout_recipe": self.recipe.to_dict(),
+            "view": {
+                "normalized_values": self.normalized_values.tolist(),
+                "row_order": list(self.row_order),
+                "column_order": list(self.column_order),
+            },
+            "provenance": _thaw_json(self.provenance),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.to_identity_payload()
+        payload["artifact_id"] = self.artifact_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: JsonMap) -> "VPMArtifact":
+        view = data["view"]
+        return cls(
+            source=ScoreTable.from_dict(data["source"]),
+            recipe=LayoutRecipe.from_dict(data["layout_recipe"]),
+            normalized_values=view["normalized_values"],
+            row_order=view["row_order"],
+            column_order=view["column_order"],
+            provenance=data.get("provenance") or {},
+            artifact_id=data.get("artifact_id"),
+            spec_version=data.get("spec_version", SPEC_VERSION),
+        )
+
+    def cell(self, view_row: int, view_column: int) -> VPMCell:
+        if not (0 <= view_row < len(self.row_order)):
+            raise IndexError(f"view_row out of range: {view_row}")
+        if not (0 <= view_column < len(self.column_order)):
+            raise IndexError(f"view_column out of range: {view_column}")
+
+        source_row_index = self.row_order[view_row]
+        source_metric_index = self.column_order[view_column]
+        return VPMCell(
+            view_row=view_row,
+            view_column=view_column,
+            source_row_index=source_row_index,
+            source_metric_index=source_metric_index,
+            row_id=self.source.row_ids[source_row_index],
+            metric_id=self.source.metric_ids[source_metric_index],
+            raw_value=float(self.source.values[source_row_index, source_metric_index]),
+            normalized_value=float(self.normalized_values[view_row, view_column]),
+        )
+
+    def region(self, rows: slice, columns: slice) -> VPMRegion:
+        row_indices = tuple(range(*rows.indices(len(self.row_order))))
+        column_indices = tuple(range(*columns.indices(len(self.column_order))))
+        cells = tuple(
+            self.cell(row, column)
+            for row in row_indices
+            for column in column_indices
+        )
+        if not row_indices or not column_indices:
+            raise VPMValidationError("region must select at least one row and one column")
+        return VPMRegion(rows=row_indices, columns=column_indices, cells=cells)
+
+
+def _normalize_per_metric_minmax(table: ScoreTable, clip: bool) -> np.ndarray:
+    values = table.values.astype(np.float64, copy=True)
+    mins = values.min(axis=0)
+    maxs = values.max(axis=0)
+    ranges = maxs - mins
+    normalized = np.zeros_like(values, dtype=np.float64)
+    non_constant = ranges > 0
+    normalized[:, non_constant] = (values[:, non_constant] - mins[non_constant]) / ranges[non_constant]
+    if clip:
+        normalized = np.clip(normalized, 0.0, 1.0)
+    return normalized
+
+
+def _compare_lexicographic(table: ScoreTable, keys: Sequence[Mapping[str, Any]], left: int, right: int) -> int:
+    for key in keys:
+        metric_index = table.metric_index(str(key["metric_id"]))
+        left_value = float(table.values[left, metric_index])
+        right_value = float(table.values[right, metric_index])
+        if left_value < right_value:
+            return -1 if key["direction"] == "asc" else 1
+        if left_value > right_value:
+            return 1 if key["direction"] == "asc" else -1
+    return (table.row_ids[left] > table.row_ids[right]) - (table.row_ids[left] < table.row_ids[right])
+
+
+def _weighted_score(table: ScoreTable, keys: Sequence[Mapping[str, Any]], row_index: int) -> float:
+    total = 0.0
+    for key in keys:
+        metric_index = table.metric_index(str(key["metric_id"]))
+        value = float(table.values[row_index, metric_index])
+        direction = str(key["direction"])
+        signed_value = value if direction == "desc" else -value
+        total += float(key["weight"]) * signed_value
+    return total
+
+
+def _compile_row_order(table: ScoreTable, recipe: LayoutRecipe) -> tuple[int, ...]:
+    row_order = recipe.data["row_order"]
+    kind = row_order["kind"]
+    row_indices = tuple(range(len(table.row_ids)))
+
+    if kind == "source":
+        return row_indices
+
+    keys = tuple(row_order.get("keys") or row_order.get("metrics"))
+    if kind == "lexicographic":
+        return tuple(
+            sorted(
+                row_indices,
+                key=cmp_to_key(lambda left, right: _compare_lexicographic(table, keys, left, right)),
+            )
+        )
+
+    if kind == "weighted_score":
+        return tuple(
+            sorted(
+                row_indices,
+                key=lambda index: (-_weighted_score(table, keys, index), table.row_ids[index]),
+            )
+        )
+
+    raise VPMValidationError(f"Unsupported row_order kind: {kind!r}")
+
+
+def _compile_column_order(table: ScoreTable, recipe: LayoutRecipe) -> tuple[int, ...]:
+    column_order = recipe.data["column_order"]
+    kind = column_order["kind"]
+    if kind == "source":
+        return tuple(range(len(table.metric_ids)))
+    if kind == "explicit":
+        return tuple(table.metric_index(str(metric_id)) for metric_id in column_order["metric_ids"])
+    raise VPMValidationError(f"Unsupported column_order kind: {kind!r}")
+
+
+def build_vpm(
+    score_table: ScoreTable,
+    recipe: LayoutRecipe,
+    provenance: Mapping[str, Any] | None = None,
+) -> VPMArtifact:
+    """Build an immutable VPM artifact from a score table and layout recipe."""
+    score_table.validate()
+    recipe.validate_against(score_table)
+
+    normalization = recipe.data["normalization"]
+    normalized_source = _normalize_per_metric_minmax(
+        score_table,
+        clip=bool(normalization.get("clip", True)),
+    )
+    row_order = _compile_row_order(score_table, recipe)
+    column_order = _compile_column_order(score_table, recipe)
+    normalized_view = normalized_source[np.ix_(row_order, column_order)]
+
+    default_provenance = {
+        "source_digest": f"sha256:{score_table.digest}",
+        "recipe_digest": f"sha256:{recipe.digest}",
+        "parents": [],
+    }
+    if provenance:
+        default_provenance.update(dict(provenance))
+
+    return VPMArtifact(
+        source=score_table,
+        recipe=recipe,
+        normalized_values=normalized_view,
+        row_order=row_order,
+        column_order=column_order,
+        provenance=default_provenance,
+    )


### PR DESCRIPTION
## What changed

- adds `zeromodel/v2/` as the first-principles artifact kernel
- implements immutable `ScoreTable`, `LayoutRecipe`, `VPMArtifact`, `VPMCell`, and `VPMRegion`
- implements `build_vpm()` for deterministic artifact construction
- supports per-metric min-max normalization
- supports source, lexicographic, and weighted row ordering
- supports source and explicit metric ordering
- preserves exact cell-to-source mapping through `artifact.cell()`
- adds rectangular region inspection through `artifact.region()`
- adds JSON-compatible dictionary round-trip through `to_dict()` / `from_dict()`
- computes deterministic source, recipe, provenance, and artifact digests
- makes top-level `zeromodel` imports lazy so v2 imports do not initialize the old v1 runtime or global config
- updates the README so it describes what is implemented now versus what comes next
- adds contract tests for deterministic IDs, tie-breaking, source mapping, region summaries, validation failures, round-trip, and tamper detection

## Why

The merged rebuild reset the project around one narrow claim: a VPM is a deterministic spatial view over a table of scored items. This PR turns that claim into a small Python kernel without pulling in the old package’s runtime, database adapters, image stack, or edge protocols.

## Boundaries

This does **not** implement bundle serialization, PNG/SVG rendering, hierarchy, edge consumers, visual composition, or artifact diffing. Those should remain separate follow-up slices.

## Validation

- branch comparison: 6 commits ahead of `main`, 0 behind
- contract tests were added under `tests/v2/test_artifact_kernel.py`
- I could not execute the test suite locally from this environment, so I am not claiming a local green run; CI should be treated as source of truth
