### PR TITLE
[codex] audit ZeroModel claims against implementation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  v2-contracts:
-    name: v2 contracts / Python ${{ matrix.python-version }}
+  package-tests:
+    name: package tests / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -44,5 +44,5 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[dev]
 
-      - name: Run v2 tests
+      - name: Run package tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A VPM is a deterministic spatial view over a table of scored items. It carries v
 
 The package is now the clean new ZeroModel surface. There is no public `zeromodel.v2` namespace: import directly from `zeromodel`.
 
+Public claims are tracked in [`docs/claims-audit.md`](docs/claims-audit.md). Treat that file as the source of truth for what is validated, what is implemented with thin evidence, and what remains a roadmap claim.
+
 ## Install from GitHub
 
 ```bash
@@ -87,13 +89,3 @@ assert loaded.artifact_id == artifact.artifact_id
 ## Design rule
 
 The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.
-
-## Website
-
-The zero-dependency static website lives in `site/`:
-
-```bash
-python -m http.server 4173 -d site
-```
-
-Then open `http://localhost:4173`.

--- a/docs/claims-audit.md
+++ b/docs/claims-audit.md
@@ -1,0 +1,80 @@
+# ZeroModel claims audit
+
+This document compares the public ZeroModel claims against the current clean `zeromodel` package.
+
+Sources reviewed:
+
+- Public blog post: <https://programmer.ie/post/zeromodel/>
+- Current package README
+- Current implementation under `zeromodel/`
+- Current tests under `tests/`
+
+## Status labels
+
+| Status | Meaning |
+|---|---|
+| **Validated** | Implemented and covered by explicit tests in this repository. |
+| **Implemented / thin evidence** | Code exists, but tests are smoke-level or do not yet prove the stronger wording. |
+| **Not validated** | The repo does not currently contain the benchmark, fixture, or reproducible evidence needed for the claim. |
+| **Reframe** | The claim should be narrowed because the implementation supports a weaker, more precise version. |
+
+## Claim matrix
+
+| Public claim | Current repo evidence | Status | Notes / required next proof |
+|---|---|---|---|
+| A VPM is a deterministic spatial view over a table of scored items. | `ScoreTable`, `LayoutRecipe`, `VPMArtifact`, deterministic `artifact_id`, canonical JSON identity payload. Covered by `test_build_vpm_is_deterministic`. | **Validated** | This is the strongest centre of the project. Keep this as the primary claim. |
+| VPM cells map back to source evidence. | `VPMArtifact.cell()` returns source row, metric, raw value, and normalized value. Covered by `test_cell_maps_view_coordinates_to_source_coordinates`. | **Validated** | This supports inspectability. It does not by itself prove causal explanation. |
+| Layout recipes reorganize the matrix task-by-task. | `LayoutRecipe` supports source, lexicographic, and weighted row ordering plus source/explicit column ordering. Tests cover lexicographic ordering and tie-breaking. | **Validated** | More recipes and examples would improve confidence, but the core mechanism is real. |
+| No model at decision time. | `TopLeftGate` consumes an already-built artifact/field and thresholds a top-left region. Covered by `test_edge_gate_evaluates_without_model`. | **Validated for simple gates** | Valid wording: “a deployed consumer can make a threshold decision from a prepared artifact without invoking a model.” Avoid implying the artifact independently reasons. |
+| Task-aware top-left concentration. | `phos_sort_pack`, `pack_artifact`, `guarded_pack_artifact`, and `top_left_concentration`; covered by `test_phos_guarded_pack_measures_concentration`. | **Implemented / thin evidence** | The code measures and guards concentration, but we need benchmark fixtures showing improvement across realistic datasets. |
+| Compositional visual logic: AND/OR/NOT/XOR/add/subtract. | `zeromodel.compose` implements shape-checked fuzzy operators; tests cover AND/OR/XOR and comparison. | **Validated for numeric field operations** | Reframe as “explicit fuzzy field composition.” Do not call this symbolic reasoning unless a semantic layer is added and tested. |
+| Deterministic reproducible provenance. | Artifacts include source and recipe digests, parents, provenance payload, and identity mismatch validation. Tests cover artifact ID and tamper rejection. | **Validated for artifact identity** | Add tests for parent lineage, multi-artifact provenance graphs, and replay from bundles. |
+| Lossless `.vpm` artifact bundles. | `to_bundle()` writes a zip with `manifest.json`; `from_bundle()` validates bundle version and reconstructs `VPMArtifact`. Test covers identity round-trip. | **Validated** | The current bundle is a JSON manifest inside zip, not PNG metadata. |
+| PNG as universal self-describing artifact. | `render.png_bytes()` writes a grayscale PNG image from a field. | **Reframe / not validated** | Current PNG is a rendering/transport image only. It is not self-describing and does not embed manifest/provenance. If we want this claim, add PNG metadata chunks plus round-trip tests. |
+| PNG survives image pipelines. | No current tests for resize/crop/JPEG/social-media pipelines. | **Not validated** | Avoid this claim. Lossy transforms will likely destroy exact numeric semantics. |
+| Hierarchical pyramids / zoomable navigation. | `build_pyramid()` reduces fields into levels with mean/max/sum. Test covers reduced level shapes. | **Implemented / thin evidence** | Supports hierarchy construction, not planet-scale navigation. Need pointer model, child tile IDs, resolver, traversal benchmark. |
+| Planet-scale / infinite memory / 40-hop traversal. | No current benchmark or fixture proving the blog’s latency/scale claims. | **Not validated** | Treat as research ambition until benchmarks are in repo. Required: generated corpus, pyramid builder, traversal harness, hardware info, raw results. |
+| Milliseconds on tiny hardware / 25KB RAM. | `TopLeftGate` is tiny Python logic, but there is no microcontroller implementation or benchmark. | **Not validated** | Required: C/Rust or MicroPython consumer, target hardware profile, timing and memory report. |
+| Edge ↔ cloud symmetry. | Same artifact/field can be rendered, bundled, inspected, and gated. | **Implemented / thin evidence** | Need a concrete edge fixture and cloud viewer example using the same artifact bytes. |
+| Multi-metric, multi-view by design. | `ScoreTable` supports multiple metrics; `LayoutRecipe` supports different ordering/column recipes. | **Validated core mechanism** | Add examples showing two recipes over the same source table and asserting source digest is unchanged. |
+| Storage-agnostic routing via pointers. | No current pointer/resolver abstraction. | **Not validated** | Add `resolver` interfaces and tests before claiming storage-agnostic routing. |
+| Traceable “thought” / 40+ levels. | Current code has provenance and controller signals, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage” once parent-chain tests exist. Avoid “thought” unless strictly metaphorical. |
+| Human-compatible explanations. | Cell/source mapping and SVG/PNG rendering allow inspection. | **Implemented / thin evidence** | Reframe as “inspectable evidence mapping.” Explanation quality requires user-facing viewer tests and examples. |
+| Cheap to adopt. | Package requires only NumPy; README shows short install and simple API. | **Supported, not benchmarked** | Add an end-to-end example from metric rows to gate/render/bundle in under 30 lines. |
+| Works with your stack. | `metrics.pack_metrics()` accepts common aliases and builds score tables from metric rows. | **Implemented / thin evidence** | Add adapters/examples for pandas, JSONL, and common evaluation logs if we want broader wording. |
+| Great fits: anomaly detection, safety gates, code review traces, search triage. | Current package has primitives but no domain examples. | **Not validated as applications** | Create examples for each application before promoting them as out-of-the-box fits. |
+| Viewer you’ll actually use. | Static site exists, but package has no bundled viewer or click-through pointer graph. | **Implemented as website demo only / thin evidence** | Add screenshot tests or a static demo fixture; add pointer graph before claiming Google-Maps-style navigation. |
+
+## Current honest headline
+
+The repo can honestly claim:
+
+> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, and small consumer decisions such as top-left gates without invoking a model at decision time.
+
+## Claims to avoid until benchmarks exist
+
+Avoid or soften these phrases in README/package copy until the repository contains reproducible evidence:
+
+- “planet-scale”
+- “infinite memory”
+- “constant-time decision”
+- “milliseconds on tiny hardware”
+- “25KB RAM”
+- “survives image pipelines”
+- “watch AI think” as a literal claim
+- “visual logic equals reasoning”
+- “self-describing PNG” unless metadata chunks are implemented
+
+## Recommended validation backlog
+
+1. **PNG metadata round-trip** — embed manifest/provenance in PNG text chunks and prove decode returns the same artifact ID.
+2. **Hierarchy traversal benchmark** — generated corpus, child pointers, resolver, traversal harness, raw timing report.
+3. **Edge benchmark** — minimal no-model gate in a tiny runtime, with memory and timing measurements.
+4. **Multi-view invariant test** — same source table, multiple recipes, identical source digest, different view ordering.
+5. **Lineage/provenance replay** — parent artifact chain and deterministic replay from bundles.
+6. **Examples package** — search triage, safety gate, anomaly toy dataset, code review trace.
+7. **Website claim labels** — mark claims as implemented, benchmarked, or roadmap in the static site.
+
+## Bottom line
+
+The cleaned repo now validates the core abstraction. It does **not** yet validate the strongest blog-scale performance claims. The next work should be evidence production, not more broadening of the API.


### PR DESCRIPTION
## What changed

- adds `docs/claims-audit.md`, a claim-by-claim validation matrix comparing the public ZeroModel blog/README claims against the current clean package
- links the claims audit from the README so future wording has a source of truth
- renames the Python workflow job labels from transitional `v2` wording to package-level wording

## Why

The repo now has a clean package and the core VPM implementation, but the public blog contains stronger claims around planet-scale traversal, tiny hardware latency, self-describing PNGs, image-pipeline survival, and traceable “thought.” This PR separates what is validated from what is implemented with thin evidence and what still needs benchmarks.

## Audit conclusion

Validated now:

- deterministic VPM artifact identity
- cell-to-source mapping
- explicit layout recipes
- simple no-model-at-decision-time gates
- numeric visual composition operations
- artifact bundle identity round-trips

Implemented but still needing stronger evidence:

- PHOS/top-left concentration across real workloads
- hierarchy as practical navigation
- edge/cloud symmetry
- human-facing explanation quality

Not validated yet:

- planet-scale / infinite memory claims
- milliseconds on tiny hardware / 25KB RAM claims
- self-describing PNG artifact claims
- PNG survival through lossy image pipelines
- storage-agnostic pointer routing
- “watch AI think” as a literal claim

## Validation

- documentation-only plus workflow label cleanup
- no local test run claimed from this environment
