### PR TITLE
[codex] prepare PyPI release candidate

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,42 @@
+name: Publish TestPyPI release candidate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-testpypi:
+    name: build and publish to TestPyPI
+    runs-on: ubuntu-latest
+    environment: testpypi
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install release tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[release]
+
+      - name: Build source and wheel distributions
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: false

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,11 @@ on:
       - "zeromodel/**"
       - "tests/**"
       - "pyproject.toml"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "docs/release.md"
       - ".github/workflows/python.yml"
+      - ".github/workflows/publish-testpypi.yml"
   push:
     branches:
       - main
@@ -14,7 +18,11 @@ on:
       - "zeromodel/**"
       - "tests/**"
       - "pyproject.toml"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "docs/release.md"
       - ".github/workflows/python.yml"
+      - ".github/workflows/publish-testpypi.yml"
   workflow_dispatch:
 
 permissions:
@@ -46,3 +54,28 @@ jobs:
 
       - name: Run package tests
         run: pytest -q
+
+  package-build:
+    name: build distribution artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[release]
+
+      - name: Build source and wheel distributions
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.0a1 - Unreleased
+
+First TestPyPI release candidate for the clean `zeromodel` package surface.
+
+### Highlights
+
+- Publishes ZeroModel as an alpha package rather than presenting the current surface as a stable 2.x release.
+- Keeps the primary claim narrow: deterministic, inspectable Visual Policy Map artifacts for scored data.
+- Includes the validated core artifact kernel, dense policy views, spatial optimizer, temporal decision manifold, learning traces, training progress artifacts, tracker-export adapters, critic/evidence risk artifacts, bundles, rendering, and edge gates.
+- Adds release validation through source/wheel build checks and `twine check`.
+- Adds a manual TestPyPI publishing workflow using GitHub Actions Trusted Publishing.
+
+### Release posture
+
+This release candidate is intentionally alpha. It does not claim planet-scale traversal, automatic semantic view learning, task-level decision accuracy improvement, real-world hallucination detection, or real training-run validation. See `docs/claims-audit.md` for the claim boundary.

--- a/README.md
+++ b/README.md
@@ -8,18 +8,39 @@ The package is now the clean new ZeroModel surface. There is no public `zeromode
 
 Public claims are tracked in [`docs/claims-audit.md`](docs/claims-audit.md). Treat that file as the source of truth for what is validated, what is implemented with thin evidence, and what remains a roadmap claim.
 
-## Install from GitHub
+## Install
+
+Current GitHub install:
 
 ```bash
-pip install git+https://github.com/ernanhughes/zeromodel.git@main
+python -m pip install "git+https://github.com/ernanhughes/zeromodel.git@main"
+```
+
+After the TestPyPI release candidate workflow publishes `0.1.0a1`:
+
+```bash
+python -m pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  zeromodel==0.1.0a1
+```
+
+After the production PyPI release is cut:
+
+```bash
+python -m pip install zeromodel
 ```
 
 For development:
 
 ```bash
-pip install -e .[dev]
+python -m pip install -e .[dev]
 pytest
+python -m build
+python -m twine check dist/*
 ```
+
+Release steps are documented in [`docs/release.md`](docs/release.md).
 
 ## Core artifact
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,110 @@
+# Release process
+
+ZeroModel should reach PyPI in two steps:
+
+1. Publish the current alpha package to TestPyPI.
+2. Verify install/import behavior from TestPyPI in a clean environment before promoting the same release posture to production PyPI.
+
+The release is intentionally alpha. The validated public claim is:
+
+> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts.
+
+Do not use stronger claims such as planet-scale traversal, automatic semantic view learning, task-level decision accuracy improvement, real-world hallucination detection, or real training-run validation unless the repository contains the matching benchmark or fixture evidence.
+
+## Version policy
+
+Use pre-release versions for release candidates until the package install path is proven:
+
+- `0.1.0a1` for the first TestPyPI alpha.
+- `0.1.0a2`, `0.1.0a3`, etc. for packaging fixes.
+- `0.1.0` only after TestPyPI install/import checks pass.
+
+Do not publish the current package as `2.0.0` unless there is a deliberate historical compatibility reason.
+
+## Local build check
+
+From a clean checkout:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install -e .[dev]
+pytest -q
+python -m build
+python -m twine check dist/*
+```
+
+The GitHub `Python package` workflow runs the test matrix and distribution metadata checks on pull requests.
+
+## TestPyPI trusted publishing setup
+
+Before running `.github/workflows/publish-testpypi.yml`, configure a trusted publisher on TestPyPI with these values:
+
+- Owner: `ernanhughes`
+- Repository: `zeromodel`
+- Workflow name: `publish-testpypi.yml`
+- Environment name: `testpypi`
+
+The workflow uses GitHub OIDC (`id-token: write`) and does not require a long-lived API token.
+
+## Publish to TestPyPI
+
+1. Merge the release candidate PR.
+2. Open GitHub Actions.
+3. Run **Publish TestPyPI release candidate** manually from the target branch or tag.
+4. Confirm the workflow builds both `sdist` and wheel, checks metadata, and uploads to TestPyPI.
+
+## Verify TestPyPI install
+
+Use a clean virtual environment. Because TestPyPI may not host dependencies such as NumPy, keep PyPI as an extra dependency index:
+
+```bash
+python -m venv .venv-testpypi
+. .venv-testpypi/bin/activate
+python -m pip install --upgrade pip
+python -m pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  zeromodel==0.1.0a1
+python - <<'PY'
+from zeromodel import LayoutRecipe, ScoreTable, build_vpm
+
+score_table = ScoreTable(
+    values=[[0.9, 0.2], [0.4, 0.8]],
+    row_ids=["candidate-a", "candidate-b"],
+    metric_ids=["quality", "uncertainty"],
+)
+recipe = LayoutRecipe.from_dict({
+    "version": "vpm-layout/0",
+    "name": "quality-first",
+    "row_order": {
+        "kind": "lexicographic",
+        "keys": [{"metric_id": "quality", "direction": "desc"}],
+        "tie_break": "row_id",
+    },
+    "column_order": {"kind": "source"},
+    "normalization": {"kind": "per_metric_minmax", "clip": True},
+})
+artifact = build_vpm(score_table, recipe)
+assert artifact.cell(0, 0).row_id == "candidate-a"
+print("zeromodel import/build smoke test passed")
+PY
+```
+
+On Windows PowerShell, activate with:
+
+```powershell
+.venv-testpypi\Scripts\Activate.ps1
+```
+
+## Promote to production PyPI
+
+Only cut the production PyPI release after:
+
+- the test matrix is green,
+- source and wheel builds pass,
+- `twine check` passes,
+- TestPyPI install/import works in a clean environment,
+- README install instructions are updated for the production release, and
+- `docs/claims-audit.md` still matches the public wording.
+
+The first production release should probably be `0.1.0`, not `2.0.0`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel"
-version = "2.0.0"
+version = "0.1.0a1"
 description = "Deterministic Visual Policy Map artifacts and consumers"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -29,7 +29,8 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7"]
+dev = ["pytest>=7", "build>=1.2", "twine>=5"]
+release = ["build>=1.2", "twine>=5"]
 
 [project.urls]
 Homepage = "https://github.com/ernanhughes/zeromodel"


### PR DESCRIPTION
## What changed

- changes the package version from `2.0.0` to alpha release candidate `0.1.0a1`
- adds release/build tooling to the optional extras
- expands the Python package workflow with source/wheel build validation and `twine check`
- adds a manual TestPyPI publishing workflow using GitHub Actions OIDC / Trusted Publishing
- adds `CHANGELOG.md` for the first alpha release candidate
- adds `docs/release.md` with the TestPyPI verification and production promotion checklist
- updates README install instructions for GitHub, TestPyPI, future PyPI, and local release checks

## Why

The package is now ready for a release track, but it should not be published as a stable `2.0.0` package yet. This PR turns the current state into an explicit alpha release candidate and routes publishing through TestPyPI first.

## Release posture

Valid wording:

> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts.

Still invalid without further benchmarks/fixtures:

> ZeroModel is planet-scale.

> ZeroModel automatically learns the best view for every task.

> ZeroModel improves decision accuracy.

> ZeroModel detects hallucinations by itself.

## Validation

- CI now runs `pytest -q` across Python 3.10, 3.11, and 3.12
- CI now builds source and wheel distributions
- CI now runs `twine check dist/*`
- no local test run claimed from this environment; GitHub Actions should be treated as source of truth

## Follow-up after merge

1. Configure TestPyPI Trusted Publishing for `ernanhughes/zeromodel`, workflow `publish-testpypi.yml`, environment `testpypi`.
2. Run the **Publish TestPyPI release candidate** workflow manually.
3. Verify clean install/import from TestPyPI using `docs/release.md`.
4. If clean, cut production PyPI as `0.1.0`.