### PR TITLE
Add selection-corrected Bertin pattern discovery MVP

### DIFF
--- a/docs/research/bertin-pattern-detection.md
+++ b/docs/research/bertin-pattern-detection.md
@@ -1,0 +1,115 @@
+# Bertin-inspired pattern detection
+
+Status: **Research / synthetic-fixture validation**
+
+ZeroModel can already build deterministic views from declared layout recipes. This experiment asks a different question:
+
+> Can ZeroModel discover a useful row ordering from an apparently disordered scored matrix, calibrate the apparent structure against a null model, and freeze the result as linked identity-bearing artifacts?
+
+The MVP is deliberately narrow. It implements:
+
+- one NumPy-only spectral-seriation method;
+- two numeric objectives: adjacent coherence and anti-Robinson structure;
+- a selection-corrected permutation null;
+- an explicit discovered row order;
+- a pattern-report VPM linked to the analyzed artifact;
+- a discovered-view VPM linked to both the source and the report.
+
+It does **not** yet implement biclustering, anomaly interpretation, domain-semantic labels, multiple ordering methods, column seriation, human-inspection evidence, or real-world validation.
+
+## Why the null is selection-corrected
+
+The detector does not compare an optimized real matrix against unoptimized shuffled matrices. Every null sample:
+
+1. independently permutes values within each metric column, preserving column marginals while destroying joint row structure;
+2. reruns the complete ordering pipeline;
+3. evaluates every declared objective;
+4. contributes its maximum standardized objective score to the family null distribution.
+
+This corrects for selecting the most favorable objective after looking at the data. Adding future ordering methods must also add those methods to every null run.
+
+## Determinism and identity
+
+Spectral discovery is a compile-time analysis. The result is frozen as an explicit row-ID permutation:
+
+```text
+source VPM
+    ↓ analyzed by
+pattern-report VPM
+    ↓ orders
+explicit discovered-view VPM
+```
+
+The discovered view does not depend on rerunning the eigensolver. Its `LayoutRecipe` stores the complete row order, and normal VPM source mappings remain available.
+
+The report stores:
+
+- analyzed artifact ID;
+- detector/checker version;
+- method and objective IDs;
+- value source;
+- null sample count and seed;
+- specification digest;
+- discovered row order;
+- observed scores;
+- null mean and standard deviation;
+- per-objective permutation p-values;
+- family-level p-value;
+- degeneracy flag.
+
+## Public API
+
+```python
+from zeromodel import MatrixPatternDetector, PatternAnalysisSpec
+
+spec = PatternAnalysisSpec(
+    value_source="normalized",
+    null_samples=199,
+    seed=11,
+)
+detector = MatrixPatternDetector(spec)
+report = detector.detect(source_artifact)
+view = detector.build_view(source_artifact, report)
+
+print(report.family_p_value)
+print(report.primary_objective)
+print(report.row_order)
+```
+
+The lower-level functions `detect_patterns()` and `build_discovered_view()` are also available.
+
+## Current evidence
+
+The committed tests establish the following narrow claims:
+
+- a planted three-block matrix is recovered with strong same-block adjacency;
+- its family-level statistic is significant under the declared permutation null;
+- selected pure-noise fixtures are not reported as significant;
+- constant matrices are marked degenerate and fall back to source order;
+- identical analysis inputs produce identical report digests and artifact identities;
+- changing only the calibration seed changes the report lineage but not the frozen discovered ordering;
+- report and view artifacts preserve lineage and `.vpm` round trips;
+- incomplete explicit row permutations are rejected.
+
+These tests do not establish broad matrix-pattern discovery or practical inspection benefit.
+
+## Kill conditions
+
+The direction should be reconsidered if broader synthetic evaluation shows any of the following:
+
+1. false positives materially exceed the declared family alpha on pure noise;
+2. planted structure recovery does not beat source order or simple conventional baselines at moderate signal-to-noise ratios;
+3. a commodity seriation or clustered-heatmap implementation provides the same analytical and lineage value with substantially less machinery;
+4. discovered layouts do not improve an automated or human inspection task.
+
+## Next experiment
+
+The next step is not to add more algorithms. It is to run a generated benchmark across signal strengths and random seeds, reporting:
+
+- family false-positive rate;
+- block recovery;
+- stability under small perturbations;
+- runtime by row count;
+- comparison with source order and one conventional clustering baseline.
+
+Only after that gate should the detector add biclustering, anomalies, multiple methods, or a real deployment-policy fixture.

--- a/examples/bertin_pattern_detection.py
+++ b/examples/bertin_pattern_detection.py
@@ -1,0 +1,113 @@
+"""Recover planted matrix structure and freeze the result as VPM artifacts.
+
+This is a bounded research fixture for the Bertin-inspired pattern detector.
+It does not assign domain meaning to the recovered geometry. It demonstrates:
+
+- deterministic spectral seriation;
+- selection-corrected permutation-null calibration;
+- an identity-bearing pattern report;
+- an explicit-order discovered view over the unchanged source table.
+
+Run:
+
+    python examples/bertin_pattern_detection.py
+    python examples/bertin_pattern_detection.py --output-dir build/patterns
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from zeromodel import LayoutRecipe, ScoreTable, build_vpm, to_bundle, write_png
+from zeromodel.patterns import MatrixPatternDetector, PatternAnalysisSpec
+
+
+def planted_block_matrix(*, seed: int = 7, noise: float = 0.08) -> tuple[np.ndarray, np.ndarray]:
+    """Return a shuffled three-block matrix and its hidden row labels."""
+
+    rng = np.random.default_rng(seed)
+    signatures = np.array(
+        [
+            [1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    labels = np.repeat(np.arange(3), 8)
+    matrix = signatures[labels] + rng.normal(0.0, noise, size=(24, 6))
+    shuffle = rng.permutation(matrix.shape[0])
+    return matrix[shuffle], labels[shuffle]
+
+
+def source_artifact(matrix: np.ndarray):
+    table = ScoreTable(
+        values=matrix,
+        row_ids=["state:%03d" % index for index in range(matrix.shape[0])],
+        metric_ids=["signal:%d" % index for index in range(matrix.shape[1])],
+        metadata={"kind": "bertin-pattern-recovery-fixture"},
+    )
+    recipe = LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "bertin-pattern-source-order",
+            "row_order": {"kind": "source", "tie_break": "row_id"},
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+    return build_vpm(table, recipe, provenance={"kind": "pattern-source"})
+
+
+def block_adjacency(row_order: tuple[str, ...], row_ids: tuple[str, ...], labels: np.ndarray) -> float:
+    label_by_row = dict(zip(row_ids, labels))
+    ordered = [label_by_row[row_id] for row_id in row_order]
+    return sum(left == right for left, right in zip(ordered, ordered[1:])) / float(len(ordered) - 1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--null-samples", type=int, default=199)
+    parser.add_argument("--seed", type=int, default=11)
+    args = parser.parse_args()
+
+    matrix, labels = planted_block_matrix()
+    source = source_artifact(matrix)
+    detector = MatrixPatternDetector(
+        PatternAnalysisSpec(null_samples=args.null_samples, seed=args.seed)
+    )
+    report = detector.detect(source)
+    report_artifact = report.to_vpm()
+    discovered_view = detector.build_view(source, report)
+    adjacency = block_adjacency(report.row_order, source.source.row_ids, labels)
+
+    output = {
+        "source_artifact_id": source.artifact_id,
+        "pattern_report_artifact_id": report_artifact.artifact_id,
+        "discovered_view_artifact_id": discovered_view.artifact_id,
+        "pattern_spec_digest": report.spec.digest,
+        "primary_objective": report.primary_objective,
+        "family_p_value": report.family_p_value,
+        "significant_at_0_05": report.significant,
+        "same_block_adjacency": adjacency,
+        "row_count": matrix.shape[0],
+        "metric_count": matrix.shape[1],
+    }
+
+    if args.output_dir is not None:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        to_bundle(source, args.output_dir / "pattern-source.vpm")
+        to_bundle(report_artifact, args.output_dir / "pattern-report.vpm")
+        to_bundle(discovered_view, args.output_dir / "pattern-view.vpm")
+        write_png(discovered_view, args.output_dir / "pattern-view.png")
+        output["output_dir"] = str(args.output_dir)
+
+    print(json.dumps(output, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,202 @@
+"""Tests for the Bertin-inspired pattern detector.
+
+The three kill conditions from the design review are asserted directly:
+
+1. Planted structure recovery: the detector must recover known block structure
+   from a shuffled matrix and report significance.
+2. Null calibration: on structureless noise the detector must not report
+   significance (deterministic seeds; the selection-corrected null makes this
+   the load-bearing test).
+3. Frozen-outcome determinism: identical inputs yield identical report digests
+   and identical discovered-view identities, and the view's identity derives
+   from the explicit ordering, not from re-running discovery.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from zeromodel import LayoutRecipe, ScoreTable, build_vpm
+from zeromodel.artifact import VPMValidationError
+from zeromodel.patterns import (
+    PatternAnalysisSpec,
+    build_discovered_view,
+    detect_patterns,
+)
+
+
+def _artifact_from_matrix(matrix: np.ndarray, prefix: str = "row"):
+    table = ScoreTable(
+        values=matrix.tolist(),
+        row_ids=["%s:%03d" % (prefix, index) for index in range(matrix.shape[0])],
+        metric_ids=["m%d" % index for index in range(matrix.shape[1])],
+        metadata={"kind": "pattern-test"},
+    )
+    recipe = LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "pattern-test-source",
+            "row_order": {"kind": "source", "tie_break": "row_id"},
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+    return build_vpm(table, recipe, provenance={"kind": "pattern-test"})
+
+
+def _planted_matrix(seed: int = 7, noise: float = 0.08) -> tuple[np.ndarray, np.ndarray]:
+    """Three planted row blocks with distinct column signatures, shuffled."""
+
+    rng = np.random.default_rng(seed)
+    signatures = np.array(
+        [
+            [1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+        ]
+    )
+    labels = np.repeat(np.arange(3), 8)
+    matrix = signatures[labels] + rng.normal(0.0, noise, size=(24, 6))
+    shuffle = rng.permutation(24)
+    return matrix[shuffle], labels[shuffle]
+
+
+def _same_block_adjacency(order_row_ids, row_ids, labels) -> float:
+    label_by_row_id = dict(zip(row_ids, labels))
+    ordered_labels = [label_by_row_id[row_id] for row_id in order_row_ids]
+    adjacent = sum(
+        1 for a, b in zip(ordered_labels, ordered_labels[1:]) if a == b
+    )
+    return adjacent / (len(ordered_labels) - 1)
+
+
+def test_planted_structure_is_recovered_and_significant() -> None:
+    matrix, labels = _planted_matrix()
+    artifact = _artifact_from_matrix(matrix)
+    spec = PatternAnalysisSpec(null_samples=99, seed=11)
+    report = detect_patterns(artifact, spec)
+
+    adjacency = _same_block_adjacency(
+        report.row_order, artifact.source.row_ids, labels
+    )
+    # Perfect recovery groups all three blocks: 21/23 same-block adjacencies.
+    assert adjacency > 0.85
+    assert report.family_p_value <= 0.05
+    assert not report.degenerate
+
+
+def test_pure_noise_is_not_reported_as_structure() -> None:
+    rng = np.random.default_rng(3)
+    for seed in (0, 1, 2):
+        matrix = rng.uniform(size=(20, 6))
+        artifact = _artifact_from_matrix(matrix, prefix="noise%d" % seed)
+        spec = PatternAnalysisSpec(null_samples=99, seed=seed)
+        report = detect_patterns(artifact, spec)
+        assert report.family_p_value > 0.05, (
+            "detector reported structure in noise (seed=%d, p=%.4f)"
+            % (seed, report.family_p_value)
+        )
+
+
+def test_report_and_view_are_deterministic_and_frozen() -> None:
+    matrix, _ = _planted_matrix()
+    artifact = _artifact_from_matrix(matrix)
+    spec = PatternAnalysisSpec(null_samples=25, seed=5)
+
+    first = detect_patterns(artifact, spec)
+    second = detect_patterns(artifact, spec)
+    assert first.digest == second.digest
+    assert first.to_vpm().artifact_id == second.to_vpm().artifact_id
+
+    view_a = build_discovered_view(artifact, first)
+    view_b = build_discovered_view(artifact, second)
+    assert view_a.artifact_id == view_b.artifact_id
+
+    # The discovered ordering is calibration-independent: a different null seed
+    # changes p-values but not the order, the recipe, or the rendered content.
+    # The view's record identity legitimately differs because its provenance
+    # cites a different report lineage; content invariants must still match.
+    other_seed = detect_patterns(artifact, PatternAnalysisSpec(null_samples=25, seed=99))
+    assert other_seed.row_order == first.row_order
+    assert other_seed.digest != first.digest
+    view_c = build_discovered_view(artifact, other_seed)
+    assert view_c.recipe.digest == view_a.recipe.digest
+    assert np.array_equal(view_c.normalized_values, view_a.normalized_values)
+    assert view_c.artifact_id != view_a.artifact_id
+
+
+def test_view_lineage_links_analyzed_artifact_and_report() -> None:
+    matrix, _ = _planted_matrix()
+    artifact = _artifact_from_matrix(matrix)
+    report = detect_patterns(artifact, PatternAnalysisSpec(null_samples=25, seed=5))
+    report_artifact = report.to_vpm()
+    view = build_discovered_view(artifact, report)
+
+    relations = {
+        parent["relation"]: parent["artifact_id"]
+        for parent in view.provenance["parents"]
+    }
+    assert relations["derived_from"] == artifact.artifact_id
+    assert relations["ordered_by"] == report_artifact.artifact_id
+    report_parents = report_artifact.provenance["parents"]
+    assert report_parents[0]["relation"] == "analyzes"
+    assert report_parents[0]["artifact_id"] == artifact.artifact_id
+
+    # The view is a pure permutation of the same source.
+    assert view.source.digest == artifact.source.digest
+
+
+def test_degenerate_constant_matrix_falls_back_without_significance() -> None:
+    artifact = _artifact_from_matrix(np.full((8, 4), 0.5), prefix="const")
+    report = detect_patterns(artifact, PatternAnalysisSpec(null_samples=25, seed=1))
+    assert report.degenerate
+    assert report.row_order == tuple(artifact.source.row_ids)
+    assert report.family_p_value > 0.05
+
+
+def test_explicit_row_order_rejects_incomplete_permutations() -> None:
+    matrix, _ = _planted_matrix()
+    artifact = _artifact_from_matrix(matrix)
+    incomplete = {
+        "version": "vpm-layout/0",
+        "name": "bad-explicit",
+        "row_order": {
+            "kind": "explicit",
+            "row_ids": list(artifact.source.row_ids[:-1]),
+            "tie_break": "row_id",
+        },
+        "column_order": {"kind": "source"},
+        "normalization": {"kind": "per_metric_minmax", "clip": True},
+    }
+    recipe = LayoutRecipe.from_dict(incomplete)
+    with pytest.raises(VPMValidationError):
+        build_vpm(artifact.source, recipe)
+
+
+def test_report_rejects_mismatched_artifact() -> None:
+    matrix, _ = _planted_matrix()
+    artifact = _artifact_from_matrix(matrix)
+    other = _artifact_from_matrix(matrix + 0.5, prefix="other")
+    report = detect_patterns(artifact, PatternAnalysisSpec(null_samples=10, seed=2))
+    with pytest.raises(VPMValidationError):
+        build_discovered_view(other, report)
+
+
+def test_detector_wrapper_and_bundle_round_trip(tmp_path) -> None:
+    from zeromodel.bundle import from_bundle, to_bundle
+    from zeromodel.patterns import MatrixPatternDetector
+
+    matrix, _ = _planted_matrix()
+    artifact = _artifact_from_matrix(matrix)
+    detector = MatrixPatternDetector(PatternAnalysisSpec(null_samples=25, seed=5))
+    report = detector.detect(artifact)
+    view = detector.build_view(artifact, report)
+
+    assert report.significant
+    assert report.primary_objective in {"adjacent_coherence", "anti_robinson"}
+    report_path = to_bundle(report.to_vpm(), tmp_path / "pattern-report.vpm")
+    view_path = to_bundle(view, tmp_path / "pattern-view.vpm")
+    assert from_bundle(report_path).artifact_id == report.to_vpm().artifact_id
+    assert from_bundle(view_path).artifact_id == view.artifact_id
+    assert "family_p_value" in report.to_vpm().source.metric_ids

--- a/zeromodel/__init__.py
+++ b/zeromodel/__init__.py
@@ -13,6 +13,15 @@ from .learning import LEARNING_METRICS, LearningAssessment, LearningObservation,
 from .lua import POLICY_LUA_FORMAT, compiled_plan_id, lua_policy_source, write_lua_policy
 from .manifold import DecisionManifold, ManifoldFrame, ManifoldSummary, ManifoldTransition, build_decision_manifold, find_inflection_points
 from .metrics import CANONICAL_METRICS, metric_ids_for_rows, pack_metrics, score_table_from_metric_rows
+from .patterns import (
+    PATTERN_CHECKER_VERSION,
+    MatrixPatternDetector,
+    ObjectiveResult,
+    PatternAnalysisSpec,
+    PatternReport,
+    build_discovered_view,
+    detect_patterns,
+)
 from .phos import PHOSResult, guarded_pack_artifact, image_entropy, pack_artifact, phos_sort_pack, robust01, to_square, top_left_concentration
 from .policy_diagnostics import CRITICALITY_METRIC_ID, DECISION_MARGIN_METRIC_ID, with_q_diagnostics
 from .policy_lookup import POLICY_PLAN_VERSION, PolicyLookupDecision, SignReader, VPMPolicyLookup
@@ -51,9 +60,14 @@ __all__ = [
     "ManifoldFrame",
     "ManifoldSummary",
     "ManifoldTransition",
+    "MatrixPatternDetector",
+    "ObjectiveResult",
+    "PATTERN_CHECKER_VERSION",
     "PHOSResult",
     "POLICY_LUA_FORMAT",
     "POLICY_PLAN_VERSION",
+    "PatternAnalysisSpec",
+    "PatternReport",
     "Policy",
     "PolicyLookupDecision",
     "PolicyPropertyChecker",
@@ -86,6 +100,7 @@ __all__ = [
     "as_field",
     "build_critic_vpm",
     "build_decision_manifold",
+    "build_discovered_view",
     "build_learning_vpm",
     "build_optimized_view",
     "build_pyramid",
@@ -98,6 +113,7 @@ __all__ = [
     "critic_recipe",
     "decode_key_value_row_id",
     "default_controller",
+    "detect_patterns",
     "find_inflection_points",
     "from_bundle",
     "guarded_pack_artifact",

--- a/zeromodel/artifact.py
+++ b/zeromodel/artifact.py
@@ -249,8 +249,13 @@ class LayoutRecipe:
             raise VPMValidationError("LayoutRecipe requires normalization mapping")
 
         row_kind = row_order.get("kind")
-        if row_kind not in {"source", "lexicographic", "weighted_score"}:
+        if row_kind not in {"source", "lexicographic", "weighted_score", "explicit"}:
             raise VPMValidationError("Unsupported row_order kind: %r" % row_kind)
+        if row_kind == "explicit":
+            row_ids = row_order.get("row_ids")
+            if not isinstance(row_ids, tuple) or len(row_ids) == 0:
+                raise VPMValidationError("explicit row_order requires non-empty row_ids")
+            _validate_unique([str(row_id) for row_id in row_ids], "explicit row")
         if row_kind in {"lexicographic", "weighted_score"}:
             keys = row_order.get("keys") or row_order.get("metrics")
             if not isinstance(keys, tuple) or len(keys) == 0:
@@ -287,6 +292,13 @@ class LayoutRecipe:
     def validate_against(self, table: ScoreTable) -> None:
         row_order = self.data["row_order"]
         row_kind = row_order["kind"]
+        if row_kind == "explicit":
+            declared = tuple(str(row_id) for row_id in row_order["row_ids"])
+            if sorted(declared) != sorted(table.row_ids):
+                raise VPMValidationError(
+                    "explicit row_order must be a complete permutation of the "
+                    "table row_ids"
+                )
         if row_kind in {"lexicographic", "weighted_score"}:
             keys = row_order.get("keys") or row_order.get("metrics")
             for key in keys:
@@ -544,6 +556,11 @@ def _compile_row_order(table: ScoreTable, recipe: LayoutRecipe) -> Tuple[int, ..
     row_indices = tuple(range(len(table.row_ids)))
     if kind == "source":
         return row_indices
+    if kind == "explicit":
+        index_by_row_id = {row_id: index for index, row_id in enumerate(table.row_ids)}
+        return tuple(
+            index_by_row_id[str(row_id)] for row_id in row_order["row_ids"]
+        )
     keys = tuple(row_order.get("keys") or row_order.get("metrics"))
     if kind == "lexicographic":
         return tuple(

--- a/zeromodel/patterns.py
+++ b/zeromodel/patterns.py
@@ -1,0 +1,503 @@
+"""Bertin-inspired pattern discovery over VPM score matrices.
+
+This module searches for latent row structure inside a scored matrix instead of
+only rendering a declared layout. The design contract:
+
+1. Discovery may use numeric methods, but every published outcome is frozen:
+   the discovered ordering compiles into an explicit ``row_order`` recipe, so
+   the derived view artifact's identity depends on the outcome, never on
+   re-running the procedure.
+2. Confidence is calibrated against a selection-corrected null: the FULL
+   pipeline (ordering + every objective) runs on each null sample (independent
+   within-column permutations), and the family p-value compares the observed
+   maximum standardized statistic against the null distribution of maxima.
+3. Reports name structures numerically (orders, statistics, p-values). They do
+   not assert domain meaning; geometry is not meaning.
+
+Outputs are two linked artifacts:
+
+- a pattern-report artifact (``relation: analyzes`` parent), mirroring the
+  verification-report conventions in :mod:`zeromodel.policy_properties`;
+- a reordered view artifact (``relation: derived_from`` the analyzed artifact,
+  ``relation: ordered_by`` the report), built with the explicit row order.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .artifact import (
+    LayoutRecipe,
+    ScoreTable,
+    VPMArtifact,
+    VPMValidationError,
+    build_vpm,
+)
+
+PATTERN_CHECKER_VERSION = "bertin-pattern-detector/v1"
+PATTERN_METHOD = "spectral_seriation/v1"
+OBJECTIVE_IDS = ("adjacent_coherence", "anti_robinson")
+REPORT_METRICS = (
+    "observed",
+    "null_mean",
+    "null_std",
+    "z_score",
+    "p_value",
+    "family_p_value",
+)
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class PatternAnalysisSpec:
+    """Declares one deterministic pattern analysis.
+
+    ``null_samples`` and ``seed`` control only the calibration; the discovered
+    ordering itself is deterministic given the matrix and ``value_source``.
+    """
+
+    method: str = PATTERN_METHOD
+    objectives: Tuple[str, ...] = OBJECTIVE_IDS
+    value_source: str = "normalized"
+    null_samples: int = 200
+    seed: int = 0
+
+    def validate(self) -> None:
+        if self.method != PATTERN_METHOD:
+            raise VPMValidationError("Unsupported pattern method: %r" % self.method)
+        if self.value_source not in {"normalized", "raw"}:
+            raise VPMValidationError(
+                "value_source must be 'normalized' or 'raw', got %r"
+                % self.value_source
+            )
+        if not self.objectives:
+            raise VPMValidationError("At least one objective is required")
+        for objective in self.objectives:
+            if objective not in OBJECTIVE_IDS:
+                raise VPMValidationError("Unknown objective: %r" % objective)
+        if len(set(self.objectives)) != len(self.objectives):
+            raise VPMValidationError("Objectives must be unique")
+        if self.null_samples < 1:
+            raise VPMValidationError("null_samples must be positive")
+        if self.seed < 0:
+            raise VPMValidationError("seed must be non-negative")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "method": self.method,
+            "objectives": list(self.objectives),
+            "value_source": self.value_source,
+            "null_samples": int(self.null_samples),
+            "seed": int(self.seed),
+        }
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(_canonical_json_bytes(self.to_dict())).hexdigest()
+
+
+@dataclass(frozen=True)
+class ObjectiveResult:
+    objective_id: str
+    observed: float
+    null_mean: float
+    null_std: float
+    z_score: float
+    p_value: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "objective_id": self.objective_id,
+            "observed": self.observed,
+            "null_mean": self.null_mean,
+            "null_std": self.null_std,
+            "z_score": self.z_score,
+            "p_value": self.p_value,
+        }
+
+
+@dataclass(frozen=True)
+class PatternReport:
+    """Frozen outcome of one pattern analysis over one artifact."""
+
+    analyzed_artifact_id: str
+    spec: PatternAnalysisSpec
+    row_order: Tuple[str, ...]
+    objective_results: Tuple[ObjectiveResult, ...]
+    family_p_value: float
+    degenerate: bool
+    checker_version: str = PATTERN_CHECKER_VERSION
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.spec.validate()
+        if not self.analyzed_artifact_id:
+            raise VPMValidationError("PatternReport requires analyzed_artifact_id")
+        if not self.row_order:
+            raise VPMValidationError("PatternReport requires a non-empty row_order")
+        if len(set(self.row_order)) != len(self.row_order):
+            raise VPMValidationError("PatternReport row_order must be unique")
+        if not self.objective_results:
+            raise VPMValidationError("PatternReport requires objective results")
+        if not np.isfinite(float(self.family_p_value)):
+            raise VPMValidationError("PatternReport family_p_value must be finite")
+        if not (0.0 <= float(self.family_p_value) <= 1.0):
+            raise VPMValidationError("PatternReport family_p_value must be in [0, 1]")
+        _canonical_json_bytes(dict(self.metadata))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "checker_version": self.checker_version,
+            "analyzed_artifact_id": self.analyzed_artifact_id,
+            "spec": self.spec.to_dict(),
+            "spec_digest": self.spec.digest,
+            "row_order": list(self.row_order),
+            "objectives": [result.to_dict() for result in self.objective_results],
+            "family_p_value": self.family_p_value,
+            "degenerate": self.degenerate,
+            "metadata": dict(self.metadata),
+        }
+
+    @property
+    def significant(self) -> bool:
+        """Whether the family-level null test rejects at alpha=0.05."""
+
+        return (not self.degenerate) and self.family_p_value <= 0.05
+
+    @property
+    def primary_objective(self) -> str:
+        """Return the objective with the largest standardized observed effect."""
+
+        return max(
+            self.objective_results,
+            key=lambda result: (float(result.z_score), result.objective_id),
+        ).objective_id
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(_canonical_json_bytes(self.to_dict())).hexdigest()
+
+    def to_vpm(self) -> VPMArtifact:
+        """Materialize this report as an identity-bearing pattern artifact."""
+
+        values = [
+            (
+                result.observed,
+                result.null_mean,
+                result.null_std,
+                result.z_score,
+                result.p_value,
+                self.family_p_value,
+            )
+            for result in self.objective_results
+        ]
+        table = ScoreTable(
+            values=values,
+            row_ids=[result.objective_id for result in self.objective_results],
+            metric_ids=list(REPORT_METRICS),
+            metadata={
+                "kind": "pattern_report",
+                "analyzed_artifact_id": self.analyzed_artifact_id,
+                "checker_version": self.checker_version,
+                "pattern_spec_digest": self.spec.digest,
+                "report": self.to_dict(),
+            },
+        )
+        recipe = LayoutRecipe.from_dict(
+            {
+                "version": "vpm-layout/0",
+                "name": "pattern-report-source-order",
+                "row_order": {"kind": "source", "tie_break": "row_id"},
+                "column_order": {"kind": "source"},
+                "normalization": {"kind": "per_metric_minmax", "clip": True},
+            }
+        )
+        return build_vpm(
+            table,
+            recipe,
+            provenance={
+                "kind": "pattern_report",
+                "checker": self.checker_version,
+                "pattern_spec_digest": self.spec.digest,
+                "parents": [
+                    {
+                        "artifact_id": self.analyzed_artifact_id,
+                        "relation": "analyzes",
+                    }
+                ],
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic spectral seriation
+# ---------------------------------------------------------------------------
+
+def _source_matrix(artifact: VPMArtifact, value_source: str) -> np.ndarray:
+    values = np.asarray(artifact.source.values, dtype=np.float64)
+    if value_source == "raw":
+        return values
+    lo = values.min(axis=0, keepdims=True)
+    hi = values.max(axis=0, keepdims=True)
+    span = np.where(hi > lo, hi - lo, 1.0)
+    return np.clip((values - lo) / span, 0.0, 1.0)
+
+
+def _pairwise_distances(matrix: np.ndarray) -> np.ndarray:
+    squared = np.sum(matrix**2, axis=1)
+    gram = matrix @ matrix.T
+    distances = squared[:, None] + squared[None, :] - 2.0 * gram
+    np.maximum(distances, 0.0, out=distances)
+    return np.sqrt(distances)
+
+
+def _spectral_order(
+    matrix: np.ndarray, row_ids: Sequence[str]
+) -> Tuple[Tuple[int, ...], bool]:
+    """Order rows by the Fiedler vector of the similarity Laplacian.
+
+    Deterministic: symmetric ``eigh``, canonical sign fixing (first component
+    above tolerance made positive), and ``row_id`` tie-breaking on plateaus.
+    Returns (source-index order, degenerate flag).
+    """
+
+    n = matrix.shape[0]
+    identity_order = tuple(range(n))
+    if n <= 2:
+        return identity_order, True
+    distances = _pairwise_distances(matrix)
+    max_distance = float(distances.max())
+    if max_distance <= 0.0:
+        return identity_order, True
+    similarity = max_distance - distances
+    np.fill_diagonal(similarity, 0.0)
+    laplacian = np.diag(similarity.sum(axis=1)) - similarity
+    _, eigenvectors = np.linalg.eigh(laplacian)
+    fiedler = eigenvectors[:, 1]
+    above_tolerance = np.flatnonzero(np.abs(fiedler) > 1e-12)
+    if above_tolerance.size == 0:
+        return identity_order, True
+    if fiedler[above_tolerance[0]] < 0.0:
+        fiedler = -fiedler
+    order = tuple(
+        sorted(range(n), key=lambda index: (float(fiedler[index]), row_ids[index]))
+    )
+    return order, False
+
+
+# ---------------------------------------------------------------------------
+# Structural objectives (higher = more structure)
+# ---------------------------------------------------------------------------
+
+def _adjacent_coherence(ordered_matrix: np.ndarray) -> float:
+    """Negative mean squared difference between vertically adjacent cells."""
+
+    if ordered_matrix.shape[0] < 2:
+        return 0.0
+    deltas = np.diff(ordered_matrix, axis=0)
+    return -float(np.mean(deltas**2))
+
+
+def _inversions(vector: np.ndarray) -> int:
+    if vector.size < 2:
+        return 0
+    return int(np.sum(np.triu(vector[:, None] > vector[None, :], k=1)))
+
+
+def _anti_robinson(ordered_distances: np.ndarray) -> float:
+    """Negative count of anti-Robinson events in the ordered distance matrix."""
+
+    n = ordered_distances.shape[0]
+    events = 0
+    for i in range(n - 2):
+        events += _inversions(ordered_distances[i, i + 1 :])
+    for k in range(2, n):
+        events += _inversions(ordered_distances[:k, k][::-1])
+    return -float(events)
+
+
+def _score_arrangement(
+    matrix: np.ndarray,
+    order: Sequence[int],
+    objectives: Sequence[str],
+) -> Dict[str, float]:
+    ordered = matrix[np.asarray(order, dtype=int)]
+    scores: Dict[str, float] = {}
+    if "adjacent_coherence" in objectives:
+        scores["adjacent_coherence"] = _adjacent_coherence(ordered)
+    if "anti_robinson" in objectives:
+        scores["anti_robinson"] = _anti_robinson(_pairwise_distances(ordered))
+    return scores
+
+
+def _run_pipeline(
+    matrix: np.ndarray,
+    row_ids: Sequence[str],
+    objectives: Sequence[str],
+) -> Tuple[Tuple[int, ...], Dict[str, float], bool]:
+    order, degenerate = _spectral_order(matrix, row_ids)
+    return order, _score_arrangement(matrix, order, objectives), degenerate
+
+
+# ---------------------------------------------------------------------------
+# Selection-corrected null calibration
+# ---------------------------------------------------------------------------
+
+def detect_patterns(
+    artifact: VPMArtifact,
+    spec: Optional[PatternAnalysisSpec] = None,
+) -> PatternReport:
+    """Run pattern discovery with selection-corrected null calibration.
+
+    Every null sample destroys joint row structure with independent
+    within-column permutations while preserving column marginals, then runs
+    the complete discovery pipeline, so the observed statistics are compared
+    against nulls that received the same optimization opportunity.
+    """
+
+    spec = spec or PatternAnalysisSpec()
+    spec.validate()
+    artifact.validate()
+
+    matrix = _source_matrix(artifact, spec.value_source)
+    row_ids = artifact.source.row_ids
+    order, observed_scores, degenerate = _run_pipeline(
+        matrix, row_ids, spec.objectives
+    )
+
+    rng = np.random.default_rng(spec.seed)
+    null_scores: Dict[str, list] = {objective: [] for objective in spec.objectives}
+    null_row_ids = tuple("null:%06d" % index for index in range(matrix.shape[0]))
+    for _ in range(spec.null_samples):
+        null_matrix = np.empty_like(matrix)
+        for column in range(matrix.shape[1]):
+            null_matrix[:, column] = matrix[
+                rng.permutation(matrix.shape[0]), column
+            ]
+        _, scores, _ = _run_pipeline(null_matrix, null_row_ids, spec.objectives)
+        for objective, score in scores.items():
+            null_scores[objective].append(score)
+
+    results = []
+    observed_z: Dict[str, float] = {}
+    null_z_rows = np.zeros((spec.null_samples, len(spec.objectives)))
+    for column_index, objective in enumerate(spec.objectives):
+        null_values = np.asarray(null_scores[objective], dtype=np.float64)
+        null_mean = float(null_values.mean())
+        null_std = float(null_values.std())
+        safe_std = null_std if null_std > 0.0 else 1.0
+        observed = float(observed_scores[objective])
+        z_score = (observed - null_mean) / safe_std
+        exceed = int(np.sum(null_values >= observed))
+        p_value = (1.0 + exceed) / (1.0 + spec.null_samples)
+        observed_z[objective] = z_score
+        null_z_rows[:, column_index] = (null_values - null_mean) / safe_std
+        results.append(
+            ObjectiveResult(
+                objective_id=objective,
+                observed=observed,
+                null_mean=null_mean,
+                null_std=null_std,
+                z_score=z_score,
+                p_value=p_value,
+            )
+        )
+
+    observed_max_z = max(observed_z.values())
+    null_max_z = null_z_rows.max(axis=1)
+    family_exceed = int(np.sum(null_max_z >= observed_max_z))
+    family_p = (1.0 + family_exceed) / (1.0 + spec.null_samples)
+
+    return PatternReport(
+        analyzed_artifact_id=artifact.artifact_id,
+        spec=spec,
+        row_order=tuple(row_ids[index] for index in order),
+        objective_results=tuple(results),
+        family_p_value=family_p,
+        degenerate=degenerate,
+    )
+
+
+class MatrixPatternDetector:
+    """Configured Bertin-inspired detector over immutable VPM artifacts.
+
+    The detector is intentionally compile-time analysis. It does not change
+    runtime policy semantics. ``detect`` returns a frozen report; ``build_view``
+    compiles that report's explicit ordering into a normal VPM artifact.
+    """
+
+    def __init__(self, spec: Optional[PatternAnalysisSpec] = None) -> None:
+        self.spec = spec or PatternAnalysisSpec()
+        self.spec.validate()
+
+    def detect(self, artifact: VPMArtifact) -> PatternReport:
+        return detect_patterns(artifact, self.spec)
+
+    def build_view(
+        self,
+        artifact: VPMArtifact,
+        report: Optional[PatternReport] = None,
+        *,
+        name: str = "bertin-discovered-order",
+    ) -> VPMArtifact:
+        resolved = report or self.detect(artifact)
+        return build_discovered_view(artifact, resolved, name=name)
+
+
+def build_discovered_view(
+    artifact: VPMArtifact,
+    report: PatternReport,
+    *,
+    name: str = "bertin-discovered-order",
+) -> VPMArtifact:
+    """Compile the report's discovered ordering into a frozen view artifact.
+
+    The view's identity depends on the explicit ordering outcome recorded in
+    the report, never on re-running the discovery procedure.
+    """
+
+    if report.analyzed_artifact_id != artifact.artifact_id:
+        raise VPMValidationError(
+            "Report analyzes artifact %s, not %s"
+            % (report.analyzed_artifact_id, artifact.artifact_id)
+        )
+    recipe = LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": name,
+            "row_order": {
+                "kind": "explicit",
+                "row_ids": list(report.row_order),
+                "tie_break": "row_id",
+            },
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+    return build_vpm(
+        artifact.source,
+        recipe,
+        provenance={
+            "kind": "pattern_discovered_view",
+            "pattern_spec_digest": report.spec.digest,
+            "pattern_report_digest": report.digest,
+            "parents": [
+                {"artifact_id": artifact.artifact_id, "relation": "derived_from"},
+                {"artifact_id": report.to_vpm().artifact_id, "relation": "ordered_by"},
+            ],
+        },
+    )


### PR DESCRIPTION
## Summary

This PR adds a deliberately narrow Bertin-inspired pattern-discovery experiment over immutable VPM score matrices.

### Detector

- one NumPy-only deterministic spectral-seriation method
- two explicit numeric objectives: adjacent coherence and anti-Robinson structure
- independent within-column permutation nulls that preserve metric marginals while destroying joint row structure
- the **complete discovery pipeline** reruns on every null sample
- family-level max-statistic calibration across the declared objectives
- raw or normalized analysis semantics
- explicit degeneracy handling

### Frozen artifact outputs

- a pattern-report VPM linked to the exact analyzed artifact with `relation: analyzes`
- a discovered-view VPM linked to the source and report with `derived_from` and `ordered_by`
- a new explicit row-order recipe that requires a complete permutation of stable row IDs
- analysis specification digest, method/checker version, null seed/count, objective statistics, p-values and family p-value

### Validation

The committed tests cover:

- planted block-structure recovery
- selected pure-noise rejection
- constant-matrix degeneracy
- deterministic report and view identity
- calibration-seed versus frozen-order separation
- report/view lineage
- `.vpm` round trips
- incomplete explicit-order rejection
- mismatched artifact/report rejection

The example can write the source, report and discovered view as `.vpm` bundles plus a PNG rendering.

## Boundaries

This is **Research / synthetic-fixture validation**. It does not yet claim:

- general matrix-pattern discovery
- biclustering
- anomaly or policy-regime interpretation
- semantic meaning from geometry
- column seriation
- human-inspection improvement
- real-world validation
- superiority over established seriation or clustering tools

The next gate is a generated benchmark across signal strengths, random seeds, noise matrices, runtime sizes and a conventional baseline. The feature should be reconsidered if false-positive calibration fails or planted recovery does not beat simple baselines.

The public blog is intentionally unchanged in this PR.