### PR TITLE
[codex] add critic evidence VPMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ region = artifact.region(rows=slice(0, 1), columns=slice(0, 2))
 | Before/after/held-out/regression learning traces | `zeromodel.learning` |
 | Model-training progress artifacts | `zeromodel.training` |
 | Tracker-export adapters | `zeromodel.adapters` |
+| Critic/evidence/policy risk artifacts | `zeromodel.critic` |
 
 ## PHOS and edge usage
 
@@ -143,6 +144,40 @@ Supported inputs are JSON, JSONL/NDJSON, and CSV exports. TensorBoard scalar CSV
 
 See [`docs/examples/training-tracker-adapters.md`](docs/examples/training-tracker-adapters.md).
 
+## Critic evidence usage
+
+Critic, verifier, RAG, or policy outputs can become risk-first VPMs for inspection. The module is shaped around Writer-style critic results: `score`, `label`, `verdict`, `explanation`, and numeric feature scores.
+
+```python
+from zeromodel import CriticObservation, build_critic_vpm
+
+assessment = build_critic_vpm([
+    CriticObservation(
+        item_id="claim_supported",
+        critic_score=0.91,
+        policy_fit=0.95,
+        evidence_support=0.92,
+        citation_match=0.94,
+        semantic_drift=0.04,
+    ),
+    CriticObservation(
+        item_id="claim_hallucinated",
+        critic_score=0.25,
+        policy_fit=0.38,
+        evidence_support=0.18,
+        citation_match=0.20,
+        semantic_drift=0.82,
+        hallucination_energy=0.86,
+        verifiability=0.25,
+    ),
+])
+
+print(assessment.highest_risk_item_id, assessment.warnings)
+critic_artifact = assessment.artifact
+```
+
+See [`docs/examples/critic-evidence-vpm.md`](docs/examples/critic-evidence-vpm.md) and [`docs/research/hallucination-energy-to-zeromodel.md`](docs/research/hallucination-energy-to-zeromodel.md).
+
 ## Research readiness examples
 
 The repository includes committed training fixtures and end-to-end scripts so the full path can be reproduced before making broader research claims.
@@ -150,6 +185,7 @@ The repository includes committed training fixtures and end-to-end scripts so th
 ```bash
 python examples/end_to_end_training_progress.py
 python examples/end_to_end_learning_trace.py
+python examples/research_hallucination_energy_vpm.py
 ```
 
 The training example reads `tests/fixtures/training/tensorboard_scalars.csv`, builds a training progress VPM, renders PNG/SVG, writes a `.vpm` bundle, and emits a JSON summary under `.zeromodel-demo/`.
@@ -168,4 +204,4 @@ assert loaded.artifact_id == artifact.artifact_id
 
 ## Design rule
 
-The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, learning traces, training progress, tracker adapters, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.
+The artifact remains a representation. Routing, gates, visual logic, hierarchy, rendering, PHOS packing, learning traces, training progress, tracker adapters, critic evidence maps, and controllers are consumers around the artifact. This keeps the core auditable while allowing the full ZeroModel system to grow.

--- a/docs/claims-audit.md
+++ b/docs/claims-audit.md
@@ -30,6 +30,7 @@ Sources reviewed:
 | Training progress can be visualized. | `TrainingCheckpoint` and `build_training_progress_vpm()` convert checkpoint telemetry into progress VPMs with train progress, held-out progress, regression safety, stability, efficiency, best checkpoint, warnings, and `learned`. Tests cover best checkpoint selection, overfit-like train-without-heldout warnings, regression failure, cell mapping, and validation errors. | **Validated for checkpoint telemetry** | Valid wording: “ZeroModel can turn model-training telemetry into deterministic progress artifacts.” This does not replace TensorBoard/W&B or prove internal model causality. |
 | Tracker exports can feed training progress artifacts. | `zeromodel.adapters` parses generic JSON/JSONL/CSV, TensorBoard scalar CSV, W&B history JSONL/CSV/JSON, and Trackio JSON/JSONL/CSV exports into `TrainingCheckpoint` objects. Tests cover TensorBoard scalar grouping, W&B flat history rows, Trackio nested JSON, and generic JSONL. | **Validated for exported files** | Valid wording: “ZeroModel can ingest dependency-light tracker exports.” Do not claim live SDK/API integration yet. |
 | End-to-end fixtures can reproduce progress artifacts. | `tests/fixtures/training/` contains deterministic TensorBoard-style, W&B-style, Trackio-style, and generic telemetry fixtures. `test_research_readiness_fixtures.py` verifies best-checkpoint selection, warnings, VPM cell mapping, `.vpm` round-trip, and PNG/SVG rendering. | **Validated for synthetic fixtures** | This is research-readiness evidence, not a scale benchmark or real-world tracker validation. Next proof: sanitized real exports from actual runs. |
+| Critic/evidence scores can become risk-first artifacts. | `CriticObservation`, `build_critic_vpm()`, and `observations_from_critic_lines()` convert Writer-style critic results and hallucination/policy/evidence scores into VPMs. Tests cover highest-risk ordering, warnings, Writer line-result conversion, cell mapping, and validation errors. | **Validated for scored critic traces** | Valid wording: “ZeroModel can turn critic/evidence/policy scores into deterministic risk-first artifacts for inspection.” This does not mean ZeroModel detects hallucinations by itself. |
 | Task-aware top-left concentration. | `phos_sort_pack`, `pack_artifact`, `guarded_pack_artifact`, and `top_left_concentration`; covered by `test_phos_guarded_pack_measures_concentration`. | **Implemented / thin evidence** | The code measures and guards concentration, but we need benchmark fixtures showing improvement across realistic datasets. |
 | Compositional visual logic: AND/OR/NOT/XOR/add/subtract. | `zeromodel.compose` implements shape-checked fuzzy operators; tests cover AND/OR/XOR and comparison. | **Validated for numeric field operations** | Reframe as “explicit fuzzy field composition.” Do not call this symbolic reasoning unless a semantic layer is added and tested. |
 | Deterministic reproducible provenance. | Artifacts include source and recipe digests, parents, provenance payload, and identity mismatch validation. Tests cover artifact ID and tamper rejection. | **Validated for artifact identity** | Add tests for parent lineage, multi-artifact provenance graphs, and replay from bundles. |
@@ -42,18 +43,18 @@ Sources reviewed:
 | Edge ↔ cloud symmetry. | Same artifact/field can be rendered, bundled, inspected, and gated. | **Implemented / thin evidence** | Need a concrete edge fixture and cloud viewer example using the same artifact bytes. |
 | Multi-metric, multi-view by design. | `ScoreTable` supports multiple metrics; `LayoutRecipe` supports different ordering/column recipes. | **Validated core mechanism** | Add examples showing two recipes over the same source table and asserting source digest is unchanged. |
 | Storage-agnostic routing via pointers. | No current pointer/resolver abstraction. | **Not validated** | Add `resolver` interfaces and tests before claiming storage-agnostic routing. |
-| Traceable “thought” / 40+ levels. | Current code has provenance, controller signals, learning traces, training progress artifacts, tracker export adapters, and end-to-end fixtures, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage,” “learning trace,” “training progress artifact,” “tracker export adapter,” or “research fixture” when those are the actual artifacts. Avoid “thought” unless strictly metaphorical. |
-| Human-compatible explanations. | Cell/source mapping and SVG/PNG rendering allow inspection. | **Implemented / thin evidence** | Reframe as “inspectable evidence mapping.” Explanation quality requires user-facing viewer tests and examples. |
+| Traceable “thought” / 40+ levels. | Current code has provenance, controller signals, learning traces, training progress artifacts, tracker export adapters, end-to-end fixtures, and critic evidence artifacts, but no router frame chain or step graph implementation. | **Reframe / not validated** | Use “traceable artifact lineage,” “learning trace,” “training progress artifact,” “tracker export adapter,” “critic evidence artifact,” or “research fixture” when those are the actual artifacts. Avoid “thought” unless strictly metaphorical. |
+| Human-compatible explanations. | Cell/source mapping, SVG/PNG rendering, and critic explanation metadata allow inspection. | **Implemented / thin evidence** | Reframe as “inspectable evidence mapping.” Explanation quality requires user-facing viewer tests and examples. |
 | Cheap to adopt. | Package requires only NumPy; README shows short install and simple API. | **Supported, not benchmarked** | Add an end-to-end example from metric rows to gate/render/bundle in under 30 lines. |
-| Works with your stack. | `metrics.pack_metrics()` accepts common aliases and builds score tables from metric rows; `zeromodel.adapters` ingests exported tracker logs. | **Implemented for exported telemetry** | Add pandas adapters, real fixture exports, and optional live SDK integrations if broader wording is needed. |
-| Great fits: anomaly detection, safety gates, code review traces, search triage. | Current package has primitives but no domain examples. | **Not validated as applications** | Create examples for each application before promoting them as out-of-the-box fits. |
+| Works with your stack. | `metrics.pack_metrics()` accepts common aliases and builds score tables from metric rows; `zeromodel.adapters` ingests exported tracker logs; `zeromodel.critic` ingests Writer-style critic outputs. | **Implemented for exported telemetry and critic traces** | Add pandas adapters, real fixture exports, sanitized Writer critic outputs, and optional live SDK integrations if broader wording is needed. |
+| Great fits: anomaly detection, safety gates, code review traces, search triage. | Current package has primitives and early domain examples for training, learning, and critic traces. | **Implemented / thin evidence** | Create examples for anomaly detection, safety gates, code review traces, and search triage before promoting them as out-of-the-box fits. |
 | Viewer you’ll actually use. | Static site exists, but package has no bundled viewer or click-through pointer graph. | **Implemented as website demo only / thin evidence** | Add screenshot tests or a static demo fixture; add pointer graph before claiming Google-Maps-style navigation. |
 
 ## Current honest headline
 
 The repo can honestly claim:
 
-> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, small consumer decisions such as top-left gates without invoking a model at decision time, scored learning traces that distinguish tracking from train/held-out/regression evidence of learning, checkpoint-level training progress artifacts for model telemetry, dependency-light adapters for tracker exports, and committed end-to-end fixtures for reproducing the training-progress path.
+> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts. Those artifacts preserve source mapping, deterministic identity, provenance digests, renderable fields, bundle round-trips, small consumer decisions such as top-left gates without invoking a model at decision time, scored learning traces that distinguish tracking from train/held-out/regression evidence of learning, checkpoint-level training progress artifacts for model telemetry, dependency-light adapters for tracker exports, committed end-to-end fixtures for reproducing the training-progress path, and critic/evidence/policy risk artifacts for inspection.
 
 ## Claims to avoid until benchmarks exist
 
@@ -71,6 +72,7 @@ Avoid or soften these phrases in README/package copy until the repository contai
 - “understands why the model learned”
 - “connects to every tracker automatically”
 - “validated on real training runs” until sanitized real exports are added
+- “detects hallucinations by itself”
 
 ## Recommended validation backlog
 
@@ -79,11 +81,12 @@ Avoid or soften these phrases in README/package copy until the repository contai
 3. **Edge benchmark** — minimal no-model gate in a tiny runtime, with memory and timing measurements.
 4. **Multi-view invariant test** — same source table, multiple recipes, identical source digest, different view ordering.
 5. **Lineage/provenance replay** — parent artifact chain and deterministic replay from bundles.
-6. **Learning trace domain examples** — agent trace learning, RAG correction learning, Writer evaluator learning.
-7. **Sanitized real tracker exports** — real TensorBoard, W&B, and Trackio exports checked into tests or docs.
-8. **Examples package** — search triage, safety gate, anomaly toy dataset, code review trace.
-9. **Website claim labels** — mark claims as implemented, benchmarked, or roadmap in the static site.
+6. **Sanitized critic exports** — real Writer critic or RAG verifier outputs checked into tests or docs.
+7. **Learning trace domain examples** — agent trace learning, RAG correction learning, Writer evaluator learning.
+8. **Sanitized real tracker exports** — real TensorBoard, W&B, and Trackio exports checked into tests or docs.
+9. **Examples package** — search triage, safety gate, anomaly toy dataset, code review trace.
+10. **Website claim labels** — mark claims as implemented, benchmarked, or roadmap in the static site.
 
 ## Bottom line
 
-The cleaned repo now validates the core abstraction, adds a concrete scored-trace definition of visible learning, adds checkpoint-level model-training progress artifacts, can ingest common tracker export files, and includes deterministic end-to-end fixtures. It does **not** yet validate the strongest blog-scale performance claims. The next work should be research design and real-world evidence, not broadening the API.
+The cleaned repo now validates the core abstraction, adds a concrete scored-trace definition of visible learning, adds checkpoint-level model-training progress artifacts, can ingest common tracker export files, includes deterministic end-to-end fixtures, and can artifactize critic/evidence/policy scores. It does **not** yet validate the strongest blog-scale performance claims or real-world hallucination detection. The next work should be research design and real-world evidence, not broadening the API.

--- a/docs/examples/critic-evidence-vpm.md
+++ b/docs/examples/critic-evidence-vpm.md
@@ -1,0 +1,115 @@
+# Critic evidence VPM
+
+ZeroModel can turn critic outputs into deterministic risk-first artifacts.
+
+This example is shaped by the Writer critic domain: upstream code extracts features, a critic returns `score`, `label`, `verdict`, and `explanation`, and downstream review needs to know which item deserves inspection first.
+
+ZeroModel does not train or run the critic. It artifactizes the critic/evidence result.
+
+## Minimum observation
+
+A critic observation can include:
+
+| Field | Meaning |
+|---|---|
+| `critic_score` | Higher means the critic thinks the item is better or safer. |
+| `policy_fit` | Whether the claim/action fits the declared policy boundary. |
+| `evidence_support` | Whether the available evidence supports the claim. |
+| `citation_match` | Whether the citation points to the right supporting evidence. |
+| `semantic_drift` | How far the claim has drifted from the evidence. |
+| `hallucination_energy` | Optional explicit hallucination-energy score. |
+| `verifiability` | Optional explicit score for whether the claim can be checked. |
+
+When `hallucination_energy` or `verifiability` is omitted, ZeroModel derives conservative scores from evidence support, citation match, policy fit, and semantic drift.
+
+## Example
+
+```python
+from zeromodel import CriticObservation, build_critic_vpm
+
+assessment = build_critic_vpm([
+    CriticObservation(
+        item_id="claim_supported",
+        critic_score=0.91,
+        policy_fit=0.95,
+        evidence_support=0.92,
+        citation_match=0.94,
+        semantic_drift=0.04,
+    ),
+    CriticObservation(
+        item_id="claim_hallucinated",
+        critic_score=0.25,
+        policy_fit=0.38,
+        evidence_support=0.18,
+        citation_match=0.20,
+        semantic_drift=0.82,
+        hallucination_energy=0.86,
+        verifiability=0.25,
+    ),
+])
+
+print(assessment.highest_risk_item_id)
+artifact = assessment.artifact
+```
+
+The resulting artifact is a normal VPM. You can inspect cells, render PNG/SVG, save a `.vpm` bundle, compare artifacts, or gate the top-left risk region.
+
+## Writer critic result shape
+
+Writer-style line criticism can be converted directly:
+
+```python
+from zeromodel import build_critic_vpm, observations_from_critic_lines
+
+observations = observations_from_critic_lines({
+    "items": [
+        {
+            "index": 0,
+            "text": "Grounded sentence.",
+            "score": 0.82,
+            "verdict": "good",
+            "features": {"support_score": 0.90},
+        },
+        {
+            "index": 1,
+            "text": "Ungrounded sentence.",
+            "score": 0.28,
+            "verdict": "bad",
+            "features": {
+                "support_score": 0.20,
+                "citation_score": 0.30,
+                "semantic_drift": 0.76,
+            },
+        },
+    ]
+})
+
+assessment = build_critic_vpm(observations)
+```
+
+## Metrics
+
+`build_critic_vpm()` creates these metrics:
+
+| Metric | Meaning |
+|---|---|
+| `risk_score` | Weighted inspection priority. |
+| `hallucination_energy` | Explicit or derived hallucination-energy score. |
+| `semantic_drift` | Claim/evidence semantic drift. |
+| `critic_risk` | `1 - critic_score`. |
+| `policy_gap` | `1 - policy_fit`. |
+| `evidence_gap` | `1 - evidence_support`. |
+| `citation_gap` | `1 - citation_match`. |
+| `verifiability` | Explicit or derived verifiability score. |
+
+## Correct claim
+
+Use this wording:
+
+> ZeroModel can turn critic/evidence/policy scores into deterministic risk-first artifacts for inspection.
+
+Avoid this wording:
+
+> ZeroModel detects hallucinations by itself.
+
+The artifact summarizes scored evidence. It does not replace the critic, verifier, judge, or retrieval system that produced the scores.

--- a/docs/research/hallucination-energy-to-zeromodel.md
+++ b/docs/research/hallucination-energy-to-zeromodel.md
@@ -1,0 +1,75 @@
+# Hallucination Energy to ZeroModel
+
+This note connects the hallucination/policy-gating work to the current ZeroModel implementation.
+
+The working thesis is:
+
+```text
+Hallucination Energy was the scoring idea.
+Policy gates were the enforcement idea.
+ZeroModel is the artifactization layer.
+```
+
+ZeroModel does not decide whether text is true on its own. It takes outputs from a critic, verifier, RAG evaluator, judge, or policy engine and turns those outputs into deterministic Visual Policy Map artifacts.
+
+## Mapping
+
+| Hallucination / critic concept | ZeroModel representation |
+|---|---|
+| Claim or sentence | VPM row |
+| Evidence support | Metric column |
+| Citation match | Metric column |
+| Semantic drift | Metric column |
+| Policy fit | Metric column |
+| Hallucination energy | Metric column |
+| Verifiability | Metric column |
+| Critic score | Metric column, inverted into critic risk |
+| Critic explanation | Observation metadata |
+| Highest-risk item | VPM row ordered to the top-left |
+| Accept/reject/review boundary | Downstream gate or controller |
+
+## Writer critic shape
+
+Writer's critic domain provides a useful source shape:
+
+```text
+features -> critic score -> label -> verdict -> explanation
+```
+
+It also normalizes multiple surfaces into that shape:
+
+- text criticism
+- line criticism
+- code criticism
+- image criticism
+- expert-mode review
+
+ZeroModel's `zeromodel.critic` module is designed around that contract. It accepts Writer-style critic result dictionaries and builds risk-first VPM artifacts without depending on Writer runtime internals.
+
+## First research question
+
+> Can deterministic critic/evidence VPMs make hallucination risk and policy failure easier to inspect than scalar scores or raw claim/evidence tables?
+
+The first version should stay synthetic and reproducible:
+
+```text
+claim/evidence/policy fixture
+  -> critic observations
+  -> risk-first VPM
+  -> top-left inspection
+  -> bundle/render/summary
+```
+
+The next version should use real sanitized Writer critic outputs or RAG evaluator outputs.
+
+## Correct claim
+
+Use:
+
+> ZeroModel can turn critic/evidence/policy scores into deterministic risk-first artifacts for inspection.
+
+Avoid:
+
+> ZeroModel detects hallucinations by itself.
+
+ZeroModel is the artifact layer. It preserves evidence mapping and prioritizes inspection. The scorer, critic, retriever, verifier, or judge remains responsible for producing the scores.

--- a/examples/research_hallucination_energy_vpm.py
+++ b/examples/research_hallucination_energy_vpm.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from zeromodel import CriticObservation, build_critic_vpm, from_bundle, to_bundle, write_png, write_svg
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = ROOT / ".zeromodel-demo" / "critic_evidence"
+
+
+def main() -> None:
+    observations = [
+        CriticObservation(
+            item_id="claim_supported",
+            critic_score=0.91,
+            policy_fit=0.95,
+            evidence_support=0.92,
+            citation_match=0.94,
+            semantic_drift=0.04,
+            verdict="good",
+            metadata={
+                "claim": "The cited source states the model improved on the held-out check.",
+                "evidence_id": "source_a",
+            },
+        ),
+        CriticObservation(
+            item_id="claim_weak_citation",
+            critic_score=0.62,
+            policy_fit=0.70,
+            evidence_support=0.48,
+            citation_match=0.35,
+            semantic_drift=0.42,
+            verdict="risky",
+            explanation=[{"feature": "citation_match", "contribution": -0.41}],
+            metadata={
+                "claim": "The source proves the policy boundary was satisfied.",
+                "evidence_id": "source_b",
+            },
+        ),
+        CriticObservation(
+            item_id="claim_hallucinated",
+            critic_score=0.25,
+            policy_fit=0.38,
+            evidence_support=0.18,
+            citation_match=0.20,
+            semantic_drift=0.82,
+            hallucination_energy=0.86,
+            verifiability=0.25,
+            verdict="bad",
+            explanation=[{"feature": "semantic_drift", "contribution": -0.77}],
+            metadata={
+                "claim": "The evidence says the system was validated on real production runs.",
+                "evidence_id": "source_c",
+                "note": "Synthetic example: claim exceeds the available evidence.",
+            },
+        ),
+    ]
+
+    assessment = build_critic_vpm(observations)
+    artifact = assessment.artifact
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    bundle_path = to_bundle(artifact, OUT_DIR / "critic_evidence.vpm")
+    png_path = write_png(artifact, OUT_DIR / "critic_evidence.png")
+    svg_path = write_svg(artifact, OUT_DIR / "critic_evidence.svg")
+    loaded = from_bundle(bundle_path)
+
+    summary = assessment.to_dict()
+    summary["bundle_roundtrip"] = loaded.artifact_id == artifact.artifact_id
+    summary["outputs"] = {
+        "bundle": str(bundle_path.relative_to(ROOT)),
+        "png": str(png_path.relative_to(ROOT)),
+        "svg": str(svg_path.relative_to(ROOT)),
+    }
+    summary_path = OUT_DIR / "critic_evidence_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+
+    print("highest_risk_item_id:", assessment.highest_risk_item_id)
+    print("highest_risk_score:", round(assessment.highest_risk_score, 3))
+    print("warnings:", ",".join(assessment.warnings))
+    print("bundle_roundtrip:", summary["bundle_roundtrip"])
+    print("wrote:", summary_path.relative_to(ROOT))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_critic.py
+++ b/tests/test_critic.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel import CriticObservation, build_critic_vpm, observations_from_critic_lines
+from zeromodel.artifact import VPMValidationError
+
+
+def test_critic_vpm_places_highest_risk_first_and_warns() -> None:
+    assessment = build_critic_vpm(
+        [
+            CriticObservation(
+                item_id="supported-claim",
+                critic_score=0.88,
+                policy_fit=0.95,
+                evidence_support=0.90,
+                citation_match=0.92,
+                semantic_drift=0.05,
+            ),
+            CriticObservation(
+                item_id="risky-claim",
+                critic_score=0.36,
+                policy_fit=0.45,
+                evidence_support=0.32,
+                citation_match=0.40,
+                semantic_drift=0.72,
+                hallucination_energy=0.78,
+                verifiability=0.39,
+            ),
+        ],
+        risk_threshold=0.50,
+        hallucination_energy_threshold=0.50,
+        verifiability_threshold=0.60,
+    )
+
+    assert assessment.highest_risk_item_id == "risky-claim"
+    assert assessment.risky_count == 1
+    assert "risk_score_above_threshold" in assessment.warnings
+    assert "hallucination_energy_above_threshold" in assessment.warnings
+    assert "verifiability_below_threshold" in assessment.warnings
+    assert assessment.artifact.provenance["highest_risk_item_id"] == "risky-claim"
+    assert assessment.artifact.source.metric_ids == (
+        "risk_score",
+        "hallucination_energy",
+        "semantic_drift",
+        "critic_risk",
+        "policy_gap",
+        "evidence_gap",
+        "citation_gap",
+        "verifiability",
+    )
+
+    cell = assessment.artifact.cell(0, 0)
+    assert cell.row_id == "risky-claim"
+    assert cell.metric_id == "risk_score"
+
+
+def test_critic_observation_computes_energy_and_verifiability() -> None:
+    observation = CriticObservation(
+        item_id="claim-a",
+        critic_score=0.50,
+        policy_fit=0.80,
+        evidence_support=0.60,
+        citation_match=0.40,
+        semantic_drift=0.20,
+    )
+
+    assert observation.computed_hallucination_energy == pytest.approx((0.20 + 0.40 + 0.60 + 0.20) / 4.0)
+    assert observation.computed_verifiability == pytest.approx((0.60 + 0.40 + 0.80) / 3.0)
+    assert observation.critic_risk == pytest.approx(0.50)
+
+
+def test_from_writer_style_critic_result_extracts_features() -> None:
+    observation = CriticObservation.from_critic_result(
+        {
+            "index": 2,
+            "text": "The model claims the source says something it does not say.",
+            "score": 0.41,
+            "label": 0,
+            "threshold": 0.50,
+            "verdict": "risky",
+            "explanation": [{"feature": "semantic_drift", "contribution": 0.8}],
+            "features": {
+                "policy_score": 0.58,
+                "support_score": 0.31,
+                "citation_score": 0.44,
+                "semantic_drift": 0.70,
+            },
+        },
+        item_id="line_2",
+    )
+
+    assert observation.item_id == "line_2"
+    assert observation.critic_score == pytest.approx(0.41)
+    assert observation.policy_fit == pytest.approx(0.58)
+    assert observation.evidence_support == pytest.approx(0.31)
+    assert observation.citation_match == pytest.approx(0.44)
+    assert observation.semantic_drift == pytest.approx(0.70)
+    assert observation.metadata["threshold"] == 0.50
+    assert observation.metadata["label"] == 0
+    assert observation.explanation[0]["feature"] == "semantic_drift"
+
+
+def test_observations_from_critic_lines_matches_writer_shape() -> None:
+    observations = observations_from_critic_lines(
+        {
+            "ok": True,
+            "count": 2,
+            "risky_count": 1,
+            "items": [
+                {
+                    "index": 0,
+                    "text": "Grounded sentence.",
+                    "score": 0.82,
+                    "verdict": "good",
+                    "features": {"support_score": 0.90},
+                },
+                {
+                    "index": 1,
+                    "text": "Ungrounded sentence.",
+                    "score": 0.28,
+                    "verdict": "bad",
+                    "features": {
+                        "support_score": 0.20,
+                        "citation_score": 0.30,
+                        "semantic_drift": 0.76,
+                    },
+                },
+            ],
+        }
+    )
+
+    assert [observation.item_id for observation in observations] == ["line_0", "line_1"]
+    assessment = build_critic_vpm(observations)
+    assert assessment.highest_risk_item_id == "line_1"
+
+
+def test_critic_vpm_rejects_duplicate_items_and_invalid_values() -> None:
+    with pytest.raises(VPMValidationError):
+        CriticObservation(item_id="bad", critic_score=1.2)
+
+    with pytest.raises(VPMValidationError):
+        build_critic_vpm(
+            [
+                CriticObservation(item_id="same", critic_score=0.9),
+                CriticObservation(item_id="same", critic_score=0.8),
+            ]
+        )

--- a/zeromodel/__init__.py
+++ b/zeromodel/__init__.py
@@ -6,6 +6,7 @@ from .bundle import from_bundle, to_bundle
 from .compare import VPMComparison, compare_fields
 from .compose import as_field, vpm_add, vpm_and, vpm_not, vpm_or, vpm_subtract, vpm_xor
 from .controller import Decision, Policy, Signal, Thresholds, VPMController, VPMRow, default_controller
+from .critic import CRITIC_METRICS, CriticAssessment, CriticObservation, build_critic_vpm, critic_recipe, observations_from_critic_lines
 from .edge import TopLeftGate, TopLeftGateResult
 from .hierarchy import HierarchyLevel, build_pyramid, reduce_blocks
 from .learning import LEARNING_METRICS, LearningAssessment, LearningObservation, build_learning_vpm, learning_recipe
@@ -18,6 +19,9 @@ __version__ = "2.0.0"
 
 __all__ = [
     "CANONICAL_METRICS",
+    "CRITIC_METRICS",
+    "CriticAssessment",
+    "CriticObservation",
     "Decision",
     "HierarchyLevel",
     "LEARNING_METRICS",
@@ -41,17 +45,20 @@ __all__ = [
     "VPMRegion",
     "VPMRow",
     "as_field",
+    "build_critic_vpm",
     "build_learning_vpm",
     "build_pyramid",
     "build_training_progress_vpm",
     "build_vpm",
     "compare_fields",
+    "critic_recipe",
     "default_controller",
     "from_bundle",
     "guarded_pack_artifact",
     "image_entropy",
     "learning_recipe",
     "metric_ids_for_rows",
+    "observations_from_critic_lines",
     "pack_artifact",
     "pack_metrics",
     "phos_sort_pack",

--- a/zeromodel/critic.py
+++ b/zeromodel/critic.py
@@ -1,0 +1,377 @@
+"""Critic evidence artifacts for policy-bounded review traces.
+
+This module is inspired by Writer's critic domain shape: upstream code extracts
+features, a critic scores each item, and the result includes a score, verdict,
+threshold, explanation, and input metadata. ZeroModel does not train or run that
+critic. It turns critic/evidence outputs into deterministic VPM artifacts that
+surface which items deserve inspection first.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .artifact import LayoutRecipe, ScoreTable, VPMArtifact, VPMValidationError, build_vpm
+
+CRITIC_METRICS: Tuple[str, ...] = (
+    "risk_score",
+    "hallucination_energy",
+    "semantic_drift",
+    "critic_risk",
+    "policy_gap",
+    "evidence_gap",
+    "citation_gap",
+    "verifiability",
+)
+
+_NUMERIC_FEATURE_ALIASES: Mapping[str, Tuple[str, ...]] = {
+    "policy_fit": ("policy_fit", "policy_score", "policy_alignment"),
+    "evidence_support": ("evidence_support", "support_score", "source_support", "grounding_score"),
+    "citation_match": ("citation_match", "citation_score", "citation_support"),
+    "semantic_drift": ("semantic_drift", "drift", "semantic_distance"),
+    "hallucination_energy": ("hallucination_energy", "hallucination_risk", "he"),
+    "verifiability": ("verifiability", "verifiability_score", "evidence_verifiability"),
+}
+
+
+def _bounded01(value: float, *, label: str) -> float:
+    number = float(value)
+    if not np.isfinite(number):
+        raise VPMValidationError("%s must be finite" % label)
+    if number < 0.0 or number > 1.0:
+        raise VPMValidationError("%s must be in [0, 1]" % label)
+    return number
+
+
+def _clip01(value: float) -> float:
+    return float(np.clip(float(value), 0.0, 1.0))
+
+
+def _first_numeric(mapping: Mapping[str, Any], keys: Sequence[str]) -> Optional[float]:
+    for key in keys:
+        if key not in mapping:
+            continue
+        try:
+            number = float(mapping[key])
+        except (TypeError, ValueError):
+            continue
+        if np.isfinite(number):
+            return number
+    return None
+
+
+def _merge_features(result: Mapping[str, Any]) -> dict[str, Any]:
+    features: dict[str, Any] = {}
+    raw_features = result.get("features")
+    if isinstance(raw_features, Mapping):
+        features.update(raw_features)
+    for key, aliases in _NUMERIC_FEATURE_ALIASES.items():
+        if key in result and key not in features:
+            features[key] = result[key]
+        for alias in aliases:
+            if alias in result and alias not in features:
+                features[alias] = result[alias]
+    return features
+
+
+@dataclass(frozen=True)
+class CriticObservation:
+    """One scored critic/evidence item.
+
+    ``critic_score`` follows Writer's critic convention: higher means the item is
+    better or safer. The VPM inverts it into ``critic_risk`` so the default layout
+    can place higher-risk rows first.
+    """
+
+    item_id: str
+    critic_score: float
+    policy_fit: float = 1.0
+    evidence_support: float = 1.0
+    citation_match: float = 1.0
+    semantic_drift: float = 0.0
+    hallucination_energy: Optional[float] = None
+    verifiability: Optional[float] = None
+    verdict: Optional[str] = None
+    explanation: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        item_id = str(self.item_id).strip()
+        if not item_id:
+            raise VPMValidationError("CriticObservation item_id must be non-empty")
+        object.__setattr__(self, "item_id", item_id)
+        object.__setattr__(self, "critic_score", _bounded01(self.critic_score, label="critic_score"))
+        object.__setattr__(self, "policy_fit", _bounded01(self.policy_fit, label="policy_fit"))
+        object.__setattr__(self, "evidence_support", _bounded01(self.evidence_support, label="evidence_support"))
+        object.__setattr__(self, "citation_match", _bounded01(self.citation_match, label="citation_match"))
+        object.__setattr__(self, "semantic_drift", _bounded01(self.semantic_drift, label="semantic_drift"))
+        if self.hallucination_energy is not None:
+            object.__setattr__(
+                self,
+                "hallucination_energy",
+                _bounded01(self.hallucination_energy, label="hallucination_energy"),
+            )
+        if self.verifiability is not None:
+            object.__setattr__(self, "verifiability", _bounded01(self.verifiability, label="verifiability"))
+        object.__setattr__(self, "explanation", tuple(dict(item) for item in self.explanation))
+
+    @property
+    def critic_risk(self) -> float:
+        return 1.0 - self.critic_score
+
+    @property
+    def policy_gap(self) -> float:
+        return 1.0 - self.policy_fit
+
+    @property
+    def evidence_gap(self) -> float:
+        return 1.0 - self.evidence_support
+
+    @property
+    def citation_gap(self) -> float:
+        return 1.0 - self.citation_match
+
+    @property
+    def computed_hallucination_energy(self) -> float:
+        if self.hallucination_energy is not None:
+            return float(self.hallucination_energy)
+        return _clip01(
+            (
+                self.semantic_drift
+                + self.evidence_gap
+                + self.citation_gap
+                + self.policy_gap
+            )
+            / 4.0
+        )
+
+    @property
+    def computed_verifiability(self) -> float:
+        if self.verifiability is not None:
+            return float(self.verifiability)
+        return _clip01((self.evidence_support + self.citation_match + self.policy_fit) / 3.0)
+
+    @property
+    def risk_score(self) -> float:
+        return _clip01(
+            0.30 * self.computed_hallucination_energy
+            + 0.20 * self.critic_risk
+            + 0.15 * self.semantic_drift
+            + 0.15 * self.policy_gap
+            + 0.10 * self.evidence_gap
+            + 0.10 * self.citation_gap
+        )
+
+    def metric_row(self) -> Tuple[float, ...]:
+        return (
+            self.risk_score,
+            self.computed_hallucination_energy,
+            self.semantic_drift,
+            self.critic_risk,
+            self.policy_gap,
+            self.evidence_gap,
+            self.citation_gap,
+            self.computed_verifiability,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "critic_score": self.critic_score,
+            "policy_fit": self.policy_fit,
+            "evidence_support": self.evidence_support,
+            "citation_match": self.citation_match,
+            "semantic_drift": self.semantic_drift,
+            "hallucination_energy": self.hallucination_energy,
+            "computed_hallucination_energy": self.computed_hallucination_energy,
+            "verifiability": self.verifiability,
+            "computed_verifiability": self.computed_verifiability,
+            "risk_score": self.risk_score,
+            "verdict": self.verdict,
+            "explanation": [dict(item) for item in self.explanation],
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_critic_result(
+        cls,
+        result: Mapping[str, Any],
+        *,
+        item_id: Optional[str] = None,
+        default_policy_fit: float = 1.0,
+        default_evidence_support: float = 1.0,
+        default_citation_match: float = 1.0,
+        default_semantic_drift: float = 0.0,
+    ) -> "CriticObservation":
+        """Create an observation from a Writer-style critic result mapping."""
+        features = _merge_features(result)
+        resolved_item_id = item_id or result.get("item_id") or result.get("id") or result.get("index")
+        if resolved_item_id is None:
+            resolved_item_id = "critic_item"
+        text = result.get("text") or result.get("claim")
+        metadata = dict(result.get("metadata") or {}) if isinstance(result.get("metadata"), Mapping) else {}
+        if text is not None:
+            metadata["text"] = str(text)
+        if "threshold" in result:
+            metadata["threshold"] = result["threshold"]
+        if "label" in result:
+            metadata["label"] = result["label"]
+
+        return cls(
+            item_id=str(resolved_item_id),
+            critic_score=_bounded01(result.get("score", result.get("critic_score", 0.0)), label="critic_score"),
+            policy_fit=_clip01(_first_numeric(features, _NUMERIC_FEATURE_ALIASES["policy_fit"]) or default_policy_fit),
+            evidence_support=_clip01(_first_numeric(features, _NUMERIC_FEATURE_ALIASES["evidence_support"]) or default_evidence_support),
+            citation_match=_clip01(_first_numeric(features, _NUMERIC_FEATURE_ALIASES["citation_match"]) or default_citation_match),
+            semantic_drift=_clip01(_first_numeric(features, _NUMERIC_FEATURE_ALIASES["semantic_drift"]) or default_semantic_drift),
+            hallucination_energy=(
+                _clip01(value)
+                if (value := _first_numeric(features, _NUMERIC_FEATURE_ALIASES["hallucination_energy"])) is not None
+                else None
+            ),
+            verifiability=(
+                _clip01(value)
+                if (value := _first_numeric(features, _NUMERIC_FEATURE_ALIASES["verifiability"])) is not None
+                else None
+            ),
+            verdict=str(result.get("verdict")) if result.get("verdict") is not None else None,
+            explanation=result.get("explanation") or (),
+            metadata=metadata,
+        )
+
+
+@dataclass(frozen=True)
+class CriticAssessment:
+    """Risk-first VPM artifact and summary for critic observations."""
+
+    artifact: VPMArtifact
+    observations: Tuple[CriticObservation, ...]
+    highest_risk_item_id: str
+    highest_risk_score: float
+    risky_count: int
+    warnings: Tuple[str, ...]
+    thresholds: Mapping[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact.artifact_id,
+            "highest_risk_item_id": self.highest_risk_item_id,
+            "highest_risk_score": self.highest_risk_score,
+            "risky_count": self.risky_count,
+            "warnings": list(self.warnings),
+            "thresholds": dict(self.thresholds),
+            "observations": [observation.to_dict() for observation in self.observations],
+        }
+
+
+def critic_recipe() -> LayoutRecipe:
+    """Default layout that places critic/policy risk first."""
+    return LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "critic-risk-first",
+            "row_order": {
+                "kind": "lexicographic",
+                "keys": [
+                    {"metric_id": "risk_score", "direction": "desc"},
+                    {"metric_id": "hallucination_energy", "direction": "desc"},
+                    {"metric_id": "verifiability", "direction": "asc"},
+                ],
+                "tie_break": "row_id",
+            },
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+
+
+def observations_from_critic_lines(result: Mapping[str, Any]) -> list[CriticObservation]:
+    """Convert a Writer ``criticize_lines`` style result into observations."""
+    items = result.get("items")
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+        raise VPMValidationError("criticize_lines result must contain an items sequence")
+    observations: list[CriticObservation] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise VPMValidationError("criticize_lines items must be mappings")
+        index = item.get("index", len(observations))
+        observations.append(CriticObservation.from_critic_result(item, item_id="line_%s" % index))
+    return observations
+
+
+def build_critic_vpm(
+    observations: Sequence[CriticObservation | Mapping[str, Any]],
+    *,
+    recipe: Optional[LayoutRecipe] = None,
+    risk_threshold: float = 0.50,
+    hallucination_energy_threshold: float = 0.40,
+    verifiability_threshold: float = 0.60,
+    provenance: Optional[Mapping[str, Any]] = None,
+) -> CriticAssessment:
+    """Build a deterministic VPM for critic/evidence/policy observations."""
+    normalized = tuple(
+        item if isinstance(item, CriticObservation) else CriticObservation.from_critic_result(dict(item))
+        for item in observations
+    )
+    if not normalized:
+        raise VPMValidationError("build_critic_vpm requires at least one observation")
+    row_ids = tuple(observation.item_id for observation in normalized)
+    if len(set(row_ids)) != len(row_ids):
+        raise VPMValidationError("Critic observations require unique item_id values")
+
+    risk_threshold = _bounded01(risk_threshold, label="risk_threshold")
+    hallucination_energy_threshold = _bounded01(
+        hallucination_energy_threshold,
+        label="hallucination_energy_threshold",
+    )
+    verifiability_threshold = _bounded01(verifiability_threshold, label="verifiability_threshold")
+
+    table = ScoreTable(
+        values=[observation.metric_row() for observation in normalized],
+        row_ids=row_ids,
+        metric_ids=CRITIC_METRICS,
+        metadata={
+            "kind": "critic_evidence",
+            "observations": [observation.to_dict() for observation in normalized],
+        },
+    )
+
+    highest = max(normalized, key=lambda observation: (observation.risk_score, observation.item_id))
+    risky = [observation for observation in normalized if observation.risk_score >= risk_threshold]
+    warnings: list[str] = []
+    if risky:
+        warnings.append("risk_score_above_threshold")
+    if any(observation.computed_hallucination_energy >= hallucination_energy_threshold for observation in normalized):
+        warnings.append("hallucination_energy_above_threshold")
+    if any(observation.computed_verifiability < verifiability_threshold for observation in normalized):
+        warnings.append("verifiability_below_threshold")
+
+    artifact = build_vpm(
+        table,
+        recipe or critic_recipe(),
+        provenance={
+            "kind": "critic_evidence",
+            "parents": [],
+            "highest_risk_item_id": highest.item_id,
+            "highest_risk_score": highest.risk_score,
+            "risky_count": len(risky),
+            "warnings": warnings,
+            **dict(provenance or {}),
+        },
+    )
+
+    return CriticAssessment(
+        artifact=artifact,
+        observations=normalized,
+        highest_risk_item_id=highest.item_id,
+        highest_risk_score=highest.risk_score,
+        risky_count=len(risky),
+        warnings=tuple(warnings),
+        thresholds={
+            "risk_threshold": risk_threshold,
+            "hallucination_energy_threshold": hallucination_energy_threshold,
+            "verifiability_threshold": verifiability_threshold,
+        },
+    )


### PR DESCRIPTION
## What changed

- adds `zeromodel.critic` with:
  - `CriticObservation`
  - `CriticAssessment`
  - `critic_recipe()`
  - `observations_from_critic_lines()`
  - `build_critic_vpm()`
- converts Writer-style critic outputs (`score`, `label`, `verdict`, `explanation`, `features`) into deterministic risk-first VPM artifacts
- adds hallucination/policy/evidence metrics:
  - `risk_score`
  - `hallucination_energy`
  - `semantic_drift`
  - `critic_risk`
  - `policy_gap`
  - `evidence_gap`
  - `citation_gap`
  - `verifiability`
- adds tests for highest-risk ordering, warnings, derived hallucination energy, Writer line-result conversion, cell mapping, and validation errors
- adds `examples/research_hallucination_energy_vpm.py`
- adds `docs/examples/critic-evidence-vpm.md`
- adds `docs/research/hallucination-energy-to-zeromodel.md`
- updates README and claims audit

## Why

Writer's critic domain has the right shape for the hallucination/policy bridge: upstream features, critic score, verdict, explanation, and per-line/text/code/image review surfaces. ZeroModel should not run that critic or claim hallucination detection. It should artifactize the critic/evidence/policy scores so hallucination risk, semantic drift, policy gaps, and weak evidence are inspectable as deterministic VPMs.

## New claim

Valid wording:

> ZeroModel can turn critic/evidence/policy scores into deterministic risk-first artifacts for inspection.

Invalid wording:

> ZeroModel detects hallucinations by itself.

## Validation

- added `tests/test_critic.py`
- no local test run claimed from this environment; GitHub Actions should be treated as source of truth
