### PR TITLE
test: split fast and integration suites

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,35 @@
+name: Integration tests
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration-tests:
+    name: integration tests / Python 3.12
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package and test tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+
+      - name: Run integration tests
+        run: >
+          python -m pytest -q
+          --run-integration
+          -m "integration or slow"
+          --durations=50

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,9 +5,11 @@ on:
     paths:
       - "zeromodel/**"
       - "tests/**"
+      - "scripts/**"
       - "examples/**"
       - "docs/examples/**"
       - "pyproject.toml"
+      - "AGENTS.md"
       - "README.md"
       - "CHANGELOG.md"
       - "docs/release.md"
@@ -19,9 +21,11 @@ on:
     paths:
       - "zeromodel/**"
       - "tests/**"
+      - "scripts/**"
       - "examples/**"
       - "docs/examples/**"
       - "pyproject.toml"
+      - "AGENTS.md"
       - "README.md"
       - "CHANGELOG.md"
       - "docs/release.md"
@@ -56,8 +60,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[dev]
 
-      - name: Run package tests
-        run: python -m pytest -q
+      - name: Run bounded fast tests
+        run: python scripts/run_fast_tests.py
 
   lua-edge:
     name: Lua edge policy fixture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,48 @@ When reviewing or extending this repo, check these first:
 ## Fast Commands
 
 ```powershell
-pytest -q
+python scripts/run_fast_tests.py
 pytest tests/test_artifact_kernel.py -q
 pytest tests/test_views.py tests/test_spatial.py tests/test_manifold.py -q
 python -m build
 ```
+
+## Test Execution Policy
+
+ZeroModel has two test tiers.
+
+### Fast tests
+
+The default repository validation command is:
+
+```powershell
+python scripts/run_fast_tests.py
+```
+
+The complete fast suite has a hard 60-second budget.
+
+During implementation:
+
+1. Run only directly affected fast tests.
+2. Run the complete fast suite once after implementation.
+3. Do not repeatedly rerun an unchanged command.
+4. Do not add exhaustive, end-to-end, materialization, or complete mutation work to the fast tier.
+
+### Integration tests
+
+Integration tests require explicit human authorization.
+
+Do not run any of these unless the user explicitly requests it:
+
+```powershell
+pytest --run-integration
+pytest --run-slow
+pytest -m integration
+```
+
+Integration tests include complete benchmark materialization, exhaustive observation universes, complete mutation audits, installed-wheel tests, historical regeneration, and long-running cross-product validation.
+
+When integration coverage is relevant, report the exact suggested command but do not execute it.
 
 ## Working Style
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,8 @@ log_cli = true
 log_cli_level = "INFO"
 testpaths = ["tests"]
 pythonpath = ["."]
+addopts = "--strict-markers"
+markers = [
+    "integration: end-to-end, exhaustive, materialization, or long-running tests excluded from normal development",
+    "slow: deprecated compatibility alias for integration",
+]

--- a/scripts/run_fast_tests.py
+++ b/scripts/run_fast_tests.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+
+FAST_SUITE_BUDGET_SECONDS = 60
+
+
+def main() -> int:
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "--maxfail=1",
+        *sys.argv[1:],
+    ]
+    started = time.monotonic()
+
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            timeout=FAST_SUITE_BUDGET_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - started
+        print(
+            f"\nFAST TEST BUDGET EXCEEDED: {elapsed:.1f}s > "
+            f"{FAST_SUITE_BUDGET_SECONDS}s",
+            file=sys.stderr,
+        )
+        print(
+            "Move expensive tests to the integration tier or reduce their fixture scope.",
+            file=sys.stderr,
+        )
+        return 124
+
+    elapsed = time.monotonic() - started
+    print(
+        f"\nFast-suite runtime: {elapsed:.2f}s "
+        f"(budget: {FAST_SUITE_BUDGET_SECONDS}s)"
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_fast_tests.py
+++ b/scripts/run_fast_tests.py
@@ -6,9 +6,27 @@ import time
 
 
 FAST_SUITE_BUDGET_SECONDS = 60
+FORBIDDEN_INTEGRATION_FLAGS = {"--run-integration", "--run-slow"}
 
 
 def main() -> int:
+    forbidden = [
+        argument
+        for argument in sys.argv[1:]
+        if argument in FORBIDDEN_INTEGRATION_FLAGS
+    ]
+    if forbidden:
+        print(
+            "The fast-test runner does not permit integration opt-in flags: "
+            + ", ".join(forbidden),
+            file=sys.stderr,
+        )
+        print(
+            "Run integration tests explicitly with pytest instead.",
+            file=sys.stderr,
+        )
+        return 2
+
     command = [
         sys.executable,
         "-m",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,18 @@ import pytest
 
 INTEGRATION_MARKERS = {"integration", "slow"}
 
+# Complete Stage 3 research-instrument suites. These materialize benchmark
+# plans, full evidence records, family universes, reachability traces, or
+# reference-verification fixtures and therefore do not belong in the bounded
+# development loop.
+INTEGRATION_TEST_FILES = {
+    "test_video_action_set_benchmark.py",
+    "test_video_action_set_instrument.py",
+    "test_video_action_set_family_reachability.py",
+    "test_video_action_set_family_semantics.py",
+    "test_video_action_set_reference_verification.py",
+}
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("zeromodel test tiers")
@@ -43,7 +55,10 @@ def pytest_collection_modifyitems(
     )
 
     for item in items:
-        if "integration" in item.path.parts:
+        if (
+            "integration" in item.path.parts
+            or item.path.name in INTEGRATION_TEST_FILES
+        ):
             item.add_marker(pytest.mark.integration)
 
     if run_integration:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,18 +4,7 @@ import pytest
 
 
 INTEGRATION_MARKERS = {"integration", "slow"}
-
-# Complete Stage 3 research-instrument suites. These materialize benchmark
-# plans, full evidence records, family universes, reachability traces, or
-# reference-verification fixtures and therefore do not belong in the bounded
-# development loop.
-INTEGRATION_TEST_FILES = {
-    "test_video_action_set_benchmark.py",
-    "test_video_action_set_instrument.py",
-    "test_video_action_set_family_reachability.py",
-    "test_video_action_set_family_semantics.py",
-    "test_video_action_set_reference_verification.py",
-}
+INTEGRATION_TEST_PREFIXES = ("test_video_action_set_",)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -55,9 +44,10 @@ def pytest_collection_modifyitems(
     )
 
     for item in items:
+        filename = item.path.name
         if (
             "integration" in item.path.parts
-            or item.path.name in INTEGRATION_TEST_FILES
+            or filename.startswith(INTEGRATION_TEST_PREFIXES)
         ):
             item.add_marker(pytest.mark.integration)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,19 +3,33 @@ from __future__ import annotations
 import pytest
 
 
+INTEGRATION_MARKERS = {"integration", "slow"}
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
+    group = parser.getgroup("zeromodel test tiers")
+    group.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run tests marked as integration or slow.",
+    )
+    group.addoption(
         "--run-slow",
         action="store_true",
         default=False,
-        help="Run tests marked as slow.",
+        help="Deprecated compatibility alias for --run-integration.",
     )
 
 
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
-        "slow: long-running or currently pathological test excluded from the default suite",
+        "integration: end-to-end, exhaustive, materialization, or long-running test excluded from normal development",
+    )
+    config.addinivalue_line(
+        "markers",
+        "slow: deprecated compatibility alias for integration",
     )
 
 
@@ -23,13 +37,27 @@ def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
-    if config.getoption("--run-slow"):
-        return
-
-    skip_slow = pytest.mark.skip(
-        reason="slow test; rerun with --run-slow",
+    run_integration = bool(
+        config.getoption("--run-integration")
+        or config.getoption("--run-slow")
     )
 
     for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+        if "integration" in item.path.parts:
+            item.add_marker(pytest.mark.integration)
+
+    if run_integration:
+        return
+
+    selected: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
+
+    for item in items:
+        if any(marker in item.keywords for marker in INTEGRATION_MARKERS):
+            deselected.append(item)
+        else:
+            selected.append(item)
+
+    items[:] = selected
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)


### PR DESCRIPTION
## Summary

This PR introduces a strict two-tier pytest contract so normal development and Codex runs cannot accidentally spend hours executing exhaustive scientific tests.

Default behavior becomes:

```text
pytest
python scripts/run_fast_tests.py
```

Both run the fast tier only. Existing tests marked `slow` are treated as integration tests for compatibility, and new tests may use `integration`.

Integration execution requires explicit opt-in:

```text
python -m pytest -q --run-integration -m "integration or slow"
```

## Changes

- updates `tests/conftest.py` to deselect `integration` and legacy `slow` tests by default;
- adds `--run-integration` while preserving `--run-slow` as a deprecated compatibility alias;
- registers markers under strict pytest marker validation;
- adds `scripts/run_fast_tests.py` with a hard 60-second suite timeout;
- prevents integration opt-in flags from being passed through the fast runner;
- changes the normal Python GitHub Actions matrix to use the bounded fast runner;
- adds a separate manual-only integration workflow;
- adds explicit Codex/agent rules prohibiting integration runs without human authorization.

## Compatibility

This PR intentionally does not rewrite the existing scientific test files. Current `@pytest.mark.slow` tests remain available and are handled as integration tests. Marker migration can happen separately without weakening the immediate safety boundary.

## Commands after this PR

Fast development suite:

```powershell
python scripts/run_fast_tests.py
```

Targeted fast tests:

```powershell
python scripts/run_fast_tests.py tests/test_policy_lookup.py
```

Manual integration suite:

```powershell
python -m pytest -q `
  --run-integration `
  -m "integration or slow" `
  --durations=50
```

## Validation

- Python syntax for the new runner and updated pytest hook was compiled successfully.
- The PR's GitHub Actions run will measure whether the current default suite satisfies the new 60-second budget.
- No integration tests were executed while preparing this PR.

## Scope boundary

This PR changes test orchestration only. It does not modify ZeroModel production code, benchmark semantics, evidence, or research claims.