### PR TITLE
[codex] add training tracker export adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ region = artifact.region(rows=slice(0, 1), columns=slice(0, 2))
 | Trend-aware EDIT/RESAMPLE/ESCALATE/STOP/SPINOFF control | `zeromodel.controller` |
 | Before/after/held-out/regression learning traces | `zeromodel.learning` |
 | Model-training progress artifacts | `zeromodel.training` |
+| Tracker-export adapters | `zeromodel.adapters` |
 
 ## PHOS and edge usage
 
@@ -125,6 +126,23 @@ training_artifact = progress.artifact
 
 See [`docs/examples/training-progress-vpm.md`](docs/examples/training-progress-vpm.md).
 
+## Tracker adapter usage
+
+Adapters parse exported tracker files into `TrainingCheckpoint` objects without requiring TensorBoard, W&B, or Trackio SDKs at runtime.
+
+```python
+from zeromodel import build_training_progress_vpm
+from zeromodel.adapters import checkpoints_from_tensorboard_scalars
+
+checkpoints = checkpoints_from_tensorboard_scalars("runs/scalars.csv")
+progress = build_training_progress_vpm(checkpoints)
+print(progress.best_checkpoint_id, progress.learned, progress.warnings)
+```
+
+Supported inputs are JSON, JSONL/NDJSON, and CSV exports. TensorBoard scalar CSV rows shaped like `wall_time,step,tag,value` are grouped into one checkpoint per step.
+
+See [`docs/examples/training-tracker-adapters.md`](docs/examples/training-tracker-adapters.md).
+
 ## Bundle usage
 
 ```python
@@ -137,4 +155,4 @@ assert loaded.artifact_id == artifact.artifact_id
 
 ## Design rule
 
-The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, learning traces, training progress, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.
+The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, learning traces, training progress, tracker adapters, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.

--- a/docs/claims-audit.md
+++ b/docs/claims-audit.md
@@ -28,6 +28,7 @@ Sources reviewed:
 | No model at decision time. | `TopLeftGate` consumes an already-built artifact/field and thresholds a top-left region. Covered by `test_edge_gate_evaluates_without_model`. | **Validated for simple gates** | Valid wording: “a deployed consumer can make a threshold decision from a prepared artifact without invoking a model.” Avoid implying the artifact independently reasons. |
 | Learning can be made visible. | `LearningObservation` and `build_learning_vpm()` require train, held-out, and regression observations before `learned=True`. Tests cover positive learning, tracking-without-heldout, and regression failure. | **Validated for scored traces** | Valid wording: “ZeroModel can make learning visible as deterministic before/after/held-out/regression artifact traces.” This does not prove a model’s internal mechanism changed. |
 | Training progress can be visualized. | `TrainingCheckpoint` and `build_training_progress_vpm()` convert checkpoint telemetry into progress VPMs with train progress, held-out progress, regression safety, stability, efficiency, best checkpoint, warnings, and `learned`. Tests cover best checkpoint selection, overfit-like train-without-heldout warnings, regression failure, cell mapping, and validation errors. | **Validated for checkpoint telemetry** | Valid wording: “ZeroModel can turn model-training telemetry into deterministic progress artifacts.” This does not replace TensorBoard/W&B or prove internal model causality. |
+| Tracker exports can feed training progress artifacts. | `zeromodel.adapters` parses generic JSON/JSONL/CSV, TensorBoard scalar CSV, W&B history JSONL/CSV/JSON, and Trackio JSON/JSONL/CSV exports into `TrainingCheckpoint` objects. Tests cover TensorBoard scalar grouping, W&B flat history rows, Trackio nested JSON, and generic JSONL. | **Validated for exported files** | Valid wording: “ZeroModel can ingest dependency-light tracker exports.” Do not claim live SDK/API integration yet. |
 | Task-aware top-left concentration. | `phos_sort_pack`, `pack_artifact`, `guarded_pack_artifact`, and `top_left_concentration`; covered by `test_phos_guarded_pack_measures_concentration`. | **Implemented / thin evidence** | The code measures and guards concentration, but we need benchmark fixtures showing improvement across realistic datasets. |
 | Compositional visual logic: AND/OR/NOT/XOR/add/subtract. | `zeromodel.compose` implements shape-checked fuzzy operators; tests cover AND/OR/XOR and comparison. | **Validated for numeric field operations** | Reframe as “explicit fuzzy field composition.” Do not call this symbolic reasoning unless a semantic layer is added and tested. |
 | Deterministic reproducible provenance. | Artifacts include source and recipe digests, parents, provenance payload, and identity mismatch validation. Tests cover artifact ID and tamper rejection. | **Validated for artifact identity** | Add tests for parent lineage, multi-artifact provenance graphs, and replay from bundles. |
@@ -40,10 +41,10 @@ Sources reviewed:
 | Edge ↔ cloud symmetry. | Same artifact/field can be rendered, bundled, inspected, and gated. | **Implemented / thin evidence** | Need a concrete edge fixture and cloud viewer example using the same artifact bytes. |
 | Multi-metric, multi-view by design. | `ScoreTable` supports multiple metrics; `LayoutRecipe` supports different ordering/column recipes. | **Validated core mechanism** | Add examples showing two recipes over the same source table and asserting source digest is unchanged. |
 | Storage-agnostic routing via pointers. | No current pointer/resolver abstraction. | **Not validated** | Add `resolver` interfaces and tests before claiming storage-agnostic routing. |
-| Traceable “thought” / 40+ levels. | Current code has provenance, controller signals, learning traces, and training progress artifacts, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage,” “learning trace,” or “training progress artifact” when those are the actual artifacts. Avoid “thought” unless strictly metaphorical. |
+| Traceable “thought” / 40+ levels. | Current code has provenance, controller signals, learning traces, training progress artifacts, and tracker export adapters, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage,” “learning trace,” “training progress artifact,” or “tracker export adapter” when those are the actual artifacts. Avoid “thought” unless strictly metaphorical. |
 | Human-compatible explanations. | Cell/source mapping and SVG/PNG rendering allow inspection. | **Implemented / thin evidence** | Reframe as “inspectable evidence mapping.” Explanation quality requires user-facing viewer tests and examples. |
 | Cheap to adopt. | Package requires only NumPy; README shows short install and simple API. | **Supported, not benchmarked** | Add an end-to-end example from metric rows to gate/render/bundle in under 30 lines. |
-| Works with your stack. | `metrics.pack_metrics()` accepts common aliases and builds score tables from metric rows. | **Implemented / thin evidence** | Add adapters/examples for pandas, JSONL, TensorBoard logs, W&B exports, Trackio runs, and common evaluation logs if we want broader wording. |
+| Works with your stack. | `metrics.pack_metrics()` accepts common aliases and builds score tables from metric rows; `zeromodel.adapters` ingests exported tracker logs. | **Implemented for exported telemetry** | Add pandas adapters, real fixture exports, and optional live SDK integrations if broader wording is needed. |
 | Great fits: anomaly detection, safety gates, code review traces, search triage. | Current package has primitives but no domain examples. | **Not validated as applications** | Create examples for each application before promoting them as out-of-the-box fits. |
 | Viewer you’ll actually use. | Static site exists, but package has no bundled viewer or click-through pointer graph. | **Implemented as website demo only / thin evidence** | Add screenshot tests or a static demo fixture; add pointer graph before claiming Google-Maps-style navigation. |
 
@@ -51,7 +52,7 @@ Sources reviewed:
 
 The repo can honestly claim:
 
-> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, small consumer decisions such as top-left gates without invoking a model at decision time, scored learning traces that distinguish tracking from train/held-out/regression evidence of learning, and checkpoint-level training progress artifacts for model telemetry.
+> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, small consumer decisions such as top-left gates without invoking a model at decision time, scored learning traces that distinguish tracking from train/held-out/regression evidence of learning, checkpoint-level training progress artifacts for model telemetry, and dependency-light adapters for tracker exports.
 
 ## Claims to avoid until benchmarks exist
 
@@ -67,6 +68,7 @@ Avoid or soften these phrases in README/package copy until the repository contai
 - “visual logic equals reasoning”
 - “self-describing PNG” unless metadata chunks are implemented
 - “understands why the model learned”
+- “connects to every tracker automatically”
 
 ## Recommended validation backlog
 
@@ -76,10 +78,10 @@ Avoid or soften these phrases in README/package copy until the repository contai
 4. **Multi-view invariant test** — same source table, multiple recipes, identical source digest, different view ordering.
 5. **Lineage/provenance replay** — parent artifact chain and deterministic replay from bundles.
 6. **Learning trace domain examples** — agent trace learning, RAG correction learning, Writer evaluator learning.
-7. **Training tracker adapters** — TensorBoard scalar export, W&B/Trackio JSON export, and checkpoint artifact fixtures.
+7. **Real tracker fixtures** — sanitized TensorBoard, W&B, and Trackio exports checked into tests or docs.
 8. **Examples package** — search triage, safety gate, anomaly toy dataset, code review trace.
 9. **Website claim labels** — mark claims as implemented, benchmarked, or roadmap in the static site.
 
 ## Bottom line
 
-The cleaned repo now validates the core abstraction, adds a concrete scored-trace definition of visible learning, and adds checkpoint-level model-training progress artifacts. It does **not** yet validate the strongest blog-scale performance claims. The next work should be evidence production and practical adapters, not more broadening of the API.
+The cleaned repo now validates the core abstraction, adds a concrete scored-trace definition of visible learning, adds checkpoint-level model-training progress artifacts, and can ingest common tracker export files. It does **not** yet validate the strongest blog-scale performance claims. The next work should be evidence production, real fixtures, and domain examples, not broadening the API.

--- a/docs/examples/training-tracker-adapters.md
+++ b/docs/examples/training-tracker-adapters.md
@@ -1,0 +1,92 @@
+# Training tracker adapters
+
+ZeroModel training adapters convert exported tracker logs into `TrainingCheckpoint` objects. The adapters intentionally read files rather than live tracker APIs so progress artifacts can be reproduced from committed fixtures.
+
+## Supported export shapes
+
+| Source | Function | Input shape |
+|---|---|---|
+| Generic JSONL | `checkpoints_from_jsonl()` | one checkpoint per line, either flat metrics or nested `metrics` |
+| Generic JSON | `checkpoints_from_json()` | list/object with `records`, `history`, `checkpoints`, `rows`, or `data` |
+| Generic CSV | `checkpoints_from_csv()` | flat metric columns |
+| TensorBoard | `checkpoints_from_tensorboard_scalars()` | scalar rows such as `wall_time,step,tag,value` |
+| W&B | `checkpoints_from_wandb_export()` | history JSONL/JSON/CSV exports, usually flat rows with `_step` |
+| Trackio | `checkpoints_from_trackio_export()` | JSON/JSONL/CSV exports with flat metrics or nested `metrics` |
+
+## TensorBoard scalar CSV
+
+```csv
+wall_time,step,tag,value
+1,1000,train/loss,1.0
+1,1000,eval/accuracy,0.50
+1,1000,regression_safety,0.99
+2,2000,train/loss,0.82
+2,2000,eval/accuracy,0.57
+2,2000,regression_safety,0.98
+```
+
+```python
+from zeromodel import build_training_progress_vpm
+from zeromodel.adapters import checkpoints_from_tensorboard_scalars
+
+checkpoints = checkpoints_from_tensorboard_scalars("tb_scalars.csv")
+progress = build_training_progress_vpm(checkpoints)
+```
+
+TensorBoard event protobuf parsing is not included. Export scalar data to CSV/JSON first to keep the ZeroModel dependency surface small and reproducible.
+
+## W&B history JSONL
+
+```jsonl
+{"_step":1000,"train/loss":1.0,"val/accuracy":0.50,"regression/safety":0.99}
+{"_step":2000,"train/loss":0.82,"val/accuracy":0.57,"regression/safety":0.98}
+```
+
+```python
+from zeromodel.adapters import checkpoints_from_wandb_export
+
+checkpoints = checkpoints_from_wandb_export("wandb-history.jsonl")
+```
+
+## Trackio or generic nested JSON
+
+```json
+{
+  "checkpoints": [
+    {"step": 1000, "metrics": {"train_loss": 1.0, "heldout_score": 0.50, "regression_safety": 0.99}},
+    {"step": 2000, "metrics": {"train_loss": 0.76, "heldout_score": 0.62, "regression_safety": 0.97}}
+  ]
+}
+```
+
+```python
+from zeromodel.adapters import checkpoints_from_trackio_export
+
+checkpoints = checkpoints_from_trackio_export("trackio.json")
+```
+
+## Metric aliases
+
+Adapters include common aliases such as:
+
+| Export metric | ZeroModel metric |
+|---|---|
+| `train/loss` | `train_loss` |
+| `eval/accuracy` | `heldout_score` |
+| `val/accuracy` | `heldout_score` |
+| `regression/safety` | `regression_safety` |
+| `tokens/sec` | `tokens_per_second` |
+
+You can pass `metric_aliases={...}` to override or extend these mappings.
+
+## Correct claim
+
+Use this wording:
+
+> ZeroModel can ingest dependency-light tracker exports and turn them into deterministic training progress artifacts.
+
+Avoid this wording:
+
+> ZeroModel connects to every tracker automatically.
+
+The adapters currently parse exported files. Live tracker APIs should remain optional integration layers outside the core package.

--- a/examples/training_tracker_adapters_demo.py
+++ b/examples/training_tracker_adapters_demo.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from zeromodel import build_training_progress_vpm, from_bundle, to_bundle, write_png, write_svg
+from zeromodel.adapters import checkpoints_from_tensorboard_scalars
+
+
+def main() -> None:
+    out_dir = Path(".zeromodel-tracker-demo")
+    out_dir.mkdir(exist_ok=True)
+    export_path = out_dir / "tb_scalars.csv"
+    export_path.write_text(
+        "wall_time,step,tag,value\n"
+        "1,1000,train/loss,1.00\n"
+        "1,1000,eval/accuracy,0.50\n"
+        "1,1000,regression_safety,0.99\n"
+        "2,2000,train/loss,0.82\n"
+        "2,2000,eval/accuracy,0.57\n"
+        "2,2000,regression_safety,0.98\n"
+        "3,3000,train/loss,0.70\n"
+        "3,3000,eval/accuracy,0.55\n"
+        "3,3000,regression_safety,0.92\n",
+        encoding="utf-8",
+    )
+
+    checkpoints = checkpoints_from_tensorboard_scalars(export_path)
+    progress = build_training_progress_vpm(checkpoints)
+    artifact = progress.artifact
+
+    bundle_path = to_bundle(artifact, out_dir / "tracker_progress.vpm")
+    png_path = write_png(artifact, out_dir / "tracker_progress.png")
+    svg_path = write_svg(artifact, out_dir / "tracker_progress.svg")
+    loaded = from_bundle(bundle_path)
+
+    print("checkpoints:", [checkpoint.checkpoint_id for checkpoint in checkpoints])
+    print("best_checkpoint_id:", progress.best_checkpoint_id)
+    print("learned:", progress.learned)
+    print("warnings:", progress.warnings)
+    print("artifact_id:", artifact.artifact_id)
+    print("bundle_roundtrip:", loaded.artifact_id == artifact.artifact_id)
+    print("wrote:", bundle_path, png_path, svg_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_training_adapters.py
+++ b/tests/test_training_adapters.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+
+from zeromodel import build_training_progress_vpm
+from zeromodel.adapters import (
+    checkpoints_from_jsonl,
+    checkpoints_from_tensorboard_scalars,
+    checkpoints_from_trackio_export,
+    checkpoints_from_wandb_export,
+)
+
+
+def test_tensorboard_scalar_csv_groups_tags_by_step(tmp_path) -> None:
+    path = tmp_path / "tb_scalars.csv"
+    path.write_text(
+        "wall_time,step,tag,value\n"
+        "1,1000,train/loss,1.0\n"
+        "1,1000,eval/accuracy,0.50\n"
+        "1,1000,regression_safety,0.99\n"
+        "2,2000,train/loss,0.80\n"
+        "2,2000,eval/accuracy,0.58\n"
+        "2,2000,regression_safety,0.98\n",
+        encoding="utf-8",
+    )
+
+    checkpoints = checkpoints_from_tensorboard_scalars(path)
+    progress = build_training_progress_vpm(checkpoints)
+
+    assert [checkpoint.step for checkpoint in checkpoints] == [1000, 2000]
+    assert checkpoints[0].metrics["train_loss"] == 1.0
+    assert checkpoints[1].metrics["heldout_score"] == 0.58
+    assert progress.learned is True
+
+
+def test_wandb_jsonl_flat_history_rows(tmp_path) -> None:
+    path = tmp_path / "wandb-history.jsonl"
+    rows = [
+        {"_step": 1000, "train/loss": 1.0, "val/accuracy": 0.50, "regression/safety": 0.99},
+        {"_step": 2000, "train/loss": 0.82, "val/accuracy": 0.57, "regression/safety": 0.98},
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    checkpoints = checkpoints_from_wandb_export(path)
+
+    assert checkpoints[0].checkpoint_id == "step_1000"
+    assert checkpoints[1].metrics["train_loss"] == 0.82
+    assert checkpoints[1].metrics["heldout_score"] == 0.57
+    assert checkpoints[1].metrics["regression_safety"] == 0.98
+
+
+def test_trackio_nested_json_export(tmp_path) -> None:
+    path = tmp_path / "trackio.json"
+    path.write_text(
+        json.dumps(
+            {
+                "checkpoints": [
+                    {"step": 1000, "metrics": {"train_loss": 1.0, "heldout_score": 0.50, "regression_safety": 0.99}},
+                    {"step": 2000, "metrics": {"train_loss": 0.76, "heldout_score": 0.62, "regression_safety": 0.97}},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    checkpoints = checkpoints_from_trackio_export(path)
+    progress = build_training_progress_vpm(checkpoints)
+
+    assert progress.best_checkpoint_id == "step_2000"
+    assert progress.artifact.source.metadata["kind"] == "training_progress"
+
+
+def test_generic_jsonl_adapter_supports_nested_metrics(tmp_path) -> None:
+    path = tmp_path / "training.jsonl"
+    rows = [
+        {"step": 10, "metrics": {"train_loss": 1.2, "heldout_score": 0.4, "regression_safety": 1.0}},
+        {"step": 20, "metrics": {"train_loss": 0.9, "heldout_score": 0.45, "regression_safety": 1.0}},
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    checkpoints = checkpoints_from_jsonl(path)
+
+    assert [checkpoint.step for checkpoint in checkpoints] == [10, 20]
+    assert checkpoints[0].metrics["heldout_score"] == 0.4

--- a/zeromodel/adapters/__init__.py
+++ b/zeromodel/adapters/__init__.py
@@ -1,0 +1,20 @@
+"""Dependency-light adapters from tracker exports to ZeroModel checkpoints."""
+from __future__ import annotations
+
+from .common import checkpoints_from_export, load_tracker_records, records_to_checkpoints
+from .jsonl import checkpoints_from_csv, checkpoints_from_json, checkpoints_from_jsonl
+from .tensorboard import checkpoints_from_tensorboard_scalars
+from .trackio import checkpoints_from_trackio_export
+from .wandb import checkpoints_from_wandb_export
+
+__all__ = [
+    "checkpoints_from_csv",
+    "checkpoints_from_export",
+    "checkpoints_from_json",
+    "checkpoints_from_jsonl",
+    "checkpoints_from_tensorboard_scalars",
+    "checkpoints_from_trackio_export",
+    "checkpoints_from_wandb_export",
+    "load_tracker_records",
+    "records_to_checkpoints",
+]

--- a/zeromodel/adapters/common.py
+++ b/zeromodel/adapters/common.py
@@ -1,0 +1,194 @@
+"""Common helpers for converting tracker exports into training checkpoints.
+
+The adapters in this package intentionally parse exported files rather than live
+tracker APIs. That keeps ZeroModel dependency-light and makes the resulting
+training progress artifacts reproducible from checked-in fixtures.
+"""
+from __future__ import annotations
+
+import csv
+import json
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from zeromodel.artifact import VPMValidationError
+from zeromodel.training import TrainingCheckpoint
+
+_DEFAULT_IGNORE_KEYS = {
+    "step",
+    "global_step",
+    "_step",
+    "checkpoint_id",
+    "metadata",
+    "wall_time",
+    "timestamp",
+    "time",
+    "epoch",
+    "tag",
+    "name",
+    "value",
+}
+
+
+def _as_number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in (float("inf"), float("-inf")):
+        return None
+    return number
+
+
+def _load_json(path: Path) -> list[Mapping[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        records = payload
+    elif isinstance(payload, dict):
+        for key in ("records", "history", "checkpoints", "rows", "data"):
+            if isinstance(payload.get(key), list):
+                records = payload[key]
+                break
+        else:
+            records = [payload]
+    else:
+        raise VPMValidationError("JSON tracker export must be an object or list of objects")
+    if not all(isinstance(item, Mapping) for item in records):
+        raise VPMValidationError("Tracker export records must be objects")
+    return [dict(item) for item in records]
+
+
+def _load_jsonl(path: Path) -> list[Mapping[str, Any]]:
+    records: list[Mapping[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        text = line.strip()
+        if not text:
+            continue
+        item = json.loads(text)
+        if not isinstance(item, Mapping):
+            raise VPMValidationError("JSONL tracker record on line %s must be an object" % line_number)
+        records.append(dict(item))
+    return records
+
+
+def _load_csv(path: Path) -> list[Mapping[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return [dict(row) for row in csv.DictReader(handle)]
+
+
+def load_tracker_records(path: str | Path) -> list[Mapping[str, Any]]:
+    """Load JSON, JSONL, or CSV tracker records from ``path``."""
+    source = Path(path)
+    suffix = source.suffix.lower()
+    if suffix == ".json":
+        return _load_json(source)
+    if suffix in {".jsonl", ".ndjson"}:
+        return _load_jsonl(source)
+    if suffix == ".csv":
+        return _load_csv(source)
+    raise VPMValidationError("Unsupported tracker export format: %s" % suffix)
+
+
+def _first_present(record: Mapping[str, Any], keys: Sequence[str]) -> str | None:
+    for key in keys:
+        if key in record:
+            return key
+    return None
+
+
+def _metric_name(name: str, aliases: Mapping[str, str]) -> str:
+    return str(aliases.get(name, name)).replace("/", "_").replace(" ", "_")
+
+
+def _metadata_for_record(record: Mapping[str, Any], metadata_keys: Iterable[str]) -> dict[str, Any]:
+    return {key: record[key] for key in metadata_keys if key in record}
+
+
+def records_to_checkpoints(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    step_keys: Sequence[str] = ("step", "global_step", "_step"),
+    metrics_key: str = "metrics",
+    tag_key: str | None = None,
+    value_key: str | None = None,
+    checkpoint_id_key: str = "checkpoint_id",
+    metric_aliases: Mapping[str, str] | None = None,
+    metadata_keys: Sequence[str] = ("wall_time", "timestamp", "time", "epoch"),
+    ignore_keys: Iterable[str] = _DEFAULT_IGNORE_KEYS,
+) -> list[TrainingCheckpoint]:
+    """Convert tracker records into ordered ``TrainingCheckpoint`` objects.
+
+    Two export shapes are supported:
+
+    1. one row per checkpoint, with either a nested ``metrics`` object or flat
+       numeric columns;
+    2. one row per scalar, with ``tag`` and ``value`` columns that are grouped by
+       step, as in TensorBoard scalar CSV exports.
+    """
+    if not records:
+        raise VPMValidationError("Tracker export contained no records")
+
+    aliases = {str(key): str(value) for key, value in dict(metric_aliases or {}).items()}
+    ignored = {str(key) for key in ignore_keys}
+    by_step: "OrderedDict[int, dict[str, Any]]" = OrderedDict()
+
+    for record in records:
+        step_key = _first_present(record, step_keys)
+        if step_key is None:
+            raise VPMValidationError("Tracker record is missing a step key; tried %r" % (tuple(step_keys),))
+        step_number = _as_number(record[step_key])
+        if step_number is None:
+            raise VPMValidationError("Tracker step value must be numeric")
+        step = int(step_number)
+        if step not in by_step:
+            by_step[step] = {"metrics": {}, "metadata": {}}
+        bucket = by_step[step]
+
+        if tag_key and value_key and tag_key in record and value_key in record:
+            value = _as_number(record[value_key])
+            if value is not None:
+                bucket["metrics"][_metric_name(str(record[tag_key]), aliases)] = value
+        elif isinstance(record.get(metrics_key), Mapping):
+            for key, value in record[metrics_key].items():
+                number = _as_number(value)
+                if number is not None:
+                    bucket["metrics"][_metric_name(str(key), aliases)] = number
+        else:
+            for key, value in record.items():
+                if key in ignored:
+                    continue
+                number = _as_number(value)
+                if number is not None:
+                    bucket["metrics"][_metric_name(str(key), aliases)] = number
+
+        bucket["metadata"].update(_metadata_for_record(record, metadata_keys))
+        if checkpoint_id_key in record:
+            bucket["checkpoint_id"] = str(record[checkpoint_id_key])
+
+    checkpoints: list[TrainingCheckpoint] = []
+    for step, payload in by_step.items():
+        metrics = payload["metrics"]
+        if not metrics:
+            continue
+        checkpoints.append(
+            TrainingCheckpoint(
+                step=step,
+                checkpoint_id=payload.get("checkpoint_id") or "step_%s" % step,
+                metrics=metrics,
+                metadata=payload.get("metadata", {}),
+            )
+        )
+    if not checkpoints:
+        raise VPMValidationError("Tracker export contained no numeric metrics")
+    return sorted(checkpoints, key=lambda checkpoint: checkpoint.step)
+
+
+def checkpoints_from_export(
+    path: str | Path,
+    **kwargs: Any,
+) -> list[TrainingCheckpoint]:
+    """Load records from a tracker export and convert them to checkpoints."""
+    return records_to_checkpoints(load_tracker_records(path), **kwargs)

--- a/zeromodel/adapters/jsonl.py
+++ b/zeromodel/adapters/jsonl.py
@@ -1,0 +1,45 @@
+"""Generic JSON/JSONL/CSV training telemetry adapters."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from zeromodel.training import TrainingCheckpoint
+
+from .common import checkpoints_from_export
+
+
+def checkpoints_from_jsonl(
+    path: str | Path,
+    *,
+    step_keys: Sequence[str] = ("step", "global_step", "_step"),
+    metric_aliases: Mapping[str, str] | None = None,
+) -> list[TrainingCheckpoint]:
+    """Load checkpoint telemetry from a JSONL export.
+
+    Each line may contain a nested ``metrics`` object or flat numeric metric
+    columns. The return value can be passed directly to
+    ``build_training_progress_vpm``.
+    """
+    return checkpoints_from_export(path, step_keys=step_keys, metric_aliases=metric_aliases)
+
+
+def checkpoints_from_json(
+    path: str | Path,
+    *,
+    step_keys: Sequence[str] = ("step", "global_step", "_step"),
+    metric_aliases: Mapping[str, str] | None = None,
+) -> list[TrainingCheckpoint]:
+    """Load checkpoint telemetry from a JSON export."""
+    return checkpoints_from_export(path, step_keys=step_keys, metric_aliases=metric_aliases)
+
+
+def checkpoints_from_csv(
+    path: str | Path,
+    *,
+    step_keys: Sequence[str] = ("step", "global_step", "_step"),
+    metric_aliases: Mapping[str, str] | None = None,
+    **kwargs: Any,
+) -> list[TrainingCheckpoint]:
+    """Load checkpoint telemetry from a CSV export."""
+    return checkpoints_from_export(path, step_keys=step_keys, metric_aliases=metric_aliases, **kwargs)

--- a/zeromodel/adapters/tensorboard.py
+++ b/zeromodel/adapters/tensorboard.py
@@ -1,0 +1,51 @@
+"""TensorBoard scalar export adapter.
+
+This adapter parses exported scalar CSV/JSON/JSONL files. It deliberately does not
+parse TensorBoard event protobufs directly, keeping ZeroModel free of TensorBoard
+runtime dependencies.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from zeromodel.training import TrainingCheckpoint
+
+from .common import checkpoints_from_export
+
+TENSORBOARD_DEFAULT_ALIASES = {
+    "train/loss": "train_loss",
+    "loss/train": "train_loss",
+    "eval/loss": "eval_loss",
+    "validation/loss": "eval_loss",
+    "eval/accuracy": "heldout_score",
+    "validation/accuracy": "heldout_score",
+    "eval/reward": "heldout_score",
+    "tokens/sec": "tokens_per_second",
+    "tokens_per_second": "tokens_per_second",
+}
+
+
+def checkpoints_from_tensorboard_scalars(
+    path: str | Path,
+    *,
+    step_keys: Sequence[str] = ("step", "global_step"),
+    tag_key: str = "tag",
+    value_key: str = "value",
+    metric_aliases: Mapping[str, str] | None = None,
+) -> list[TrainingCheckpoint]:
+    """Load checkpoints from TensorBoard scalar exports.
+
+    TensorBoard's scalar dashboard can export rows shaped like
+    ``wall_time,step,tag,value``. Those rows are grouped into one checkpoint per
+    step.
+    """
+    aliases = dict(TENSORBOARD_DEFAULT_ALIASES)
+    aliases.update(dict(metric_aliases or {}))
+    return checkpoints_from_export(
+        path,
+        step_keys=step_keys,
+        tag_key=tag_key,
+        value_key=value_key,
+        metric_aliases=aliases,
+    )

--- a/zeromodel/adapters/trackio.py
+++ b/zeromodel/adapters/trackio.py
@@ -1,0 +1,39 @@
+"""Trackio training telemetry export adapter.
+
+Supports JSON/JSONL/CSV metric exports shaped as flat rows or rows with nested
+``metrics`` dictionaries. No Trackio runtime dependency is required.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from zeromodel.training import TrainingCheckpoint
+
+from .common import checkpoints_from_export
+
+TRACKIO_DEFAULT_ALIASES = {
+    "train/loss": "train_loss",
+    "train_loss": "train_loss",
+    "eval/loss": "eval_loss",
+    "validation/loss": "eval_loss",
+    "eval/accuracy": "heldout_score",
+    "validation/accuracy": "heldout_score",
+    "eval/reward": "heldout_score",
+    "regression_safety": "regression_safety",
+    "safety/regression": "regression_safety",
+    "tokens/sec": "tokens_per_second",
+    "tokens_per_second": "tokens_per_second",
+}
+
+
+def checkpoints_from_trackio_export(
+    path: str | Path,
+    *,
+    step_keys: Sequence[str] = ("step", "global_step", "_step"),
+    metric_aliases: Mapping[str, str] | None = None,
+) -> list[TrainingCheckpoint]:
+    """Load checkpoints from a Trackio metrics export."""
+    aliases = dict(TRACKIO_DEFAULT_ALIASES)
+    aliases.update(dict(metric_aliases or {}))
+    return checkpoints_from_export(path, step_keys=step_keys, metric_aliases=aliases)

--- a/zeromodel/adapters/wandb.py
+++ b/zeromodel/adapters/wandb.py
@@ -1,0 +1,44 @@
+"""Weights & Biases history export adapter.
+
+Supports exported history JSONL/JSON/CSV files. No W&B SDK is required.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from zeromodel.training import TrainingCheckpoint
+
+from .common import checkpoints_from_export
+
+WANDB_DEFAULT_ALIASES = {
+    "train/loss": "train_loss",
+    "train_loss": "train_loss",
+    "eval/loss": "eval_loss",
+    "val/loss": "eval_loss",
+    "validation/loss": "eval_loss",
+    "eval/accuracy": "heldout_score",
+    "val/accuracy": "heldout_score",
+    "validation/accuracy": "heldout_score",
+    "eval/reward": "heldout_score",
+    "safety/regression": "regression_safety",
+    "regression/safety": "regression_safety",
+    "system/tokens_per_second": "tokens_per_second",
+    "tokens/sec": "tokens_per_second",
+}
+
+
+def checkpoints_from_wandb_export(
+    path: str | Path,
+    *,
+    step_keys: Sequence[str] = ("_step", "step", "global_step"),
+    metric_aliases: Mapping[str, str] | None = None,
+) -> list[TrainingCheckpoint]:
+    """Load checkpoints from a W&B history export.
+
+    The adapter accepts flat history rows and nested ``metrics`` rows. Metric names
+    with slashes are normalized to underscores after aliasing.
+    """
+    aliases = dict(WANDB_DEFAULT_ALIASES)
+    aliases.update(dict(metric_aliases or {}))
+    return checkpoints_from_export(path, step_keys=step_keys, metric_aliases=aliases)


### PR DESCRIPTION
## What changed

- adds `zeromodel.adapters` as a dependency-light adapter package for exported tracker logs
- adds common JSON/JSONL/CSV parsing helpers that convert tracker rows into `TrainingCheckpoint` objects
- adds tracker-specific wrappers:
  - `checkpoints_from_tensorboard_scalars()` for TensorBoard scalar CSV/JSON/JSONL exports shaped like `wall_time,step,tag,value`
  - `checkpoints_from_wandb_export()` for W&B history JSONL/JSON/CSV exports
  - `checkpoints_from_trackio_export()` for Trackio JSON/JSONL/CSV exports
  - generic `checkpoints_from_jsonl()`, `checkpoints_from_json()`, and `checkpoints_from_csv()` helpers
- adds tests for TensorBoard scalar grouping, W&B flat history rows, Trackio nested JSON, and generic JSONL nested metrics
- adds `examples/training_tracker_adapters_demo.py`
- adds `docs/examples/training-tracker-adapters.md`
- updates README and claims audit with the new adapter claim

## Why

Training progress artifacts become much more useful when they can ingest real tracker exports. This PR keeps the integration reproducible by parsing exported files instead of depending on live tracker SDKs or remote APIs.

## New claim

Valid wording:

> ZeroModel can ingest dependency-light tracker exports and turn them into deterministic training progress artifacts.

Invalid wording:

> ZeroModel connects to every tracker automatically.

## Validation

- added `tests/test_training_adapters.py`
- no local test run claimed from this environment; GitHub Actions should be treated as source of truth
