### PR TITLE
[codex] add training progress VPMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ region = artifact.region(rows=slice(0, 1), columns=slice(0, 2))
 | Edge top-left gates | `zeromodel.edge` |
 | Trend-aware EDIT/RESAMPLE/ESCALATE/STOP/SPINOFF control | `zeromodel.controller` |
 | Before/after/held-out/regression learning traces | `zeromodel.learning` |
+| Model-training progress artifacts | `zeromodel.training` |
 
 ## PHOS and edge usage
 
@@ -96,6 +97,34 @@ learning_artifact = assessment.artifact
 
 See [`docs/examples/learning-trace-vpm.md`](docs/examples/learning-trace-vpm.md).
 
+## Training progress usage
+
+Training telemetry can become a checkpoint-level VPM that shows train improvement, held-out transfer, regression safety, stability, efficiency, and best-checkpoint evidence.
+
+```python
+from zeromodel import TrainingCheckpoint, build_training_progress_vpm
+
+progress = build_training_progress_vpm(
+    [
+        TrainingCheckpoint(step=1000, metrics={
+            "train_loss": 1.00,
+            "heldout_score": 0.50,
+            "regression_safety": 0.99,
+        }),
+        TrainingCheckpoint(step=2000, metrics={
+            "train_loss": 0.82,
+            "heldout_score": 0.57,
+            "regression_safety": 0.98,
+        }),
+    ]
+)
+
+print(progress.best_checkpoint_id, progress.learned, progress.warnings)
+training_artifact = progress.artifact
+```
+
+See [`docs/examples/training-progress-vpm.md`](docs/examples/training-progress-vpm.md).
+
 ## Bundle usage
 
 ```python
@@ -108,4 +137,4 @@ assert loaded.artifact_id == artifact.artifact_id
 
 ## Design rule
 
-The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, learning traces, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.
+The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, learning traces, training progress, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.

--- a/docs/claims-audit.md
+++ b/docs/claims-audit.md
@@ -27,6 +27,7 @@ Sources reviewed:
 | Layout recipes reorganize the matrix task-by-task. | `LayoutRecipe` supports source, lexicographic, and weighted row ordering plus source/explicit column ordering. Tests cover lexicographic ordering and tie-breaking. | **Validated** | More recipes and examples would improve confidence, but the core mechanism is real. |
 | No model at decision time. | `TopLeftGate` consumes an already-built artifact/field and thresholds a top-left region. Covered by `test_edge_gate_evaluates_without_model`. | **Validated for simple gates** | Valid wording: “a deployed consumer can make a threshold decision from a prepared artifact without invoking a model.” Avoid implying the artifact independently reasons. |
 | Learning can be made visible. | `LearningObservation` and `build_learning_vpm()` require train, held-out, and regression observations before `learned=True`. Tests cover positive learning, tracking-without-heldout, and regression failure. | **Validated for scored traces** | Valid wording: “ZeroModel can make learning visible as deterministic before/after/held-out/regression artifact traces.” This does not prove a model’s internal mechanism changed. |
+| Training progress can be visualized. | `TrainingCheckpoint` and `build_training_progress_vpm()` convert checkpoint telemetry into progress VPMs with train progress, held-out progress, regression safety, stability, efficiency, best checkpoint, warnings, and `learned`. Tests cover best checkpoint selection, overfit-like train-without-heldout warnings, regression failure, cell mapping, and validation errors. | **Validated for checkpoint telemetry** | Valid wording: “ZeroModel can turn model-training telemetry into deterministic progress artifacts.” This does not replace TensorBoard/W&B or prove internal model causality. |
 | Task-aware top-left concentration. | `phos_sort_pack`, `pack_artifact`, `guarded_pack_artifact`, and `top_left_concentration`; covered by `test_phos_guarded_pack_measures_concentration`. | **Implemented / thin evidence** | The code measures and guards concentration, but we need benchmark fixtures showing improvement across realistic datasets. |
 | Compositional visual logic: AND/OR/NOT/XOR/add/subtract. | `zeromodel.compose` implements shape-checked fuzzy operators; tests cover AND/OR/XOR and comparison. | **Validated for numeric field operations** | Reframe as “explicit fuzzy field composition.” Do not call this symbolic reasoning unless a semantic layer is added and tested. |
 | Deterministic reproducible provenance. | Artifacts include source and recipe digests, parents, provenance payload, and identity mismatch validation. Tests cover artifact ID and tamper rejection. | **Validated for artifact identity** | Add tests for parent lineage, multi-artifact provenance graphs, and replay from bundles. |
@@ -39,10 +40,10 @@ Sources reviewed:
 | Edge ↔ cloud symmetry. | Same artifact/field can be rendered, bundled, inspected, and gated. | **Implemented / thin evidence** | Need a concrete edge fixture and cloud viewer example using the same artifact bytes. |
 | Multi-metric, multi-view by design. | `ScoreTable` supports multiple metrics; `LayoutRecipe` supports different ordering/column recipes. | **Validated core mechanism** | Add examples showing two recipes over the same source table and asserting source digest is unchanged. |
 | Storage-agnostic routing via pointers. | No current pointer/resolver abstraction. | **Not validated** | Add `resolver` interfaces and tests before claiming storage-agnostic routing. |
-| Traceable “thought” / 40+ levels. | Current code has provenance, controller signals, and learning traces, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage” or “learning trace” when those are the actual artifacts. Avoid “thought” unless strictly metaphorical. |
+| Traceable “thought” / 40+ levels. | Current code has provenance, controller signals, learning traces, and training progress artifacts, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage,” “learning trace,” or “training progress artifact” when those are the actual artifacts. Avoid “thought” unless strictly metaphorical. |
 | Human-compatible explanations. | Cell/source mapping and SVG/PNG rendering allow inspection. | **Implemented / thin evidence** | Reframe as “inspectable evidence mapping.” Explanation quality requires user-facing viewer tests and examples. |
 | Cheap to adopt. | Package requires only NumPy; README shows short install and simple API. | **Supported, not benchmarked** | Add an end-to-end example from metric rows to gate/render/bundle in under 30 lines. |
-| Works with your stack. | `metrics.pack_metrics()` accepts common aliases and builds score tables from metric rows. | **Implemented / thin evidence** | Add adapters/examples for pandas, JSONL, and common evaluation logs if we want broader wording. |
+| Works with your stack. | `metrics.pack_metrics()` accepts common aliases and builds score tables from metric rows. | **Implemented / thin evidence** | Add adapters/examples for pandas, JSONL, TensorBoard logs, W&B exports, Trackio runs, and common evaluation logs if we want broader wording. |
 | Great fits: anomaly detection, safety gates, code review traces, search triage. | Current package has primitives but no domain examples. | **Not validated as applications** | Create examples for each application before promoting them as out-of-the-box fits. |
 | Viewer you’ll actually use. | Static site exists, but package has no bundled viewer or click-through pointer graph. | **Implemented as website demo only / thin evidence** | Add screenshot tests or a static demo fixture; add pointer graph before claiming Google-Maps-style navigation. |
 
@@ -50,7 +51,7 @@ Sources reviewed:
 
 The repo can honestly claim:
 
-> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, small consumer decisions such as top-left gates without invoking a model at decision time, and scored learning traces that distinguish tracking from train/held-out/regression evidence of learning.
+> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, small consumer decisions such as top-left gates without invoking a model at decision time, scored learning traces that distinguish tracking from train/held-out/regression evidence of learning, and checkpoint-level training progress artifacts for model telemetry.
 
 ## Claims to avoid until benchmarks exist
 
@@ -65,6 +66,7 @@ Avoid or soften these phrases in README/package copy until the repository contai
 - “watch AI think” as a literal claim
 - “visual logic equals reasoning”
 - “self-describing PNG” unless metadata chunks are implemented
+- “understands why the model learned”
 
 ## Recommended validation backlog
 
@@ -74,9 +76,10 @@ Avoid or soften these phrases in README/package copy until the repository contai
 4. **Multi-view invariant test** — same source table, multiple recipes, identical source digest, different view ordering.
 5. **Lineage/provenance replay** — parent artifact chain and deterministic replay from bundles.
 6. **Learning trace domain examples** — agent trace learning, RAG correction learning, Writer evaluator learning.
-7. **Examples package** — search triage, safety gate, anomaly toy dataset, code review trace.
-8. **Website claim labels** — mark claims as implemented, benchmarked, or roadmap in the static site.
+7. **Training tracker adapters** — TensorBoard scalar export, W&B/Trackio JSON export, and checkpoint artifact fixtures.
+8. **Examples package** — search triage, safety gate, anomaly toy dataset, code review trace.
+9. **Website claim labels** — mark claims as implemented, benchmarked, or roadmap in the static site.
 
 ## Bottom line
 
-The cleaned repo now validates the core abstraction and adds a concrete scored-trace definition of visible learning. It does **not** yet validate the strongest blog-scale performance claims. The next work should be evidence production, not more broadening of the API.
+The cleaned repo now validates the core abstraction, adds a concrete scored-trace definition of visible learning, and adds checkpoint-level model-training progress artifacts. It does **not** yet validate the strongest blog-scale performance claims. The next work should be evidence production and practical adapters, not more broadening of the API.

--- a/docs/examples/training-progress-vpm.md
+++ b/docs/examples/training-progress-vpm.md
@@ -1,0 +1,75 @@
+# Training progress VPM
+
+ZeroModel can turn model-training telemetry into deterministic progress artifacts.
+
+A normal tracker shows movement over time: loss down, accuracy up, throughput, GPU memory. A training progress VPM adds an evidence layer: did the checkpoint improve the training objective, transfer to held-out evaluation, avoid regression, remain stable, and keep acceptable efficiency?
+
+## Minimum telemetry
+
+A useful training progress trace should include at least two checkpoints and metrics for:
+
+| Evidence | Typical metric |
+|---|---|
+| Train objective | `train_loss`, `reward`, `train_score` |
+| Held-out transfer | `heldout_score`, `eval_accuracy`, `validation_reward` |
+| Regression safety | `regression_safety`, `safety_score`, `backward_compatibility` |
+| Stability | `stability`, `grad_health`, `nan_free_rate` |
+| Efficiency | `tokens_per_second`, `samples_per_second`, `cost_efficiency` |
+
+## Example
+
+```python
+from zeromodel import TrainingCheckpoint, build_training_progress_vpm
+
+assessment = build_training_progress_vpm(
+    [
+        TrainingCheckpoint(step=1000, metrics={
+            "train_loss": 1.00,
+            "heldout_score": 0.50,
+            "regression_safety": 0.99,
+            "stability": 0.96,
+            "tokens_per_second": 1000,
+        }),
+        TrainingCheckpoint(step=2000, metrics={
+            "train_loss": 0.82,
+            "heldout_score": 0.57,
+            "regression_safety": 0.98,
+            "stability": 0.94,
+            "tokens_per_second": 1120,
+        }),
+    ],
+    stability_metric="stability",
+    efficiency_metric="tokens_per_second",
+)
+
+print(assessment.best_checkpoint_id)
+print(assessment.learned)
+artifact = assessment.artifact
+```
+
+The artifact is a normal VPM. You can inspect cells, render PNG/SVG, save a `.vpm` bundle, compare artifacts across runs, or use a gate to decide whether a checkpoint should be promoted.
+
+## Metrics
+
+`build_training_progress_vpm()` creates these metrics:
+
+| Metric | Meaning |
+|---|---|
+| `progress_score` | Weighted checkpoint progress score. |
+| `train_progress` | Relative train-objective improvement from the first checkpoint. |
+| `heldout_progress` | Relative held-out improvement from the first checkpoint. |
+| `regression_safety` | Safety/regression score, where higher is safer. |
+| `stability` | Stability score, where higher is healthier. |
+| `efficiency` | Relative efficiency progress or default neutral score. |
+
+## Correct claim
+
+Use this wording:
+
+> ZeroModel can turn model-training telemetry into deterministic progress artifacts that show train improvement, held-out transfer, regression risk, stability, efficiency, and checkpoint selection evidence.
+
+Avoid this wording:
+
+> ZeroModel understands why the model learned.
+
+The artifact summarizes observable evidence. It does not inspect or prove internal mechanisms.

--- a/examples/training_progress_demo.py
+++ b/examples/training_progress_demo.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from zeromodel import TrainingCheckpoint, build_training_progress_vpm, from_bundle, to_bundle, write_png, write_svg
+
+
+def main() -> None:
+    checkpoints = [
+        TrainingCheckpoint(
+            step=1000,
+            metrics={
+                "train_loss": 1.00,
+                "heldout_score": 0.50,
+                "regression_safety": 0.99,
+                "stability": 0.96,
+                "tokens_per_second": 1000,
+            },
+        ),
+        TrainingCheckpoint(
+            step=2000,
+            metrics={
+                "train_loss": 0.82,
+                "heldout_score": 0.57,
+                "regression_safety": 0.98,
+                "stability": 0.94,
+                "tokens_per_second": 1120,
+            },
+        ),
+        TrainingCheckpoint(
+            step=3000,
+            metrics={
+                "train_loss": 0.67,
+                "heldout_score": 0.65,
+                "regression_safety": 0.97,
+                "stability": 0.91,
+                "tokens_per_second": 1260,
+            },
+        ),
+        TrainingCheckpoint(
+            step=4000,
+            metrics={
+                "train_loss": 0.58,
+                "heldout_score": 0.63,
+                "regression_safety": 0.89,
+                "stability": 0.84,
+                "tokens_per_second": 1240,
+            },
+        ),
+    ]
+
+    assessment = build_training_progress_vpm(
+        checkpoints,
+        stability_metric="stability",
+        efficiency_metric="tokens_per_second",
+    )
+    artifact = assessment.artifact
+
+    out_dir = Path(".zeromodel-training-demo")
+    out_dir.mkdir(exist_ok=True)
+    bundle_path = to_bundle(artifact, out_dir / "training_progress.vpm")
+    png_path = write_png(artifact, out_dir / "training_progress.png")
+    svg_path = write_svg(artifact, out_dir / "training_progress.svg")
+    loaded = from_bundle(bundle_path)
+
+    print("learned:", assessment.learned)
+    print("best_checkpoint:", assessment.best_checkpoint_id)
+    print("best_step:", assessment.best_step)
+    print("warnings:", list(assessment.warnings))
+    print("artifact_id:", artifact.artifact_id)
+    print("bundle_roundtrip:", loaded.artifact_id == artifact.artifact_id)
+    print("wrote:", bundle_path, png_path, svg_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel import TrainingCheckpoint, build_training_progress_vpm
+from zeromodel.artifact import VPMValidationError
+
+
+def checkpoints():
+    return [
+        TrainingCheckpoint(
+            step=1000,
+            metrics={
+                "train_loss": 1.00,
+                "heldout_score": 0.50,
+                "regression_safety": 0.99,
+                "stability": 0.96,
+                "tokens_per_second": 1000,
+            },
+        ),
+        TrainingCheckpoint(
+            step=2000,
+            metrics={
+                "train_loss": 0.80,
+                "heldout_score": 0.56,
+                "regression_safety": 0.98,
+                "stability": 0.94,
+                "tokens_per_second": 1100,
+            },
+        ),
+        TrainingCheckpoint(
+            step=3000,
+            metrics={
+                "train_loss": 0.65,
+                "heldout_score": 0.64,
+                "regression_safety": 0.97,
+                "stability": 0.92,
+                "tokens_per_second": 1250,
+            },
+        ),
+    ]
+
+
+def test_training_progress_vpm_selects_best_checkpoint() -> None:
+    assessment = build_training_progress_vpm(
+        checkpoints(),
+        stability_metric="stability",
+        efficiency_metric="tokens_per_second",
+    )
+
+    assert assessment.learned is True
+    assert assessment.best_checkpoint_id == "step_3000"
+    assert assessment.best_step == 3000
+    assert assessment.warnings == ()
+    assert assessment.artifact.source.metric_ids == (
+        "progress_score",
+        "train_progress",
+        "heldout_progress",
+        "regression_safety",
+        "stability",
+        "efficiency",
+    )
+    assert assessment.artifact.provenance["kind"] == "training_progress"
+    assert assessment.artifact.provenance["learned"] is True
+
+
+def test_training_progress_warns_when_train_improves_without_heldout_transfer() -> None:
+    assessment = build_training_progress_vpm(
+        [
+            {"step": 0, "metrics": {"train_loss": 1.0, "heldout_score": 0.50, "regression_safety": 0.99}},
+            {"step": 1, "metrics": {"train_loss": 0.5, "heldout_score": 0.50, "regression_safety": 0.99}},
+        ]
+    )
+
+    assert assessment.learned is False
+    assert "train_progress_without_heldout_transfer" in assessment.warnings
+
+
+def test_training_progress_regression_blocks_learning() -> None:
+    assessment = build_training_progress_vpm(
+        [
+            {"step": 0, "metrics": {"train_loss": 1.0, "heldout_score": 0.50, "regression_safety": 0.99}},
+            {"step": 1, "metrics": {"train_loss": 0.7, "heldout_score": 0.60, "regression_safety": 0.70}},
+        ]
+    )
+
+    assert assessment.learned is False
+    assert "regression_safety_below_threshold" in assessment.warnings
+
+
+def test_training_progress_cell_maps_to_checkpoint() -> None:
+    assessment = build_training_progress_vpm(checkpoints(), stability_metric="stability")
+    cell = assessment.artifact.cell(0, 0)
+
+    assert cell.metric_id == "progress_score"
+    assert cell.row_id in {"step_1000", "step_2000", "step_3000"}
+    assert 0.0 <= cell.normalized_value <= 1.0
+
+
+def test_training_progress_rejects_invalid_checkpoints() -> None:
+    with pytest.raises(VPMValidationError, match="at least two checkpoints"):
+        build_training_progress_vpm([{"step": 0, "metrics": {"train_loss": 1.0, "heldout_score": 0.5}}])
+
+    with pytest.raises(VPMValidationError, match="ordered"):
+        build_training_progress_vpm(
+            [
+                {"step": 2, "metrics": {"train_loss": 1.0, "heldout_score": 0.5}},
+                {"step": 1, "metrics": {"train_loss": 0.9, "heldout_score": 0.6}},
+            ]
+        )
+
+    with pytest.raises(VPMValidationError, match="finite"):
+        TrainingCheckpoint(step=1, metrics={"train_loss": float("nan")})

--- a/zeromodel/__init__.py
+++ b/zeromodel/__init__.py
@@ -12,6 +12,7 @@ from .learning import LEARNING_METRICS, LearningAssessment, LearningObservation,
 from .metrics import CANONICAL_METRICS, metric_ids_for_rows, pack_metrics, score_table_from_metric_rows
 from .phos import PHOSResult, guarded_pack_artifact, image_entropy, pack_artifact, phos_sort_pack, robust01, to_square, top_left_concentration
 from .render import png_bytes, svg_text, to_uint8, write_png, write_svg
+from .training import TRAINING_METRICS, TrainingCheckpoint, TrainingProgressAssessment, build_training_progress_vpm, training_progress_recipe
 
 __version__ = "2.0.0"
 
@@ -27,9 +28,12 @@ __all__ = [
     "Policy",
     "ScoreTable",
     "Signal",
+    "TRAINING_METRICS",
     "Thresholds",
     "TopLeftGate",
     "TopLeftGateResult",
+    "TrainingCheckpoint",
+    "TrainingProgressAssessment",
     "VPMArtifact",
     "VPMCell",
     "VPMComparison",
@@ -39,6 +43,7 @@ __all__ = [
     "as_field",
     "build_learning_vpm",
     "build_pyramid",
+    "build_training_progress_vpm",
     "build_vpm",
     "compare_fields",
     "default_controller",
@@ -59,6 +64,7 @@ __all__ = [
     "to_square",
     "to_uint8",
     "top_left_concentration",
+    "training_progress_recipe",
     "vpm_add",
     "vpm_and",
     "vpm_not",

--- a/zeromodel/training.py
+++ b/zeromodel/training.py
@@ -1,0 +1,331 @@
+"""Training progress artifacts for model training telemetry.
+
+This module turns checkpoint telemetry into deterministic VPM artifacts. It is not a
+trainer and it does not inspect model internals. It summarizes observable training
+evidence: train improvement, held-out improvement, regression safety, stability,
+efficiency, and checkpoint selection signals.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .artifact import LayoutRecipe, ScoreTable, VPMArtifact, VPMValidationError, build_vpm
+
+TRAINING_METRICS: Tuple[str, ...] = (
+    "progress_score",
+    "train_progress",
+    "heldout_progress",
+    "regression_safety",
+    "stability",
+    "efficiency",
+)
+
+_DIRECTION_VALUES = ("increase", "decrease")
+
+
+@dataclass(frozen=True)
+class TrainingCheckpoint:
+    """One observed checkpoint from a training run.
+
+    ``metrics`` is intentionally a plain mapping so callers can adapt TensorBoard,
+    W&B, Trackio, JSONL logs, or custom training loops without depending on any
+    tracker-specific SDK.
+    """
+
+    step: int
+    metrics: Mapping[str, float]
+    checkpoint_id: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        step = int(self.step)
+        if step < 0:
+            raise VPMValidationError("TrainingCheckpoint step must be non-negative")
+        if not self.metrics:
+            raise VPMValidationError("TrainingCheckpoint requires at least one metric")
+        normalized_metrics: dict[str, float] = {}
+        for key, value in self.metrics.items():
+            metric_id = str(key)
+            number = float(value)
+            if not np.isfinite(number):
+                raise VPMValidationError("TrainingCheckpoint metrics must be finite")
+            normalized_metrics[metric_id] = number
+        checkpoint_id = self.checkpoint_id or "step_%s" % step
+        object.__setattr__(self, "step", step)
+        object.__setattr__(self, "checkpoint_id", str(checkpoint_id))
+        object.__setattr__(self, "metrics", normalized_metrics)
+
+    def metric(self, name: str) -> float:
+        try:
+            return float(self.metrics[name])
+        except KeyError as exc:
+            raise VPMValidationError("Missing checkpoint metric: %s" % name) from exc
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step": self.step,
+            "checkpoint_id": self.checkpoint_id,
+            "metrics": dict(self.metrics),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class TrainingProgressAssessment:
+    """Summary and VPM artifact for a training run."""
+
+    artifact: VPMArtifact
+    checkpoints: Tuple[TrainingCheckpoint, ...]
+    best_checkpoint_id: str
+    best_step: int
+    learned: bool
+    warnings: Tuple[str, ...]
+    thresholds: Mapping[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact.artifact_id,
+            "best_checkpoint_id": self.best_checkpoint_id,
+            "best_step": self.best_step,
+            "learned": self.learned,
+            "warnings": list(self.warnings),
+            "thresholds": dict(self.thresholds),
+            "checkpoints": [checkpoint.to_dict() for checkpoint in self.checkpoints],
+        }
+
+
+def training_progress_recipe() -> LayoutRecipe:
+    """Default recipe that places strongest training progress first."""
+    return LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "training-progress-first",
+            "row_order": {
+                "kind": "lexicographic",
+                "keys": [
+                    {"metric_id": "progress_score", "direction": "desc"},
+                    {"metric_id": "heldout_progress", "direction": "desc"},
+                    {"metric_id": "regression_safety", "direction": "desc"},
+                ],
+                "tie_break": "row_id",
+            },
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+
+
+def _validate_direction(direction: str) -> str:
+    direction = str(direction)
+    if direction not in _DIRECTION_VALUES:
+        raise VPMValidationError("direction must be one of %r" % (_DIRECTION_VALUES,))
+    return direction
+
+
+def _relative_progress(baseline: float, current: float, direction: str) -> float:
+    """Return non-negative relative progress from baseline toward current."""
+    denom = max(abs(float(baseline)), 1e-12)
+    if direction == "decrease":
+        delta = float(baseline) - float(current)
+    else:
+        delta = float(current) - float(baseline)
+    return max(0.0, float(delta / denom))
+
+
+def _bounded01(value: float, *, label: str) -> float:
+    number = float(value)
+    if not np.isfinite(number):
+        raise VPMValidationError("%s must be finite" % label)
+    return float(np.clip(number, 0.0, 1.0))
+
+
+def _metric_progress(
+    checkpoints: Sequence[TrainingCheckpoint],
+    metric: str,
+    direction: str,
+) -> list[float]:
+    baseline = checkpoints[0].metric(metric)
+    return [_relative_progress(baseline, checkpoint.metric(metric), direction) for checkpoint in checkpoints]
+
+
+def _direct_metric(checkpoints: Sequence[TrainingCheckpoint], metric: Optional[str], default: float) -> list[float]:
+    if metric is None:
+        return [float(default) for _ in checkpoints]
+    return [_bounded01(checkpoint.metric(metric), label=metric) for checkpoint in checkpoints]
+
+
+def _efficiency_progress(
+    checkpoints: Sequence[TrainingCheckpoint],
+    metric: Optional[str],
+    direction: str,
+    default: float,
+) -> list[float]:
+    if metric is None:
+        return [float(default) for _ in checkpoints]
+    return [min(1.0, value) for value in _metric_progress(checkpoints, metric, direction)]
+
+
+def _weighted_score(
+    train_progress: float,
+    heldout_progress: float,
+    regression_safety: float,
+    stability: float,
+    efficiency: float,
+    weights: Mapping[str, float],
+) -> float:
+    total = 0.0
+    total_weight = 0.0
+    values = {
+        "train_progress": train_progress,
+        "heldout_progress": heldout_progress,
+        "regression_safety": regression_safety,
+        "stability": stability,
+        "efficiency": efficiency,
+    }
+    for key, value in values.items():
+        weight = float(weights.get(key, 0.0))
+        if weight < 0:
+            raise VPMValidationError("training score weights must be non-negative")
+        total += weight * float(value)
+        total_weight += weight
+    if total_weight <= 0:
+        raise VPMValidationError("training score weights must contain positive mass")
+    return float(total / total_weight)
+
+
+def build_training_progress_vpm(
+    checkpoints: Sequence[TrainingCheckpoint | Mapping[str, Any]],
+    *,
+    train_metric: str = "train_loss",
+    train_direction: str = "decrease",
+    heldout_metric: str = "heldout_score",
+    heldout_direction: str = "increase",
+    regression_metric: Optional[str] = "regression_safety",
+    stability_metric: Optional[str] = None,
+    efficiency_metric: Optional[str] = None,
+    efficiency_direction: str = "increase",
+    min_train_progress: float = 0.05,
+    min_heldout_progress: float = 0.02,
+    min_regression_safety: float = 0.95,
+    min_stability: float = 0.80,
+    score_weights: Optional[Mapping[str, float]] = None,
+    recipe: Optional[LayoutRecipe] = None,
+    provenance: Optional[Mapping[str, Any]] = None,
+) -> TrainingProgressAssessment:
+    """Build a checkpoint-level training progress VPM.
+
+    ``learned=True`` means the best checkpoint shows enough train progress, enough
+    held-out progress, acceptable regression safety, and acceptable stability. It
+    does not prove a model's internal mechanism; it proves that the observed
+    checkpoint telemetry meets the declared evidence thresholds.
+    """
+    normalized_checkpoints = tuple(
+        item if isinstance(item, TrainingCheckpoint) else TrainingCheckpoint(**dict(item))
+        for item in checkpoints
+    )
+    if len(normalized_checkpoints) < 2:
+        raise VPMValidationError("build_training_progress_vpm requires at least two checkpoints")
+
+    steps = [checkpoint.step for checkpoint in normalized_checkpoints]
+    if steps != sorted(steps):
+        raise VPMValidationError("Training checkpoints must be ordered by non-decreasing step")
+    checkpoint_ids = [checkpoint.checkpoint_id for checkpoint in normalized_checkpoints]
+    if len(set(checkpoint_ids)) != len(checkpoint_ids):
+        raise VPMValidationError("Training checkpoints require unique checkpoint_id values")
+
+    train_direction = _validate_direction(train_direction)
+    heldout_direction = _validate_direction(heldout_direction)
+    efficiency_direction = _validate_direction(efficiency_direction)
+
+    train_progress = _metric_progress(normalized_checkpoints, train_metric, train_direction)
+    heldout_progress = _metric_progress(normalized_checkpoints, heldout_metric, heldout_direction)
+    regression_safety = _direct_metric(normalized_checkpoints, regression_metric, 1.0)
+    stability = _direct_metric(normalized_checkpoints, stability_metric, 1.0)
+    efficiency = _efficiency_progress(normalized_checkpoints, efficiency_metric, efficiency_direction, 1.0)
+
+    weights = {
+        "train_progress": 0.25,
+        "heldout_progress": 0.35,
+        "regression_safety": 0.20,
+        "stability": 0.15,
+        "efficiency": 0.05,
+    }
+    if score_weights:
+        weights.update({str(key): float(value) for key, value in score_weights.items()})
+
+    rows: list[Tuple[float, ...]] = []
+    progress_scores: list[float] = []
+    for values in zip(train_progress, heldout_progress, regression_safety, stability, efficiency):
+        score = _weighted_score(*values, weights=weights)
+        progress_scores.append(score)
+        rows.append((score, *values))
+
+    best_index = max(
+        range(len(normalized_checkpoints)),
+        key=lambda index: (progress_scores[index], normalized_checkpoints[index].step),
+    )
+    best = normalized_checkpoints[best_index]
+
+    warnings: list[str] = []
+    if train_progress[best_index] >= min_train_progress and heldout_progress[best_index] < min_heldout_progress:
+        warnings.append("train_progress_without_heldout_transfer")
+    if regression_safety[best_index] < min_regression_safety:
+        warnings.append("regression_safety_below_threshold")
+    if stability[best_index] < min_stability:
+        warnings.append("stability_below_threshold")
+    if progress_scores[-1] < progress_scores[best_index]:
+        warnings.append("latest_checkpoint_is_not_best")
+
+    learned = bool(
+        train_progress[best_index] >= float(min_train_progress)
+        and heldout_progress[best_index] >= float(min_heldout_progress)
+        and regression_safety[best_index] >= float(min_regression_safety)
+        and stability[best_index] >= float(min_stability)
+    )
+
+    table = ScoreTable(
+        values=rows,
+        row_ids=tuple(checkpoint.checkpoint_id for checkpoint in normalized_checkpoints),
+        metric_ids=TRAINING_METRICS,
+        metadata={
+            "kind": "training_progress",
+            "train_metric": train_metric,
+            "heldout_metric": heldout_metric,
+            "regression_metric": regression_metric,
+            "stability_metric": stability_metric,
+            "efficiency_metric": efficiency_metric,
+            "checkpoints": [checkpoint.to_dict() for checkpoint in normalized_checkpoints],
+        },
+    )
+
+    artifact = build_vpm(
+        table,
+        recipe or training_progress_recipe(),
+        provenance={
+            "kind": "training_progress",
+            "parents": [],
+            "best_checkpoint_id": best.checkpoint_id,
+            "best_step": best.step,
+            "learned": learned,
+            "warnings": warnings,
+            **dict(provenance or {}),
+        },
+    )
+
+    return TrainingProgressAssessment(
+        artifact=artifact,
+        checkpoints=normalized_checkpoints,
+        best_checkpoint_id=best.checkpoint_id,
+        best_step=best.step,
+        learned=learned,
+        warnings=tuple(warnings),
+        thresholds={
+            "min_train_progress": float(min_train_progress),
+            "min_heldout_progress": float(min_heldout_progress),
+            "min_regression_safety": float(min_regression_safety),
+            "min_stability": float(min_stability),
+        },
+    )


### PR DESCRIPTION
## What changed

- adds `zeromodel.training` with `TrainingCheckpoint`, `TrainingProgressAssessment`, `training_progress_recipe()`, and `build_training_progress_vpm()`
- converts model-training checkpoint telemetry into deterministic VPM artifacts
- scores checkpoints across train progress, held-out progress, regression safety, stability, and efficiency
- selects a best checkpoint and emits warnings such as `train_progress_without_heldout_transfer`, `regression_safety_below_threshold`, `stability_below_threshold`, and `latest_checkpoint_is_not_best`
- exports training primitives from the top-level `zeromodel` package
- adds tests for best checkpoint selection, train-without-heldout warning, regression failure, cell mapping, and validation errors
- adds `examples/training_progress_demo.py`
- adds `docs/examples/training-progress-vpm.md`
- updates README and claims audit

## Why

For a large model training run, line charts show tracking. ZeroModel should add an artifact layer that asks whether the run is genuinely improving, transferring to held-out checks, avoiding regression, staying stable, and producing a checkpoint worth keeping.

## New claim

Valid wording:

> ZeroModel can turn model-training telemetry into deterministic progress artifacts that show train improvement, held-out transfer, regression risk, stability, efficiency, and checkpoint selection evidence.

Invalid wording:

> ZeroModel understands why the model learned.

## Validation

- added `tests/test_training.py`
- no local test run claimed from this environment; GitHub Actions should be treated as source of truth
