### PR TITLE
[codex] fix Pages workflow enablement

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload static site
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## What changed

- updates `.github/workflows/pages.yml`
- passes `enablement: true` to `actions/configure-pages@v5`

## Why

The website workflow was failing in the deploy job with:

```text
Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action.
```

The Node 20 message is a warning from the runner/action ecosystem; the actual failure is `configure-pages` not finding an enabled Pages site.

## Validation

- no local workflow run claimed from this environment; GitHub Actions should be treated as source of truth
