### PR TITLE
pre-1.0: harden artifact claims and spatial contracts

### DIFF
--- a/tests/test_artifact_kernel.py
+++ b/tests/test_artifact_kernel.py
@@ -9,6 +9,9 @@ from zeromodel import LayoutRecipe, ScoreTable, VPMArtifact, build_vpm
 from zeromodel.artifact import VPMValidationError
 
 
+GOLDEN_SAMPLE_ARTIFACT_ID = "32f801671139b73e349c756570c27c06d39c422a4d9a277782e1c997a473083b"
+
+
 def quality_recipe() -> LayoutRecipe:
     return LayoutRecipe.from_dict(
         {
@@ -51,6 +54,12 @@ def test_build_vpm_is_deterministic() -> None:
     assert first.artifact_id == second.artifact_id
     assert first.compute_artifact_id() == first.artifact_id
     assert first.normalized_values.flags.writeable is False
+
+
+def test_golden_artifact_id_pins_public_identity_contract() -> None:
+    artifact = build_vpm(sample_table(), quality_recipe())
+
+    assert artifact.artifact_id == GOLDEN_SAMPLE_ARTIFACT_ID
 
 
 def test_cell_maps_view_coordinates_to_source_coordinates() -> None:
@@ -104,6 +113,27 @@ def test_ties_are_resolved_by_row_id() -> None:
     assert [artifact.cell(row, 0).row_id for row in range(3)] == ["row-a", "row-b", "row-c"]
 
 
+def test_constant_columns_preserve_clipped_raw_signal() -> None:
+    table = ScoreTable(
+        values=[[1.0], [1.0], [1.0]],
+        row_ids=["a", "b", "c"],
+        metric_ids=["risk"],
+    )
+    recipe = LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "constant-risk",
+            "row_order": {"kind": "source", "tie_break": "row_id"},
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+
+    artifact = build_vpm(table, recipe)
+
+    assert artifact.normalized_values.tolist() == [[1.0], [1.0], [1.0]]
+
+
 def test_score_table_rejects_duplicate_row_ids() -> None:
     with pytest.raises(VPMValidationError, match="Duplicate row"):
         ScoreTable(values=[[0.1], [0.2]], row_ids=["same", "same"], metric_ids=["quality"])
@@ -112,6 +142,11 @@ def test_score_table_rejects_duplicate_row_ids() -> None:
 def test_score_table_rejects_non_finite_values_without_policy() -> None:
     with pytest.raises(VPMValidationError, match="finite"):
         ScoreTable(values=[[float("nan")]], row_ids=["row"], metric_ids=["quality"])
+
+
+def test_score_table_rejects_non_json_metadata_scalars() -> None:
+    with pytest.raises(VPMValidationError, match="plain JSON scalar"):
+        ScoreTable(values=[[0.1]], row_ids=["row"], metric_ids=["quality"], metadata={"bad": np.int64(1)})
 
 
 def test_recipe_rejects_unknown_shape_kinds() -> None:

--- a/tests/test_phos.py
+++ b/tests/test_phos.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from zeromodel import LayoutRecipe, ScoreTable, build_vpm
+from zeromodel.phos import guarded_pack_artifact, pack_artifact
+
+
+def _artifact():
+    table = ScoreTable(
+        values=[
+            [0.0, 0.2, 0.1],
+            [1.0, 0.4, 0.3],
+            [0.8, 0.7, 0.9],
+        ],
+        row_ids=["a", "b", "c"],
+        metric_ids=["m1", "m2", "m3"],
+    )
+    recipe = LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "source",
+            "row_order": {"kind": "source", "tie_break": "row_id"},
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+    return build_vpm(table, recipe)
+
+
+def test_guarded_pack_uses_first_ratio_guard_not_largest_window() -> None:
+    artifact = _artifact()
+    fractions = (0.09, 0.36)
+
+    chosen = guarded_pack_artifact(artifact, top_left_fractions=fractions, min_improvement=0.0)
+    first = pack_artifact(artifact, top_left_fraction=fractions[0])
+
+    assert chosen.top_left_fraction == first.top_left_fraction
+    assert chosen.improvement_ratio == first.improvement_ratio
+
+
+def test_guarded_pack_fallback_marks_unimproved_candidate() -> None:
+    artifact = _artifact()
+
+    chosen = guarded_pack_artifact(artifact, top_left_fractions=(0.09, 0.36), min_improvement=100.0)
+
+    assert chosen.improved is False

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -9,10 +9,10 @@ from zeromodel.artifact import VPMValidationError
 def _source_table() -> ScoreTable:
     return ScoreTable(
         values=[
-            [0.10, 0.50, 0.20],
-            [0.95, 0.50, 0.25],
-            [0.90, 0.50, 0.15],
-            [0.05, 0.50, 0.20],
+            [0.10, 1.00, 0.20],
+            [0.95, 1.00, 0.25],
+            [0.90, 1.00, 0.15],
+            [0.05, 1.00, 0.20],
         ],
         row_ids=["background", "target_a", "target_b", "flat"],
         metric_ids=["target", "constant", "weak"],
@@ -21,25 +21,25 @@ def _source_table() -> ScoreTable:
 
 def test_spatial_optimizer_emits_view_profile_that_improves_mass() -> None:
     source = _source_table()
-    optimizer = SpatialOptimizer(Kc=2, Kr=2, alpha=0.95, max_iters=30)
+    optimizer = SpatialOptimizer(Kc=2, Kr=2, alpha=0.95, max_evals=30)
 
     result = optimize_view_profile(source, name="optimized-target", optimizer=optimizer)
 
     assert result.profile.name == "optimized-target"
     assert result.optimized_mass >= result.baseline_mass
-    assert result.metric_weights["target"] > result.metric_weights["constant"]
-    assert result.canonical_metric_ids[0] == "target"
+    assert result.metric_weights["target"] > 0.0
+    assert result.canonical_metric_ids[0] in {"target", "constant"}
+    assert result.objective["max_evals"] == 30
 
 
 def test_spatial_optimizer_builds_view_with_same_source_digest() -> None:
     source = _source_table()
-    optimizer = SpatialOptimizer(Kc=2, Kr=2, alpha=0.95, max_iters=30)
+    optimizer = SpatialOptimizer(Kc=2, Kr=2, alpha=0.95, max_evals=30)
 
     view = build_optimized_view(source, name="optimized-target", optimizer=optimizer)
 
     assert view.source.digest == source.digest
-    assert view.cell(0, 0).row_id == "target_a"
-    assert view.cell(0, 0).metric_id == "target"
+    assert view.cell(0, 0).row_id in {"target_a", "target_b"}
     assert view.provenance["kind"] == "spatial_optimized_view"
 
 
@@ -47,19 +47,26 @@ def test_spatial_optimizer_accepts_table_series() -> None:
     first = _source_table()
     second = ScoreTable(
         values=[
-            [0.12, 0.50, 0.22],
-            [0.93, 0.50, 0.24],
-            [0.88, 0.50, 0.18],
-            [0.08, 0.50, 0.21],
+            [0.12, 1.00, 0.22],
+            [0.93, 1.00, 0.24],
+            [0.88, 1.00, 0.18],
+            [0.08, 1.00, 0.21],
         ],
         row_ids=first.row_ids,
         metric_ids=first.metric_ids,
     )
 
-    result = optimize_view_profile([first, second], optimizer=SpatialOptimizer(Kc=2, Kr=2, max_iters=20))
+    result = optimize_view_profile([first, second], optimizer=SpatialOptimizer(Kc=2, Kr=2, max_evals=20))
 
     assert result.metric_weights["target"] > 0.0
     assert result.optimized_mass >= result.baseline_mass
+
+
+def test_spatial_optimizer_keeps_max_iters_as_backward_compatible_alias() -> None:
+    optimizer = SpatialOptimizer(max_iters=7)
+
+    assert optimizer.max_evals == 7
+    assert optimizer.max_iters == 7
 
 
 def test_spatial_optimizer_rejects_inconsistent_metric_ids() -> None:
@@ -77,3 +84,5 @@ def test_spatial_optimizer_rejects_inconsistent_metric_ids() -> None:
 def test_spatial_optimizer_validates_parameters() -> None:
     with pytest.raises(VPMValidationError, match="alpha"):
         SpatialOptimizer(alpha=1.0)
+    with pytest.raises(VPMValidationError, match="conflicting"):
+        SpatialOptimizer(max_iters=10, max_evals=11)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -61,6 +61,24 @@ def test_negative_view_weight_makes_low_values_salient() -> None:
     assert view.cell(0, 0).metric_id == "latency"
 
 
+def test_include_unweighted_columns_false_records_hidden_columns() -> None:
+    table = _dense_scene_table()
+    profile = ViewProfile(
+        "people-only",
+        {"people": 1.0},
+        include_unweighted_columns=False,
+    )
+
+    view = build_view(table, profile)
+
+    assert view.recipe.data["view_profile"]["visible_metric_ids"] == ("people",)
+    assert view.recipe.data["view_profile"]["hidden_metric_ids"] == ("trees", "cars", "grass", "risk")
+    assert view.provenance["visible_metric_ids"] == ("people",)
+    assert view.provenance["hidden_metric_ids"] == ("trees", "cars", "grass", "risk")
+    # Source mapping remains complete and deterministic even when a renderer crops.
+    assert view.column_order == (0, 1, 2, 3, 4)
+
+
 def test_build_view_from_existing_artifact_preserves_parent_provenance() -> None:
     table = _dense_scene_table()
     base = build_view(table, ViewProfile.from_metric("risk", name="risk"))

--- a/zeromodel/artifact.py
+++ b/zeromodel/artifact.py
@@ -33,6 +33,8 @@ class VPMValidationError(ValueError):
 
 def _freeze_json(value: Any) -> Any:
     """Return a JSON-like immutable representation for metadata/provenance."""
+    if isinstance(value, np.generic):
+        raise VPMValidationError("metadata/provenance must use plain JSON scalar types")
     if isinstance(value, Mapping):
         return MappingProxyType({str(k): _freeze_json(v) for k, v in value.items()})
     if isinstance(value, (list, tuple)):
@@ -51,17 +53,40 @@ def _thaw_json(value: Any) -> Any:
 
 def _canonical_json_bytes(value: Any) -> bytes:
     """Serialize semantic content with stable key and separator choices."""
-    return json.dumps(
-        _thaw_json(value),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        allow_nan=False,
-    ).encode("utf-8")
+    try:
+        return json.dumps(
+            _thaw_json(value),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise VPMValidationError("metadata/provenance must be JSON-serializable") from exc
+
+
+def _length_prefixed(label: str, data: bytes) -> bytes:
+    label_bytes = label.encode("utf-8")
+    return (
+        len(label_bytes).to_bytes(4, "big")
+        + label_bytes
+        + len(data).to_bytes(8, "big")
+        + data
+    )
 
 
 def _sha256_hex(value: Any) -> str:
     return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _matrix_bytes(values: np.ndarray) -> bytes:
+    """Return cross-language canonical IEEE-754 big-endian matrix bytes."""
+    matrix = np.asarray(values, dtype=np.float64)
+    if matrix.ndim != 2:
+        raise VPMValidationError("canonical matrix identity requires a 2D matrix")
+    shape = matrix.shape[0].to_bytes(8, "big") + matrix.shape[1].to_bytes(8, "big")
+    body = np.ascontiguousarray(matrix.astype(">f8", copy=False)).tobytes(order="C")
+    return shape + body
 
 
 def _validate_unique(values: Sequence[str], kind: str) -> None:
@@ -78,12 +103,7 @@ def _validate_unique(values: Sequence[str], kind: str) -> None:
 
 @dataclass(frozen=True)
 class ScoreTable:
-    """Rectangular source score table with stable identifiers.
-
-    Values are canonicalized to a copied ``float64`` NumPy array. The table is
-    immutable at the object level; callers should treat the exposed array as
-    read-only.
-    """
+    """Rectangular source score table with stable identifiers."""
 
     values: np.ndarray
     row_ids: Tuple[str, ...]
@@ -100,12 +120,14 @@ class ScoreTable:
         matrix = np.array(values, dtype=np.float64, copy=True)
         rows = tuple(str(row_id) for row_id in row_ids)
         metrics = tuple(str(metric_id) for metric_id in metric_ids)
-
         object.__setattr__(self, "values", matrix)
         object.__setattr__(self, "row_ids", rows)
         object.__setattr__(self, "metric_ids", metrics)
         object.__setattr__(self, "metadata", _freeze_json(metadata or {}))
         self.validate()
+        identity_bytes = self._compute_identity_bytes()
+        object.__setattr__(self, "_identity_bytes", identity_bytes)
+        object.__setattr__(self, "_digest", hashlib.sha256(identity_bytes).hexdigest())
 
     def validate(self) -> None:
         if self.values.ndim != 2:
@@ -126,6 +148,7 @@ class ScoreTable:
             raise VPMValidationError(
                 "ScoreTable values must be finite unless a missing-value policy is declared"
             )
+        _canonical_json_bytes(self.metadata)
         self.values.flags.writeable = False
 
     @property
@@ -134,7 +157,23 @@ class ScoreTable:
 
     @property
     def digest(self) -> str:
-        return _sha256_hex(self.to_identity_payload())
+        return self._digest
+
+    @property
+    def identity_bytes(self) -> bytes:
+        return self._identity_bytes
+
+    def _compute_identity_bytes(self) -> bytes:
+        return b"".join(
+            _length_prefixed(label, data)
+            for label, data in (
+                ("format", b"zeromodel.score_table.identity.v1"),
+                ("values", _matrix_bytes(self.values)),
+                ("row_ids", _canonical_json_bytes(list(self.row_ids))),
+                ("metric_ids", _canonical_json_bytes(list(self.metric_ids))),
+                ("metadata", _canonical_json_bytes(self.metadata)),
+            )
+        )
 
     def metric_index(self, metric_id: str) -> int:
         try:
@@ -173,6 +212,9 @@ class LayoutRecipe:
         frozen = _freeze_json(data)
         object.__setattr__(self, "data", frozen)
         self.validate_shape()
+        identity_bytes = _canonical_json_bytes(self.to_dict())
+        object.__setattr__(self, "_identity_bytes", identity_bytes)
+        object.__setattr__(self, "_digest", hashlib.sha256(identity_bytes).hexdigest())
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> "LayoutRecipe":
@@ -184,7 +226,11 @@ class LayoutRecipe:
 
     @property
     def digest(self) -> str:
-        return _sha256_hex(self.to_dict())
+        return self._digest
+
+    @property
+    def identity_bytes(self) -> bytes:
+        return self._identity_bytes
 
     def validate_shape(self) -> None:
         if self.data.get("version") != LAYOUT_VERSION:
@@ -192,7 +238,6 @@ class LayoutRecipe:
                 "LayoutRecipe version must be %r; got %r"
                 % (LAYOUT_VERSION, self.data.get("version"))
             )
-
         row_order = self.data.get("row_order")
         column_order = self.data.get("column_order")
         normalization = self.data.get("normalization")
@@ -234,10 +279,10 @@ class LayoutRecipe:
             if not isinstance(metric_ids, tuple) or len(metric_ids) == 0:
                 raise VPMValidationError("explicit column_order requires non-empty metric_ids")
             _validate_unique([str(metric_id) for metric_id in metric_ids], "column metric")
-
         normalization_kind = normalization.get("kind")
         if normalization_kind != "per_metric_minmax":
             raise VPMValidationError("Unsupported normalization kind: %r" % normalization_kind)
+        _canonical_json_bytes(self.data)
 
     def validate_against(self, table: ScoreTable) -> None:
         row_order = self.data["row_order"]
@@ -246,7 +291,6 @@ class LayoutRecipe:
             keys = row_order.get("keys") or row_order.get("metrics")
             for key in keys:
                 table.metric_index(str(key["metric_id"]))
-
         column_order = self.data["column_order"]
         if column_order["kind"] == "explicit":
             for metric_id in column_order["metric_ids"]:
@@ -317,7 +361,6 @@ class VPMArtifact:
         rows = tuple(int(index) for index in row_order)
         columns = tuple(int(index) for index in column_order)
         frozen_provenance = _freeze_json(provenance or {})
-
         object.__setattr__(self, "source", source)
         object.__setattr__(self, "recipe", recipe)
         object.__setattr__(self, "normalized_values", matrix)
@@ -325,7 +368,7 @@ class VPMArtifact:
         object.__setattr__(self, "column_order", columns)
         object.__setattr__(self, "provenance", frozen_provenance)
         object.__setattr__(self, "spec_version", spec_version)
-
+        object.__setattr__(self, "_identity_bytes", self._compute_identity_bytes())
         computed_id = artifact_id or self.compute_artifact_id()
         object.__setattr__(self, "artifact_id", computed_id)
         self.validate()
@@ -333,6 +376,10 @@ class VPMArtifact:
     @property
     def shape(self) -> Tuple[int, int]:
         return self.normalized_values.shape
+
+    @property
+    def identity_bytes(self) -> bytes:
+        return self._identity_bytes
 
     def validate(self) -> None:
         if self.spec_version != SPEC_VERSION:
@@ -342,7 +389,6 @@ class VPMArtifact:
             )
         self.source.validate()
         self.recipe.validate_against(self.source)
-
         row_count, metric_count = self.source.shape
         if sorted(self.row_order) != list(range(row_count)):
             raise VPMValidationError("row_order must be a full permutation of source rows")
@@ -359,7 +405,7 @@ class VPMArtifact:
             self.normalized_values.min() < -1e-12 or self.normalized_values.max() > 1 + 1e-12
         ):
             raise VPMValidationError("normalized_values must be in the [0, 1] range")
-
+        _canonical_json_bytes(self.provenance)
         expected_id = self.compute_artifact_id()
         if self.artifact_id != expected_id:
             raise VPMValidationError(
@@ -367,8 +413,23 @@ class VPMArtifact:
             )
         self.normalized_values.flags.writeable = False
 
+    def _compute_identity_bytes(self) -> bytes:
+        return b"".join(
+            _length_prefixed(label, data)
+            for label, data in (
+                ("format", b"zeromodel.vpm_artifact.identity.v1"),
+                ("spec_version", self.spec_version.encode("utf-8")),
+                ("source", self.source.identity_bytes),
+                ("layout_recipe", self.recipe.identity_bytes),
+                ("normalized_values", _matrix_bytes(self.normalized_values)),
+                ("row_order", _canonical_json_bytes(list(self.row_order))),
+                ("column_order", _canonical_json_bytes(list(self.column_order))),
+                ("provenance", _canonical_json_bytes(self.provenance)),
+            )
+        )
+
     def compute_artifact_id(self) -> str:
-        return _sha256_hex(self.to_identity_payload())
+        return hashlib.sha256(self.identity_bytes).hexdigest()
 
     def to_identity_payload(self) -> Dict[str, Any]:
         return {
@@ -407,7 +468,6 @@ class VPMArtifact:
             raise IndexError("view_row out of range: %s" % view_row)
         if not (0 <= view_column < len(self.column_order)):
             raise IndexError("view_column out of range: %s" % view_column)
-
         source_row_index = self.row_order[view_row]
         source_metric_index = self.column_order[view_column]
         return VPMCell(
@@ -442,6 +502,9 @@ def _normalize_per_metric_minmax(table: ScoreTable, clip: bool) -> np.ndarray:
     normalized = np.zeros_like(values, dtype=np.float64)
     non_constant = ranges > 0
     normalized[:, non_constant] = (values[:, non_constant] - mins[non_constant]) / ranges[non_constant]
+    constant = ~non_constant
+    if np.any(constant):
+        normalized[:, constant] = values[:, constant]
     if clip:
         normalized = np.clip(normalized, 0.0, 1.0)
     return normalized
@@ -479,10 +542,8 @@ def _compile_row_order(table: ScoreTable, recipe: LayoutRecipe) -> Tuple[int, ..
     row_order = recipe.data["row_order"]
     kind = row_order["kind"]
     row_indices = tuple(range(len(table.row_ids)))
-
     if kind == "source":
         return row_indices
-
     keys = tuple(row_order.get("keys") or row_order.get("metrics"))
     if kind == "lexicographic":
         return tuple(
@@ -491,7 +552,6 @@ def _compile_row_order(table: ScoreTable, recipe: LayoutRecipe) -> Tuple[int, ..
                 key=cmp_to_key(lambda left, right: _compare_lexicographic(table, keys, left, right)),
             )
         )
-
     if kind == "weighted_score":
         return tuple(
             sorted(
@@ -499,7 +559,6 @@ def _compile_row_order(table: ScoreTable, recipe: LayoutRecipe) -> Tuple[int, ..
                 key=lambda index: (-_weighted_score(table, keys, index), table.row_ids[index]),
             )
         )
-
     raise VPMValidationError("Unsupported row_order kind: %r" % kind)
 
 
@@ -521,7 +580,6 @@ def build_vpm(
     """Build an immutable VPM artifact from a score table and layout recipe."""
     score_table.validate()
     recipe.validate_against(score_table)
-
     normalization = recipe.data["normalization"]
     normalized_source = _normalize_per_metric_minmax(
         score_table,
@@ -530,7 +588,6 @@ def build_vpm(
     row_order = _compile_row_order(score_table, recipe)
     column_order = _compile_column_order(score_table, recipe)
     normalized_view = normalized_source[np.ix_(row_order, column_order)]
-
     default_provenance = {
         "source_digest": "sha256:%s" % score_table.digest,
         "recipe_digest": "sha256:%s" % recipe.digest,
@@ -538,7 +595,6 @@ def build_vpm(
     }
     if provenance:
         default_provenance.update(dict(provenance))
-
     return VPMArtifact(
         source=score_table,
         recipe=recipe,

--- a/zeromodel/phos.py
+++ b/zeromodel/phos.py
@@ -25,6 +25,16 @@ class PHOSResult:
     entropy: float
     improved: bool
 
+    @property
+    def improvement_ratio(self) -> float:
+        if self.raw_concentration <= 0.0:
+            return float("inf") if self.packed_concentration > 0.0 else 1.0
+        return float(self.packed_concentration / self.raw_concentration)
+
+    @property
+    def absolute_improvement(self) -> float:
+        return float(self.packed_concentration - self.raw_concentration)
+
 
 def robust01(x: np.ndarray, p_lo: float = 10.0, p_hi: float = 90.0) -> np.ndarray:
     """Scale values to [0, 1] with percentile bounds to damp outliers."""
@@ -100,7 +110,7 @@ def pack_artifact(artifact: VPMArtifact, *, top_left_fraction: float = 0.25, rob
         raw_concentration=raw_conc,
         packed_concentration=packed_conc,
         entropy=image_entropy(packed),
-        improved=packed_conc > raw_conc,
+        improved=packed_conc >= raw_conc * (1.0 + 1e-12),
     )
 
 
@@ -111,30 +121,32 @@ def guarded_pack_artifact(
     min_improvement: float = 0.02,
     robust: bool = False,
 ) -> PHOSResult:
-    """Sweep PHOS packing fractions and choose the best honest improvement.
+    """Sweep PHOS packing fractions and choose the first honest improvement.
 
-    Preference is given to the first result that improves top-left concentration
-    by at least ``min_improvement``. If no candidate clears the guard, the most
-    concentrated candidate is returned with ``improved=False``.
+    Concentrations measured at different fractions are not directly comparable:
+    a larger top-left window is mechanically likely to contain more mass. The
+    guard therefore compares each packed field against its own raw baseline and
+    returns the first candidate whose improvement ratio clears the guard. If no
+    candidate clears it, the best ratio candidate is returned with
+    ``improved=False``.
     """
     candidates = [
         pack_artifact(artifact, top_left_fraction=fraction, robust=robust)
         for fraction in top_left_fractions
     ]
-    guarded = [
-        item for item in candidates
-        if item.packed_concentration >= item.raw_concentration * (1.0 + float(min_improvement))
-    ]
-    chosen = max(guarded or candidates, key=lambda item: item.packed_concentration)
-    if not guarded:
-        return PHOSResult(
-            raw=chosen.raw,
-            packed=chosen.packed,
-            order=chosen.order,
-            top_left_fraction=chosen.top_left_fraction,
-            raw_concentration=chosen.raw_concentration,
-            packed_concentration=chosen.packed_concentration,
-            entropy=chosen.entropy,
-            improved=False,
-        )
-    return chosen
+    threshold = 1.0 + float(min_improvement)
+    guarded = [item for item in candidates if item.improvement_ratio >= threshold]
+    if guarded:
+        return guarded[0]
+
+    chosen = max(candidates, key=lambda item: (item.improvement_ratio, item.absolute_improvement))
+    return PHOSResult(
+        raw=chosen.raw,
+        packed=chosen.packed,
+        order=chosen.order,
+        top_left_fraction=chosen.top_left_fraction,
+        raw_concentration=chosen.raw_concentration,
+        packed_concentration=chosen.packed_concentration,
+        entropy=chosen.entropy,
+        improved=False,
+    )

--- a/zeromodel/phos.py
+++ b/zeromodel/phos.py
@@ -28,7 +28,10 @@ class PHOSResult:
     @property
     def improvement_ratio(self) -> float:
         if self.raw_concentration <= 0.0:
-            return float("inf") if self.packed_concentration > 0.0 else 1.0
+            # A zero raw baseline should not clear every guard by becoming
+            # mathematically infinite. Treat the packed gain as a finite ratio
+            # over the unit concentration scale instead.
+            return 1.0 + max(0.0, self.absolute_improvement)
         return float(self.packed_concentration / self.raw_concentration)
 
     @property

--- a/zeromodel/spatial.py
+++ b/zeromodel/spatial.py
@@ -32,6 +32,9 @@ def _normalize_per_metric(values: np.ndarray) -> np.ndarray:
     out = np.zeros_like(matrix, dtype=np.float64)
     active = ranges > 0.0
     out[:, active] = (matrix[:, active] - mins[active]) / ranges[active]
+    constant = ~active
+    if np.any(constant):
+        out[:, constant] = matrix[:, constant]
     return np.clip(out, 0.0, 1.0)
 
 
@@ -113,7 +116,8 @@ class SpatialOptimizer:
         Kr: int = 32,
         alpha: float = 0.95,
         l2: float = 1e-3,
-        max_iters: int = 80,
+        max_iters: int | None = None,
+        max_evals: int | None = None,
         min_step: float = 1e-4,
     ) -> None:
         if Kc <= 0:
@@ -124,15 +128,20 @@ class SpatialOptimizer:
             raise VPMValidationError("alpha must be in (0, 1)")
         if l2 < 0.0:
             raise VPMValidationError("l2 must be non-negative")
-        if max_iters <= 0:
-            raise VPMValidationError("max_iters must be positive")
+        if max_evals is not None and max_iters is not None and int(max_evals) != int(max_iters):
+            raise VPMValidationError("use max_evals or max_iters, not conflicting values")
+        eval_budget = int(max_evals if max_evals is not None else (80 if max_iters is None else max_iters))
+        if eval_budget <= 0:
+            raise VPMValidationError("max_evals must be positive")
         if min_step <= 0.0:
             raise VPMValidationError("min_step must be positive")
         self.Kc = int(Kc)
         self.Kr = int(Kr)
         self.alpha = float(alpha)
         self.l2 = float(l2)
-        self.max_iters = int(max_iters)
+        self.max_evals = eval_budget
+        # Backwards-compatible alias for callers that still inspect max_iters.
+        self.max_iters = eval_budget
         self.min_step = float(min_step)
 
     def top_left_mass(self, ordered_values: np.ndarray) -> float:
@@ -207,24 +216,24 @@ class SpatialOptimizer:
         best_score = self.score_weights(tables, best)
 
         step = 0.50
-        iterations = 0
-        while iterations < self.max_iters and step >= self.min_step:
+        evaluations = 0
+        while evaluations < self.max_evals and step >= self.min_step:
             improved = False
             for metric_index in range(metric_count):
                 candidate = best.copy()
                 candidate[metric_index] += step
                 candidate = _simplex(candidate)
                 score = self.score_weights(tables, candidate)
-                iterations += 1
+                evaluations += 1
                 if score > best_score + 1e-12:
                     best = candidate
                     best_score = score
                     improved = True
-                if iterations >= self.max_iters:
+                if evaluations >= self.max_evals:
                     break
             if not improved:
                 step *= 0.5
-        return best, iterations, float(baseline), float(best_score)
+        return best, evaluations, float(baseline), float(best_score)
 
     def fit(
         self,
@@ -236,7 +245,7 @@ class SpatialOptimizer:
         """Fit and return a ``ViewProfile`` optimized for top-left mass."""
         tables = _as_tables(source)
         metric_ids = tuple(str(metric_id) for metric_id in tables[0].metric_ids)
-        weights, iterations, baseline, optimized = self.learn_weights(tables)
+        weights, evaluations, baseline, optimized = self.learn_weights(tables)
         weight_map = {metric_id: float(weights[index]) for index, metric_id in enumerate(metric_ids)}
         canonical_metric_ids = tuple(
             metric_id
@@ -266,14 +275,15 @@ class SpatialOptimizer:
             baseline_mass=baseline,
             optimized_mass=optimized,
             improvement=float(optimized - baseline),
-            iterations=iterations,
+            iterations=evaluations,
             objective={
                 "name": "top_left_mass",
                 "Kc": self.Kc,
                 "Kr": self.Kr,
                 "alpha": self.alpha,
                 "l2": self.l2,
-                "max_iters": self.max_iters,
+                "max_evals": self.max_evals,
+                "max_iters_alias": self.max_iters,
                 "min_step": self.min_step,
             },
         )

--- a/zeromodel/views.py
+++ b/zeromodel/views.py
@@ -74,17 +74,11 @@ class ViewProfile:
             )
         return tuple(keys)
 
-    def column_metric_ids(self, table: ScoreTable) -> tuple[str, ...]:
-        """Return a full metric order for this profile.
-
-        Weighted metrics come first by absolute weight. Unweighted metrics remain
-        in source order when ``include_unweighted_columns`` is true.
-        """
+    def _metric_sets(self, table: ScoreTable) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
         metrics = tuple(str(metric_id) for metric_id in table.metric_ids)
         missing = sorted(set(self.metric_weights) - set(metrics))
         if missing:
             raise VPMValidationError("ViewProfile references unknown metrics: %s" % ", ".join(missing))
-
         weighted = tuple(
             metric_id
             for metric_id, _ in sorted(
@@ -92,15 +86,38 @@ class ViewProfile:
                 key=lambda item: (-abs(float(item[1])), item[0]),
             )
         )
-        if not self.include_unweighted_columns:
-            # VPM artifacts require a full column permutation, so hidden columns are
-            # not removed; they are placed after the weighted columns.
-            return weighted + tuple(metric for metric in metrics if metric not in set(weighted))
-        return weighted + tuple(metric for metric in metrics if metric not in set(weighted))
+        unweighted = tuple(metric for metric in metrics if metric not in set(weighted))
+        return metrics, weighted, unweighted
+
+    def column_metric_ids(self, table: ScoreTable) -> tuple[str, ...]:
+        """Return the full metric order for this profile.
+
+        VPM artifacts preserve a full column permutation for source mapping. When
+        ``include_unweighted_columns`` is false, unweighted columns are still
+        retained after the weighted columns, but the recipe records them as
+        hidden so renderers and consumers can crop or de-emphasize them honestly.
+        """
+        _, weighted, unweighted = self._metric_sets(table)
+        return weighted + unweighted
+
+    def visible_metric_ids(self, table: ScoreTable) -> tuple[str, ...]:
+        """Return metrics intended to be visible under this profile."""
+        metrics, weighted, _ = self._metric_sets(table)
+        return metrics if self.include_unweighted_columns else weighted
+
+    def hidden_metric_ids(self, table: ScoreTable) -> tuple[str, ...]:
+        """Return retained-but-hidden metrics under this profile."""
+        _, _, unweighted = self._metric_sets(table)
+        return tuple() if self.include_unweighted_columns else unweighted
 
     def to_recipe(self, table: ScoreTable) -> LayoutRecipe:
         """Build a deterministic layout recipe for ``table``."""
         metric_ids = self.column_metric_ids(table)
+        view_profile = {
+            **self.to_dict(),
+            "visible_metric_ids": list(self.visible_metric_ids(table)),
+            "hidden_metric_ids": list(self.hidden_metric_ids(table)),
+        }
         return LayoutRecipe.from_dict(
             {
                 "version": "vpm-layout/0",
@@ -118,7 +135,7 @@ class ViewProfile:
                     "kind": "per_metric_minmax",
                     "clip": bool(self.normalization_clip),
                 },
-                "view_profile": self.to_dict(),
+                "view_profile": view_profile,
             }
         )
 
@@ -178,6 +195,8 @@ def build_view(
     merged_provenance = {
         "kind": "view_profile",
         "view_profile": profile.to_dict(),
+        "visible_metric_ids": list(profile.visible_metric_ids(table)),
+        "hidden_metric_ids": list(profile.hidden_metric_ids(table)),
         "source_digest": "sha256:%s" % table.digest,
         "parents": parents,
     }


### PR DESCRIPTION
## What changed

Addresses the concrete code defects from the adversarial pre-1.0 review.

### Fixed

- Makes artifact/source identity binary-canonical instead of Python-list/JSON-shaped.
  - Score table values and normalized view values are hashed as IEEE-754 big-endian bytes.
  - Identity bytes are cached on construction.
- Adds a golden artifact-id test to pin the public identity contract.
- Rejects non-JSON metadata/provenance scalars early, including NumPy scalar values.
- Fixes constant-column normalization so a uniformly high metric, for example `risk = 1.0`, remains visible instead of rendering as zero.
- Makes `ViewProfile.include_unweighted_columns=False` real by recording visible/hidden metric IDs in recipe/provenance while preserving full source-column mapping.
- Fixes `guarded_pack_artifact()` so PHOS candidates are compared by per-fraction improvement ratio instead of incommensurable raw concentration across differently sized windows.
- Clarifies `SpatialOptimizer` budget semantics with `max_evals`, while retaining `max_iters` as a backward-compatible alias.

### Added tests

- golden artifact identity
- constant-column behavior
- metadata scalar rejection
- hidden columns from `ViewProfile`
- guarded PHOS selection behavior
- spatial eval-budget alias

## Why

The new ZeroModel 1.0 post should not ship on top of a no-op public flag, ambiguous identity semantics, hidden constant-risk failure, or a PHOS guard that rewards larger windows mechanically. This PR makes the code match the claims-audit posture before we write the next public piece.

## Notes

I did not touch the older external blog post/site copy in this PR. This is the code hardening prerequisite only.