### PR TITLE
[codex] add learning trace VPMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ region = artifact.region(rows=slice(0, 1), columns=slice(0, 2))
 | Hierarchical pyramids | `zeromodel.hierarchy` |
 | Edge top-left gates | `zeromodel.edge` |
 | Trend-aware EDIT/RESAMPLE/ESCALATE/STOP/SPINOFF control | `zeromodel.controller` |
+| Before/after/held-out/regression learning traces | `zeromodel.learning` |
 
 ## PHOS and edge usage
 
@@ -76,6 +77,25 @@ result = TopLeftGate(threshold=0.75).evaluate(packed.packed)
 print(result.accepted, result.score)
 ```
 
+## Learning trace usage
+
+Tracking means a score moved. Learning means a feedback-driven change improves corrected work, transfers to held-out work, and avoids unacceptable regression.
+
+```python
+from zeromodel import LearningObservation, build_learning_vpm
+
+assessment = build_learning_vpm([
+    LearningObservation("claim-support", before=0.42, after=0.72, split="train"),
+    LearningObservation("related-claim", before=0.50, after=0.63, split="heldout"),
+    LearningObservation("summary-quality", before=0.82, after=0.81, split="regression"),
+])
+
+print(assessment.learned)
+learning_artifact = assessment.artifact
+```
+
+See [`docs/examples/learning-trace-vpm.md`](docs/examples/learning-trace-vpm.md).
+
 ## Bundle usage
 
 ```python
@@ -88,4 +108,4 @@ assert loaded.artifact_id == artifact.artifact_id
 
 ## Design rule
 
-The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.
+The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, learning traces, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.

--- a/docs/claims-audit.md
+++ b/docs/claims-audit.md
@@ -26,6 +26,7 @@ Sources reviewed:
 | VPM cells map back to source evidence. | `VPMArtifact.cell()` returns source row, metric, raw value, and normalized value. Covered by `test_cell_maps_view_coordinates_to_source_coordinates`. | **Validated** | This supports inspectability. It does not by itself prove causal explanation. |
 | Layout recipes reorganize the matrix task-by-task. | `LayoutRecipe` supports source, lexicographic, and weighted row ordering plus source/explicit column ordering. Tests cover lexicographic ordering and tie-breaking. | **Validated** | More recipes and examples would improve confidence, but the core mechanism is real. |
 | No model at decision time. | `TopLeftGate` consumes an already-built artifact/field and thresholds a top-left region. Covered by `test_edge_gate_evaluates_without_model`. | **Validated for simple gates** | Valid wording: “a deployed consumer can make a threshold decision from a prepared artifact without invoking a model.” Avoid implying the artifact independently reasons. |
+| Learning can be made visible. | `LearningObservation` and `build_learning_vpm()` require train, held-out, and regression observations before `learned=True`. Tests cover positive learning, tracking-without-heldout, and regression failure. | **Validated for scored traces** | Valid wording: “ZeroModel can make learning visible as deterministic before/after/held-out/regression artifact traces.” This does not prove a model’s internal mechanism changed. |
 | Task-aware top-left concentration. | `phos_sort_pack`, `pack_artifact`, `guarded_pack_artifact`, and `top_left_concentration`; covered by `test_phos_guarded_pack_measures_concentration`. | **Implemented / thin evidence** | The code measures and guards concentration, but we need benchmark fixtures showing improvement across realistic datasets. |
 | Compositional visual logic: AND/OR/NOT/XOR/add/subtract. | `zeromodel.compose` implements shape-checked fuzzy operators; tests cover AND/OR/XOR and comparison. | **Validated for numeric field operations** | Reframe as “explicit fuzzy field composition.” Do not call this symbolic reasoning unless a semantic layer is added and tested. |
 | Deterministic reproducible provenance. | Artifacts include source and recipe digests, parents, provenance payload, and identity mismatch validation. Tests cover artifact ID and tamper rejection. | **Validated for artifact identity** | Add tests for parent lineage, multi-artifact provenance graphs, and replay from bundles. |
@@ -38,7 +39,7 @@ Sources reviewed:
 | Edge ↔ cloud symmetry. | Same artifact/field can be rendered, bundled, inspected, and gated. | **Implemented / thin evidence** | Need a concrete edge fixture and cloud viewer example using the same artifact bytes. |
 | Multi-metric, multi-view by design. | `ScoreTable` supports multiple metrics; `LayoutRecipe` supports different ordering/column recipes. | **Validated core mechanism** | Add examples showing two recipes over the same source table and asserting source digest is unchanged. |
 | Storage-agnostic routing via pointers. | No current pointer/resolver abstraction. | **Not validated** | Add `resolver` interfaces and tests before claiming storage-agnostic routing. |
-| Traceable “thought” / 40+ levels. | Current code has provenance and controller signals, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage” once parent-chain tests exist. Avoid “thought” unless strictly metaphorical. |
+| Traceable “thought” / 40+ levels. | Current code has provenance, controller signals, and learning traces, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage” or “learning trace” when those are the actual artifacts. Avoid “thought” unless strictly metaphorical. |
 | Human-compatible explanations. | Cell/source mapping and SVG/PNG rendering allow inspection. | **Implemented / thin evidence** | Reframe as “inspectable evidence mapping.” Explanation quality requires user-facing viewer tests and examples. |
 | Cheap to adopt. | Package requires only NumPy; README shows short install and simple API. | **Supported, not benchmarked** | Add an end-to-end example from metric rows to gate/render/bundle in under 30 lines. |
 | Works with your stack. | `metrics.pack_metrics()` accepts common aliases and builds score tables from metric rows. | **Implemented / thin evidence** | Add adapters/examples for pandas, JSONL, and common evaluation logs if we want broader wording. |
@@ -49,7 +50,7 @@ Sources reviewed:
 
 The repo can honestly claim:
 
-> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, and small consumer decisions such as top-left gates without invoking a model at decision time.
+> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, small consumer decisions such as top-left gates without invoking a model at decision time, and scored learning traces that distinguish tracking from train/held-out/regression evidence of learning.
 
 ## Claims to avoid until benchmarks exist
 
@@ -72,9 +73,10 @@ Avoid or soften these phrases in README/package copy until the repository contai
 3. **Edge benchmark** — minimal no-model gate in a tiny runtime, with memory and timing measurements.
 4. **Multi-view invariant test** — same source table, multiple recipes, identical source digest, different view ordering.
 5. **Lineage/provenance replay** — parent artifact chain and deterministic replay from bundles.
-6. **Examples package** — search triage, safety gate, anomaly toy dataset, code review trace.
-7. **Website claim labels** — mark claims as implemented, benchmarked, or roadmap in the static site.
+6. **Learning trace domain examples** — agent trace learning, RAG correction learning, Writer evaluator learning.
+7. **Examples package** — search triage, safety gate, anomaly toy dataset, code review trace.
+8. **Website claim labels** — mark claims as implemented, benchmarked, or roadmap in the static site.
 
 ## Bottom line
 
-The cleaned repo now validates the core abstraction. It does **not** yet validate the strongest blog-scale performance claims. The next work should be evidence production, not more broadening of the API.
+The cleaned repo now validates the core abstraction and adds a concrete scored-trace definition of visible learning. It does **not** yet validate the strongest blog-scale performance claims. The next work should be evidence production, not more broadening of the API.

--- a/docs/examples/learning-trace-vpm.md
+++ b/docs/examples/learning-trace-vpm.md
@@ -1,0 +1,59 @@
+# Learning trace VPM
+
+ZeroModel can show more than tracking when the input data contains the right evidence.
+
+Tracking means a value moved over time. Learning means a behavior changed after feedback and the change survives checks beyond the exact corrected example.
+
+## Minimum evidence
+
+A learning trace should contain at least three kinds of observations:
+
+| Split | Question answered |
+|---|---|
+| `train` | Did the corrected or experienced unit improve? |
+| `heldout` | Did related unseen or future work improve too? |
+| `regression` | Did unrelated or previously good work avoid degradation? |
+
+ZeroModel marks an assessment as `learned=True` only when train improvement clears the training threshold, held-out improvement clears the transfer threshold, and regression degradation stays below the safety threshold.
+
+## Example
+
+```python
+from zeromodel import LearningObservation, build_learning_vpm
+
+assessment = build_learning_vpm([
+    LearningObservation("claim-support", before=0.42, after=0.72, split="train"),
+    LearningObservation("related-claim", before=0.50, after=0.63, split="heldout"),
+    LearningObservation("summary-quality", before=0.82, after=0.81, split="regression"),
+])
+
+print(assessment.learned)
+artifact = assessment.artifact
+```
+
+The resulting artifact is an ordinary VPM. It can be inspected, rendered, bundled, gated, and compared like any other artifact.
+
+## Metrics
+
+`build_learning_vpm()` creates these metrics:
+
+| Metric | Meaning |
+|---|---|
+| `learning_score` | Split-aware score used to put strongest evidence first. |
+| `delta_positive` | Positive before/after improvement. |
+| `feedback_alignment` | How well the update corresponds to the feedback. |
+| `generalization` | Held-out improvement, zero for non-held-out rows. |
+| `regression_safety` | One minus observed degradation. |
+| `after_score` | Final observed score. |
+
+## Correct claim
+
+Use this wording:
+
+> ZeroModel can make learning visible as a deterministic before/after/held-out/regression artifact trace.
+
+Avoid this wording:
+
+> ZeroModel watches AI think.
+
+The first statement is testable. The second is metaphorical and should not be used as a literal technical claim.

--- a/examples/learning_trace_demo.py
+++ b/examples/learning_trace_demo.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from zeromodel import LearningObservation, build_learning_vpm, from_bundle, to_bundle, write_png, write_svg
+
+
+def main() -> None:
+    observations = [
+        LearningObservation(
+            unit_id="claim-support",
+            before=0.42,
+            after=0.72,
+            split="train",
+            metadata={"feedback": "added missing source citation"},
+        ),
+        LearningObservation(
+            unit_id="related-claim-support",
+            before=0.50,
+            after=0.63,
+            split="heldout",
+            metadata={"check": "new claim not used in feedback"},
+        ),
+        LearningObservation(
+            unit_id="unrelated-summary-quality",
+            before=0.82,
+            after=0.81,
+            split="regression",
+            metadata={"check": "previously good behavior stayed intact"},
+        ),
+    ]
+
+    assessment = build_learning_vpm(observations)
+    artifact = assessment.artifact
+
+    out_dir = Path(".zeromodel-learning-demo")
+    out_dir.mkdir(exist_ok=True)
+    bundle_path = to_bundle(artifact, out_dir / "learning_trace.vpm")
+    png_path = write_png(artifact, out_dir / "learning_trace.png")
+    svg_path = write_svg(artifact, out_dir / "learning_trace.svg")
+    loaded = from_bundle(bundle_path)
+
+    print("learned:", assessment.learned)
+    print("train_delta:", round(assessment.train_delta, 3))
+    print("heldout_delta:", round(assessment.heldout_delta, 3))
+    print("regression_degradation:", round(assessment.regression_degradation, 3))
+    print("artifact_id:", artifact.artifact_id)
+    print("bundle_roundtrip:", loaded.artifact_id == artifact.artifact_id)
+    print("wrote:", bundle_path, png_path, svg_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel import LearningObservation, build_learning_vpm
+from zeromodel.artifact import VPMValidationError
+
+
+def test_learning_vpm_requires_train_heldout_and_regression_evidence() -> None:
+    assessment = build_learning_vpm(
+        [
+            LearningObservation(unit_id="claim-a", before=0.40, after=0.70, split="train"),
+            LearningObservation(unit_id="claim-b", before=0.50, after=0.62, split="heldout"),
+            LearningObservation(unit_id="claim-c", before=0.80, after=0.80, split="regression"),
+        ]
+    )
+
+    assert assessment.learned is True
+    assert assessment.train_delta == pytest.approx(0.30)
+    assert assessment.heldout_delta == pytest.approx(0.12)
+    assert assessment.regression_degradation == pytest.approx(0.0)
+    assert assessment.artifact.source.metric_ids == (
+        "learning_score",
+        "delta_positive",
+        "feedback_alignment",
+        "generalization",
+        "regression_safety",
+        "after_score",
+    )
+    assert assessment.artifact.provenance["kind"] == "learning_trace"
+    assert assessment.artifact.provenance["learned"] is True
+
+
+def test_tracking_without_heldout_evidence_is_not_learning() -> None:
+    assessment = build_learning_vpm(
+        [
+            {"unit_id": "same-example", "before": 0.2, "after": 0.9, "split": "train"},
+            {"unit_id": "safety-check", "before": 0.8, "after": 0.8, "split": "regression"},
+        ]
+    )
+
+    assert assessment.train_delta > 0
+    assert assessment.heldout_delta == 0.0
+    assert assessment.learned is False
+
+
+def test_regression_prevents_learning_claim() -> None:
+    assessment = build_learning_vpm(
+        [
+            LearningObservation(unit_id="claim-a", before=0.40, after=0.75, split="train"),
+            LearningObservation(unit_id="claim-b", before=0.50, after=0.64, split="heldout"),
+            LearningObservation(unit_id="claim-c", before=0.90, after=0.70, split="regression"),
+        ]
+    )
+
+    assert assessment.regression_degradation == pytest.approx(0.20)
+    assert assessment.learned is False
+
+
+def test_learning_vpm_cell_maps_to_learning_observation() -> None:
+    assessment = build_learning_vpm(
+        [
+            LearningObservation(unit_id="train-unit", before=0.3, after=0.6, split="train"),
+            LearningObservation(unit_id="heldout-unit", before=0.4, after=0.55, split="heldout"),
+            LearningObservation(unit_id="regression-unit", before=0.9, after=0.9, split="regression"),
+        ]
+    )
+
+    first_cell = assessment.artifact.cell(0, 0)
+
+    assert first_cell.metric_id == "learning_score"
+    assert first_cell.row_id in {"train:train-unit", "heldout:heldout-unit", "regression:regression-unit"}
+    assert 0.0 <= first_cell.normalized_value <= 1.0
+
+
+def test_learning_observation_rejects_invalid_scores_and_splits() -> None:
+    with pytest.raises(VPMValidationError, match="Unsupported learning split"):
+        LearningObservation(unit_id="x", before=0.1, after=0.2, split="future")
+
+    with pytest.raises(VPMValidationError, match="scores must be in"):
+        LearningObservation(unit_id="x", before=0.1, after=1.2)
+
+
+def test_learning_vpm_rejects_duplicate_split_unit_rows() -> None:
+    with pytest.raises(VPMValidationError, match="unique split:unit_id"):
+        build_learning_vpm(
+            [
+                LearningObservation(unit_id="same", before=0.1, after=0.2, split="train"),
+                LearningObservation(unit_id="same", before=0.2, after=0.3, split="train"),
+            ]
+        )

--- a/zeromodel/__init__.py
+++ b/zeromodel/__init__.py
@@ -19,7 +19,6 @@ __all__ = [
     "CANONICAL_METRICS",
     "Decision",
     "HierarchyLevel",
-    "LAYOUT_VERSION",
     "LEARNING_METRICS",
     "LayoutRecipe",
     "LearningAssessment",

--- a/zeromodel/__init__.py
+++ b/zeromodel/__init__.py
@@ -8,6 +8,7 @@ from .compose import as_field, vpm_add, vpm_and, vpm_not, vpm_or, vpm_subtract, 
 from .controller import Decision, Policy, Signal, Thresholds, VPMController, VPMRow, default_controller
 from .edge import TopLeftGate, TopLeftGateResult
 from .hierarchy import HierarchyLevel, build_pyramid, reduce_blocks
+from .learning import LEARNING_METRICS, LearningAssessment, LearningObservation, build_learning_vpm, learning_recipe
 from .metrics import CANONICAL_METRICS, metric_ids_for_rows, pack_metrics, score_table_from_metric_rows
 from .phos import PHOSResult, guarded_pack_artifact, image_entropy, pack_artifact, phos_sort_pack, robust01, to_square, top_left_concentration
 from .render import png_bytes, svg_text, to_uint8, write_png, write_svg
@@ -18,7 +19,11 @@ __all__ = [
     "CANONICAL_METRICS",
     "Decision",
     "HierarchyLevel",
+    "LAYOUT_VERSION",
+    "LEARNING_METRICS",
     "LayoutRecipe",
+    "LearningAssessment",
+    "LearningObservation",
     "PHOSResult",
     "Policy",
     "ScoreTable",
@@ -33,6 +38,7 @@ __all__ = [
     "VPMRegion",
     "VPMRow",
     "as_field",
+    "build_learning_vpm",
     "build_pyramid",
     "build_vpm",
     "compare_fields",
@@ -40,6 +46,7 @@ __all__ = [
     "from_bundle",
     "guarded_pack_artifact",
     "image_entropy",
+    "learning_recipe",
     "metric_ids_for_rows",
     "pack_artifact",
     "pack_metrics",

--- a/zeromodel/learning.py
+++ b/zeromodel/learning.py
@@ -1,0 +1,260 @@
+"""Learning trace artifacts for showing durable behavior change.
+
+This module distinguishes tracking from learning. A score moving over time is only
+tracking. Learning requires a before/after change tied to feedback plus evidence
+that the change transfers to held-out work without unacceptable regression.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .artifact import LayoutRecipe, ScoreTable, VPMArtifact, VPMValidationError, build_vpm
+
+LEARNING_METRICS: Tuple[str, ...] = (
+    "learning_score",
+    "delta_positive",
+    "feedback_alignment",
+    "generalization",
+    "regression_safety",
+    "after_score",
+)
+
+VALID_SPLITS = ("train", "heldout", "regression")
+
+
+@dataclass(frozen=True)
+class LearningObservation:
+    """One before/after measurement for a unit affected by feedback.
+
+    ``split`` controls how the observation contributes to the learning claim:
+
+    - ``train``: did the corrected/experienced unit improve?
+    - ``heldout``: did related future or unseen work improve?
+    - ``regression``: did unrelated or previously good work stay intact?
+    """
+
+    unit_id: str
+    before: float
+    after: float
+    split: str = "train"
+    feedback_alignment: float = 1.0
+    weight: float = 1.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        unit_id = str(self.unit_id)
+        split = str(self.split)
+        before = float(self.before)
+        after = float(self.after)
+        feedback_alignment = float(self.feedback_alignment)
+        weight = float(self.weight)
+        if not unit_id:
+            raise VPMValidationError("LearningObservation requires a non-empty unit_id")
+        if split not in VALID_SPLITS:
+            raise VPMValidationError("Unsupported learning split: %r" % split)
+        values = [before, after, feedback_alignment, weight]
+        if not np.isfinite(values).all():
+            raise VPMValidationError("LearningObservation numeric values must be finite")
+        if not (0.0 <= before <= 1.0 and 0.0 <= after <= 1.0):
+            raise VPMValidationError("LearningObservation before/after scores must be in [0, 1]")
+        if not (0.0 <= feedback_alignment <= 1.0):
+            raise VPMValidationError("feedback_alignment must be in [0, 1]")
+        if weight <= 0:
+            raise VPMValidationError("weight must be positive")
+        object.__setattr__(self, "unit_id", unit_id)
+        object.__setattr__(self, "split", split)
+        object.__setattr__(self, "before", before)
+        object.__setattr__(self, "after", after)
+        object.__setattr__(self, "feedback_alignment", feedback_alignment)
+        object.__setattr__(self, "weight", weight)
+
+    @property
+    def delta(self) -> float:
+        return float(self.after - self.before)
+
+    @property
+    def improvement(self) -> float:
+        return max(self.delta, 0.0)
+
+    @property
+    def degradation(self) -> float:
+        return max(-self.delta, 0.0)
+
+    @property
+    def regression_safety(self) -> float:
+        return max(0.0, 1.0 - self.degradation)
+
+    @property
+    def generalization(self) -> float:
+        return self.improvement if self.split == "heldout" else 0.0
+
+    @property
+    def learning_score(self) -> float:
+        if self.split == "regression":
+            return self.regression_safety
+        return self.improvement * self.feedback_alignment
+
+    def metric_row(self) -> Tuple[float, ...]:
+        return (
+            self.learning_score,
+            self.improvement,
+            self.feedback_alignment,
+            self.generalization,
+            self.regression_safety,
+            self.after,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "unit_id": self.unit_id,
+            "before": self.before,
+            "after": self.after,
+            "delta": self.delta,
+            "split": self.split,
+            "feedback_alignment": self.feedback_alignment,
+            "weight": self.weight,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class LearningAssessment:
+    """Summary of whether a trace shows learning rather than mere tracking."""
+
+    artifact: VPMArtifact
+    observations: Tuple[LearningObservation, ...]
+    train_delta: float
+    heldout_delta: float
+    regression_degradation: float
+    learned: bool
+    thresholds: Mapping[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact.artifact_id,
+            "learned": self.learned,
+            "train_delta": self.train_delta,
+            "heldout_delta": self.heldout_delta,
+            "regression_degradation": self.regression_degradation,
+            "thresholds": dict(self.thresholds),
+            "observations": [observation.to_dict() for observation in self.observations],
+        }
+
+
+def learning_recipe() -> LayoutRecipe:
+    """Default recipe that places strongest learning evidence first."""
+    return LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "learning-evidence-first",
+            "row_order": {
+                "kind": "lexicographic",
+                "keys": [
+                    {"metric_id": "learning_score", "direction": "desc"},
+                    {"metric_id": "generalization", "direction": "desc"},
+                    {"metric_id": "regression_safety", "direction": "desc"},
+                ],
+                "tie_break": "row_id",
+            },
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+
+
+def _weighted_mean(values: Sequence[float], weights: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    total_weight = float(sum(weights))
+    if total_weight <= 0:
+        return 0.0
+    return float(sum(value * weight for value, weight in zip(values, weights)) / total_weight)
+
+
+def _mean_delta(observations: Sequence[LearningObservation], split: str) -> float:
+    subset = [observation for observation in observations if observation.split == split]
+    return _weighted_mean([observation.delta for observation in subset], [observation.weight for observation in subset])
+
+
+def _mean_degradation(observations: Sequence[LearningObservation], split: str) -> float:
+    subset = [observation for observation in observations if observation.split == split]
+    return _weighted_mean([observation.degradation for observation in subset], [observation.weight for observation in subset])
+
+
+def build_learning_vpm(
+    observations: Sequence[LearningObservation | Mapping[str, Any]],
+    *,
+    recipe: Optional[LayoutRecipe] = None,
+    min_train_delta: float = 0.05,
+    min_heldout_delta: float = 0.02,
+    max_regression_degradation: float = 0.01,
+    provenance: Optional[Mapping[str, Any]] = None,
+) -> LearningAssessment:
+    """Build a learning-evidence VPM and decide whether learning is demonstrated.
+
+    The returned assessment marks ``learned=True`` only when:
+
+    1. training/corrected units improve enough;
+    2. held-out or future units also improve enough;
+    3. regression observations do not degrade beyond the allowed threshold.
+    """
+    normalized_observations = tuple(
+        item if isinstance(item, LearningObservation) else LearningObservation(**dict(item))
+        for item in observations
+    )
+    if not normalized_observations:
+        raise VPMValidationError("build_learning_vpm requires at least one observation")
+
+    row_ids = tuple("%s:%s" % (observation.split, observation.unit_id) for observation in normalized_observations)
+    if len(set(row_ids)) != len(row_ids):
+        raise VPMValidationError("Learning observations require unique split:unit_id row identifiers")
+
+    table = ScoreTable(
+        values=[observation.metric_row() for observation in normalized_observations],
+        row_ids=row_ids,
+        metric_ids=LEARNING_METRICS,
+        metadata={
+            "kind": "learning_trace",
+            "observations": [observation.to_dict() for observation in normalized_observations],
+        },
+    )
+
+    train_delta = _mean_delta(normalized_observations, "train")
+    heldout_delta = _mean_delta(normalized_observations, "heldout")
+    regression_degradation = _mean_degradation(normalized_observations, "regression")
+    learned = bool(
+        train_delta >= float(min_train_delta)
+        and heldout_delta >= float(min_heldout_delta)
+        and regression_degradation <= float(max_regression_degradation)
+    )
+
+    artifact = build_vpm(
+        table,
+        recipe or learning_recipe(),
+        provenance={
+            "kind": "learning_trace",
+            "parents": [],
+            "train_delta": train_delta,
+            "heldout_delta": heldout_delta,
+            "regression_degradation": regression_degradation,
+            "learned": learned,
+            **dict(provenance or {}),
+        },
+    )
+
+    return LearningAssessment(
+        artifact=artifact,
+        observations=normalized_observations,
+        train_delta=train_delta,
+        heldout_delta=heldout_delta,
+        regression_degradation=regression_degradation,
+        learned=learned,
+        thresholds={
+            "min_train_delta": float(min_train_delta),
+            "min_heldout_delta": float(min_heldout_delta),
+            "max_regression_degradation": float(max_regression_degradation),
+        },
+    )

--- a/zeromodel/learning.py
+++ b/zeromodel/learning.py
@@ -94,7 +94,7 @@ class LearningObservation:
     @property
     def learning_score(self) -> float:
         if self.split == "regression":
-            return self.regression_safety
+            return 0.0
         return self.improvement * self.feedback_alignment
 
     def metric_row(self) -> Tuple[float, ...]:


### PR DESCRIPTION
## What changed

- adds `zeromodel.learning` with `LearningObservation`, `LearningAssessment`, `learning_recipe()`, and `build_learning_vpm()`
- distinguishes tracking from learning by requiring train improvement, held-out improvement, and bounded regression degradation before `learned=True`
- exports the learning primitives from the top-level `zeromodel` package
- adds tests covering positive learning evidence, tracking-without-heldout, regression failure, validation errors, and VPM cell mapping
- adds `examples/learning_trace_demo.py`
- adds `docs/examples/learning-trace-vpm.md`
- updates README and claims audit to describe the learning trace surface

## Why

Tracking shows movement. Learning requires durable behavior change after feedback. This PR makes that distinction explicit and inspectable as a deterministic VPM artifact.

## New claim

Valid wording:

> ZeroModel can make learning visible as deterministic before/after/held-out/regression artifact traces.

Invalid wording:

> ZeroModel watches AI think.

## Validation

- added `tests/test_learning.py`
- no local test run claimed from this environment; GitHub Actions should be treated as source of truth
