### PR TITLE
refactor: add episode-plan RMDTO aggregate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,13 @@ When integration coverage is relevant, report the exact suggested command but do
 - Do not add database creation at import time.
 - Do not combine structural extraction with scientific behavior changes.
 - Do not add new legacy quality exceptions for extracted modules.
+- New durable aggregates require DTO, Store protocol, in-memory Store, SQL Store, and focused tests.
+- Nested values become separate ORM tables only when they require independent query, lifecycle, integrity, or deduplication.
+- Canonical JSON payloads must be validated through DTO reconstruction when read from persistence.
+- Stores must not repair or normalize conflicting scientific records.
+- Batch Store writes must be atomic.
+- A behavior-preserving extraction must reduce the corresponding monolith quality ceiling.
+- Integration-tier persistence tests may be authored but must not be executed without explicit human authorization.
 
 ## Working Style
 

--- a/docs/architecture/video-action-set-rmdto.md
+++ b/docs/architecture/video-action-set-rmdto.md
@@ -1,7 +1,8 @@
 # Video Action-Set RMDTO Slice
 
-This PR implements only the benchmark identity aggregate for the video action-set
-domain.
+This document describes the RMDTO boundary for the video action-set domain. The
+first slice introduced the benchmark identity aggregate; the second slice adds
+episode plans and the sealed final split-plan envelope.
 
 The dependency path is:
 
@@ -67,11 +68,51 @@ directly rather than storing a JSON copy of the DTO. Not every nested value in
 future aggregates should become an ORM table; relational structure should be
 introduced only where it supports query, integrity, or lifecycle needs.
 
+## Episode-Plan Aggregate
+
+The aggregate ownership chain is:
+
+```text
+BenchmarkIdentity
+    -> EpisodePlan
+    -> SealedFinalSplitPlan
+```
+
+An episode plan cannot be stored until its benchmark identity exists. The root
+seed digest in the plan seed lineage is persistence metadata derived from the
+plan contract, so the Store uses it to enforce ownership without adding a new
+serialized plan field.
+
+Individual episode plans have queryable ORM columns for seed digest, split,
+ordinal, family, disposition, source rows, derived seed identity, frame count,
+and plan digest. Those fields support deterministic listing and integrity
+checks. Nested frame plans, seed lineage, family contracts, and family
+interventions remain canonical JSON because they do not yet have independent
+query, lifecycle, integrity, or deduplication requirements.
+
+The sealed final split-plan row stores only the envelope metadata, counts, ID
+manifest, and sealed digest. It does not duplicate every episode payload. The
+SQL Store reconstructs the sealed DTO by reading the envelope row and episode
+rows for the same seed and split, ordered by ordinal and episode ID, then
+validating the reconstructed DTO digest.
+
+The legacy generator remains authoritative for the scientific plan derivation in
+this slice. It still chooses source rows, derives seeds, constructs family
+interventions, plans frames, and validates deterministic regeneration. The RMDTO
+boundary records and validates the deterministic plan contract so those concerns
+can be extracted later behind the same Store and Runtime surface.
+
+Final materialization remains prohibited. The sealed final split-plan is a
+plan-only artifact; persistence does not make final observations renderable,
+scorable, or materialized.
+
+Persistence records the deterministic plan contract; it does not become the
+authority that invents or repairs scientific plans.
+
 ## Future aggregates
 
 Future slices can add DTOs, Stores, and persistence mappings for:
 
-- episode plans;
 - observations and MatrixBlob references;
 - operation chains;
 - verification reports;

--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -9,7 +9,7 @@ maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
 reason = "Stage 3 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 5966
+maximum_lines = 5957
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -8,14 +8,22 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_ROOT = REPO_ROOT / "zeromodel"
 VIDEO_ACTION_SET_PREFIX = "zeromodel.video_action_set"
+VIDEO_ACTION_SET_BENCHMARK_MODULE = "zeromodel.video_action_set_benchmark"
 DOMAIN_VIDEO_ACTION_SET_PREFIX = "zeromodel.domains.video_action_set"
 DB_ORM_PREFIX = "zeromodel.db.orm"
 DB_STORES_PREFIX = "zeromodel.db.stores"
 VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
+    "zeromodel.domains.video_action_set.episode_plan_service",
     "zeromodel.domains.video_action_set.identity_service",
     "zeromodel.domains.video_action_set.engine",
     "zeromodel.domains.video_action_set.facade",
     "zeromodel.runtime",
+}
+VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
+    "zeromodel.domains.video_action_set.canonical_json",
+    "zeromodel.domains.video_action_set.contracts",
+    "zeromodel.domains.video_action_set.dto",
+    "zeromodel.domains.video_action_set.episode_plan_service",
 }
 VIDEO_ACTION_SET_POLICY_MODULES = {
     f"{VIDEO_ACTION_SET_PREFIX}.contracts",
@@ -347,6 +355,25 @@ def rmdto_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
                 edge,
             )
         )
+    if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
+        edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+    ):
+        violations.append(
+            edge_violation(
+                "video_action_set domain modules must not import legacy benchmark",
+                edge,
+            )
+        )
+    if edge.importer in VIDEO_ACTION_SET_PURE_DOMAIN_MODULES and (
+        is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+    ):
+        violations.append(
+            edge_violation(
+                "video_action_set DTO, contracts, and Services must not import runtime layers",
+                edge,
+            )
+        )
     if edge.importer == "zeromodel.runtime" and (
         is_module_under(edge.imported, "zeromodel.db")
         or is_sqlalchemy_import(edge.imported)
@@ -359,19 +386,21 @@ def rmdto_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
         )
     if is_module_under(edge.importer, DB_ORM_PREFIX) and (
         edge.imported in VIDEO_ACTION_SET_ORCHESTRATION_MODULES
+        or edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
     ):
         violations.append(
             edge_violation(
-                "ORM modules must not import Services, Engines, Facades, or Runtime",
+                "ORM modules must not import Services, Engines, Facades, Runtime, or legacy benchmark",
                 edge,
             )
         )
     if is_module_under(edge.importer, DB_STORES_PREFIX) and (
         edge.imported in VIDEO_ACTION_SET_ORCHESTRATION_MODULES
+        or edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
     ):
         violations.append(
             edge_violation(
-                "database Store implementations must not import orchestration layers",
+                "database Store implementations must not import orchestration or legacy benchmark layers",
                 edge,
             )
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 
 INTEGRATION_MARKERS = {"integration", "slow"}
+INTEGRATION_TEST_FILES = {"test_video_episode_plan_sql_store.py"}
 INTEGRATION_TEST_PREFIXES = ("test_video_action_set_",)
 INTEGRATION_TEST_FILES = {
     "test_arcade_visual_local_baseline_showdown.py",
@@ -57,14 +58,14 @@ def pytest_collection_modifyitems(
     items: list[pytest.Item],
 ) -> None:
     run_integration = bool(
-        config.getoption("--run-integration")
-        or config.getoption("--run-slow")
+        config.getoption("--run-integration") or config.getoption("--run-slow")
     )
 
     for item in items:
         filename = item.path.name
         if (
             "integration" in item.path.parts
+            or filename in INTEGRATION_TEST_FILES
             or filename.startswith(INTEGRATION_TEST_PREFIXES)
             or filename in INTEGRATION_TEST_FILES
         ):

--- a/tests/test_video_episode_plan_rmdto.py
+++ b/tests/test_video_episode_plan_rmdto.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import FrozenInstanceError
+import hashlib
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel import build_runtime
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.canonical_json import (
+    canonical_json_bytes,
+    canonical_json_text,
+    canonical_sha256,
+)
+from zeromodel.domains.video_action_set.contracts import (
+    BENCHMARK_VERSION,
+    EPISODE_PLAN_VERSION,
+    GENERATOR_VERSION,
+    SEED_DERIVATION_VERSION,
+)
+from zeromodel.domains.video_action_set.dto import (
+    BenchmarkIdentityDTO,
+    CanonicalJsonDTO,
+    EpisodePlanDTO,
+    SealedSplitPlanDTO,
+)
+from zeromodel.domains.video_action_set.store import (
+    EPISODE_PLAN_CONFLICT_MESSAGE,
+    SEALED_SPLIT_PLAN_CONFLICT_MESSAGE,
+    UNKNOWN_BENCHMARK_IDENTITY_MESSAGE,
+)
+from zeromodel.stores.video_action_set_memory import InMemoryVideoActionSetStore
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def sample_identity(
+    seed_material: str = "episode-plan-rmdto-seed",
+) -> BenchmarkIdentityDTO:
+    seed_digest = "sha256:" + hashlib.sha256(seed_material.encode("utf-8")).hexdigest()
+    return BenchmarkIdentityDTO(
+        contract_commit="aed523b04c258d7e28cd9466413b49fc817b4e35",
+        seed_material=seed_material,
+        seed_digest=seed_digest,
+        policy_artifact_id="policy-artifact",
+        parent_audit_sha="parent-audit",
+        parent_v3_sha="parent-v3",
+    )
+
+
+def _seed_int_from_digest(digest: str) -> int:
+    return int(digest.removeprefix("sha256:")[:16], 16)
+
+
+def _seed_node(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    namespace: str,
+    parents: tuple[tuple[str, str], ...],
+) -> dict[str, Any]:
+    payload = {
+        "version": SEED_DERIVATION_VERSION,
+        "root_seed_digest": identity.seed_digest,
+        "split": split,
+        "episode_ordinal": ordinal,
+        "namespace": namespace,
+        "parent_identities": [
+            {"name": name, "identity": value} for name, value in parents
+        ],
+    }
+    digest = canonical_sha256(payload)
+    return payload | {
+        "seed_digest": digest,
+        "seed_int64": _seed_int_from_digest(digest),
+    }
+
+
+def _observation_provenance(split: str) -> dict[str, Any]:
+    if split == "final":
+        return {
+            "materialization_status": "prospective_materialization_prohibited",
+            "observation_payload_included": False,
+            "provenance": "sealed_plan_only",
+        }
+    return {
+        "materialization_status": "materialized",
+        "observation_payload_included": True,
+        "provenance": "in_memory_generation",
+    }
+
+
+def sample_plan_payload(
+    identity: BenchmarkIdentityDTO | None = None,
+    *,
+    split: str = "final",
+    ordinal: int = 0,
+    family_label: str = "valid",
+    family_ordinal: int = 0,
+    frame_count: int = 2,
+    source_row_id: str = "row:source",
+    mutation_kind: str | None = None,
+    secondary_row_id: str | None = None,
+) -> dict[str, Any]:
+    identity = identity or sample_identity()
+    episode_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="concrete_episode_seed",
+        parents=(
+            ("benchmark_version", BENCHMARK_VERSION),
+            ("generator_version", GENERATOR_VERSION),
+            ("family_label", family_label),
+            ("family_ordinal", str(family_ordinal)),
+            ("source_row_id", source_row_id),
+            ("secondary_row_id", secondary_row_id or "none"),
+            ("mutation_kind", mutation_kind or "none"),
+            ("frame_count", str(frame_count)),
+        ),
+    )
+    contract = {"family_label": family_label, "family_version": "test-family/v1"}
+    intervention = {
+        "source_row_id": source_row_id,
+        "secondary_row_id": secondary_row_id,
+        "mutation_kind": mutation_kind,
+    }
+    intervention = intervention | {
+        "intervention_digest": canonical_sha256(intervention)
+    }
+    episode_id_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="concrete_episode_id",
+        parents=(
+            ("concrete_episode_seed", episode_seed["seed_digest"]),
+            ("family_contract", contract["family_version"]),
+            ("family_intervention", intervention["intervention_digest"]),
+        ),
+    )
+    frame_plans = [
+        {
+            "frame_index": index,
+            "frame_seed_identity": _seed_node(
+                identity,
+                split=split,
+                ordinal=ordinal,
+                namespace="frame_identity",
+                parents=(
+                    ("concrete_episode_seed", episode_seed["seed_digest"]),
+                    ("frame_index", str(index)),
+                ),
+            )["seed_digest"],
+            "transformation_family": "exact",
+        }
+        for index in range(frame_count)
+    ]
+    plan = {
+        "version": EPISODE_PLAN_VERSION,
+        "seed_derivation_version": SEED_DERIVATION_VERSION,
+        "episode_id": f"{split}:{family_label}:{episode_id_seed['seed_digest'][7:23]}",
+        "split": split,
+        "ordinal": ordinal,
+        "family_label": family_label,
+        "family_ordinal": family_ordinal,
+        "episode_family": family_label,
+        "episode_disposition": family_label,
+        "denominator_class": family_label,
+        "final_observation_provenance": _observation_provenance(split),
+        "mutation_kind": mutation_kind,
+        "source_row_id": source_row_id,
+        "secondary_row_id": secondary_row_id,
+        "family_contract": contract,
+        "family_intervention": intervention,
+        "derived_seed_identity": episode_seed["seed_digest"],
+        "episode_seed": episode_seed["seed_int64"],
+        "frame_count": frame_count,
+        "seed_lineage": {
+            "concrete_episode_seed": episode_seed,
+            "concrete_episode_id": episode_id_seed,
+        },
+        "frame_plans": frame_plans,
+    }
+    return plan | {"plan_digest": canonical_sha256(plan)}
+
+
+def plan_dto(**kwargs: Any) -> EpisodePlanDTO:
+    return EpisodePlanDTO.from_dict(sample_plan_payload(**kwargs))
+
+
+def _redigest(
+    payload: dict[str, Any], digest_key: str = "plan_digest"
+) -> dict[str, Any]:
+    payload[digest_key] = canonical_sha256(
+        {key: value for key, value in payload.items() if key != digest_key}
+    )
+    return payload
+
+
+def test_canonical_json_contract() -> None:
+    value = {"b": 1, "a": ("é", {"z": 2})}
+    text = '{"a":["é",{"z":2}],"b":1}'
+
+    assert canonical_json_text(value) == text
+    assert canonical_json_bytes(value) == text.encode("utf-8")
+    assert (
+        canonical_sha256(value)
+        == "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+    )
+    with pytest.raises(ValueError):
+        canonical_json_text(float("nan"))
+    with pytest.raises(VPMValidationError):
+        CanonicalJsonDTO.from_value(object())
+
+    dto = CanonicalJsonDTO.from_value({"items": []})
+    first = dto.to_value()
+    second = dto.to_value()
+    assert first == second == {"items": []}
+    assert first is not second
+    first["items"].append("changed")  # type: ignore[index, union-attr]
+    assert dto.to_value() == {"items": []}
+
+
+def test_episode_plan_round_trip_hashing_and_nested_immutability() -> None:
+    payload = sample_plan_payload()
+    dto = EpisodePlanDTO.from_dict(payload)
+
+    assert dto.to_dict() == payload
+    assert dto == EpisodePlanDTO.from_dict(payload)
+    assert hash(dto) == hash(EpisodePlanDTO.from_dict(payload))
+    with pytest.raises(FrozenInstanceError):
+        dto.episode_id = "changed"  # type: ignore[misc]
+    assert isinstance(dto.frame_plans, tuple)
+    returned = dto.to_dict()
+    returned["family_contract"]["family_label"] = "changed"  # type: ignore[index]
+    returned["frame_plans"][0]["frame_seed_identity"] = "changed"  # type: ignore[index]
+    assert dto.to_dict() == payload
+    assert dto.benchmark_seed_digest == sample_identity().seed_digest
+
+
+def test_episode_plan_rejects_digest_and_structural_tampering() -> None:
+    payload = sample_plan_payload()
+    scalar = deepcopy(payload)
+    scalar["denominator_class"] = "changed"
+    with pytest.raises(VPMValidationError, match="episode plan digest mismatch"):
+        EpisodePlanDTO.from_dict(scalar)
+
+    frame = deepcopy(payload)
+    frame["frame_plans"][0]["frame_seed_identity"] = "changed"
+    with pytest.raises(VPMValidationError, match="episode plan digest mismatch"):
+        EpisodePlanDTO.from_dict(frame)
+
+    count = deepcopy(payload)
+    count["frame_count"] = 99
+    with pytest.raises(VPMValidationError, match="episode plan frame count mismatch"):
+        EpisodePlanDTO.from_dict(count)
+
+    indexes = deepcopy(payload)
+    indexes["frame_plans"][1]["frame_index"] = 3
+    with pytest.raises(VPMValidationError, match="frame indexes"):
+        EpisodePlanDTO.from_dict(indexes)
+
+    lineage = deepcopy(payload)
+    lineage["seed_lineage"]["concrete_episode_seed"]["root_seed_digest"] = (
+        "sha256:" + "0" * 64
+    )
+    with pytest.raises(VPMValidationError, match="root seed lineage mismatch"):
+        EpisodePlanDTO.from_dict(lineage)
+
+    split = deepcopy(payload)
+    split["episode_id"] = split["episode_id"].replace("final:", "selection:", 1)
+    with pytest.raises(VPMValidationError, match="episode id does not match split"):
+        EpisodePlanDTO.from_dict(split)
+
+
+def test_sealed_split_plan_construction_validation_and_round_trip() -> None:
+    identity = sample_identity()
+    episodes = (
+        plan_dto(
+            identity=identity,
+            ordinal=2,
+            family_label="temporal_negative",
+            family_ordinal=0,
+        ),
+        plan_dto(identity=identity, ordinal=0, family_label="valid", family_ordinal=0),
+        plan_dto(
+            identity=identity, ordinal=1, family_label="frame_invalid", family_ordinal=0
+        ),
+        plan_dto(
+            identity=identity,
+            ordinal=3,
+            family_label="information_control",
+            family_ordinal=0,
+        ),
+    )
+
+    sealed = SealedSplitPlanDTO.build_final(
+        episodes=episodes,
+        seed_commitment=identity.seed_digest,
+    )
+    payload = sealed.to_dict()
+    without_digest = dict(payload)
+    digest = without_digest.pop("sealed_plan_digest")
+
+    assert sealed.episodes == episodes
+    assert sealed.episode_counts.to_dict() == {
+        "valid": 1,
+        "frame_invalid": 1,
+        "temporal_negative": 1,
+        "information_control": 1,
+    }
+    assert sealed.sealed_episode_ids.to_dict() == {
+        "valid": [episodes[1].episode_id],
+        "frame_invalid": [episodes[2].episode_id],
+        "temporal_negative": [episodes[0].episode_id],
+        "information_control": [episodes[3].episode_id],
+    }
+    assert sealed.frame_count == sum(episode.frame_count for episode in episodes)
+    assert digest == canonical_sha256(without_digest)
+    assert SealedSplitPlanDTO.from_dict(payload) == sealed
+
+    with pytest.raises(VPMValidationError, match="duplicate episode ids"):
+        SealedSplitPlanDTO.build_final(
+            episodes=(episodes[0], episodes[0]), seed_commitment=identity.seed_digest
+        )
+    with pytest.raises(VPMValidationError, match="non-final episode"):
+        SealedSplitPlanDTO.build_final(
+            episodes=(plan_dto(identity=identity, split="selection"),),
+            seed_commitment=identity.seed_digest,
+        )
+    with pytest.raises(VPMValidationError, match="seed commitment mismatch"):
+        SealedSplitPlanDTO.build_final(
+            episodes=episodes, seed_commitment="sha256:" + "0" * 64
+        )
+
+    tampered = dict(payload)
+    tampered["sealed_plan_digest"] = "sha256:" + "0" * 64
+    with pytest.raises(VPMValidationError, match="sealed plan digest mismatch"):
+        SealedSplitPlanDTO.from_dict(tampered)
+
+
+def test_in_memory_store_plan_and_sealed_semantics() -> None:
+    identity = sample_identity()
+    other_identity = sample_identity("other-episode-plan-rmdto-seed")
+    store = InMemoryVideoActionSetStore()
+    plan = plan_dto(identity=identity, split="selection", ordinal=1)
+
+    with pytest.raises(VPMValidationError, match=UNKNOWN_BENCHMARK_IDENTITY_MESSAGE):
+        store.save_episode_plan(plan)
+    store.save_identity(identity)
+    store.save_identity(other_identity)
+    assert store.save_episode_plan(plan) == plan
+    assert store.save_episode_plan(plan) == plan
+    assert store.get_episode_plan(plan.episode_id) == plan
+
+    conflict_payload = deepcopy(plan.to_dict())
+    conflict_payload["source_row_id"] = "row:changed"
+    conflict = EpisodePlanDTO.from_dict(_redigest(conflict_payload))
+    with pytest.raises(VPMValidationError, match=EPISODE_PLAN_CONFLICT_MESSAGE):
+        store.save_episode_plan(conflict)
+
+    new_plan = plan_dto(
+        identity=identity, split="selection", ordinal=2, source_row_id="row:new"
+    )
+    with pytest.raises(VPMValidationError, match=EPISODE_PLAN_CONFLICT_MESSAGE):
+        store.save_episode_plans((new_plan, conflict))
+    assert store.get_episode_plan(new_plan.episode_id) is None
+
+    first = plan_dto(identity=identity, split="development", ordinal=0)
+    second = plan_dto(
+        identity=identity, split="development", ordinal=2, source_row_id="row:two"
+    )
+    third = plan_dto(
+        identity=identity, split="development", ordinal=1, source_row_id="row:one"
+    )
+    other_seed = plan_dto(identity=other_identity, split="development", ordinal=0)
+    store.save_episode_plans((second, third, first, other_seed))
+    assert store.list_episode_plans(
+        benchmark_seed_digest=identity.seed_digest,
+        split="development",
+    ) == (first, third, second)
+    assert store.list_episode_plans(
+        benchmark_seed_digest=other_identity.seed_digest,
+        split="development",
+    ) == (other_seed,)
+
+    final_episodes = (
+        plan_dto(identity=identity, ordinal=0, family_label="valid", family_ordinal=0),
+        plan_dto(
+            identity=identity, ordinal=1, family_label="frame_invalid", family_ordinal=0
+        ),
+    )
+    sealed = SealedSplitPlanDTO.build_final(
+        episodes=final_episodes,
+        seed_commitment=identity.seed_digest,
+    )
+    assert store.save_sealed_split_plan(sealed) == sealed
+    assert (
+        store.get_sealed_split_plan(seed_commitment=identity.seed_digest, split="final")
+        == sealed
+    )
+    assert isinstance(
+        store.get_episode_plan(final_episodes[0].episode_id), EpisodePlanDTO
+    )
+    conflicting_sealed = SealedSplitPlanDTO.build_final(
+        episodes=(
+            plan_dto(
+                identity=identity,
+                ordinal=2,
+                family_label="information_control",
+                family_ordinal=0,
+            ),
+        ),
+        seed_commitment=identity.seed_digest,
+    )
+    with pytest.raises(VPMValidationError, match=SEALED_SPLIT_PLAN_CONFLICT_MESSAGE):
+        store.save_sealed_split_plan(conflicting_sealed)
+
+
+def test_runtime_facade_delegates_with_one_shared_store() -> None:
+    identity = sample_identity()
+    store = InMemoryVideoActionSetStore()
+    runtime = build_runtime(video_action_set_store=store)
+    plan = plan_dto(identity=identity)
+
+    assert runtime.video_action_set.engine.identity_service.store is store
+    assert runtime.video_action_set.engine.episode_plan_service.store is store
+    with pytest.raises(VPMValidationError, match=UNKNOWN_BENCHMARK_IDENTITY_MESSAGE):
+        runtime.video_action_set.save_episode_plan(plan)
+
+    runtime.video_action_set.save_identity(identity)
+    assert runtime.video_action_set.save_episode_plan(plan) == plan
+    assert runtime.video_action_set.get_episode_plan(plan.episode_id) == plan
+    sealed = runtime.video_action_set.seal_final_split(
+        episodes=(plan,),
+        seed_commitment=identity.seed_digest,
+    )
+    assert (
+        runtime.video_action_set.get_sealed_split_plan(
+            seed_commitment=identity.seed_digest,
+            split="final",
+        )
+        == sealed
+    )
+
+
+def test_core_runtime_import_remains_sqlalchemy_free() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import zeromodel; print('sqlalchemy' in sys.modules)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+def test_legacy_private_generator_returns_episode_plan_dto_payload() -> None:
+    identity = benchmark.load_identity(REPO_ROOT)
+    policy = benchmark.compile_policy_artifact()
+    lookup = benchmark.VPMPolicyLookup(policy, action_metric_ids=benchmark.ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
+
+    legacy_plan = benchmark._make_episode_plan(
+        identity,
+        split="development",
+        ordinal=0,
+        family_label="valid",
+        family_ordinal=0,
+        source_row_id=row_ids[0],
+        row_actions=row_actions,
+    )
+
+    assert EpisodePlanDTO.from_dict(legacy_plan).to_dict() == legacy_plan

--- a/tests/test_video_episode_plan_sql_store.py
+++ b/tests/test_video_episode_plan_sql_store.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from sqlalchemy import inspect
+
+from test_video_episode_plan_rmdto import (
+    _redigest,
+    plan_dto,
+    sample_identity,
+)
+from zeromodel.artifact import VPMValidationError
+from zeromodel.db.orm.video_action_set import EpisodePlanORM, SealedSplitPlanORM
+from zeromodel.db.runtime import build_sqlite_runtime
+from zeromodel.db.session import (
+    create_database_engine,
+    create_schema,
+    create_session_factory,
+)
+from zeromodel.db.stores.video_action_set import SqlAlchemyVideoActionSetStore
+from zeromodel.domains.video_action_set.canonical_json import canonical_json_text
+from zeromodel.domains.video_action_set.dto import EpisodePlanDTO, SealedSplitPlanDTO
+from zeromodel.domains.video_action_set.store import (
+    EPISODE_PLAN_CONFLICT_MESSAGE,
+    UNKNOWN_BENCHMARK_IDENTITY_MESSAGE,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+def sql_safe_identity(prefix: str = "sql-episode-plan-rmdto-seed"):
+    for index in range(100):
+        identity = sample_identity(f"{prefix}-{index}")
+        if plan_dto(identity=identity).episode_seed < 2**63:
+            return identity
+    raise AssertionError("could not find SQLite-safe episode seed")
+
+
+def build_store():
+    engine = create_database_engine("sqlite:///:memory:")
+    create_schema(engine)
+    session_factory = create_session_factory(engine)
+    return SqlAlchemyVideoActionSetStore(session_factory), session_factory, engine
+
+
+def test_sql_schema_creation_registers_episode_plan_tables() -> None:
+    engine = create_database_engine("sqlite:///:memory:")
+    assert "video_action_set_episode_plan" not in inspect(engine).get_table_names()
+
+    create_schema(engine)
+    table_names = set(inspect(engine).get_table_names())
+
+    assert "video_action_set_benchmark_identity" in table_names
+    assert "video_action_set_episode_plan" in table_names
+    assert "video_action_set_sealed_split_plan" in table_names
+
+
+def test_sql_plan_identity_ownership_and_canonical_round_trip() -> None:
+    store, session_factory, _engine = build_store()
+    identity = sql_safe_identity()
+    plan = plan_dto(identity=identity)
+
+    with pytest.raises(VPMValidationError, match=UNKNOWN_BENCHMARK_IDENTITY_MESSAGE):
+        store.save_episode_plan(plan)
+
+    store.save_identity(identity)
+    assert store.save_episode_plan(plan) == plan
+    assert store.get_episode_plan(plan.episode_id) == plan
+    with session_factory() as session:
+        row = session.get(EpisodePlanORM, plan.episode_id)
+        assert row is not None
+        assert row.payload_json == canonical_json_text(plan.to_dict())
+
+
+def test_sql_plan_retrieval_across_sessions_idempotence_and_conflict() -> None:
+    _store, session_factory, _engine = build_store()
+    identity = sql_safe_identity()
+    plan = plan_dto(identity=identity)
+    save_store = SqlAlchemyVideoActionSetStore(session_factory)
+    read_store = SqlAlchemyVideoActionSetStore(session_factory)
+
+    save_store.save_identity(identity)
+    assert save_store.save_episode_plan(plan) == plan
+    assert read_store.get_episode_plan(plan.episode_id) == plan
+    assert read_store.save_episode_plan(plan) == plan
+
+    conflict_payload = deepcopy(plan.to_dict())
+    conflict_payload["source_row_id"] = "row:changed"
+    conflict = EpisodePlanDTO.from_dict(_redigest(conflict_payload))
+    with pytest.raises(VPMValidationError, match=EPISODE_PLAN_CONFLICT_MESSAGE):
+        read_store.save_episode_plan(conflict)
+    assert not isinstance(read_store.get_episode_plan(plan.episode_id), EpisodePlanORM)
+
+
+def test_sql_batch_rollback_ordering_and_filters() -> None:
+    store, _session_factory, _engine = build_store()
+    identity = sql_safe_identity()
+    other_identity = sql_safe_identity("sql-episode-plan-other-seed")
+    first = plan_dto(identity=identity, split="development", ordinal=0)
+    second = plan_dto(
+        identity=identity,
+        split="development",
+        ordinal=2,
+        source_row_id="row:two",
+    )
+    third = plan_dto(
+        identity=identity,
+        split="development",
+        ordinal=1,
+        source_row_id="row:one",
+    )
+    other_seed = plan_dto(identity=other_identity, split="development", ordinal=0)
+
+    store.save_identity(identity)
+    store.save_identity(other_identity)
+    store.save_episode_plan(first)
+    conflict_payload = deepcopy(first.to_dict())
+    conflict_payload["source_row_id"] = "row:changed"
+    conflict = EpisodePlanDTO.from_dict(_redigest(conflict_payload))
+    with pytest.raises(VPMValidationError, match=EPISODE_PLAN_CONFLICT_MESSAGE):
+        store.save_episode_plans((second, conflict))
+    assert store.get_episode_plan(second.episode_id) is None
+
+    store.save_episode_plans((second, third, other_seed))
+    assert store.list_episode_plans(
+        benchmark_seed_digest=identity.seed_digest,
+        split="development",
+    ) == (first, third, second)
+    assert store.list_episode_plans(
+        benchmark_seed_digest=other_identity.seed_digest,
+        split="development",
+    ) == (other_seed,)
+
+
+def test_sql_sealed_envelope_reconstructs_from_episode_rows() -> None:
+    store, session_factory, _engine = build_store()
+    identity = sql_safe_identity()
+    episodes = (
+        plan_dto(identity=identity, ordinal=0, family_label="valid", family_ordinal=0),
+        plan_dto(
+            identity=identity,
+            ordinal=1,
+            family_label="frame_invalid",
+            family_ordinal=0,
+        ),
+    )
+    sealed = SealedSplitPlanDTO.build_final(
+        episodes=episodes,
+        seed_commitment=identity.seed_digest,
+    )
+
+    store.save_identity(identity)
+    assert store.save_sealed_split_plan(sealed) == sealed
+    with session_factory() as session:
+        row = session.get(SealedSplitPlanORM, (identity.seed_digest, "final"))
+        assert row is not None
+        assert row.sealed_plan_digest == sealed.sealed_plan_digest
+        assert (
+            canonical_json_text(sealed.episode_counts.to_dict())
+            == row.episode_counts_json
+        )
+        assert "episodes" not in inspect(SealedSplitPlanORM).columns
+
+    read_store = SqlAlchemyVideoActionSetStore(session_factory)
+    assert (
+        read_store.get_sealed_split_plan(
+            seed_commitment=identity.seed_digest,
+            split="final",
+        )
+        == sealed
+    )
+
+
+def test_sql_sealed_digest_validation_rejects_corrupted_envelope() -> None:
+    store, session_factory, _engine = build_store()
+    identity = sql_safe_identity()
+    plan = plan_dto(identity=identity)
+    sealed = SealedSplitPlanDTO.build_final(
+        episodes=(plan,),
+        seed_commitment=identity.seed_digest,
+    )
+    store.save_identity(identity)
+    store.save_sealed_split_plan(sealed)
+    with session_factory.begin() as session:
+        row = session.get(SealedSplitPlanORM, (identity.seed_digest, "final"))
+        assert row is not None
+        row.sealed_plan_digest = "sha256:" + "0" * 64
+
+    with pytest.raises(VPMValidationError, match="sealed plan digest mismatch"):
+        store.get_sealed_split_plan(seed_commitment=identity.seed_digest, split="final")
+
+
+def test_sqlite_runtime_composes_episode_plan_store() -> None:
+    runtime = build_sqlite_runtime("sqlite:///:memory:", initialize_schema=True)
+    identity = sql_safe_identity()
+    plan = plan_dto(identity=identity)
+
+    runtime.video_action_set.save_identity(identity)
+    assert runtime.video_action_set.save_episode_plan(plan) == plan
+    sealed = runtime.video_action_set.seal_final_split(
+        episodes=(plan,),
+        seed_commitment=identity.seed_digest,
+    )
+
+    assert (
+        runtime.video_action_set.get_sealed_split_plan(
+            seed_commitment=identity.seed_digest,
+            split="final",
+        )
+        == sealed
+    )

--- a/zeromodel/db/orm/__init__.py
+++ b/zeromodel/db/orm/__init__.py
@@ -1,6 +1,6 @@
 """SQLAlchemy ORM mappings for optional persistence."""
 
 from .base import Base
-from .video_action_set import BenchmarkIdentityORM
+from .video_action_set import BenchmarkIdentityORM, EpisodePlanORM, SealedSplitPlanORM
 
-__all__ = ["Base", "BenchmarkIdentityORM"]
+__all__ = ["Base", "BenchmarkIdentityORM", "EpisodePlanORM", "SealedSplitPlanORM"]

--- a/zeromodel/db/orm/video_action_set.py
+++ b/zeromodel/db/orm/video_action_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import String
+from sqlalchemy import BigInteger, Boolean, ForeignKey, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
@@ -17,4 +17,69 @@ class BenchmarkIdentityORM(Base):
     parent_v3_sha: Mapped[str] = mapped_column(String, nullable=False)
 
 
-__all__ = ["BenchmarkIdentityORM"]
+class EpisodePlanORM(Base):
+    __tablename__ = "video_action_set_episode_plan"
+    __table_args__ = (
+        UniqueConstraint(
+            "benchmark_seed_digest",
+            "split",
+            "ordinal",
+            name="uq_video_action_set_episode_plan_seed_split_ordinal",
+        ),
+        UniqueConstraint(
+            "plan_digest",
+            name="uq_video_action_set_episode_plan_digest",
+        ),
+    )
+
+    episode_id: Mapped[str] = mapped_column(String, primary_key=True)
+    benchmark_seed_digest: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("video_action_set_benchmark_identity.seed_digest"),
+        index=True,
+        nullable=False,
+    )
+    plan_digest: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    version: Mapped[str] = mapped_column(String, nullable=False)
+    seed_derivation_version: Mapped[str] = mapped_column(String, nullable=False)
+    split: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    ordinal: Mapped[int] = mapped_column(nullable=False)
+    family_label: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    family_ordinal: Mapped[int] = mapped_column(nullable=False)
+    episode_disposition: Mapped[str] = mapped_column(String, nullable=False)
+    denominator_class: Mapped[str] = mapped_column(String, nullable=False)
+    mutation_kind: Mapped[str | None] = mapped_column(String, nullable=True)
+    source_row_id: Mapped[str] = mapped_column(String, nullable=False)
+    secondary_row_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    derived_seed_identity: Mapped[str] = mapped_column(String, nullable=False)
+    episode_seed: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    frame_count: Mapped[int] = mapped_column(nullable=False)
+    payload_json: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class SealedSplitPlanORM(Base):
+    __tablename__ = "video_action_set_sealed_split_plan"
+    __table_args__ = (
+        UniqueConstraint(
+            "sealed_plan_digest",
+            name="uq_video_action_set_sealed_split_plan_digest",
+        ),
+    )
+
+    seed_commitment: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("video_action_set_benchmark_identity.seed_digest"),
+        primary_key=True,
+    )
+    split: Mapped[str] = mapped_column(String, primary_key=True)
+    version: Mapped[str] = mapped_column(String, nullable=False)
+    seed_derivation_version: Mapped[str] = mapped_column(String, nullable=False)
+    plan_only: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    materialization_prohibited: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    frame_count: Mapped[int] = mapped_column(nullable=False)
+    episode_counts_json: Mapped[str] = mapped_column(Text, nullable=False)
+    sealed_episode_ids_json: Mapped[str] = mapped_column(Text, nullable=False)
+    sealed_plan_digest: Mapped[str] = mapped_column(String, nullable=False)
+
+
+__all__ = ["BenchmarkIdentityORM", "EpisodePlanORM", "SealedSplitPlanORM"]

--- a/zeromodel/db/session.py
+++ b/zeromodel/db/session.py
@@ -24,6 +24,8 @@ def create_session_factory(engine: Engine) -> sessionmaker[Session]:
 
 def create_schema(engine: Engine) -> None:
     _ = _video_action_set_orm.BenchmarkIdentityORM
+    _ = _video_action_set_orm.EpisodePlanORM
+    _ = _video_action_set_orm.SealedSplitPlanORM
     Base.metadata.create_all(engine)
 
 

--- a/zeromodel/db/stores/video_action_set.py
+++ b/zeromodel/db/stores/video_action_set.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
-from ...domains.video_action_set.dto import BenchmarkIdentityDTO
+from ...artifact import VPMValidationError
+from ...domains.video_action_set.canonical_json import canonical_json_text
+from ...domains.video_action_set.dto import (
+    BenchmarkIdentityDTO,
+    EpisodePlanDTO,
+    SealedSplitPlanDTO,
+)
 from ...domains.video_action_set.store import (
     VideoActionSetStore,
+    raise_episode_plan_conflict,
     raise_identity_conflict,
+    raise_sealed_split_plan_conflict,
+    raise_unknown_benchmark_identity,
 )
-from ..orm.video_action_set import BenchmarkIdentityORM
+from ..orm.video_action_set import (
+    BenchmarkIdentityORM,
+    EpisodePlanORM,
+    SealedSplitPlanORM,
+)
 
 
 class SqlAlchemyVideoActionSetStore(VideoActionSetStore):
@@ -46,6 +64,107 @@ class SqlAlchemyVideoActionSetStore(VideoActionSetStore):
         finally:
             session.close()
 
+    def save_episode_plan(self, plan: EpisodePlanDTO) -> EpisodePlanDTO:
+        return self.save_episode_plans((plan,))[0]
+
+    def save_episode_plans(
+        self,
+        plans: Sequence[EpisodePlanDTO],
+    ) -> tuple[EpisodePlanDTO, ...]:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                return self._save_episode_plans_in_session(session, tuple(plans))
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def get_episode_plan(self, episode_id: str) -> EpisodePlanDTO | None:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                existing = session.get(EpisodePlanORM, episode_id)
+                if existing is None:
+                    return None
+                return self._to_episode_plan_dto(existing)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def list_episode_plans(
+        self,
+        *,
+        benchmark_seed_digest: str,
+        split: str,
+    ) -> tuple[EpisodePlanDTO, ...]:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                rows = session.scalars(
+                    select(EpisodePlanORM)
+                    .where(
+                        EpisodePlanORM.benchmark_seed_digest == benchmark_seed_digest,
+                        EpisodePlanORM.split == split,
+                    )
+                    .order_by(EpisodePlanORM.ordinal, EpisodePlanORM.episode_id)
+                ).all()
+                return tuple(self._to_episode_plan_dto(row) for row in rows)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def save_sealed_split_plan(
+        self,
+        plan: SealedSplitPlanDTO,
+    ) -> SealedSplitPlanDTO:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                if session.get(BenchmarkIdentityORM, plan.seed_commitment) is None:
+                    raise_unknown_benchmark_identity()
+                existing = session.get(
+                    SealedSplitPlanORM,
+                    (plan.seed_commitment, plan.split),
+                )
+                if existing is not None:
+                    existing_dto = self._to_sealed_split_plan_dto(session, existing)
+                    if existing_dto != plan:
+                        raise_sealed_split_plan_conflict()
+                    return existing_dto
+                self._save_episode_plans_in_session(session, plan.episodes)
+                session.add(self._to_sealed_split_plan_orm(plan))
+                return plan
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def get_sealed_split_plan(
+        self,
+        *,
+        seed_commitment: str,
+        split: str,
+    ) -> SealedSplitPlanDTO | None:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                existing = session.get(SealedSplitPlanORM, (seed_commitment, split))
+                if existing is None:
+                    return None
+                return self._to_sealed_split_plan_dto(session, existing)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
     @staticmethod
     def _to_dto(identity: BenchmarkIdentityORM) -> BenchmarkIdentityDTO:
         return BenchmarkIdentityDTO(
@@ -67,6 +186,205 @@ class SqlAlchemyVideoActionSetStore(VideoActionSetStore):
             parent_audit_sha=identity.parent_audit_sha,
             parent_v3_sha=identity.parent_v3_sha,
         )
+
+    def _save_episode_plans_in_session(
+        self,
+        session: Session,
+        plans: Sequence[EpisodePlanDTO],
+    ) -> tuple[EpisodePlanDTO, ...]:
+        existing_dtos: dict[str, EpisodePlanDTO] = {}
+        self._preflight_episode_plans(session, plans, existing_dtos)
+        added_ids: set[str] = set()
+        for plan in plans:
+            if (
+                plan.episode_id not in existing_dtos
+                and plan.episode_id not in added_ids
+            ):
+                session.add(self._to_episode_plan_orm(plan))
+                added_ids.add(plan.episode_id)
+        return tuple(existing_dtos.get(plan.episode_id, plan) for plan in plans)
+
+    def _preflight_episode_plans(
+        self,
+        session: Session,
+        plans: Sequence[EpisodePlanDTO],
+        existing_dtos: dict[str, EpisodePlanDTO],
+    ) -> None:
+        seen_ids: dict[str, EpisodePlanDTO] = {}
+        seen_ordinals: dict[tuple[str, str, int], EpisodePlanDTO] = {}
+        for plan in plans:
+            if session.get(BenchmarkIdentityORM, plan.benchmark_seed_digest) is None:
+                raise_unknown_benchmark_identity()
+            existing = session.get(EpisodePlanORM, plan.episode_id)
+            if existing is not None:
+                existing_dto = self._to_episode_plan_dto(existing)
+                if existing_dto != plan:
+                    raise_episode_plan_conflict()
+                existing_dtos[plan.episode_id] = existing_dto
+            ordinal_key = (plan.benchmark_seed_digest, plan.split, plan.ordinal)
+            existing_for_ordinal = self._episode_plan_for_ordinal(
+                session,
+                ordinal_key,
+            )
+            if existing_for_ordinal is not None:
+                ordinal_dto = self._to_episode_plan_dto(existing_for_ordinal)
+                if ordinal_dto != plan:
+                    raise_episode_plan_conflict()
+            self._preflight_batch_keys(plan, seen_ids, seen_ordinals, ordinal_key)
+
+    @staticmethod
+    def _preflight_batch_keys(
+        plan: EpisodePlanDTO,
+        seen_ids: dict[str, EpisodePlanDTO],
+        seen_ordinals: dict[tuple[str, str, int], EpisodePlanDTO],
+        ordinal_key: tuple[str, str, int],
+    ) -> None:
+        seen = seen_ids.get(plan.episode_id)
+        if seen is not None and seen != plan:
+            raise_episode_plan_conflict()
+        seen_ids[plan.episode_id] = plan
+        seen_for_ordinal = seen_ordinals.get(ordinal_key)
+        if seen_for_ordinal is not None and seen_for_ordinal != plan:
+            raise_episode_plan_conflict()
+        seen_ordinals[ordinal_key] = plan
+
+    @staticmethod
+    def _episode_plan_for_ordinal(
+        session: Session,
+        ordinal_key: tuple[str, str, int],
+    ) -> EpisodePlanORM | None:
+        benchmark_seed_digest, split, ordinal = ordinal_key
+        return session.scalars(
+            select(EpisodePlanORM).where(
+                EpisodePlanORM.benchmark_seed_digest == benchmark_seed_digest,
+                EpisodePlanORM.split == split,
+                EpisodePlanORM.ordinal == ordinal,
+            )
+        ).first()
+
+    @staticmethod
+    def _to_episode_plan_dto(row: EpisodePlanORM) -> EpisodePlanDTO:
+        payload = _json_mapping(row.payload_json, "episode plan digest mismatch")
+        dto = EpisodePlanDTO.from_dict(payload)
+        if (
+            row.episode_id != dto.episode_id
+            or row.benchmark_seed_digest != dto.benchmark_seed_digest
+            or row.plan_digest != dto.plan_digest
+            or row.version != dto.version
+            or row.seed_derivation_version != dto.seed_derivation_version
+            or row.split != dto.split
+            or row.ordinal != dto.ordinal
+            or row.family_label != dto.family_label
+            or row.family_ordinal != dto.family_ordinal
+            or row.episode_disposition != dto.episode_disposition
+            or row.denominator_class != dto.denominator_class
+            or row.mutation_kind != dto.mutation_kind
+            or row.source_row_id != dto.source_row_id
+            or row.secondary_row_id != dto.secondary_row_id
+            or row.derived_seed_identity != dto.derived_seed_identity
+            or row.episode_seed != dto.episode_seed
+            or row.frame_count != dto.frame_count
+        ):
+            raise VPMValidationError("episode plan digest mismatch")
+        return dto
+
+    @staticmethod
+    def _to_episode_plan_orm(plan: EpisodePlanDTO) -> EpisodePlanORM:
+        return EpisodePlanORM(
+            episode_id=plan.episode_id,
+            benchmark_seed_digest=plan.benchmark_seed_digest,
+            plan_digest=plan.plan_digest,
+            version=plan.version,
+            seed_derivation_version=plan.seed_derivation_version,
+            split=plan.split,
+            ordinal=plan.ordinal,
+            family_label=plan.family_label,
+            family_ordinal=plan.family_ordinal,
+            episode_disposition=plan.episode_disposition,
+            denominator_class=plan.denominator_class,
+            mutation_kind=plan.mutation_kind,
+            source_row_id=plan.source_row_id,
+            secondary_row_id=plan.secondary_row_id,
+            derived_seed_identity=plan.derived_seed_identity,
+            episode_seed=plan.episode_seed,
+            frame_count=plan.frame_count,
+            payload_json=canonical_json_text(plan.to_dict()),
+        )
+
+    def _to_sealed_split_plan_dto(
+        self,
+        session: Session,
+        row: SealedSplitPlanORM,
+    ) -> SealedSplitPlanDTO:
+        episodes = self.list_episode_plans_for_session(
+            session,
+            benchmark_seed_digest=row.seed_commitment,
+            split=row.split,
+        )
+        payload = {
+            "version": row.version,
+            "seed_derivation_version": row.seed_derivation_version,
+            "split": row.split,
+            "plan_only": row.plan_only,
+            "materialization_prohibited": row.materialization_prohibited,
+            "episode_counts": _json_mapping(
+                row.episode_counts_json,
+                "sealed plan episode counts mismatch",
+            ),
+            "frame_count": row.frame_count,
+            "sealed_episode_ids": _json_mapping(
+                row.sealed_episode_ids_json,
+                "sealed plan episode id manifest mismatch",
+            ),
+            "episodes": [episode.to_dict() for episode in episodes],
+            "seed_commitment": row.seed_commitment,
+            "sealed_plan_digest": row.sealed_plan_digest,
+        }
+        return SealedSplitPlanDTO.from_dict(payload)
+
+    def list_episode_plans_for_session(
+        self,
+        session: Session,
+        *,
+        benchmark_seed_digest: str,
+        split: str,
+    ) -> tuple[EpisodePlanDTO, ...]:
+        rows = session.scalars(
+            select(EpisodePlanORM)
+            .where(
+                EpisodePlanORM.benchmark_seed_digest == benchmark_seed_digest,
+                EpisodePlanORM.split == split,
+            )
+            .order_by(EpisodePlanORM.ordinal, EpisodePlanORM.episode_id)
+        ).all()
+        return tuple(self._to_episode_plan_dto(row) for row in rows)
+
+    @staticmethod
+    def _to_sealed_split_plan_orm(plan: SealedSplitPlanDTO) -> SealedSplitPlanORM:
+        return SealedSplitPlanORM(
+            seed_commitment=plan.seed_commitment,
+            split=plan.split,
+            version=plan.version,
+            seed_derivation_version=plan.seed_derivation_version,
+            plan_only=plan.plan_only,
+            materialization_prohibited=plan.materialization_prohibited,
+            frame_count=plan.frame_count,
+            episode_counts_json=canonical_json_text(plan.episode_counts.to_dict()),
+            sealed_episode_ids_json=canonical_json_text(
+                plan.sealed_episode_ids.to_dict()
+            ),
+            sealed_plan_digest=plan.sealed_plan_digest,
+        )
+
+
+def _json_mapping(text: str, message: str) -> Mapping[str, object]:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise VPMValidationError(message) from exc
+    if not isinstance(value, Mapping):
+        raise VPMValidationError(message)
+    return cast(Mapping[str, object], value)
 
 
 __all__ = ["SqlAlchemyVideoActionSetStore"]

--- a/zeromodel/domains/video_action_set/__init__.py
+++ b/zeromodel/domains/video_action_set/__init__.py
@@ -1,11 +1,25 @@
 """Runtime domain slice for video action-set capabilities."""
 
-from .dto import BenchmarkIdentityDTO
+from .dto import (
+    BenchmarkIdentityDTO,
+    CanonicalJsonDTO,
+    EpisodeCountsDTO,
+    EpisodeIdsByFamilyDTO,
+    EpisodePlanDTO,
+    SealedSplitPlanDTO,
+)
+from .episode_plan_service import EpisodePlanService
 from .facade import VideoActionSetFacade
 from .store import VideoActionSetStore
 
 __all__ = [
     "BenchmarkIdentityDTO",
+    "CanonicalJsonDTO",
+    "EpisodeCountsDTO",
+    "EpisodeIdsByFamilyDTO",
+    "EpisodePlanDTO",
+    "EpisodePlanService",
+    "SealedSplitPlanDTO",
     "VideoActionSetFacade",
     "VideoActionSetStore",
 ]

--- a/zeromodel/domains/video_action_set/canonical_json.py
+++ b/zeromodel/domains/video_action_set/canonical_json.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import TypeAlias
+
+JsonValue: TypeAlias = (
+    None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+)
+
+
+def canonical_json_value(value: object) -> JsonValue:
+    if isinstance(value, Mapping):
+        return {str(key): canonical_json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [canonical_json_value(item) for item in value]
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    raise TypeError(f"value is not JSON serializable: {type(value).__name__}")
+
+
+def canonical_json_text(value: object) -> str:
+    return json.dumps(
+        canonical_json_value(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return canonical_json_text(value).encode("utf-8")
+
+
+def canonical_sha256(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+__all__ = [
+    "JsonValue",
+    "canonical_json_bytes",
+    "canonical_json_text",
+    "canonical_json_value",
+    "canonical_sha256",
+]

--- a/zeromodel/domains/video_action_set/contracts.py
+++ b/zeromodel/domains/video_action_set/contracts.py
@@ -1,15 +1,19 @@
 """Identity-owned video action-set contracts."""
 
 BENCHMARK_VERSION = "zeromodel-video-action-set-reachability-benchmark/v1"
+EPISODE_PLAN_VERSION = "zeromodel-video-action-set-sealed-episode-plan/v1"
 GENERATOR_VERSION = "zeromodel-video-action-set-reachability-generator/v1"
 REACHABILITY_TILE_DIGEST = (
     "sha256:fef2bc5fd795bb92d3bd564bccdc2d32e1b23319aba55dffed5e0391e795a5df"
 )
 REACHABILITY_TILE_VERSION = "zeromodel-video-policy-reachability-tile/v1"
+SEED_DERIVATION_VERSION = "zeromodel-video-action-set-seed-derivation/v1"
 
 __all__ = [
     "BENCHMARK_VERSION",
+    "EPISODE_PLAN_VERSION",
     "GENERATOR_VERSION",
     "REACHABILITY_TILE_DIGEST",
     "REACHABILITY_TILE_VERSION",
+    "SEED_DERIVATION_VERSION",
 ]

--- a/zeromodel/domains/video_action_set/dto.py
+++ b/zeromodel/domains/video_action_set/dto.py
@@ -1,15 +1,274 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import hashlib
+import json
+import re
+from typing import cast
 
 from ...artifact import VPMValidationError
+from .canonical_json import JsonValue, canonical_json_text, canonical_sha256
 from .contracts import (
     BENCHMARK_VERSION,
+    EPISODE_PLAN_VERSION,
     GENERATOR_VERSION,
     REACHABILITY_TILE_DIGEST,
     REACHABILITY_TILE_VERSION,
+    SEED_DERIVATION_VERSION,
 )
+
+EPISODE_PLAN_KEYS = (
+    "version",
+    "seed_derivation_version",
+    "episode_id",
+    "split",
+    "ordinal",
+    "family_label",
+    "family_ordinal",
+    "episode_family",
+    "episode_disposition",
+    "denominator_class",
+    "final_observation_provenance",
+    "mutation_kind",
+    "source_row_id",
+    "secondary_row_id",
+    "family_contract",
+    "family_intervention",
+    "derived_seed_identity",
+    "episode_seed",
+    "frame_count",
+    "seed_lineage",
+    "frame_plans",
+    "plan_digest",
+)
+EPISODE_COUNT_KEYS = (
+    "valid",
+    "frame_invalid",
+    "temporal_negative",
+    "information_control",
+)
+SEALED_SPLIT_PLAN_KEYS = (
+    "version",
+    "seed_derivation_version",
+    "split",
+    "plan_only",
+    "materialization_prohibited",
+    "episode_counts",
+    "frame_count",
+    "sealed_episode_ids",
+    "episodes",
+    "seed_commitment",
+    "sealed_plan_digest",
+)
+SPLITS = frozenset({"development", "calibration", "selection", "final"})
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+FINAL_OBSERVATION_PROVENANCE = {
+    "materialization_status": "prospective_materialization_prohibited",
+    "observation_payload_included": False,
+    "provenance": "sealed_plan_only",
+}
+MATERIALIZED_OBSERVATION_PROVENANCE = {
+    "materialization_status": "materialized",
+    "observation_payload_included": True,
+    "provenance": "in_memory_generation",
+}
+
+
+def _require_exact_keys(
+    payload: Mapping[str, object],
+    keys: tuple[str, ...],
+    message: str,
+) -> None:
+    if set(payload) != set(keys):
+        raise VPMValidationError(message)
+
+
+def _require_mapping(value: object, message: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise VPMValidationError(message)
+    return cast(Mapping[str, object], value)
+
+
+def _require_sequence(value: object, message: str) -> Sequence[object]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise VPMValidationError(message)
+    return cast(Sequence[object], value)
+
+
+def _require_str(payload: Mapping[str, object], key: str, message: str) -> str:
+    value = payload[key]
+    if not isinstance(value, str):
+        raise VPMValidationError(message)
+    return value
+
+
+def _require_optional_str(
+    payload: Mapping[str, object],
+    key: str,
+    message: str,
+) -> str | None:
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise VPMValidationError(message)
+    return value
+
+
+def _require_int(payload: Mapping[str, object], key: str, message: str) -> int:
+    value = payload[key]
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise VPMValidationError(message)
+    return value
+
+
+def _require_bool(payload: Mapping[str, object], key: str, message: str) -> bool:
+    value = payload[key]
+    if not isinstance(value, bool):
+        raise VPMValidationError(message)
+    return value
+
+
+def _is_sha256_identity(value: object) -> bool:
+    return isinstance(value, str) and SHA256_RE.fullmatch(value) is not None
+
+
+def _seed_int_from_digest(digest: str) -> int:
+    if not _is_sha256_identity(digest):
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    return int(digest.removeprefix("sha256:")[:16], 16)
+
+
+def _canonical_from_payload(
+    payload: Mapping[str, object],
+    key: str,
+    message: str,
+) -> CanonicalJsonDTO:
+    try:
+        return CanonicalJsonDTO.from_value(payload[key])
+    except VPMValidationError as exc:
+        raise VPMValidationError(message) from exc
+
+
+def _frame_plan_tuple(value: object) -> tuple[CanonicalJsonDTO, ...]:
+    frames = _require_sequence(value, "episode plan frame indexes are not contiguous")
+    return tuple(CanonicalJsonDTO.from_value(frame) for frame in frames)
+
+
+def _lineage_mapping(lineage: CanonicalJsonDTO) -> dict[str, JsonValue]:
+    value = lineage.to_value()
+    if not isinstance(value, dict):
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    return value
+
+
+def _seed_node_mapping(value: JsonValue) -> dict[str, JsonValue]:
+    if not isinstance(value, dict):
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    return value
+
+
+def _validate_seed_node(
+    node: dict[str, JsonValue],
+    *,
+    split: str,
+    ordinal: int,
+) -> str:
+    if node.get("version") != SEED_DERIVATION_VERSION:
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    if node.get("split") != split or node.get("episode_ordinal") != ordinal:
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    root_seed = node.get("root_seed_digest")
+    seed_digest = node.get("seed_digest")
+    seed_int64 = node.get("seed_int64")
+    if not _is_sha256_identity(root_seed) or not _is_sha256_identity(seed_digest):
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    if not isinstance(seed_int64, int) or isinstance(seed_int64, bool):
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    payload = {
+        key: value
+        for key, value in node.items()
+        if key not in {"seed_digest", "seed_int64"}
+    }
+    if canonical_sha256(payload) != seed_digest:
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    if _seed_int_from_digest(seed_digest) != seed_int64:
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    return str(root_seed)
+
+
+def _validate_count(value: int) -> int:
+    if value < 0:
+        raise VPMValidationError("episode counts cannot be negative")
+    return value
+
+
+def _episode_counts_from_episodes(
+    episodes: Sequence[EpisodePlanDTO],
+) -> EpisodeCountsDTO:
+    counts = dict.fromkeys(EPISODE_COUNT_KEYS, 0)
+    for episode in episodes:
+        if episode.family_label not in counts:
+            raise VPMValidationError("sealed plan episode counts mismatch")
+        counts[episode.family_label] += 1
+    return EpisodeCountsDTO(
+        valid=counts["valid"],
+        frame_invalid=counts["frame_invalid"],
+        temporal_negative=counts["temporal_negative"],
+        information_control=counts["information_control"],
+    )
+
+
+def _episode_ids_from_episodes(
+    episodes: Sequence[EpisodePlanDTO],
+) -> EpisodeIdsByFamilyDTO:
+    grouped: dict[str, list[str]] = {key: [] for key in EPISODE_COUNT_KEYS}
+    for episode in episodes:
+        if episode.family_label not in grouped:
+            raise VPMValidationError("sealed plan episode id manifest mismatch")
+        grouped[episode.family_label].append(episode.episode_id)
+    return EpisodeIdsByFamilyDTO(
+        valid=tuple(grouped["valid"]),
+        frame_invalid=tuple(grouped["frame_invalid"]),
+        temporal_negative=tuple(grouped["temporal_negative"]),
+        information_control=tuple(grouped["information_control"]),
+    )
+
+
+def _sealed_payload_without_digest(plan: SealedSplitPlanDTO) -> dict[str, object]:
+    payload = plan.to_dict()
+    payload.pop("sealed_plan_digest")
+    return payload
+
+
+def _episode_payload_without_digest(plan: EpisodePlanDTO) -> dict[str, object]:
+    payload = plan.to_dict()
+    payload.pop("plan_digest")
+    return payload
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalJsonDTO:
+    canonical_text: str
+
+    def __post_init__(self) -> None:
+        try:
+            parsed = json.loads(self.canonical_text)
+            if canonical_json_text(parsed) != self.canonical_text:
+                raise ValueError
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise VPMValidationError("canonical JSON text is not canonical") from exc
+
+    @classmethod
+    def from_value(cls, value: object) -> CanonicalJsonDTO:
+        try:
+            return cls(canonical_json_text(value))
+        except (TypeError, ValueError) as exc:
+            raise VPMValidationError("value is not canonical JSON compatible") from exc
+
+    def to_value(self) -> JsonValue:
+        return cast(JsonValue, json.loads(self.canonical_text))
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,4 +304,469 @@ class BenchmarkIdentityDTO:
         }
 
 
-__all__ = ["BenchmarkIdentityDTO"]
+@dataclass(frozen=True, slots=True)
+class EpisodePlanDTO:
+    version: str
+    seed_derivation_version: str
+    episode_id: str
+    split: str
+    ordinal: int
+    family_label: str
+    family_ordinal: int
+    episode_family: str
+    episode_disposition: str
+    denominator_class: str
+    final_observation_provenance: CanonicalJsonDTO
+    mutation_kind: str | None
+    source_row_id: str
+    secondary_row_id: str | None
+    family_contract: CanonicalJsonDTO
+    family_intervention: CanonicalJsonDTO
+    derived_seed_identity: str
+    episode_seed: int
+    frame_count: int
+    seed_lineage: CanonicalJsonDTO
+    frame_plans: tuple[CanonicalJsonDTO, ...]
+    plan_digest: str
+
+    def __post_init__(self) -> None:
+        if self.version != EPISODE_PLAN_VERSION:
+            raise VPMValidationError("unsupported episode plan version")
+        if self.seed_derivation_version != SEED_DERIVATION_VERSION:
+            raise VPMValidationError("unsupported seed derivation version")
+        if self.split not in SPLITS:
+            raise VPMValidationError("unsupported episode plan split")
+        if not self.episode_id.startswith(f"{self.split}:"):
+            raise VPMValidationError("episode id does not match split")
+        if self.ordinal < 0 or self.family_ordinal < 0:
+            raise VPMValidationError("episode plan ordinal cannot be negative")
+        if self.episode_family != self.family_label:
+            raise VPMValidationError("episode plan family mismatch")
+        if self.frame_count != len(self.frame_plans):
+            raise VPMValidationError("episode plan frame count mismatch")
+        if self.frame_count < 0:
+            raise VPMValidationError("episode plan frame count mismatch")
+        self._validate_frame_indexes()
+        if not _is_sha256_identity(self.derived_seed_identity):
+            raise VPMValidationError("episode plan derived seed identity is not sha256")
+        self._validate_seed_lineage()
+        if canonical_sha256(_episode_payload_without_digest(self)) != self.plan_digest:
+            raise VPMValidationError("episode plan digest mismatch")
+        self._validate_final_observation_provenance()
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> EpisodePlanDTO:
+        _require_exact_keys(
+            payload,
+            EPISODE_PLAN_KEYS,
+            "episode plan payload keys mismatch",
+        )
+        return cls(
+            version=_require_str(
+                payload, "version", "unsupported episode plan version"
+            ),
+            seed_derivation_version=_require_str(
+                payload,
+                "seed_derivation_version",
+                "unsupported seed derivation version",
+            ),
+            episode_id=_require_str(
+                payload, "episode_id", "episode id does not match split"
+            ),
+            split=_require_str(payload, "split", "unsupported episode plan split"),
+            ordinal=_require_int(
+                payload, "ordinal", "episode plan ordinal cannot be negative"
+            ),
+            family_label=_require_str(
+                payload, "family_label", "episode plan family mismatch"
+            ),
+            family_ordinal=_require_int(
+                payload, "family_ordinal", "episode plan ordinal cannot be negative"
+            ),
+            episode_family=_require_str(
+                payload, "episode_family", "episode plan family mismatch"
+            ),
+            episode_disposition=_require_str(
+                payload, "episode_disposition", "episode plan payload keys mismatch"
+            ),
+            denominator_class=_require_str(
+                payload, "denominator_class", "episode plan payload keys mismatch"
+            ),
+            final_observation_provenance=_canonical_from_payload(
+                payload,
+                "final_observation_provenance",
+                "episode plan final observation provenance mismatch",
+            ),
+            mutation_kind=_require_optional_str(
+                payload, "mutation_kind", "episode plan payload keys mismatch"
+            ),
+            source_row_id=_require_str(
+                payload, "source_row_id", "episode plan payload keys mismatch"
+            ),
+            secondary_row_id=_require_optional_str(
+                payload, "secondary_row_id", "episode plan payload keys mismatch"
+            ),
+            family_contract=_canonical_from_payload(
+                payload, "family_contract", "episode plan payload keys mismatch"
+            ),
+            family_intervention=_canonical_from_payload(
+                payload, "family_intervention", "episode plan payload keys mismatch"
+            ),
+            derived_seed_identity=_require_str(
+                payload,
+                "derived_seed_identity",
+                "episode plan derived seed identity is not sha256",
+            ),
+            episode_seed=_require_int(
+                payload, "episode_seed", "episode plan root seed lineage mismatch"
+            ),
+            frame_count=_require_int(
+                payload, "frame_count", "episode plan frame count mismatch"
+            ),
+            seed_lineage=_canonical_from_payload(
+                payload, "seed_lineage", "episode plan root seed lineage mismatch"
+            ),
+            frame_plans=_frame_plan_tuple(payload["frame_plans"]),
+            plan_digest=_require_str(
+                payload, "plan_digest", "episode plan digest mismatch"
+            ),
+        )
+
+    @property
+    def benchmark_seed_digest(self) -> str:
+        root: str | None = None
+        for value in _lineage_mapping(self.seed_lineage).values():
+            seed_root = _validate_seed_node(
+                _seed_node_mapping(value),
+                split=self.split,
+                ordinal=self.ordinal,
+            )
+            if root is None:
+                root = seed_root
+            elif root != seed_root:
+                raise VPMValidationError("episode plan root seed lineage mismatch")
+        if root is None:
+            raise VPMValidationError("episode plan root seed lineage mismatch")
+        return root
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "seed_derivation_version": self.seed_derivation_version,
+            "episode_id": self.episode_id,
+            "split": self.split,
+            "ordinal": self.ordinal,
+            "family_label": self.family_label,
+            "family_ordinal": self.family_ordinal,
+            "episode_family": self.episode_family,
+            "episode_disposition": self.episode_disposition,
+            "denominator_class": self.denominator_class,
+            "final_observation_provenance": self.final_observation_provenance.to_value(),
+            "mutation_kind": self.mutation_kind,
+            "source_row_id": self.source_row_id,
+            "secondary_row_id": self.secondary_row_id,
+            "family_contract": self.family_contract.to_value(),
+            "family_intervention": self.family_intervention.to_value(),
+            "derived_seed_identity": self.derived_seed_identity,
+            "episode_seed": self.episode_seed,
+            "frame_count": self.frame_count,
+            "seed_lineage": self.seed_lineage.to_value(),
+            "frame_plans": [frame.to_value() for frame in self.frame_plans],
+            "plan_digest": self.plan_digest,
+        }
+
+    def _validate_frame_indexes(self) -> None:
+        for expected_index, frame in enumerate(self.frame_plans):
+            value = frame.to_value()
+            if (
+                not isinstance(value, dict)
+                or value.get("frame_index") != expected_index
+            ):
+                raise VPMValidationError(
+                    "episode plan frame indexes are not contiguous"
+                )
+
+    def _validate_seed_lineage(self) -> None:
+        root = self.benchmark_seed_digest
+        concrete_seed = _seed_node_mapping(
+            _lineage_mapping(self.seed_lineage).get("concrete_episode_seed")
+        )
+        if concrete_seed.get("seed_digest") != self.derived_seed_identity:
+            raise VPMValidationError("episode plan root seed lineage mismatch")
+        if concrete_seed.get("seed_int64") != self.episode_seed:
+            raise VPMValidationError("episode plan root seed lineage mismatch")
+        if not _is_sha256_identity(root):
+            raise VPMValidationError("episode plan root seed lineage mismatch")
+
+    def _validate_final_observation_provenance(self) -> None:
+        expected = (
+            FINAL_OBSERVATION_PROVENANCE
+            if self.split == "final"
+            else MATERIALIZED_OBSERVATION_PROVENANCE
+        )
+        if self.final_observation_provenance.to_value() != expected:
+            raise VPMValidationError(
+                "episode plan final observation provenance mismatch"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeCountsDTO:
+    valid: int
+    frame_invalid: int
+    temporal_negative: int
+    information_control: int
+
+    def __post_init__(self) -> None:
+        _validate_count(self.valid)
+        _validate_count(self.frame_invalid)
+        _validate_count(self.temporal_negative)
+        _validate_count(self.information_control)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> EpisodeCountsDTO:
+        _require_exact_keys(payload, EPISODE_COUNT_KEYS, "episode counts keys mismatch")
+        return cls(
+            valid=_validate_count(
+                _require_int(payload, "valid", "episode counts keys mismatch")
+            ),
+            frame_invalid=_validate_count(
+                _require_int(payload, "frame_invalid", "episode counts keys mismatch")
+            ),
+            temporal_negative=_validate_count(
+                _require_int(
+                    payload,
+                    "temporal_negative",
+                    "episode counts keys mismatch",
+                )
+            ),
+            information_control=_validate_count(
+                _require_int(
+                    payload,
+                    "information_control",
+                    "episode counts keys mismatch",
+                )
+            ),
+        )
+
+    @property
+    def total(self) -> int:
+        return (
+            self.valid
+            + self.frame_invalid
+            + self.temporal_negative
+            + self.information_control
+        )
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "valid": self.valid,
+            "frame_invalid": self.frame_invalid,
+            "temporal_negative": self.temporal_negative,
+            "information_control": self.information_control,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeIdsByFamilyDTO:
+    valid: tuple[str, ...]
+    frame_invalid: tuple[str, ...]
+    temporal_negative: tuple[str, ...]
+    information_control: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        episode_ids = [
+            *self.valid,
+            *self.frame_invalid,
+            *self.temporal_negative,
+            *self.information_control,
+        ]
+        if any(not isinstance(episode_id, str) for episode_id in episode_ids):
+            raise VPMValidationError("sealed plan episode id manifest mismatch")
+        if len(set(episode_ids)) != len(episode_ids):
+            raise VPMValidationError("sealed plan contains duplicate episode ids")
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> EpisodeIdsByFamilyDTO:
+        _require_exact_keys(
+            payload,
+            EPISODE_COUNT_KEYS,
+            "sealed plan episode id manifest mismatch",
+        )
+        return cls(
+            valid=_string_tuple(payload["valid"]),
+            frame_invalid=_string_tuple(payload["frame_invalid"]),
+            temporal_negative=_string_tuple(payload["temporal_negative"]),
+            information_control=_string_tuple(payload["information_control"]),
+        )
+
+    def to_dict(self) -> dict[str, list[str]]:
+        return {
+            "valid": list(self.valid),
+            "frame_invalid": list(self.frame_invalid),
+            "temporal_negative": list(self.temporal_negative),
+            "information_control": list(self.information_control),
+        }
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    items = _require_sequence(value, "sealed plan episode id manifest mismatch")
+    if any(not isinstance(item, str) for item in items):
+        raise VPMValidationError("sealed plan episode id manifest mismatch")
+    return tuple(cast(Sequence[str], items))
+
+
+@dataclass(frozen=True, slots=True)
+class SealedSplitPlanDTO:
+    version: str
+    seed_derivation_version: str
+    split: str
+    plan_only: bool
+    materialization_prohibited: bool
+    episode_counts: EpisodeCountsDTO
+    frame_count: int
+    sealed_episode_ids: EpisodeIdsByFamilyDTO
+    episodes: tuple[EpisodePlanDTO, ...]
+    seed_commitment: str
+    sealed_plan_digest: str
+
+    def __post_init__(self) -> None:
+        if self.version != EPISODE_PLAN_VERSION:
+            raise VPMValidationError("unsupported episode plan version")
+        if self.seed_derivation_version != SEED_DERIVATION_VERSION:
+            raise VPMValidationError("unsupported seed derivation version")
+        if self.split != "final":
+            raise VPMValidationError("sealed plan must describe the final split")
+        if self.plan_only is not True or self.materialization_prohibited is not True:
+            raise VPMValidationError("sealed plan permits materialization")
+        if not _is_sha256_identity(self.seed_commitment):
+            raise VPMValidationError("sealed plan seed commitment mismatch")
+        self._validate_episodes()
+        if (
+            canonical_sha256(_sealed_payload_without_digest(self))
+            != self.sealed_plan_digest
+        ):
+            raise VPMValidationError("sealed plan digest mismatch")
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> SealedSplitPlanDTO:
+        _require_exact_keys(
+            payload,
+            SEALED_SPLIT_PLAN_KEYS,
+            "sealed split plan payload keys mismatch",
+        )
+        episodes = tuple(
+            EpisodePlanDTO.from_dict(
+                _require_mapping(item, "sealed plan digest mismatch")
+            )
+            for item in _require_sequence(
+                payload["episodes"], "sealed plan digest mismatch"
+            )
+        )
+        return cls(
+            version=_require_str(
+                payload, "version", "unsupported episode plan version"
+            ),
+            seed_derivation_version=_require_str(
+                payload,
+                "seed_derivation_version",
+                "unsupported seed derivation version",
+            ),
+            split=_require_str(
+                payload, "split", "sealed plan must describe the final split"
+            ),
+            plan_only=_require_bool(
+                payload, "plan_only", "sealed plan permits materialization"
+            ),
+            materialization_prohibited=_require_bool(
+                payload,
+                "materialization_prohibited",
+                "sealed plan permits materialization",
+            ),
+            episode_counts=EpisodeCountsDTO.from_dict(
+                _require_mapping(
+                    payload["episode_counts"], "sealed plan episode counts mismatch"
+                )
+            ),
+            frame_count=_require_int(
+                payload, "frame_count", "sealed plan frame count mismatch"
+            ),
+            sealed_episode_ids=EpisodeIdsByFamilyDTO.from_dict(
+                _require_mapping(
+                    payload["sealed_episode_ids"],
+                    "sealed plan episode id manifest mismatch",
+                )
+            ),
+            episodes=episodes,
+            seed_commitment=_require_str(
+                payload, "seed_commitment", "sealed plan seed commitment mismatch"
+            ),
+            sealed_plan_digest=_require_str(
+                payload, "sealed_plan_digest", "sealed plan digest mismatch"
+            ),
+        )
+
+    @classmethod
+    def build_final(
+        cls,
+        *,
+        episodes: Sequence[EpisodePlanDTO],
+        seed_commitment: str,
+    ) -> SealedSplitPlanDTO:
+        episode_tuple = tuple(episodes)
+        payload = {
+            "version": EPISODE_PLAN_VERSION,
+            "seed_derivation_version": SEED_DERIVATION_VERSION,
+            "split": "final",
+            "plan_only": True,
+            "materialization_prohibited": True,
+            "episode_counts": _episode_counts_from_episodes(episode_tuple).to_dict(),
+            "frame_count": sum(episode.frame_count for episode in episode_tuple),
+            "sealed_episode_ids": _episode_ids_from_episodes(episode_tuple).to_dict(),
+            "episodes": [episode.to_dict() for episode in episode_tuple],
+            "seed_commitment": seed_commitment,
+        }
+        return cls.from_dict(
+            payload | {"sealed_plan_digest": canonical_sha256(payload)}
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "seed_derivation_version": self.seed_derivation_version,
+            "split": self.split,
+            "plan_only": self.plan_only,
+            "materialization_prohibited": self.materialization_prohibited,
+            "episode_counts": self.episode_counts.to_dict(),
+            "frame_count": self.frame_count,
+            "sealed_episode_ids": self.sealed_episode_ids.to_dict(),
+            "episodes": [episode.to_dict() for episode in self.episodes],
+            "seed_commitment": self.seed_commitment,
+            "sealed_plan_digest": self.sealed_plan_digest,
+        }
+
+    def _validate_episodes(self) -> None:
+        episode_ids = [episode.episode_id for episode in self.episodes]
+        if len(set(episode_ids)) != len(episode_ids):
+            raise VPMValidationError("sealed plan contains duplicate episode ids")
+        for episode in self.episodes:
+            if episode.split != "final":
+                raise VPMValidationError("sealed plan contains a non-final episode")
+            if episode.benchmark_seed_digest != self.seed_commitment:
+                raise VPMValidationError("sealed plan seed commitment mismatch")
+        if self.episode_counts != _episode_counts_from_episodes(self.episodes):
+            raise VPMValidationError("sealed plan episode counts mismatch")
+        if self.sealed_episode_ids != _episode_ids_from_episodes(self.episodes):
+            raise VPMValidationError("sealed plan episode id manifest mismatch")
+        if self.frame_count != sum(episode.frame_count for episode in self.episodes):
+            raise VPMValidationError("sealed plan frame count mismatch")
+
+
+__all__ = [
+    "BenchmarkIdentityDTO",
+    "CanonicalJsonDTO",
+    "EpisodeCountsDTO",
+    "EpisodeIdsByFamilyDTO",
+    "EpisodePlanDTO",
+    "SealedSplitPlanDTO",
+]

--- a/zeromodel/domains/video_action_set/engine.py
+++ b/zeromodel/domains/video_action_set/engine.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from .dto import BenchmarkIdentityDTO
+from .dto import BenchmarkIdentityDTO, EpisodePlanDTO, SealedSplitPlanDTO
+from .episode_plan_service import EpisodePlanService
 from .identity_service import IdentityService
 
 
 @dataclass(frozen=True, slots=True)
 class VideoActionSetEngine:
     identity_service: IdentityService
+    episode_plan_service: EpisodePlanService
 
     def load_identity(self, repo_root: Path) -> BenchmarkIdentityDTO:
         return self.identity_service.load_identity(repo_root)
@@ -19,6 +22,57 @@ class VideoActionSetEngine:
 
     def save_identity(self, identity: BenchmarkIdentityDTO) -> BenchmarkIdentityDTO:
         return self.identity_service.save_identity(identity)
+
+    def save_episode_plan(self, plan: EpisodePlanDTO) -> EpisodePlanDTO:
+        return self.episode_plan_service.save_plan(plan)
+
+    def save_episode_plans(
+        self,
+        plans: Sequence[EpisodePlanDTO],
+    ) -> tuple[EpisodePlanDTO, ...]:
+        return self.episode_plan_service.save_plans(plans)
+
+    def get_episode_plan(self, episode_id: str) -> EpisodePlanDTO | None:
+        return self.episode_plan_service.get_plan(episode_id)
+
+    def list_episode_plans(
+        self,
+        *,
+        benchmark_seed_digest: str,
+        split: str,
+    ) -> tuple[EpisodePlanDTO, ...]:
+        return self.episode_plan_service.list_plans(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+        )
+
+    def seal_final_split(
+        self,
+        *,
+        episodes: Sequence[EpisodePlanDTO],
+        seed_commitment: str,
+    ) -> SealedSplitPlanDTO:
+        return self.episode_plan_service.seal_final_split(
+            episodes=episodes,
+            seed_commitment=seed_commitment,
+        )
+
+    def save_sealed_split_plan(
+        self,
+        plan: SealedSplitPlanDTO,
+    ) -> SealedSplitPlanDTO:
+        return self.episode_plan_service.save_sealed_split(plan)
+
+    def get_sealed_split_plan(
+        self,
+        *,
+        seed_commitment: str,
+        split: str,
+    ) -> SealedSplitPlanDTO | None:
+        return self.episode_plan_service.get_sealed_split(
+            seed_commitment=seed_commitment,
+            split=split,
+        )
 
 
 __all__ = ["VideoActionSetEngine"]

--- a/zeromodel/domains/video_action_set/episode_plan_service.py
+++ b/zeromodel/domains/video_action_set/episode_plan_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .dto import EpisodePlanDTO, SealedSplitPlanDTO
+from .store import VideoActionSetStore
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodePlanService:
+    store: VideoActionSetStore
+
+    def save_plan(self, plan: EpisodePlanDTO) -> EpisodePlanDTO:
+        return self.store.save_episode_plan(plan)
+
+    def save_plans(
+        self,
+        plans: Sequence[EpisodePlanDTO],
+    ) -> tuple[EpisodePlanDTO, ...]:
+        return self.store.save_episode_plans(plans)
+
+    def get_plan(self, episode_id: str) -> EpisodePlanDTO | None:
+        return self.store.get_episode_plan(episode_id)
+
+    def list_plans(
+        self,
+        *,
+        benchmark_seed_digest: str,
+        split: str,
+    ) -> tuple[EpisodePlanDTO, ...]:
+        return self.store.list_episode_plans(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+        )
+
+    def seal_final_split(
+        self,
+        *,
+        episodes: Sequence[EpisodePlanDTO],
+        seed_commitment: str,
+    ) -> SealedSplitPlanDTO:
+        plan = SealedSplitPlanDTO.build_final(
+            episodes=episodes,
+            seed_commitment=seed_commitment,
+        )
+        return self.store.save_sealed_split_plan(plan)
+
+    def save_sealed_split(self, plan: SealedSplitPlanDTO) -> SealedSplitPlanDTO:
+        return self.store.save_sealed_split_plan(plan)
+
+    def get_sealed_split(
+        self,
+        *,
+        seed_commitment: str,
+        split: str,
+    ) -> SealedSplitPlanDTO | None:
+        return self.store.get_sealed_split_plan(
+            seed_commitment=seed_commitment,
+            split=split,
+        )
+
+
+__all__ = ["EpisodePlanService"]

--- a/zeromodel/domains/video_action_set/facade.py
+++ b/zeromodel/domains/video_action_set/facade.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from .dto import BenchmarkIdentityDTO
+from .dto import BenchmarkIdentityDTO, EpisodePlanDTO, SealedSplitPlanDTO
 from .engine import VideoActionSetEngine
 
 
@@ -19,6 +20,57 @@ class VideoActionSetFacade:
 
     def save_identity(self, identity: BenchmarkIdentityDTO) -> BenchmarkIdentityDTO:
         return self.engine.save_identity(identity)
+
+    def save_episode_plan(self, plan: EpisodePlanDTO) -> EpisodePlanDTO:
+        return self.engine.save_episode_plan(plan)
+
+    def save_episode_plans(
+        self,
+        plans: Sequence[EpisodePlanDTO],
+    ) -> tuple[EpisodePlanDTO, ...]:
+        return self.engine.save_episode_plans(plans)
+
+    def get_episode_plan(self, episode_id: str) -> EpisodePlanDTO | None:
+        return self.engine.get_episode_plan(episode_id)
+
+    def list_episode_plans(
+        self,
+        *,
+        benchmark_seed_digest: str,
+        split: str,
+    ) -> tuple[EpisodePlanDTO, ...]:
+        return self.engine.list_episode_plans(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+        )
+
+    def seal_final_split(
+        self,
+        *,
+        episodes: Sequence[EpisodePlanDTO],
+        seed_commitment: str,
+    ) -> SealedSplitPlanDTO:
+        return self.engine.seal_final_split(
+            episodes=episodes,
+            seed_commitment=seed_commitment,
+        )
+
+    def save_sealed_split_plan(
+        self,
+        plan: SealedSplitPlanDTO,
+    ) -> SealedSplitPlanDTO:
+        return self.engine.save_sealed_split_plan(plan)
+
+    def get_sealed_split_plan(
+        self,
+        *,
+        seed_commitment: str,
+        split: str,
+    ) -> SealedSplitPlanDTO | None:
+        return self.engine.get_sealed_split_plan(
+            seed_commitment=seed_commitment,
+            split=split,
+        )
 
 
 __all__ = ["VideoActionSetFacade"]

--- a/zeromodel/domains/video_action_set/store.py
+++ b/zeromodel/domains/video_action_set/store.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import NoReturn, Protocol
 
 from ...artifact import VPMValidationError
-from .dto import BenchmarkIdentityDTO
+from .dto import BenchmarkIdentityDTO, EpisodePlanDTO, SealedSplitPlanDTO
 
 
 BENCHMARK_IDENTITY_CONFLICT_MESSAGE = "benchmark identity conflict for seed digest"
+EPISODE_PLAN_CONFLICT_MESSAGE = "episode plan conflict for episode id"
+SEALED_SPLIT_PLAN_CONFLICT_MESSAGE = (
+    "sealed split plan conflict for seed commitment and split"
+)
+UNKNOWN_BENCHMARK_IDENTITY_MESSAGE = (
+    "episode plan references unknown benchmark identity"
+)
 
 
 class VideoActionSetStore(Protocol):
@@ -20,13 +28,65 @@ class VideoActionSetStore(Protocol):
         seed_digest: str,
     ) -> BenchmarkIdentityDTO | None: ...
 
+    def save_episode_plan(
+        self,
+        plan: EpisodePlanDTO,
+    ) -> EpisodePlanDTO: ...
+
+    def save_episode_plans(
+        self,
+        plans: Sequence[EpisodePlanDTO],
+    ) -> tuple[EpisodePlanDTO, ...]: ...
+
+    def get_episode_plan(
+        self,
+        episode_id: str,
+    ) -> EpisodePlanDTO | None: ...
+
+    def list_episode_plans(
+        self,
+        *,
+        benchmark_seed_digest: str,
+        split: str,
+    ) -> tuple[EpisodePlanDTO, ...]: ...
+
+    def save_sealed_split_plan(
+        self,
+        plan: SealedSplitPlanDTO,
+    ) -> SealedSplitPlanDTO: ...
+
+    def get_sealed_split_plan(
+        self,
+        *,
+        seed_commitment: str,
+        split: str,
+    ) -> SealedSplitPlanDTO | None: ...
+
 
 def raise_identity_conflict() -> NoReturn:
     raise VPMValidationError(BENCHMARK_IDENTITY_CONFLICT_MESSAGE)
 
 
+def raise_episode_plan_conflict() -> NoReturn:
+    raise VPMValidationError(EPISODE_PLAN_CONFLICT_MESSAGE)
+
+
+def raise_sealed_split_plan_conflict() -> NoReturn:
+    raise VPMValidationError(SEALED_SPLIT_PLAN_CONFLICT_MESSAGE)
+
+
+def raise_unknown_benchmark_identity() -> NoReturn:
+    raise VPMValidationError(UNKNOWN_BENCHMARK_IDENTITY_MESSAGE)
+
+
 __all__ = [
     "BENCHMARK_IDENTITY_CONFLICT_MESSAGE",
+    "EPISODE_PLAN_CONFLICT_MESSAGE",
+    "SEALED_SPLIT_PLAN_CONFLICT_MESSAGE",
+    "UNKNOWN_BENCHMARK_IDENTITY_MESSAGE",
     "VideoActionSetStore",
+    "raise_episode_plan_conflict",
     "raise_identity_conflict",
+    "raise_sealed_split_plan_conflict",
+    "raise_unknown_benchmark_identity",
 ]

--- a/zeromodel/runtime.py
+++ b/zeromodel/runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from .domains.video_action_set.engine import VideoActionSetEngine
+from .domains.video_action_set.episode_plan_service import EpisodePlanService
 from .domains.video_action_set.facade import VideoActionSetFacade
 from .domains.video_action_set.identity_service import IdentityService
 from .domains.video_action_set.store import VideoActionSetStore
@@ -20,7 +21,11 @@ def build_runtime(
 ) -> ZeroModelRuntime:
     store = video_action_set_store or InMemoryVideoActionSetStore()
     identity_service = IdentityService(store=store)
-    engine = VideoActionSetEngine(identity_service=identity_service)
+    episode_plan_service = EpisodePlanService(store=store)
+    engine = VideoActionSetEngine(
+        identity_service=identity_service,
+        episode_plan_service=episode_plan_service,
+    )
     facade = VideoActionSetFacade(engine=engine)
     return ZeroModelRuntime(video_action_set=facade)
 

--- a/zeromodel/stores/video_action_set_memory.py
+++ b/zeromodel/stores/video_action_set_memory.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
-from ..domains.video_action_set.dto import BenchmarkIdentityDTO
+from collections.abc import Sequence
+
+from ..domains.video_action_set.dto import (
+    BenchmarkIdentityDTO,
+    EpisodePlanDTO,
+    SealedSplitPlanDTO,
+)
 from ..domains.video_action_set.store import (
     VideoActionSetStore,
+    raise_episode_plan_conflict,
     raise_identity_conflict,
+    raise_sealed_split_plan_conflict,
+    raise_unknown_benchmark_identity,
 )
 
 
 class InMemoryVideoActionSetStore(VideoActionSetStore):
     def __init__(self) -> None:
         self._identities: dict[str, BenchmarkIdentityDTO] = {}
+        self._episode_plans: dict[str, EpisodePlanDTO] = {}
+        self._sealed_split_plans: dict[tuple[str, str], SealedSplitPlanDTO] = {}
 
     def save_identity(self, identity: BenchmarkIdentityDTO) -> BenchmarkIdentityDTO:
         existing = self._identities.get(identity.seed_digest)
@@ -22,6 +33,102 @@ class InMemoryVideoActionSetStore(VideoActionSetStore):
 
     def get_identity(self, seed_digest: str) -> BenchmarkIdentityDTO | None:
         return self._identities.get(seed_digest)
+
+    def save_episode_plan(self, plan: EpisodePlanDTO) -> EpisodePlanDTO:
+        return self.save_episode_plans((plan,))[0]
+
+    def save_episode_plans(
+        self,
+        plans: Sequence[EpisodePlanDTO],
+    ) -> tuple[EpisodePlanDTO, ...]:
+        plan_tuple = tuple(plans)
+        self._preflight_episode_plans(plan_tuple)
+        for plan in plan_tuple:
+            self._episode_plans.setdefault(plan.episode_id, plan)
+        return tuple(self._episode_plans[plan.episode_id] for plan in plan_tuple)
+
+    def get_episode_plan(self, episode_id: str) -> EpisodePlanDTO | None:
+        return self._episode_plans.get(episode_id)
+
+    def list_episode_plans(
+        self,
+        *,
+        benchmark_seed_digest: str,
+        split: str,
+    ) -> tuple[EpisodePlanDTO, ...]:
+        return tuple(
+            sorted(
+                (
+                    plan
+                    for plan in self._episode_plans.values()
+                    if plan.benchmark_seed_digest == benchmark_seed_digest
+                    and plan.split == split
+                ),
+                key=lambda plan: (plan.ordinal, plan.episode_id),
+            )
+        )
+
+    def save_sealed_split_plan(
+        self,
+        plan: SealedSplitPlanDTO,
+    ) -> SealedSplitPlanDTO:
+        if plan.seed_commitment not in self._identities:
+            raise_unknown_benchmark_identity()
+        key = (plan.seed_commitment, plan.split)
+        existing = self._sealed_split_plans.get(key)
+        if existing is not None:
+            if existing != plan:
+                raise_sealed_split_plan_conflict()
+            return existing
+        self._preflight_episode_plans(plan.episodes)
+        for episode in plan.episodes:
+            self._episode_plans.setdefault(episode.episode_id, episode)
+        self._sealed_split_plans[key] = plan
+        return plan
+
+    def get_sealed_split_plan(
+        self,
+        *,
+        seed_commitment: str,
+        split: str,
+    ) -> SealedSplitPlanDTO | None:
+        return self._sealed_split_plans.get((seed_commitment, split))
+
+    def _preflight_episode_plans(self, plans: Sequence[EpisodePlanDTO]) -> None:
+        seen_ids: dict[str, EpisodePlanDTO] = {}
+        seen_ordinals: dict[tuple[str, str, int], EpisodePlanDTO] = {}
+        for plan in plans:
+            if plan.benchmark_seed_digest not in self._identities:
+                raise_unknown_benchmark_identity()
+            existing = self._episode_plans.get(plan.episode_id)
+            if existing is not None and existing != plan:
+                raise_episode_plan_conflict()
+            seen = seen_ids.get(plan.episode_id)
+            if seen is not None and seen != plan:
+                raise_episode_plan_conflict()
+            seen_ids[plan.episode_id] = plan
+            ordinal_key = (plan.benchmark_seed_digest, plan.split, plan.ordinal)
+            existing_for_ordinal = self._plan_for_ordinal(ordinal_key)
+            if existing_for_ordinal is not None and existing_for_ordinal != plan:
+                raise_episode_plan_conflict()
+            seen_for_ordinal = seen_ordinals.get(ordinal_key)
+            if seen_for_ordinal is not None and seen_for_ordinal != plan:
+                raise_episode_plan_conflict()
+            seen_ordinals[ordinal_key] = plan
+
+    def _plan_for_ordinal(
+        self,
+        ordinal_key: tuple[str, str, int],
+    ) -> EpisodePlanDTO | None:
+        benchmark_seed_digest, split, ordinal = ordinal_key
+        for plan in self._episode_plans.values():
+            if (
+                plan.benchmark_seed_digest == benchmark_seed_digest
+                and plan.split == split
+                and plan.ordinal == ordinal
+            ):
+                return plan
+        return None
 
 
 __all__ = ["InMemoryVideoActionSetStore"]

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -11,13 +11,16 @@ import numpy as np
 
 from .arcade_policy import ACTIONS, CELL_PIXELS, COOLDOWN_BLOCKED_VALUE, COOLDOWN_READY_VALUE, TANK_VALUE, TARGET_VALUE, ShooterConfig, arcade_transition_spec, compile_policy_artifact, next_rows, parse_state_row_id, render_state_frame, state_row_id
 from .artifact import VPMValidationError
+from .domains.video_action_set.canonical_json import canonical_json_bytes, canonical_json_value, canonical_sha256
 from .domains.video_action_set.contracts import (
     BENCHMARK_VERSION,
+    EPISODE_PLAN_VERSION,
     GENERATOR_VERSION,
     REACHABILITY_TILE_DIGEST,
     REACHABILITY_TILE_VERSION,
+    SEED_DERIVATION_VERSION,
 )
-from .domains.video_action_set.dto import BenchmarkIdentityDTO
+from .domains.video_action_set.dto import BenchmarkIdentityDTO, EpisodePlanDTO
 from .policy_lookup import VPMPolicyLookup
 from .runtime import build_runtime
 from .video_complete_row_evidence import (
@@ -45,8 +48,6 @@ from .visual_address import IMAGE_OBSERVATION_VERSION, ImageObservation
 
 
 EPISODE_SCHEMA_VERSION = "zeromodel-video-policy-episode/v1"
-EPISODE_PLAN_VERSION = "zeromodel-video-action-set-sealed-episode-plan/v1"
-SEED_DERIVATION_VERSION = "zeromodel-video-action-set-seed-derivation/v1"
 EPISODE_FAMILY_REGISTRY_VERSION = "zeromodel-video-action-set-episode-family-registry/v4"
 TRANSFORMATION_FAMILY_VERSION = "zeromodel-video-action-set-transformation-family/v1"
 CRITICAL_COORDINATE_SET_VERSION = "zeromodel-video-action-set-critical-coordinate-set/v1"
@@ -77,25 +78,15 @@ TARGET_REGION_ID = "target_band"
 
 
 def _json_ready(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _json_ready(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_ready(item) for item in value]
-    return value
+    return canonical_json_value(value)
 
 
 def _json_bytes(value: Any) -> bytes:
-    return json.dumps(
-        _json_ready(value),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        allow_nan=False,
-    ).encode("utf-8")
+    return canonical_json_bytes(value)
 
 
 def _sha256(value: Any) -> str:
-    return "sha256:" + hashlib.sha256(_json_bytes(value)).hexdigest()
+    return canonical_sha256(value)
 
 
 def _write_json(path: Path, payload: Any) -> None:
@@ -1704,7 +1695,8 @@ def _make_episode_plan(
         },
         "frame_plans": frame_plans,
     }
-    return plan | {"plan_digest": _sha256(plan)}
+    dto = EpisodePlanDTO.from_dict(plan | {"plan_digest": _sha256(plan)})
+    return dto.to_dict()
 
 
 def _episode_plans_for_split(identity: BenchmarkIdentity, split: str, row_ids: list[str], row_actions: Mapping[str, str]) -> list[dict[str, Any]]:
@@ -1764,6 +1756,10 @@ def _episode_ids_by_family(plans: list[dict[str, Any]]) -> dict[str, list[str]]:
 
 
 def _validate_episode_plan(identity: BenchmarkIdentity, plan: Mapping[str, Any], row_actions: Mapping[str, str]) -> None:
+    try:
+        EpisodePlanDTO.from_dict(plan)
+    except VPMValidationError as exc:
+        raise VPMValidationError("episode plan is inconsistent with declared seed lineage or identity") from exc
     expected = _make_episode_plan(
         identity,
         split=str(plan["split"]),
@@ -2743,7 +2739,8 @@ def _control_episode(
 
 
 def freeze_benchmark(output_dir: Path, repo_root: Path) -> dict[str, Any]:
-    identity = load_identity(repo_root)
+    runtime = build_runtime()
+    identity = runtime.video_action_set.load_identity(repo_root)
     policy = compile_policy_artifact()
     lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
     row_ids = [str(row_id) for row_id in policy.source.row_ids]
@@ -2757,6 +2754,14 @@ def freeze_benchmark(output_dir: Path, repo_root: Path) -> dict[str, Any]:
         {"development": development_plans, "calibration": calibration_plans, "selection": selection_plans, "final": final_plans},
         row_actions,
     )
+    development_episode_dtos = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in development_plans))
+    calibration_episode_dtos = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in calibration_plans))
+    selection_episode_dtos = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in selection_plans))
+    final_episode_dtos = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in final_plans))
+    development_plans = [dto.to_dict() for dto in development_episode_dtos]
+    calibration_plans = [dto.to_dict() for dto in calibration_episode_dtos]
+    selection_plans = [dto.to_dict() for dto in selection_episode_dtos]
+    final_plans = [dto.to_dict() for dto in final_episode_dtos]
     split_manifest = {
         "development_episode_count": 112,
         "calibration_episode_count": 112,
@@ -2779,24 +2784,8 @@ def freeze_benchmark(output_dir: Path, repo_root: Path) -> dict[str, Any]:
             {"provider_id": "P3", "provider_version": PROSPECTIVE_P3_VERSION},
         ]
     }
-    final_plan = {
-        "version": EPISODE_PLAN_VERSION,
-        "seed_derivation_version": SEED_DERIVATION_VERSION,
-        "split": "final",
-        "plan_only": True,
-        "materialization_prohibited": True,
-        "episode_counts": {
-            "valid": 112,
-            "frame_invalid": 56,
-            "temporal_negative": 56,
-            "information_control": 28,
-        },
-        "frame_count": 1008,
-        "sealed_episode_ids": _episode_ids_by_family(final_plans),
-        "episodes": final_plans,
-        "seed_commitment": identity.seed_digest,
-    }
-    final_plan = final_plan | {"sealed_plan_digest": _sha256(final_plan)}
+    sealed_final = runtime.video_action_set.seal_final_split(episodes=final_episode_dtos, seed_commitment=identity.seed_digest)
+    final_plan = sealed_final.to_dict()
     _write_json(output_dir / "benchmark-contract-identity.json", identity.to_dict())
     _write_json(output_dir / "generator-identity.json", {"generator_version": GENERATOR_VERSION, "seed_digest": identity.seed_digest, "seed_material": identity.seed_material})
     _write_json(output_dir / "benchmark-manifest.json", {"benchmark_version": BENCHMARK_VERSION, "policy_artifact_id": policy.artifact_id, "row_count": len(row_ids)})
@@ -5940,9 +5929,11 @@ def _run_adversarial_mutation_checks(output_dir: Path) -> list[str]:
 __all__ = [
     "BenchmarkIdentity",
     "BENCHMARK_VERSION",
+    "EPISODE_PLAN_VERSION",
     "GENERATOR_VERSION",
     "REACHABILITY_TILE_DIGEST",
     "REACHABILITY_TILE_VERSION",
+    "SEED_DERIVATION_VERSION",
     "REFERENCE_VERIFICATION_VERSION",
     "MUTATION_AUDIT_VERSION",
     "CLOSURE_REPORT_VERSION",


### PR DESCRIPTION
## What changed

* added immutable episode-plan DTOs;
* added canonical JSON and digest utilities;
* extended DTO-only Store protocol;
* extended in-memory and SQL Stores;
* added episode-plan ORM persistence;
* added sealed final-plan persistence;
* added EpisodePlan Service, Engine, Facade, and Runtime methods;
* routed legacy freeze output through RMDTO boundaries;
* preserved existing dictionary APIs and output artifacts;
* reduced the monolith quality ceiling.

## Why

The video benchmark cannot be safely decomposed while its durable plan contract remains an untyped nested dictionary owned by a 6,000-line module.

This PR makes the episode plan a first-class immutable aggregate without prematurely moving the complete scientific generator.

## Scope boundary

The existing generator remains authoritative.

No transformation, family intervention, materialization, scoring, verification, or scientific semantics changed.

Audit-Exempt: behavior-preserving episode-plan RMDTO extraction; no claim status, benchmark evidence, scientific semantics, schema identity, digest semantics, or conclusions changed.

## Validation

* `python scripts/check_quality.py` passed.
* `python -m pytest -q tests/test_video_episode_plan_rmdto.py` passed: 8 passed in 0.80s.
* `python scripts/run_fast_tests.py` passed: 350 passed, 1 skipped, 86 deselected in 48.88s; runner duration 49.66s.
* `python -m build` passed; setuptools emitted existing license deprecation warnings.
* Integration tests not run.