### PR TITLE
refactor: add observation and provenance RMDTO aggregates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,14 @@ When integration coverage is relevant, report the exact suggested command but do
 - Batch Store writes must be atomic.
 - A behavior-preserving extraction must reduce the corresponding monolith quality ceiling.
 - Integration-tier persistence tests may be authored but must not be executed without explicit human authorization.
+- Durable benchmark runs prefer SQLite Runtime construction.
+- Durable exports should be projections of Store-returned DTOs.
+- Large binary arrays must use MatrixBlob and content-addressed deduplication.
+- MatrixBlob identity metadata must describe the payload, not the owning frame, episode, split, or sequence.
+- Provenance and operation-chain queries belong in relational Store predicates and joins.
+- Scientific rendering, transformation, mutation, replay, and digest computation stay in Python/NumPy.
+- Final split materialization is prohibited in every Store.
+- Batch observation writes must be atomic.
 
 ## Working Style
 

--- a/docs/architecture/video-action-set-rmdto.md
+++ b/docs/architecture/video-action-set-rmdto.md
@@ -2,7 +2,8 @@
 
 This document describes the RMDTO boundary for the video action-set domain. The
 first slice introduced the benchmark identity aggregate; the second slice adds
-episode plans and the sealed final split-plan envelope.
+episode plans and the sealed final split-plan envelope; the third slice adds the
+database-first observation, MatrixBlob, and provenance ledger.
 
 The dependency path is:
 
@@ -109,12 +110,68 @@ scorable, or materialized.
 Persistence records the deterministic plan contract; it does not become the
 authority that invents or repairs scientific plans.
 
+## Observation Ledger Aggregate
+
+The durable observation ownership chain is:
+
+```text
+BenchmarkIdentity
+    -> EpisodePlan
+    -> Observation
+    -> ObservationOperationChain
+    -> ObservationOperation
+```
+
+`MatrixBlob` stores canonical binary frame payloads separately from observation
+metadata. Identical pixel arrays deduplicate by `MatrixBlob.blob_id`; frame
+ownership fields such as split, episode ID, frame ID, sequence number, family,
+and expected action are observation fields and must not be included in
+MatrixBlob identity-bearing metadata. Benchmark frame blobs use payload metadata
+only, including the frame-pixel kind and historical pixel digest.
+
+`MatrixBlob` predates the RMDTO package but already satisfies the immutable DTO
+contract. It is the only Store-boundary exception to the `*DTO` naming pattern,
+and Stores may accept or return it directly.
+
+The observation ledger preserves three distinct identities:
+
+- `observation_pixel_digest`: historical raw contiguous pixel-byte digest.
+- provider raw digest: `ImageObservation` domain-separated digest including shape.
+- `matrix_blob_id`: MatrixBlob identity over version, dtype, shape, metadata,
+  quantization, and canonical bytes.
+
+Operation chains are stored as ordered relational provenance rows. Operation
+parameters remain canonical JSON, while operation names, versions, input
+digests, output digests, parameter digests, operation digests, and chain digests
+are queryable. SQL Stores apply split, episode, family, event type,
+denominator-class, pixel-presence, operation, input-digest, and output-digest
+filters in SQL predicates and joins, not by loading the table and filtering in
+Python.
+
+Batch observation writes are atomic. Stores validate existing benchmark identity
+and episode-plan ownership, MatrixBlob identity, observation identity, sequence
+uniqueness, pixel digest, provider descriptor digest, and operation-chain digest
+before committing. Stores do not repair conflicting scientific records.
+
+Durable benchmark paths use SQLite as the preferred substrate and write public
+JSON and JSONL artifacts as projections of Store-returned DTOs. Compatibility
+exports keep the legacy observation record keys and do not add MatrixBlob IDs.
+Final split materialization remains prohibited: the final split is plan-only,
+and Stores must not persist final observations or final MatrixBlob rows.
+
+Python and NumPy remain authoritative for rendering, pixel transformations,
+splicing, corruption, temporal mutation, operation replay, digest computation,
+and scientific validation. SQLite is authoritative for durable identity,
+relationships, ordering, deduplication, transactionality, provenance traversal,
+and audit retrieval.
+
+Use the database to organize, relate, constrain, and retrieve scientific
+evidence. Do not use it to invent, normalize, or repair scientific evidence.
+
 ## Future aggregates
 
 Future slices can add DTOs, Stores, and persistence mappings for:
 
-- observations and MatrixBlob references;
-- operation chains;
 - verification reports;
 - mutation audits.
 

--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -9,7 +9,7 @@ maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
 reason = "Stage 3 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 5957
+maximum_lines = 5929
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -9,7 +9,7 @@ maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
 reason = "Stage 3 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 5929
+maximum_lines = 5950
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -15,6 +15,7 @@ DB_STORES_PREFIX = "zeromodel.db.stores"
 VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
     "zeromodel.domains.video_action_set.episode_plan_service",
     "zeromodel.domains.video_action_set.identity_service",
+    "zeromodel.domains.video_action_set.observation_service",
     "zeromodel.domains.video_action_set.engine",
     "zeromodel.domains.video_action_set.facade",
     "zeromodel.runtime",
@@ -24,6 +25,8 @@ VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
     "zeromodel.domains.video_action_set.contracts",
     "zeromodel.domains.video_action_set.dto",
     "zeromodel.domains.video_action_set.episode_plan_service",
+    "zeromodel.domains.video_action_set.observation_dto",
+    "zeromodel.domains.video_action_set.observation_service",
 }
 VIDEO_ACTION_SET_POLICY_MODULES = {
     f"{VIDEO_ACTION_SET_PREFIX}.contracts",
@@ -381,6 +384,18 @@ def rmdto_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
         violations.append(
             edge_violation(
                 "zeromodel.runtime must not import database or SQLAlchemy modules",
+                edge,
+            )
+        )
+    if edge.importer == "zeromodel.matrix_blob" and (
+        is_module_under(edge.imported, DOMAIN_VIDEO_ACTION_SET_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db")
+        or is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+    ):
+        violations.append(
+            edge_violation(
+                "zeromodel.matrix_blob must remain independent of video_action_set, stores, database, and runtime",
                 edge,
             )
         )

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -25,8 +25,13 @@ VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
     "zeromodel.domains.video_action_set.contracts",
     "zeromodel.domains.video_action_set.dto",
     "zeromodel.domains.video_action_set.episode_plan_service",
+    "zeromodel.domains.video_action_set.observation_common",
     "zeromodel.domains.video_action_set.observation_dto",
+    "zeromodel.domains.video_action_set.observation_legacy_adapters",
+    "zeromodel.domains.video_action_set.observation_materialization",
+    "zeromodel.domains.video_action_set.observation_provenance_dto",
     "zeromodel.domains.video_action_set.observation_service",
+    "zeromodel.domains.video_action_set.provider_observation_dto",
 }
 VIDEO_ACTION_SET_POLICY_MODULES = {
     f"{VIDEO_ACTION_SET_PREFIX}.contracts",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,13 @@ import pytest
 
 
 INTEGRATION_MARKERS = {"integration", "slow"}
-INTEGRATION_TEST_FILES = {"test_video_episode_plan_sql_store.py"}
 INTEGRATION_TEST_PREFIXES = ("test_video_action_set_",)
 INTEGRATION_TEST_FILES = {
     "test_arcade_visual_local_baseline_showdown.py",
     "test_arcade_visual_registered_calibration_v2.py",
     "test_installed_wheel_video_instrument.py",
+    "test_video_episode_plan_sql_store.py",
+    "test_video_observation_sql_store.py",
     "test_video_discriminative_evidence.py",
     "test_video_discriminative_measurement_audit.py",
     "test_video_discriminative_representation_audit.py",
@@ -67,7 +68,6 @@ def pytest_collection_modifyitems(
             "integration" in item.path.parts
             or filename in INTEGRATION_TEST_FILES
             or filename.startswith(INTEGRATION_TEST_PREFIXES)
-            or filename in INTEGRATION_TEST_FILES
         ):
             item.add_marker(pytest.mark.integration)
 

--- a/tests/test_video_episode_plan_sql_store.py
+++ b/tests/test_video_episode_plan_sql_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy import inspect
 
 from test_video_episode_plan_rmdto import (
@@ -30,12 +31,16 @@ from zeromodel.domains.video_action_set.store import (
 pytestmark = pytest.mark.integration
 
 
-def sql_safe_identity(prefix: str = "sql-episode-plan-rmdto-seed"):
-    for index in range(100):
+def sql_identity(prefix: str = "sql-episode-plan-rmdto-seed"):
+    return sample_identity(prefix)
+
+
+def unsigned_seed_identity(prefix: str = "sql-unsigned-episode-plan-seed"):
+    for index in range(10_000):
         identity = sample_identity(f"{prefix}-{index}")
-        if plan_dto(identity=identity).episode_seed < 2**63:
+        if plan_dto(identity=identity).episode_seed >= 2**63:
             return identity
-    raise AssertionError("could not find SQLite-safe episode seed")
+    raise AssertionError("could not find unsigned 64-bit episode seed")
 
 
 def build_store():
@@ -59,7 +64,7 @@ def test_sql_schema_creation_registers_episode_plan_tables() -> None:
 
 def test_sql_plan_identity_ownership_and_canonical_round_trip() -> None:
     store, session_factory, _engine = build_store()
-    identity = sql_safe_identity()
+    identity = sql_identity()
     plan = plan_dto(identity=identity)
 
     with pytest.raises(VPMValidationError, match=UNKNOWN_BENCHMARK_IDENTITY_MESSAGE):
@@ -72,11 +77,32 @@ def test_sql_plan_identity_ownership_and_canonical_round_trip() -> None:
         row = session.get(EpisodePlanORM, plan.episode_id)
         assert row is not None
         assert row.payload_json == canonical_json_text(plan.to_dict())
+        assert row.episode_seed_hex == f"{plan.episode_seed:016x}"
+
+
+def test_sql_plan_persists_unsigned_episode_seed() -> None:
+    store, session_factory, _engine = build_store()
+    identity = unsigned_seed_identity()
+    plan = plan_dto(identity=identity)
+
+    assert plan.episode_seed >= 2**63
+    store.save_identity(identity)
+    store.save_episode_plan(plan)
+
+    with session_factory() as session:
+        row = session.get(EpisodePlanORM, plan.episode_id)
+        assert row is not None
+        assert row.episode_seed_hex == f"{plan.episode_seed:016x}"
+
+    assert (
+        SqlAlchemyVideoActionSetStore(session_factory).get_episode_plan(plan.episode_id)
+        == plan
+    )
 
 
 def test_sql_plan_retrieval_across_sessions_idempotence_and_conflict() -> None:
     _store, session_factory, _engine = build_store()
-    identity = sql_safe_identity()
+    identity = sql_identity()
     plan = plan_dto(identity=identity)
     save_store = SqlAlchemyVideoActionSetStore(session_factory)
     read_store = SqlAlchemyVideoActionSetStore(session_factory)
@@ -96,8 +122,8 @@ def test_sql_plan_retrieval_across_sessions_idempotence_and_conflict() -> None:
 
 def test_sql_batch_rollback_ordering_and_filters() -> None:
     store, _session_factory, _engine = build_store()
-    identity = sql_safe_identity()
-    other_identity = sql_safe_identity("sql-episode-plan-other-seed")
+    identity = sql_identity()
+    other_identity = sql_identity("sql-episode-plan-other-seed")
     first = plan_dto(identity=identity, split="development", ordinal=0)
     second = plan_dto(
         identity=identity,
@@ -136,7 +162,7 @@ def test_sql_batch_rollback_ordering_and_filters() -> None:
 
 def test_sql_sealed_envelope_reconstructs_from_episode_rows() -> None:
     store, session_factory, _engine = build_store()
-    identity = sql_safe_identity()
+    identity = sql_identity()
     episodes = (
         plan_dto(identity=identity, ordinal=0, family_label="valid", family_ordinal=0),
         plan_dto(
@@ -175,7 +201,7 @@ def test_sql_sealed_envelope_reconstructs_from_episode_rows() -> None:
 
 def test_sql_sealed_digest_validation_rejects_corrupted_envelope() -> None:
     store, session_factory, _engine = build_store()
-    identity = sql_safe_identity()
+    identity = sql_identity()
     plan = plan_dto(identity=identity)
     sealed = SealedSplitPlanDTO.build_final(
         episodes=(plan,),
@@ -194,7 +220,7 @@ def test_sql_sealed_digest_validation_rejects_corrupted_envelope() -> None:
 
 def test_sqlite_runtime_composes_episode_plan_store() -> None:
     runtime = build_sqlite_runtime("sqlite:///:memory:", initialize_schema=True)
-    identity = sql_safe_identity()
+    identity = sql_identity()
     plan = plan_dto(identity=identity)
 
     runtime.video_action_set.save_identity(identity)
@@ -211,3 +237,17 @@ def test_sqlite_runtime_composes_episode_plan_store() -> None:
         )
         == sealed
     )
+
+
+def test_sqlite_foreign_keys_are_enabled_and_reject_orphan_plan() -> None:
+    _store, session_factory, engine = build_store()
+
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql("PRAGMA foreign_keys").scalar_one() == 1
+
+    identity = sql_identity("sql-orphan-plan-seed")
+    plan = plan_dto(identity=identity)
+    orphan = SqlAlchemyVideoActionSetStore._to_episode_plan_orm(plan)
+    with pytest.raises(IntegrityError):
+        with session_factory.begin() as session:
+            session.add(orphan)

--- a/tests/test_video_observation_rmdto.py
+++ b/tests/test_video_observation_rmdto.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from test_video_episode_plan_rmdto import plan_dto, sample_identity
+from zeromodel import build_runtime
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+from zeromodel.domains.video_action_set.contracts import (
+    BENCHMARK_VERSION,
+    FRAME_SHAPE,
+    GENERATOR_VERSION,
+    OBSERVATION_OPERATION_CHAIN_VERSION,
+)
+from zeromodel.domains.video_action_set.observation_dto import (
+    MaterializedObservationDTO,
+    ObservationOperationChainDTO,
+    ObservationOperationDTO,
+    ProviderObservationDescriptorDTO,
+)
+from zeromodel.domains.video_action_set.store import (
+    MATRIX_BLOB_CONFLICT_MESSAGE,
+    OBSERVATION_CONFLICT_MESSAGE,
+    OBSERVATION_SEQUENCE_CONFLICT_MESSAGE,
+    UNKNOWN_BENCHMARK_IDENTITY_MESSAGE,
+    UNKNOWN_EPISODE_PLAN_MESSAGE,
+)
+from zeromodel.matrix_blob import MatrixBlob
+from zeromodel.stores.video_action_set_memory import InMemoryVideoActionSetStore
+from zeromodel.visual_address import ImageObservation
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _pixel_digest(pixels: np.ndarray) -> str:
+    return (
+        "sha256:"
+        + hashlib.sha256(np.ascontiguousarray(pixels).tobytes(order="C")).hexdigest()
+    )
+
+
+def _operation(
+    *,
+    index: int = 0,
+    operation: str = "emit_observation",
+    input_digests: tuple[str | None, ...],
+    output_digest: str | None,
+    parameters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    parameters = {"event_type": "frame"} if parameters is None else parameters
+    payload = {
+        "index": index,
+        "operation": operation,
+        "operation_version": OBSERVATION_OPERATION_CHAIN_VERSION,
+        "input_digests": list(input_digests),
+        "parameters": parameters,
+        "parameter_digest": canonical_sha256(parameters),
+        "output_digest": output_digest,
+    }
+    return payload | {"operation_digest": canonical_sha256(payload)}
+
+
+def _chain(
+    final_digest: str | None,
+    *,
+    operation: str = "emit_observation",
+) -> dict[str, Any]:
+    parameters = {"event_type": "gap_unknown" if final_digest is None else "frame"}
+    op = _operation(
+        operation=operation,
+        input_digests=(final_digest,),
+        output_digest=final_digest,
+        parameters=parameters,
+    )
+    payload = {
+        "version": OBSERVATION_OPERATION_CHAIN_VERSION,
+        "operations": [op],
+        "final_emitted_digest": final_digest,
+    }
+    return payload | {"operation_chain_digest": canonical_sha256(payload)}
+
+
+def _pixels(offset: int = 0) -> np.ndarray:
+    values = (
+        np.arange(FRAME_SHAPE[0] * FRAME_SHAPE[1], dtype=np.uint16) + offset
+    ) % 251
+    return values.astype(np.uint8).reshape(FRAME_SHAPE)
+
+
+def _provider_descriptor(pixels: np.ndarray, frame_id: str) -> dict[str, Any]:
+    return ImageObservation(pixels, source_id=frame_id).to_descriptor()
+
+
+def sample_record(
+    *,
+    split: str = "development",
+    sequence_number: int = 0,
+    frame_index: int | None = None,
+    pixels: np.ndarray | None = None,
+    event_type: str = "frame",
+    plan=None,
+    metadata_extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    identity = sample_identity()
+    plan = plan or plan_dto(identity=identity, split=split, frame_count=2)
+    frame_index = sequence_number if frame_index is None else frame_index
+    frame_id = f"{split}:{plan.episode_id}:frame-{frame_index:02d}"
+    pixel_digest = None if pixels is None else _pixel_digest(pixels)
+    metadata = {
+        "episode_seed": plan.episode_seed,
+        "seed_digest": identity.seed_digest,
+        "derived_seed_identity": plan.derived_seed_identity,
+        "episode_plan_digest": plan.plan_digest,
+        "frame_seed_identity": plan.frame_plans[0].to_value()["frame_seed_identity"],
+        "observation_operation_chain": _chain(pixel_digest),
+    }
+    if metadata_extra:
+        metadata.update(metadata_extra)
+    if pixels is not None:
+        descriptor = _provider_descriptor(pixels, frame_id)
+        descriptor_dto = ProviderObservationDescriptorDTO.from_dict(descriptor)
+        metadata.update(
+            {
+                "provider_observation_boundary_version": (
+                    benchmark.PROVIDER_OBSERVATION_BOUNDARY_VERSION
+                ),
+                "provider_observation_descriptor": descriptor,
+                "provider_observation_digest": descriptor_dto.descriptor_digest,
+            }
+        )
+    return {
+        "benchmark_version": BENCHMARK_VERSION,
+        "generator_version": GENERATOR_VERSION,
+        "split": split,
+        "episode_id": plan.episode_id,
+        "clip_id": f"{split}:{plan.episode_id}:clip",
+        "frame_id": frame_id,
+        "sequence_number": sequence_number,
+        "event_type": event_type,
+        "family": "bounded_translation",
+        "expected_disposition": "valid",
+        "episode_family": plan.episode_family,
+        "episode_disposition": plan.episode_disposition,
+        "frame_disposition": "valid_frame_payload",
+        "denominator_class": plan.denominator_class,
+        "expected_row": plan.source_row_id,
+        "expected_action": "left",
+        "actual_executed_action": "left",
+        "action_known": True,
+        "gap_declaration": None,
+        "observation_pixel_digest": pixel_digest,
+        "metadata": metadata,
+        "pixels": pixels,
+    }
+
+
+def sample_gap_record(
+    *,
+    plan=None,
+    sequence_number: int = 0,
+    frame_index: int | None = None,
+) -> dict[str, Any]:
+    record = sample_record(
+        plan=plan,
+        sequence_number=sequence_number,
+        frame_index=frame_index,
+        pixels=None,
+        event_type="gap_unknown",
+    )
+    record["expected_row"] = None
+    record["expected_action"] = None
+    record["actual_executed_action"] = None
+    record["action_known"] = False
+    record["gap_declaration"] = "declared_gap"
+    record["metadata"]["observation_operation_chain"] = _chain(None)
+    return record
+
+
+def assert_records_equivalent(left: dict[str, Any], right: dict[str, Any]) -> None:
+    left = dict(left)
+    right = dict(right)
+    left_pixels = left.pop("pixels", None)
+    right_pixels = right.pop("pixels", None)
+    assert left == right
+    if left_pixels is None or right_pixels is None:
+        assert left_pixels is right_pixels
+    else:
+        np.testing.assert_array_equal(left_pixels, right_pixels)
+
+
+def test_operation_dto_round_trip_hashing_and_tamper_rejection() -> None:
+    digest = "sha256:" + "1" * 64
+    payload = _operation(input_digests=(digest,), output_digest=digest)
+    dto = ObservationOperationDTO.from_dict(payload)
+
+    assert dto.to_dict() == payload
+    returned = dto.to_dict()
+    returned["parameters"]["event_type"] = "changed"  # type: ignore[index]
+    assert dto.to_dict() == payload
+
+    bad_index = payload | {"index": -1}
+    with pytest.raises(VPMValidationError, match="index cannot be negative"):
+        ObservationOperationDTO.from_dict(bad_index)
+
+    bad_parameter = deepcopy(payload)
+    bad_parameter["parameters"]["event_type"] = "changed"
+    with pytest.raises(VPMValidationError, match="parameter digest mismatch"):
+        ObservationOperationDTO.from_dict(bad_parameter)
+
+    bad_output = payload | {"output_digest": "not-sha256"}
+    with pytest.raises(VPMValidationError, match="digest is not sha256"):
+        ObservationOperationDTO.from_dict(bad_output)
+
+
+def test_operation_chain_round_trip_typed_gap_and_tamper_rejection() -> None:
+    digest = "sha256:" + "2" * 64
+    payload = _chain(digest)
+    dto = ObservationOperationChainDTO.from_dict(payload)
+
+    assert dto.to_dict() == payload
+    assert (
+        ObservationOperationChainDTO.from_dict(_chain(None)).final_emitted_digest
+        is None
+    )
+
+    bad_indexes = deepcopy(payload)
+    bad_indexes["operations"][0]["index"] = 1
+    bad_indexes["operations"][0]["operation_digest"] = canonical_sha256(
+        {
+            key: value
+            for key, value in bad_indexes["operations"][0].items()
+            if key != "operation_digest"
+        }
+    )
+    bad_indexes["operation_chain_digest"] = canonical_sha256(
+        {
+            key: value
+            for key, value in bad_indexes.items()
+            if key != "operation_chain_digest"
+        }
+    )
+    with pytest.raises(VPMValidationError, match="indexes are not contiguous"):
+        ObservationOperationChainDTO.from_dict(bad_indexes)
+
+    bad_final = deepcopy(payload)
+    bad_final["final_emitted_digest"] = "sha256:" + "0" * 64
+    bad_final["operation_chain_digest"] = canonical_sha256(
+        {
+            key: value
+            for key, value in bad_final.items()
+            if key != "operation_chain_digest"
+        }
+    )
+    with pytest.raises(VPMValidationError, match="final digest mismatch"):
+        ObservationOperationChainDTO.from_dict(bad_final)
+
+
+def test_provider_descriptor_round_trip_and_validation() -> None:
+    descriptor = _provider_descriptor(_pixels(), "frame:source")
+    dto = ProviderObservationDescriptorDTO.from_dict(descriptor)
+
+    assert dto.to_dict() == descriptor
+    returned = dto.to_dict()
+    returned["metadata"]["changed"] = True  # type: ignore[index]
+    assert dto.to_dict() == descriptor
+
+    with pytest.raises(VPMValidationError, match="shape mismatch"):
+        ProviderObservationDescriptorDTO.from_dict(descriptor | {"shape": [0, 28]})
+    with pytest.raises(VPMValidationError, match="raw digest"):
+        ProviderObservationDescriptorDTO.from_dict(descriptor | {"raw_digest": "bad"})
+
+
+def test_materialized_observation_record_round_trip_and_identity_separation() -> None:
+    record = sample_record(pixels=_pixels())
+    item = MaterializedObservationDTO.from_record(record)
+
+    assert item.matrix_blob is not None
+    assert item.observation.observation_pixel_digest != item.matrix_blob.blob_id
+    assert item.observation.matrix_blob_id == item.matrix_blob.blob_id
+    assert item.matrix_blob.metadata == {
+        "kind": "video_action_set_frame_pixels",
+        "pixel_digest": item.observation.observation_pixel_digest,
+    }
+    assert "matrix_blob_id" not in item.to_record(include_pixels=False)
+    assert not any(
+        key in item.observation.metadata.to_value()
+        for key in (
+            "observation_operation_chain",
+            "provider_observation_descriptor",
+            "provider_observation_digest",
+        )
+    )
+    assert_records_equivalent(record, item.to_record(include_pixels=True))
+
+    second = MaterializedObservationDTO.from_record(
+        sample_record(sequence_number=1, pixels=_pixels())
+    )
+    assert second.matrix_blob is not None
+    assert second.matrix_blob.blob_id == item.matrix_blob.blob_id
+
+
+def test_typed_gap_and_observation_validation() -> None:
+    gap = MaterializedObservationDTO.from_record(sample_gap_record())
+
+    assert gap.matrix_blob is None
+    assert gap.observation.matrix_blob_id is None
+    assert gap.observation.observation_pixel_digest is None
+    assert gap.to_record(include_pixels=True)["pixels"] is None
+
+    bad_clip = sample_record(pixels=_pixels()) | {"clip_id": "bad"}
+    with pytest.raises(VPMValidationError, match="clip id mismatch"):
+        MaterializedObservationDTO.from_record(bad_clip)
+
+    bad_action = sample_record(pixels=_pixels()) | {"action_known": False}
+    with pytest.raises(VPMValidationError, match="action_known mismatch"):
+        MaterializedObservationDTO.from_record(bad_action)
+
+    final_plan = plan_dto(identity=sample_identity(), split="final", frame_count=2)
+    final_record = sample_record(split="final", plan=final_plan, pixels=_pixels())
+    with pytest.raises(VPMValidationError, match="final split observation"):
+        MaterializedObservationDTO.from_record(final_record)
+
+
+def test_in_memory_store_observation_ownership_atomicity_and_queries() -> None:
+    identity = sample_identity()
+    plan = plan_dto(identity=identity, split="development", frame_count=3)
+    store = InMemoryVideoActionSetStore()
+    first = MaterializedObservationDTO.from_record(
+        sample_record(plan=plan, sequence_number=0, pixels=_pixels())
+    )
+
+    with pytest.raises(VPMValidationError, match=UNKNOWN_BENCHMARK_IDENTITY_MESSAGE):
+        store.save_observation(first.observation, matrix_blob=first.matrix_blob)
+    store.save_identity(identity)
+    with pytest.raises(VPMValidationError, match=UNKNOWN_EPISODE_PLAN_MESSAGE):
+        store.save_observation(first.observation, matrix_blob=first.matrix_blob)
+    store.save_episode_plan(plan)
+
+    assert store.save_observation(first.observation, matrix_blob=first.matrix_blob) == (
+        first.observation
+    )
+    assert store.save_observation(first.observation, matrix_blob=first.matrix_blob) == (
+        first.observation
+    )
+    assert store.get_observation(first.observation.frame_id) == first.observation
+    assert store.get_materialized_observation(first.observation.frame_id) == first
+
+    second = MaterializedObservationDTO.from_record(
+        sample_record(plan=plan, sequence_number=1, pixels=_pixels())
+    )
+    gap = MaterializedObservationDTO.from_record(
+        sample_gap_record(plan=plan, sequence_number=2)
+    )
+    store.save_observations((second, gap))
+
+    assert store.list_observations(split="development") == (
+        first.observation,
+        second.observation,
+        gap.observation,
+    )
+    assert store.list_observations(family="bounded_translation", has_pixels=True) == (
+        first.observation,
+        second.observation,
+    )
+    assert store.list_observations(event_type="gap_unknown", has_pixels=False) == (
+        gap.observation,
+    )
+    assert store.list_observations_by_operation(operation="emit_observation") == (
+        first.observation,
+        second.observation,
+        gap.observation,
+    )
+    assert store.list_observations_by_output_digest(
+        str(first.observation.observation_pixel_digest)
+    ) == (first.observation, second.observation)
+    assert store.list_observation_consumers_of_digest(
+        str(first.observation.observation_pixel_digest)
+    ) == (first.observation, second.observation)
+
+    conflict = MaterializedObservationDTO.from_record(
+        sample_record(plan=plan, sequence_number=0, pixels=_pixels(3))
+    )
+    with pytest.raises(VPMValidationError, match=OBSERVATION_CONFLICT_MESSAGE):
+        store.save_observation(conflict.observation, matrix_blob=conflict.matrix_blob)
+
+    sequence_conflict = MaterializedObservationDTO.from_record(
+        sample_record(
+            plan=plan,
+            sequence_number=0,
+            frame_index=3,
+            pixels=_pixels(4),
+            metadata_extra={"original_frame_index": 3, "materialized_order": [3, 0]},
+        )
+    )
+    with pytest.raises(VPMValidationError, match=OBSERVATION_SEQUENCE_CONFLICT_MESSAGE):
+        store.save_observation(
+            sequence_conflict.observation,
+            matrix_blob=sequence_conflict.matrix_blob,
+        )
+
+    before = store.list_observations()
+    third = MaterializedObservationDTO.from_record(
+        sample_record(plan=plan, sequence_number=2, pixels=_pixels(5))
+    )
+    with pytest.raises(VPMValidationError, match=OBSERVATION_CONFLICT_MESSAGE):
+        store.save_observations((third, conflict))
+    assert store.list_observations() == before
+
+
+def test_matrix_blob_save_idempotence_and_conflict() -> None:
+    store = InMemoryVideoActionSetStore()
+    blob = MatrixBlob.from_array(
+        _pixels(),
+        dtype="uint8",
+        metadata={"kind": "test", "pixel_digest": _pixel_digest(_pixels())},
+    )
+    assert store.save_matrix_blob(blob) == blob
+    assert store.save_matrix_blob(blob) == blob
+
+    conflict = MatrixBlob.from_array(
+        _pixels(7),
+        dtype="uint8",
+        metadata={"kind": "test", "pixel_digest": _pixel_digest(_pixels(7))},
+    )
+    object.__setattr__(conflict, "blob_id", blob.blob_id)
+    with pytest.raises(VPMValidationError, match=MATRIX_BLOB_CONFLICT_MESSAGE):
+        store.save_matrix_blob(conflict)
+
+
+def test_runtime_facade_observation_methods_share_one_store() -> None:
+    identity = sample_identity()
+    plan = plan_dto(identity=identity, split="development", frame_count=2)
+    store = InMemoryVideoActionSetStore()
+    runtime = build_runtime(video_action_set_store=store)
+    record = sample_record(plan=plan, pixels=_pixels())
+
+    assert runtime.video_action_set.engine.observation_service.store is store
+    runtime.video_action_set.save_identity(identity)
+    runtime.video_action_set.save_episode_plan(plan)
+    observation = runtime.video_action_set.save_observation_record(record)
+
+    assert runtime.video_action_set.get_observation(observation.frame_id) == observation
+    assert_records_equivalent(
+        record,
+        runtime.video_action_set.get_observation_record(observation.frame_id),
+    )
+    assert runtime.video_action_set.list_observations_by_operation(
+        operation="emit_observation"
+    ) == (observation,)
+
+
+def test_legacy_frame_descriptor_round_trips_through_runtime() -> None:
+    identity = sample_identity()
+    plan = plan_dto(identity=identity, split="development", frame_count=2)
+    runtime = build_runtime()
+    runtime.video_action_set.save_identity(identity)
+    runtime.video_action_set.save_episode_plan(plan)
+    pixels = _pixels()
+    digest = _pixel_digest(pixels)
+    record = benchmark._frame_descriptor(
+        split="development",
+        episode_id=plan.episode_id,
+        frame_index=0,
+        row_id=plan.source_row_id,
+        expected_action="left",
+        actual_action="left",
+        family="bounded_translation",
+        pixels=pixels,
+        expected_disposition="valid",
+        episode_family=plan.episode_family,
+        episode_disposition=plan.episode_disposition,
+        frame_disposition="valid_frame_payload",
+        denominator_class=plan.denominator_class,
+        metadata={
+            "episode_seed": plan.episode_seed,
+            "seed_digest": identity.seed_digest,
+            "derived_seed_identity": plan.derived_seed_identity,
+            "episode_plan_digest": plan.plan_digest,
+            "frame_seed_identity": plan.frame_plans[0].to_value()[
+                "frame_seed_identity"
+            ],
+            "observation_operation_chain": _chain(digest),
+        },
+    ) | {"pixels": pixels}
+
+    observation = runtime.video_action_set.save_observation_record(record)
+
+    assert_records_equivalent(
+        record,
+        runtime.video_action_set.get_observation_record(observation.frame_id),
+    )
+
+
+def test_core_import_remains_sqlalchemy_free() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import zeromodel; print('sqlalchemy' in sys.modules)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "False"

--- a/tests/test_video_observation_rmdto.py
+++ b/tests/test_video_observation_rmdto.py
@@ -53,6 +53,7 @@ def _operation(
     *,
     index: int = 0,
     operation: str = "emit_observation",
+    operation_version: str = OBSERVATION_OPERATION_CHAIN_VERSION,
     input_digests: tuple[str | None, ...],
     output_digest: str | None,
     parameters: dict[str, Any] | None = None,
@@ -61,7 +62,7 @@ def _operation(
     payload = {
         "index": index,
         "operation": operation,
-        "operation_version": OBSERVATION_OPERATION_CHAIN_VERSION,
+        "operation_version": operation_version,
         "input_digests": list(input_digests),
         "parameters": parameters,
         "parameter_digest": canonical_sha256(parameters),
@@ -118,7 +119,7 @@ def sample_record(
     pixel_digest = None if pixels is None else _pixel_digest(pixels)
     metadata = {
         "episode_seed": plan.episode_seed,
-        "seed_digest": identity.seed_digest,
+        "seed_digest": plan.benchmark_seed_digest,
         "derived_seed_identity": plan.derived_seed_identity,
         "episode_plan_digest": plan.plan_digest,
         "frame_seed_identity": plan.frame_plans[0].to_value()["frame_seed_identity"],

--- a/tests/test_video_observation_sql_store.py
+++ b/tests/test_video_observation_sql_store.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from sqlalchemy import func, inspect, select
+
+from test_video_episode_plan_sql_store import sql_safe_identity
+from test_video_observation_rmdto import (
+    _pixels,
+    assert_records_equivalent,
+    sample_gap_record,
+    sample_record,
+)
+from zeromodel.artifact import VPMValidationError
+from zeromodel.db.orm.video_action_set import (
+    MatrixBlobORM,
+    ObservationORM,
+    ObservationOperationChainORM,
+    ObservationOperationORM,
+)
+from zeromodel.db.runtime import build_sqlite_runtime
+from zeromodel.db.session import (
+    create_database_engine,
+    create_schema,
+    create_session_factory,
+)
+from zeromodel.db.stores.video_action_set import SqlAlchemyVideoActionSetStore
+from zeromodel.domains.video_action_set.observation_dto import (
+    MaterializedObservationDTO,
+)
+from zeromodel.domains.video_action_set.store import (
+    OBSERVATION_CONFLICT_MESSAGE,
+)
+
+from test_video_episode_plan_rmdto import plan_dto
+
+
+pytestmark = pytest.mark.integration
+
+
+def build_store():
+    engine = create_database_engine("sqlite:///:memory:")
+    create_schema(engine)
+    session_factory = create_session_factory(engine)
+    return SqlAlchemyVideoActionSetStore(session_factory), session_factory, engine
+
+
+def _save_identity_plan(store: SqlAlchemyVideoActionSetStore, frame_count: int = 3):
+    identity = sql_safe_identity("sql-observation-rmdto-seed")
+    plan = plan_dto(identity=identity, split="development", frame_count=frame_count)
+    store.save_identity(identity)
+    store.save_episode_plan(plan)
+    return identity, plan
+
+
+def test_sql_schema_creation_registers_observation_tables() -> None:
+    engine = create_database_engine("sqlite:///:memory:")
+    assert "video_action_set_observation" not in inspect(engine).get_table_names()
+
+    create_schema(engine)
+    table_names = set(inspect(engine).get_table_names())
+
+    assert "matrix_blob" in table_names
+    assert "video_action_set_observation" in table_names
+    assert "video_action_set_observation_operation_chain" in table_names
+    assert "video_action_set_observation_operation" in table_names
+
+
+def test_sql_observation_round_trip_dedupes_blob_and_reconstructs_rows() -> None:
+    store, session_factory, _engine = build_store()
+    identity, plan = _save_identity_plan(store)
+    first_record = sample_record(plan=plan, sequence_number=0, pixels=_pixels())
+    second_record = sample_record(plan=plan, sequence_number=1, pixels=_pixels())
+    gap_record = sample_gap_record(plan=plan, sequence_number=2)
+
+    saved = store.save_observations(
+        tuple(
+            MaterializedObservationDTO.from_record(record)
+            for record in (first_record, second_record, gap_record)
+        )
+    )
+
+    assert len(saved) == 3
+    read_store = SqlAlchemyVideoActionSetStore(session_factory)
+    first_materialized = read_store.get_materialized_observation(saved[0].frame_id)
+    assert first_materialized is not None
+    assert_records_equivalent(first_record, first_materialized.to_record())
+    assert read_store.get_operation_chain(saved[0].frame_id) == saved[0].operation_chain
+
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(MatrixBlobORM)) == 1
+        assert session.scalar(select(func.count()).select_from(ObservationORM)) == 3
+        assert (
+            session.scalar(
+                select(func.count()).select_from(ObservationOperationChainORM)
+            )
+            == 3
+        )
+        assert (
+            session.scalar(select(func.count()).select_from(ObservationOperationORM))
+            == 3
+        )
+        blob = session.get(MatrixBlobORM, saved[0].matrix_blob_id)
+        assert blob is not None
+        assert isinstance(blob.data, bytes)
+        assert blob.byte_length == len(blob.data)
+
+    assert (
+        read_store.list_observations(
+            benchmark_seed_digest=identity.seed_digest,
+            split="development",
+        )
+        == saved
+    )
+    assert read_store.list_observations(
+        family="bounded_translation", has_pixels=True
+    ) == (
+        saved[0],
+        saved[1],
+    )
+    assert read_store.list_observations(event_type="gap_unknown", has_pixels=False) == (
+        saved[2],
+    )
+    assert (
+        read_store.list_observations_by_operation(operation="emit_observation") == saved
+    )
+    assert read_store.list_observations_by_output_digest(
+        str(saved[0].observation_pixel_digest)
+    ) == (saved[0], saved[1])
+    assert read_store.list_observation_consumers_of_digest(
+        str(saved[0].observation_pixel_digest)
+    ) == (saved[0], saved[1])
+
+
+def test_sql_observation_batch_rollback_leaves_no_orphan_rows() -> None:
+    store, session_factory, _engine = build_store()
+    _identity, plan = _save_identity_plan(store)
+    first = MaterializedObservationDTO.from_record(
+        sample_record(plan=plan, sequence_number=0, pixels=_pixels())
+    )
+    store.save_observations((first,))
+
+    new_record = sample_record(plan=plan, sequence_number=1, pixels=_pixels(9))
+    conflict_record = deepcopy(
+        sample_record(plan=plan, sequence_number=0, pixels=_pixels())
+    )
+    conflict_record["expected_action"] = "right"
+    batch = (
+        MaterializedObservationDTO.from_record(new_record),
+        MaterializedObservationDTO.from_record(conflict_record),
+    )
+
+    with pytest.raises(VPMValidationError, match=OBSERVATION_CONFLICT_MESSAGE):
+        store.save_observations(batch)
+
+    assert store.get_observation(batch[0].observation.frame_id) is None
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(ObservationORM)) == 1
+        assert session.scalar(select(func.count()).select_from(MatrixBlobORM)) == 1
+        assert (
+            session.scalar(select(func.count()).select_from(ObservationOperationORM))
+            == 1
+        )
+
+
+def test_sqlite_runtime_composes_observation_store() -> None:
+    runtime = build_sqlite_runtime("sqlite:///:memory:", initialize_schema=True)
+    identity = sql_safe_identity("sql-runtime-observation-rmdto-seed")
+    plan = plan_dto(identity=identity, split="development", frame_count=1)
+    record = sample_record(plan=plan, pixels=_pixels())
+
+    runtime.video_action_set.save_identity(identity)
+    runtime.video_action_set.save_episode_plan(plan)
+    observation = runtime.video_action_set.save_observation_record(record)
+
+    assert runtime.video_action_set.get_observation(observation.frame_id) == observation
+    assert_records_equivalent(
+        record,
+        runtime.video_action_set.get_observation_record(observation.frame_id),
+    )

--- a/tests/test_video_observation_sql_store.py
+++ b/tests/test_video_observation_sql_store.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from copy import deepcopy
 
 import pytest
-from sqlalchemy import func, inspect, select
+from sqlalchemy import event, func, inspect, select
+from sqlalchemy.exc import IntegrityError
 
-from test_video_episode_plan_sql_store import sql_safe_identity
+from test_video_episode_plan_sql_store import sql_identity
 from test_video_observation_rmdto import (
+    _operation,
     _pixels,
     assert_records_equivalent,
     sample_gap_record,
@@ -17,6 +19,7 @@ from zeromodel.db.orm.video_action_set import (
     MatrixBlobORM,
     ObservationORM,
     ObservationOperationChainORM,
+    ObservationOperationInputORM,
     ObservationOperationORM,
 )
 from zeromodel.db.runtime import build_sqlite_runtime
@@ -26,12 +29,18 @@ from zeromodel.db.session import (
     create_session_factory,
 )
 from zeromodel.db.stores.video_action_set import SqlAlchemyVideoActionSetStore
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+from zeromodel.domains.video_action_set.contracts import (
+    OBSERVATION_OPERATION_CHAIN_VERSION,
+)
 from zeromodel.domains.video_action_set.observation_dto import (
     MaterializedObservationDTO,
 )
 from zeromodel.domains.video_action_set.store import (
     OBSERVATION_CONFLICT_MESSAGE,
+    OBSERVATION_SEQUENCE_CONFLICT_MESSAGE,
 )
+from zeromodel.stores.video_action_set_memory import InMemoryVideoActionSetStore
 
 from test_video_episode_plan_rmdto import plan_dto
 
@@ -47,11 +56,55 @@ def build_store():
 
 
 def _save_identity_plan(store: SqlAlchemyVideoActionSetStore, frame_count: int = 3):
-    identity = sql_safe_identity("sql-observation-rmdto-seed")
+    identity = sql_identity("sql-observation-rmdto-seed")
     plan = plan_dto(identity=identity, split="development", frame_count=frame_count)
     store.save_identity(identity)
     store.save_episode_plan(plan)
     return identity, plan
+
+
+def _multi_operation_record(*, plan, sequence_number: int) -> dict[str, object]:
+    record = sample_record(
+        plan=plan,
+        sequence_number=sequence_number,
+        pixels=_pixels(sequence_number),
+    )
+    pixel_digest = record["observation_pixel_digest"]
+    assert isinstance(pixel_digest, str)
+    render = _operation(
+        index=0,
+        operation="render_canonical_row",
+        operation_version="zeromodel-arcade-shooter-render-state-frame/v1",
+        input_digests=(),
+        parameters={"row_id": record["expected_row"]},
+        output_digest=pixel_digest,
+    )
+    emit = _operation(
+        index=1,
+        operation="emit_observation",
+        operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+        input_digests=(pixel_digest,),
+        parameters={"event_type": "frame"},
+        output_digest=pixel_digest,
+    )
+    chain = {
+        "version": OBSERVATION_OPERATION_CHAIN_VERSION,
+        "operations": [render, emit],
+        "final_emitted_digest": pixel_digest,
+    }
+    chain["operation_chain_digest"] = canonical_sha256(chain)
+    record["metadata"]["observation_operation_chain"] = chain
+    return record
+
+
+def _save_single_observation():
+    store, session_factory, engine = build_store()
+    _identity, plan = _save_identity_plan(store, frame_count=1)
+    item = MaterializedObservationDTO.from_record(
+        sample_record(plan=plan, sequence_number=0, pixels=_pixels())
+    )
+    store.save_observations((item,))
+    return SqlAlchemyVideoActionSetStore(session_factory), session_factory, engine, item
 
 
 def test_sql_schema_creation_registers_observation_tables() -> None:
@@ -65,6 +118,7 @@ def test_sql_schema_creation_registers_observation_tables() -> None:
     assert "video_action_set_observation" in table_names
     assert "video_action_set_observation_operation_chain" in table_names
     assert "video_action_set_observation_operation" in table_names
+    assert "video_action_set_observation_operation_input" in table_names
 
 
 def test_sql_observation_round_trip_dedupes_blob_and_reconstructs_rows() -> None:
@@ -87,6 +141,11 @@ def test_sql_observation_round_trip_dedupes_blob_and_reconstructs_rows() -> None
     assert first_materialized is not None
     assert_records_equivalent(first_record, first_materialized.to_record())
     assert read_store.get_operation_chain(saved[0].frame_id) == saved[0].operation_chain
+    assert read_store.list_materialized_observations(split="development") == (
+        first_materialized,
+        read_store.get_materialized_observation(saved[1].frame_id),
+        read_store.get_materialized_observation(saved[2].frame_id),
+    )
 
     with session_factory() as session:
         assert session.scalar(select(func.count()).select_from(MatrixBlobORM)) == 1
@@ -101,10 +160,25 @@ def test_sql_observation_round_trip_dedupes_blob_and_reconstructs_rows() -> None
             session.scalar(select(func.count()).select_from(ObservationOperationORM))
             == 3
         )
+        assert (
+            session.scalar(
+                select(func.count()).select_from(ObservationOperationInputORM)
+            )
+            == 3
+        )
         blob = session.get(MatrixBlobORM, saved[0].matrix_blob_id)
         assert blob is not None
         assert isinstance(blob.data, bytes)
         assert blob.byte_length == len(blob.data)
+
+    assert first_materialized.observation.provider_observation_descriptor is not None
+    assert (
+        first_materialized.observation.provider_observation_descriptor.descriptor_digest
+        == first_materialized.observation.provider_observation_digest
+    )
+    gap_materialized = read_store.get_materialized_observation(saved[2].frame_id)
+    assert gap_materialized is not None
+    assert gap_materialized.to_record(include_pixels=True)["pixels"] is None
 
     assert (
         read_store.list_observations(
@@ -131,6 +205,37 @@ def test_sql_observation_round_trip_dedupes_blob_and_reconstructs_rows() -> None
     assert read_store.list_observation_consumers_of_digest(
         str(saved[0].observation_pixel_digest)
     ) == (saved[0], saved[1])
+
+
+def test_sql_observation_duplicate_same_batch_is_idempotent() -> None:
+    store, session_factory, _engine = build_store()
+    _identity, plan = _save_identity_plan(store, frame_count=1)
+    first = MaterializedObservationDTO.from_record(
+        sample_record(plan=plan, sequence_number=0, pixels=_pixels())
+    )
+
+    saved = store.save_observations((first, first))
+
+    assert saved == (first.observation, first.observation)
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(MatrixBlobORM)) == 1
+        assert session.scalar(select(func.count()).select_from(ObservationORM)) == 1
+        assert (
+            session.scalar(
+                select(func.count()).select_from(ObservationOperationChainORM)
+            )
+            == 1
+        )
+        assert (
+            session.scalar(select(func.count()).select_from(ObservationOperationORM))
+            == 1
+        )
+        assert (
+            session.scalar(
+                select(func.count()).select_from(ObservationOperationInputORM)
+            )
+            == 1
+        )
 
 
 def test_sql_observation_batch_rollback_leaves_no_orphan_rows() -> None:
@@ -162,11 +267,248 @@ def test_sql_observation_batch_rollback_leaves_no_orphan_rows() -> None:
             session.scalar(select(func.count()).select_from(ObservationOperationORM))
             == 1
         )
+        assert (
+            session.scalar(
+                select(func.count()).select_from(ObservationOperationInputORM)
+            )
+            == 1
+        )
+
+
+def test_sqlite_foreign_keys_reject_orphan_observation_operation() -> None:
+    _store, session_factory, engine = build_store()
+
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql("PRAGMA foreign_keys").scalar_one() == 1
+
+    orphan = ObservationOperationORM(
+        frame_id="missing-frame",
+        operation_index=0,
+        operation="emit_observation",
+        operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+        parameters_json='{"event_type":"frame"}',
+        parameter_digest="sha256:" + "1" * 64,
+        output_digest=None,
+        operation_digest="sha256:" + "2" * 64,
+    )
+    with pytest.raises(IntegrityError):
+        with session_factory.begin() as session:
+            session.add(orphan)
+
+
+def test_sql_observation_sequence_uniqueness_is_preflighted() -> None:
+    store, _session_factory, _engine = build_store()
+    _identity, plan = _save_identity_plan(store, frame_count=4)
+    first = MaterializedObservationDTO.from_record(
+        sample_record(plan=plan, sequence_number=0, pixels=_pixels())
+    )
+    conflict = MaterializedObservationDTO.from_record(
+        sample_record(
+            plan=plan,
+            sequence_number=0,
+            frame_index=3,
+            pixels=_pixels(4),
+            metadata_extra={"original_frame_index": 3, "materialized_order": [3, 0]},
+        )
+    )
+
+    store.save_observations((first,))
+
+    with pytest.raises(VPMValidationError, match=OBSERVATION_SEQUENCE_CONFLICT_MESSAGE):
+        store.save_observations((conflict,))
+
+
+def test_sql_observation_multi_operation_ordering_and_inputs_round_trip() -> None:
+    store, session_factory, _engine = build_store()
+    _identity, plan = _save_identity_plan(store, frame_count=2)
+    record = _multi_operation_record(plan=plan, sequence_number=1)
+    item = MaterializedObservationDTO.from_record(record)
+
+    store.save_observations((item,))
+    read_store = SqlAlchemyVideoActionSetStore(session_factory)
+    chain = read_store.get_operation_chain(item.observation.frame_id)
+
+    assert chain is not None
+    assert [operation.operation for operation in chain.operations] == [
+        "render_canonical_row",
+        "emit_observation",
+    ]
+    assert chain.operations[0].input_digests == ()
+    assert chain.operations[1].input_digests == (
+        item.observation.observation_pixel_digest,
+    )
+    assert_records_equivalent(
+        record,
+        read_store.get_materialized_observation(item.observation.frame_id).to_record(),
+    )
+    with session_factory() as session:
+        assert (
+            session.scalar(select(func.count()).select_from(ObservationOperationORM))
+            == 2
+        )
+        assert (
+            session.scalar(
+                select(func.count()).select_from(ObservationOperationInputORM)
+            )
+            == 1
+        )
+
+
+def test_sql_read_rejects_tampered_observation_chain_digest() -> None:
+    read_store, session_factory, _engine, item = _save_single_observation()
+
+    with session_factory.begin() as session:
+        row = session.get(ObservationORM, item.observation.frame_id)
+        assert row is not None
+        row.operation_chain_digest = "sha256:" + "0" * 64
+
+    with pytest.raises(VPMValidationError, match="operation chain mismatch"):
+        read_store.get_observation(item.observation.frame_id)
+
+
+def test_sql_read_rejects_tampered_observation_plan_ownership() -> None:
+    read_store, session_factory, _engine, item = _save_single_observation()
+
+    with session_factory.begin() as session:
+        row = session.get(ObservationORM, item.observation.frame_id)
+        assert row is not None
+        row.episode_plan_digest = "sha256:" + "0" * 64
+
+    with pytest.raises(VPMValidationError, match="episode plan mismatch"):
+        read_store.get_observation(item.observation.frame_id)
+
+
+def test_sql_read_rejects_tampered_matrix_blob_length() -> None:
+    read_store, session_factory, _engine, item = _save_single_observation()
+
+    with session_factory.begin() as session:
+        row = session.get(MatrixBlobORM, item.observation.matrix_blob_id)
+        assert row is not None
+        row.byte_length += 1
+
+    with pytest.raises(VPMValidationError, match="matrix blob byte length mismatch"):
+        read_store.get_materialized_observation(item.observation.frame_id)
+
+
+def test_sql_read_rejects_tampered_operation_chain_count_and_digest() -> None:
+    read_store, session_factory, _engine, item = _save_single_observation()
+
+    with session_factory.begin() as session:
+        row = session.get(ObservationOperationChainORM, item.observation.frame_id)
+        assert row is not None
+        row.operation_count += 1
+
+    with pytest.raises(VPMValidationError, match="operation chain mismatch"):
+        read_store.get_operation_chain(item.observation.frame_id)
+
+    read_store, session_factory, _engine, item = _save_single_observation()
+    with session_factory.begin() as session:
+        row = session.get(
+            ObservationOperationORM,
+            (item.observation.frame_id, 0),
+        )
+        assert row is not None
+        row.operation_digest = "sha256:" + "0" * 64
+
+    with pytest.raises(VPMValidationError, match="operation digest mismatch"):
+        read_store.get_operation_chain(item.observation.frame_id)
+
+
+def test_sql_final_split_observation_materialization_remains_prohibited() -> None:
+    store, _session_factory, _engine = build_store()
+    identity = sql_identity("sql-final-observation-rmdto-seed")
+    plan = plan_dto(identity=identity, split="final", frame_count=1)
+    store.save_identity(identity)
+    store.save_episode_plan(plan)
+
+    with pytest.raises(VPMValidationError, match="final split observation"):
+        MaterializedObservationDTO.from_record(
+            sample_record(split="final", plan=plan, pixels=_pixels())
+        )
+
+
+def test_sql_materialized_batch_loader_uses_set_based_queries() -> None:
+    store, session_factory, engine = build_store()
+    _identity, plan = _save_identity_plan(store, frame_count=5)
+    records = tuple(
+        _multi_operation_record(plan=plan, sequence_number=index) for index in range(5)
+    )
+    store.save_observations(
+        tuple(MaterializedObservationDTO.from_record(record) for record in records)
+    )
+    statements: list[str] = []
+
+    def count_statement(
+        _connection,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", count_statement)
+    try:
+        materialized = SqlAlchemyVideoActionSetStore(
+            session_factory
+        ).list_materialized_observations(split="development")
+    finally:
+        event.remove(engine, "before_cursor_execute", count_statement)
+
+    assert len(materialized) == 5
+    assert len(statements) <= 6
+    for record, item in zip(records, materialized, strict=True):
+        assert_records_equivalent(record, item.to_record())
+
+
+def test_observation_store_query_parity_between_memory_and_sql() -> None:
+    sql_store, _session_factory, _engine = build_store()
+    memory_store = InMemoryVideoActionSetStore()
+    identity = sql_identity("sql-memory-parity-observation-rmdto-seed")
+    plan = plan_dto(identity=identity, split="development", frame_count=3)
+    records = (
+        sample_record(plan=plan, sequence_number=0, pixels=_pixels()),
+        sample_record(plan=plan, sequence_number=1, pixels=_pixels(3)),
+        sample_gap_record(plan=plan, sequence_number=2),
+    )
+    materialized = tuple(MaterializedObservationDTO.from_record(row) for row in records)
+
+    for store in (sql_store, memory_store):
+        store.save_identity(identity)
+        store.save_episode_plan(plan)
+        store.save_observations((*materialized, materialized[0]))
+
+    assert sql_store.list_observations(
+        split="development"
+    ) == memory_store.list_observations(split="development")
+    assert sql_store.list_observations(
+        has_pixels=False
+    ) == memory_store.list_observations(has_pixels=False)
+    assert sql_store.list_observations_by_operation(
+        operation="emit_observation"
+    ) == memory_store.list_observations_by_operation(operation="emit_observation")
+    assert sql_store.list_observations_by_output_digest(
+        str(materialized[0].observation.observation_pixel_digest)
+    ) == memory_store.list_observations_by_output_digest(
+        str(materialized[0].observation.observation_pixel_digest)
+    )
+    assert sql_store.list_observation_consumers_of_digest(
+        str(materialized[1].observation.observation_pixel_digest)
+    ) == memory_store.list_observation_consumers_of_digest(
+        str(materialized[1].observation.observation_pixel_digest)
+    )
+    for sql_item, memory_item in zip(
+        sql_store.list_materialized_observations(split="development"),
+        memory_store.list_materialized_observations(split="development"),
+        strict=True,
+    ):
+        assert_records_equivalent(sql_item.to_record(), memory_item.to_record())
 
 
 def test_sqlite_runtime_composes_observation_store() -> None:
     runtime = build_sqlite_runtime("sqlite:///:memory:", initialize_schema=True)
-    identity = sql_safe_identity("sql-runtime-observation-rmdto-seed")
+    identity = sql_identity("sql-runtime-observation-rmdto-seed")
     plan = plan_dto(identity=identity, split="development", frame_count=1)
     record = sample_record(plan=plan, pixels=_pixels())
 
@@ -178,4 +520,11 @@ def test_sqlite_runtime_composes_observation_store() -> None:
     assert_records_equivalent(
         record,
         runtime.video_action_set.get_observation_record(observation.frame_id),
+    )
+    assert_records_equivalent(
+        record,
+        runtime.video_action_set.list_observation_records(
+            split="development",
+            include_pixels=True,
+        )[0],
     )

--- a/zeromodel/db/orm/__init__.py
+++ b/zeromodel/db/orm/__init__.py
@@ -7,6 +7,7 @@ from .video_action_set import (
     MatrixBlobORM,
     ObservationORM,
     ObservationOperationChainORM,
+    ObservationOperationInputORM,
     ObservationOperationORM,
     SealedSplitPlanORM,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "MatrixBlobORM",
     "ObservationORM",
     "ObservationOperationChainORM",
+    "ObservationOperationInputORM",
     "ObservationOperationORM",
     "SealedSplitPlanORM",
 ]

--- a/zeromodel/db/orm/__init__.py
+++ b/zeromodel/db/orm/__init__.py
@@ -1,6 +1,23 @@
 """SQLAlchemy ORM mappings for optional persistence."""
 
 from .base import Base
-from .video_action_set import BenchmarkIdentityORM, EpisodePlanORM, SealedSplitPlanORM
+from .video_action_set import (
+    BenchmarkIdentityORM,
+    EpisodePlanORM,
+    MatrixBlobORM,
+    ObservationORM,
+    ObservationOperationChainORM,
+    ObservationOperationORM,
+    SealedSplitPlanORM,
+)
 
-__all__ = ["Base", "BenchmarkIdentityORM", "EpisodePlanORM", "SealedSplitPlanORM"]
+__all__ = [
+    "Base",
+    "BenchmarkIdentityORM",
+    "EpisodePlanORM",
+    "MatrixBlobORM",
+    "ObservationORM",
+    "ObservationOperationChainORM",
+    "ObservationOperationORM",
+    "SealedSplitPlanORM",
+]

--- a/zeromodel/db/orm/video_action_set.py
+++ b/zeromodel/db/orm/video_action_set.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
-from sqlalchemy import BigInteger, Boolean, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Float,
+    ForeignKey,
+    LargeBinary,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
@@ -82,4 +92,135 @@ class SealedSplitPlanORM(Base):
     sealed_plan_digest: Mapped[str] = mapped_column(String, nullable=False)
 
 
-__all__ = ["BenchmarkIdentityORM", "EpisodePlanORM", "SealedSplitPlanORM"]
+class MatrixBlobORM(Base):
+    __tablename__ = "matrix_blob"
+    __table_args__ = (CheckConstraint("byte_length >= 1", name="ck_matrix_blob_bytes"),)
+
+    blob_id: Mapped[str] = mapped_column(String, primary_key=True)
+    version: Mapped[str] = mapped_column(String, nullable=False)
+    dtype: Mapped[str] = mapped_column(String, nullable=False)
+    shape_json: Mapped[str] = mapped_column(Text, nullable=False)
+    scale: Mapped[float | None] = mapped_column(Float, nullable=True)
+    zero_point: Mapped[int | None] = mapped_column(nullable=True)
+    metadata_json: Mapped[str] = mapped_column(Text, nullable=False)
+    data: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    byte_length: Mapped[int] = mapped_column(nullable=False)
+
+
+class ObservationORM(Base):
+    __tablename__ = "video_action_set_observation"
+    __table_args__ = (
+        UniqueConstraint(
+            "episode_id",
+            "sequence_number",
+            name="uq_video_action_set_observation_episode_sequence",
+        ),
+        CheckConstraint(
+            "(matrix_blob_id IS NULL) = (observation_pixel_digest IS NULL)",
+            name="ck_video_action_set_observation_blob_digest_nullity",
+        ),
+    )
+
+    frame_id: Mapped[str] = mapped_column(String, primary_key=True)
+    benchmark_seed_digest: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("video_action_set_benchmark_identity.seed_digest"),
+        index=True,
+        nullable=False,
+    )
+    episode_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("video_action_set_episode_plan.episode_id"),
+        index=True,
+        nullable=False,
+    )
+    episode_plan_digest: Mapped[str] = mapped_column(
+        String,
+        index=True,
+        nullable=False,
+    )
+    split: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    clip_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    sequence_number: Mapped[int] = mapped_column(nullable=False)
+    event_type: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    family: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    expected_disposition: Mapped[str] = mapped_column(String, nullable=False)
+    episode_family: Mapped[str] = mapped_column(String, nullable=False)
+    episode_disposition: Mapped[str] = mapped_column(String, nullable=False)
+    frame_disposition: Mapped[str] = mapped_column(String, nullable=False)
+    denominator_class: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    expected_row: Mapped[str | None] = mapped_column(String, nullable=True)
+    expected_action: Mapped[str | None] = mapped_column(String, nullable=True)
+    actual_executed_action: Mapped[str | None] = mapped_column(String, nullable=True)
+    action_known: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    gap_declaration_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    observation_pixel_digest: Mapped[str | None] = mapped_column(
+        String,
+        index=True,
+        nullable=True,
+    )
+    matrix_blob_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("matrix_blob.blob_id"),
+        index=True,
+        nullable=True,
+    )
+    provider_descriptor_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    provider_observation_digest: Mapped[str | None] = mapped_column(
+        String,
+        index=True,
+        nullable=True,
+    )
+    metadata_json: Mapped[str] = mapped_column(Text, nullable=False)
+    operation_chain_digest: Mapped[str] = mapped_column(
+        String,
+        index=True,
+        nullable=False,
+    )
+
+
+class ObservationOperationChainORM(Base):
+    __tablename__ = "video_action_set_observation_operation_chain"
+
+    frame_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("video_action_set_observation.frame_id"),
+        primary_key=True,
+    )
+    version: Mapped[str] = mapped_column(String, nullable=False)
+    final_emitted_digest: Mapped[str | None] = mapped_column(String, nullable=True)
+    operation_chain_digest: Mapped[str] = mapped_column(
+        String,
+        index=True,
+        nullable=False,
+    )
+    operation_count: Mapped[int] = mapped_column(nullable=False)
+
+
+class ObservationOperationORM(Base):
+    __tablename__ = "video_action_set_observation_operation"
+
+    frame_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("video_action_set_observation.frame_id"),
+        primary_key=True,
+    )
+    operation_index: Mapped[int] = mapped_column(primary_key=True)
+    operation: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    operation_version: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    input_digests_json: Mapped[str] = mapped_column(Text, nullable=False)
+    parameters_json: Mapped[str] = mapped_column(Text, nullable=False)
+    parameter_digest: Mapped[str] = mapped_column(String, nullable=False)
+    output_digest: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
+    operation_digest: Mapped[str] = mapped_column(String, index=True, nullable=False)
+
+
+__all__ = [
+    "BenchmarkIdentityORM",
+    "EpisodePlanORM",
+    "MatrixBlobORM",
+    "ObservationORM",
+    "ObservationOperationChainORM",
+    "ObservationOperationORM",
+    "SealedSplitPlanORM",
+]

--- a/zeromodel/db/orm/video_action_set.py
+++ b/zeromodel/db/orm/video_action_set.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from sqlalchemy import (
-    BigInteger,
     Boolean,
     CheckConstraint,
     Float,
     ForeignKey,
+    ForeignKeyConstraint,
     LargeBinary,
     String,
     Text,
@@ -62,7 +62,7 @@ class EpisodePlanORM(Base):
     source_row_id: Mapped[str] = mapped_column(String, nullable=False)
     secondary_row_id: Mapped[str | None] = mapped_column(String, nullable=True)
     derived_seed_identity: Mapped[str] = mapped_column(String, nullable=False)
-    episode_seed: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    episode_seed_hex: Mapped[str] = mapped_column(String(16), nullable=False)
     frame_count: Mapped[int] = mapped_column(nullable=False)
     payload_json: Mapped[str] = mapped_column(Text, nullable=False)
 
@@ -116,8 +116,21 @@ class ObservationORM(Base):
             name="uq_video_action_set_observation_episode_sequence",
         ),
         CheckConstraint(
+            "sequence_number >= 0",
+            name="ck_video_action_set_observation_sequence_nonnegative",
+        ),
+        CheckConstraint(
+            "action_known = (actual_executed_action IS NOT NULL)",
+            name="ck_video_action_set_observation_action_known",
+        ),
+        CheckConstraint(
             "(matrix_blob_id IS NULL) = (observation_pixel_digest IS NULL)",
             name="ck_video_action_set_observation_blob_digest_nullity",
+        ),
+        CheckConstraint(
+            "(provider_descriptor_json IS NULL) = "
+            "(provider_observation_digest IS NULL)",
+            name="ck_video_action_set_observation_provider_nullity",
         ),
     )
 
@@ -181,6 +194,12 @@ class ObservationORM(Base):
 
 class ObservationOperationChainORM(Base):
     __tablename__ = "video_action_set_observation_operation_chain"
+    __table_args__ = (
+        CheckConstraint(
+            "operation_count >= 1",
+            name="ck_video_action_set_operation_chain_count",
+        ),
+    )
 
     frame_id: Mapped[str] = mapped_column(
         String,
@@ -199,6 +218,12 @@ class ObservationOperationChainORM(Base):
 
 class ObservationOperationORM(Base):
     __tablename__ = "video_action_set_observation_operation"
+    __table_args__ = (
+        CheckConstraint(
+            "operation_index >= 0",
+            name="ck_video_action_set_operation_index",
+        ),
+    )
 
     frame_id: Mapped[str] = mapped_column(
         String,
@@ -208,11 +233,36 @@ class ObservationOperationORM(Base):
     operation_index: Mapped[int] = mapped_column(primary_key=True)
     operation: Mapped[str] = mapped_column(String, index=True, nullable=False)
     operation_version: Mapped[str] = mapped_column(String, index=True, nullable=False)
-    input_digests_json: Mapped[str] = mapped_column(Text, nullable=False)
     parameters_json: Mapped[str] = mapped_column(Text, nullable=False)
     parameter_digest: Mapped[str] = mapped_column(String, nullable=False)
     output_digest: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
     operation_digest: Mapped[str] = mapped_column(String, index=True, nullable=False)
+
+
+class ObservationOperationInputORM(Base):
+    __tablename__ = "video_action_set_observation_operation_input"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["frame_id", "operation_index"],
+            [
+                "video_action_set_observation_operation.frame_id",
+                "video_action_set_observation_operation.operation_index",
+            ],
+        ),
+        CheckConstraint(
+            "operation_index >= 0",
+            name="ck_video_action_set_operation_input_operation_index",
+        ),
+        CheckConstraint(
+            "input_index >= 0",
+            name="ck_video_action_set_operation_input_index",
+        ),
+    )
+
+    frame_id: Mapped[str] = mapped_column(String, primary_key=True)
+    operation_index: Mapped[int] = mapped_column(primary_key=True)
+    input_index: Mapped[int] = mapped_column(primary_key=True)
+    input_digest: Mapped[str | None] = mapped_column(String, index=True, nullable=True)
 
 
 __all__ = [
@@ -221,6 +271,7 @@ __all__ = [
     "MatrixBlobORM",
     "ObservationORM",
     "ObservationOperationChainORM",
+    "ObservationOperationInputORM",
     "ObservationOperationORM",
     "SealedSplitPlanORM",
 ]

--- a/zeromodel/db/session.py
+++ b/zeromodel/db/session.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Engine, create_engine
+from sqlalchemy import Engine, create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -10,12 +10,26 @@ from .orm import video_action_set as _video_action_set_orm
 
 def create_database_engine(database_url: str) -> Engine:
     if database_url in {"sqlite://", "sqlite:///:memory:"}:
-        return create_engine(
+        engine = create_engine(
             database_url,
             connect_args={"check_same_thread": False},
             poolclass=StaticPool,
         )
-    return create_engine(database_url)
+    else:
+        engine = create_engine(database_url)
+    _enable_sqlite_foreign_keys(engine)
+    return engine
+
+
+def _enable_sqlite_foreign_keys(engine: Engine) -> None:
+    if engine.dialect.name != "sqlite":
+        return
+
+    @event.listens_for(engine, "connect")
+    def set_sqlite_pragma(dbapi_connection, _connection_record) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
 
 def create_session_factory(engine: Engine) -> sessionmaker[Session]:
@@ -28,6 +42,7 @@ def create_schema(engine: Engine) -> None:
     _ = _video_action_set_orm.MatrixBlobORM
     _ = _video_action_set_orm.ObservationORM
     _ = _video_action_set_orm.ObservationOperationChainORM
+    _ = _video_action_set_orm.ObservationOperationInputORM
     _ = _video_action_set_orm.ObservationOperationORM
     _ = _video_action_set_orm.SealedSplitPlanORM
     Base.metadata.create_all(engine)

--- a/zeromodel/db/session.py
+++ b/zeromodel/db/session.py
@@ -25,6 +25,10 @@ def create_session_factory(engine: Engine) -> sessionmaker[Session]:
 def create_schema(engine: Engine) -> None:
     _ = _video_action_set_orm.BenchmarkIdentityORM
     _ = _video_action_set_orm.EpisodePlanORM
+    _ = _video_action_set_orm.MatrixBlobORM
+    _ = _video_action_set_orm.ObservationORM
+    _ = _video_action_set_orm.ObservationOperationChainORM
+    _ = _video_action_set_orm.ObservationOperationORM
     _ = _video_action_set_orm.SealedSplitPlanORM
     Base.metadata.create_all(engine)
 

--- a/zeromodel/db/stores/video_action_set.py
+++ b/zeromodel/db/stores/video_action_set.py
@@ -14,21 +14,346 @@ from ...domains.video_action_set.dto import (
     EpisodePlanDTO,
     SealedSplitPlanDTO,
 )
+from ...domains.video_action_set.observation_dto import (
+    MaterializedObservationDTO,
+    ObservationDTO,
+    ObservationOperationChainDTO,
+)
 from ...domains.video_action_set.store import (
     VideoActionSetStore,
+    raise_matrix_blob_conflict,
+    raise_observation_conflict,
     raise_episode_plan_conflict,
     raise_identity_conflict,
     raise_sealed_split_plan_conflict,
     raise_unknown_benchmark_identity,
+    raise_unknown_episode_plan,
 )
+from ...matrix_blob import MatrixBlob
 from ..orm.video_action_set import (
     BenchmarkIdentityORM,
     EpisodePlanORM,
+    MatrixBlobORM,
+    ObservationORM,
+    ObservationOperationORM,
     SealedSplitPlanORM,
+)
+from .video_action_set_observation import (
+    chain_for_frame,
+    matrix_blob_for_observation,
+    observation_select,
+    operation_observation_select,
+    optional_observation_predicates,
+    preflight_observation_sequence,
+    to_matrix_blob,
+    to_matrix_blob_orm,
+    to_observation_dto,
+    to_observation_orm,
+    to_operation_chain_orm,
+    to_operation_orms,
 )
 
 
-class SqlAlchemyVideoActionSetStore(VideoActionSetStore):
+class _ObservationSqlStoreMixin:
+    _session_factory: sessionmaker[Session]
+
+    def save_matrix_blob(self, blob: MatrixBlob) -> MatrixBlob:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                return self._save_matrix_blob_in_session(session, blob)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def get_matrix_blob(self, blob_id: str) -> MatrixBlob | None:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                row = session.get(MatrixBlobORM, blob_id)
+                return None if row is None else to_matrix_blob(row)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def save_observation(
+        self,
+        observation: ObservationDTO,
+        *,
+        matrix_blob: MatrixBlob | None,
+    ) -> ObservationDTO:
+        return self.save_observations(
+            (MaterializedObservationDTO(observation, matrix_blob),)
+        )[0]
+
+    def save_observations(
+        self,
+        observations: Sequence[MaterializedObservationDTO],
+    ) -> tuple[ObservationDTO, ...]:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                return self._save_observations_in_session(session, tuple(observations))
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def get_observation(self, frame_id: str) -> ObservationDTO | None:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                row = session.get(ObservationORM, frame_id)
+                return None if row is None else to_observation_dto(session, row)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def get_materialized_observation(
+        self,
+        frame_id: str,
+    ) -> MaterializedObservationDTO | None:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                row = session.get(ObservationORM, frame_id)
+                if row is None:
+                    return None
+                observation = to_observation_dto(session, row)
+                blob = matrix_blob_for_observation(session, observation)
+                return MaterializedObservationDTO(observation, blob)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def list_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                statement = observation_select(
+                    benchmark_seed_digest=benchmark_seed_digest,
+                    split=split,
+                    episode_id=episode_id,
+                    family=family,
+                    event_type=event_type,
+                    denominator_class=denominator_class,
+                    has_pixels=has_pixels,
+                )
+                rows = session.scalars(statement).all()
+                return tuple(to_observation_dto(session, row) for row in rows)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def get_operation_chain(
+        self,
+        frame_id: str,
+    ) -> ObservationOperationChainDTO | None:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                if session.get(ObservationORM, frame_id) is None:
+                    return None
+                return chain_for_frame(session, frame_id)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def list_observations_by_operation(
+        self,
+        *,
+        operation: str,
+        split: str | None = None,
+        family: str | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                rows = session.scalars(
+                    operation_observation_select()
+                    .where(ObservationOperationORM.operation == operation)
+                    .where(*optional_observation_predicates(split=split, family=family))
+                ).all()
+                return tuple(to_observation_dto(session, row) for row in rows)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def list_observations_by_output_digest(
+        self,
+        output_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                rows = session.scalars(
+                    operation_observation_select().where(
+                        ObservationOperationORM.output_digest == output_digest
+                    )
+                ).all()
+                return tuple(to_observation_dto(session, row) for row in rows)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def list_observation_consumers_of_digest(
+        self,
+        input_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                rows = session.scalars(
+                    operation_observation_select().where(
+                        ObservationOperationORM.input_digests_json.contains(
+                            f'"{input_digest}"'
+                        )
+                    )
+                ).all()
+                return tuple(to_observation_dto(session, row) for row in rows)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def _save_observations_in_session(
+        self,
+        session: Session,
+        observations: Sequence[MaterializedObservationDTO],
+    ) -> tuple[ObservationDTO, ...]:
+        existing = self._preflight_observations(session, observations)
+        for item in observations:
+            observation = item.observation
+            if observation.frame_id in existing:
+                continue
+            if item.matrix_blob is not None:
+                self._save_matrix_blob_in_session(session, item.matrix_blob)
+            session.add(to_observation_orm(observation))
+            session.add(to_operation_chain_orm(observation))
+            session.add_all(to_operation_orms(observation))
+        return tuple(
+            existing.get(item.observation.frame_id, item.observation)
+            for item in observations
+        )
+
+    def _preflight_observations(
+        self,
+        session: Session,
+        observations: Sequence[MaterializedObservationDTO],
+    ) -> dict[str, ObservationDTO]:
+        existing_observations: dict[str, ObservationDTO] = {}
+        seen_observations: dict[str, ObservationDTO] = {}
+        seen_sequences: dict[tuple[str, int], str] = {}
+        seen_blobs: dict[str, MatrixBlob] = {}
+        for item in observations:
+            self._preflight_observation_ownership(session, item.observation)
+            self._preflight_observation_identity(
+                session,
+                item.observation,
+                existing_observations,
+                seen_observations,
+                seen_sequences,
+            )
+            self._preflight_blob(session, item.matrix_blob, seen_blobs)
+        return existing_observations
+
+    def _preflight_observation_ownership(
+        self,
+        session: Session,
+        observation: ObservationDTO,
+    ) -> None:
+        if session.get(BenchmarkIdentityORM, observation.benchmark_seed_digest) is None:
+            raise_unknown_benchmark_identity()
+        episode = session.get(EpisodePlanORM, observation.episode_id)
+        if episode is None:
+            raise_unknown_episode_plan()
+        if (
+            episode.plan_digest != observation.episode_plan_digest
+            or episode.benchmark_seed_digest != observation.benchmark_seed_digest
+            or episode.split != observation.split
+        ):
+            raise_unknown_episode_plan()
+
+    def _preflight_observation_identity(
+        self,
+        session: Session,
+        observation: ObservationDTO,
+        existing_observations: dict[str, ObservationDTO],
+        seen_observations: dict[str, ObservationDTO],
+        seen_sequences: dict[tuple[str, int], str],
+    ) -> None:
+        existing = session.get(ObservationORM, observation.frame_id)
+        if existing is not None:
+            existing_dto = to_observation_dto(session, existing)
+            if existing_dto != observation:
+                raise_observation_conflict()
+            existing_observations[observation.frame_id] = existing_dto
+        seen = seen_observations.get(observation.frame_id)
+        if seen is not None and seen != observation:
+            raise_observation_conflict()
+        seen_observations[observation.frame_id] = observation
+        preflight_observation_sequence(session, observation, seen_sequences)
+
+    def _preflight_blob(
+        self,
+        session: Session,
+        blob: MatrixBlob | None,
+        seen_blobs: dict[str, MatrixBlob],
+    ) -> None:
+        if blob is None:
+            return
+        existing = session.get(MatrixBlobORM, blob.blob_id)
+        if existing is not None and to_matrix_blob(existing) != blob:
+            raise_matrix_blob_conflict()
+        seen = seen_blobs.get(blob.blob_id)
+        if seen is not None and seen != blob:
+            raise_matrix_blob_conflict()
+        seen_blobs[blob.blob_id] = blob
+
+    @staticmethod
+    def _save_matrix_blob_in_session(
+        session: Session,
+        blob: MatrixBlob,
+    ) -> MatrixBlob:
+        existing = session.get(MatrixBlobORM, blob.blob_id)
+        if existing is not None:
+            existing_blob = to_matrix_blob(existing)
+            if existing_blob != blob:
+                raise_matrix_blob_conflict()
+            return existing_blob
+        session.add(to_matrix_blob_orm(blob))
+        return blob
+
+
+class SqlAlchemyVideoActionSetStore(_ObservationSqlStoreMixin, VideoActionSetStore):
     def __init__(self, session_factory: sessionmaker[Session]) -> None:
         self._session_factory = session_factory
 

--- a/zeromodel/db/stores/video_action_set.py
+++ b/zeromodel/db/stores/video_action_set.py
@@ -35,13 +35,15 @@ from ..orm.video_action_set import (
     EpisodePlanORM,
     MatrixBlobORM,
     ObservationORM,
+    ObservationOperationInputORM,
     ObservationOperationORM,
     SealedSplitPlanORM,
 )
 from .video_action_set_observation import (
     chain_for_frame,
-    matrix_blob_for_observation,
+    materialized_observations_from_rows,
     observation_select,
+    observations_from_rows,
     operation_observation_select,
     optional_observation_predicates,
     preflight_observation_sequence,
@@ -50,6 +52,7 @@ from .video_action_set_observation import (
     to_observation_dto,
     to_observation_orm,
     to_operation_chain_orm,
+    to_operation_input_orms,
     to_operation_orms,
 )
 
@@ -126,9 +129,7 @@ class _ObservationSqlStoreMixin:
                 row = session.get(ObservationORM, frame_id)
                 if row is None:
                     return None
-                observation = to_observation_dto(session, row)
-                blob = matrix_blob_for_observation(session, observation)
-                return MaterializedObservationDTO(observation, blob)
+                return materialized_observations_from_rows(session, (row,))[0]
         except Exception:
             session.rollback()
             raise
@@ -159,7 +160,38 @@ class _ObservationSqlStoreMixin:
                     has_pixels=has_pixels,
                 )
                 rows = session.scalars(statement).all()
-                return tuple(to_observation_dto(session, row) for row in rows)
+                return observations_from_rows(session, rows)
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def list_materialized_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[MaterializedObservationDTO, ...]:
+        session = self._session_factory()
+        try:
+            with session.begin():
+                statement = observation_select(
+                    benchmark_seed_digest=benchmark_seed_digest,
+                    split=split,
+                    episode_id=episode_id,
+                    family=family,
+                    event_type=event_type,
+                    denominator_class=denominator_class,
+                    has_pixels=has_pixels,
+                )
+                rows = session.scalars(statement).all()
+                return materialized_observations_from_rows(session, rows)
         except Exception:
             session.rollback()
             raise
@@ -197,7 +229,7 @@ class _ObservationSqlStoreMixin:
                     .where(ObservationOperationORM.operation == operation)
                     .where(*optional_observation_predicates(split=split, family=family))
                 ).all()
-                return tuple(to_observation_dto(session, row) for row in rows)
+                return observations_from_rows(session, rows)
         except Exception:
             session.rollback()
             raise
@@ -216,7 +248,7 @@ class _ObservationSqlStoreMixin:
                         ObservationOperationORM.output_digest == output_digest
                     )
                 ).all()
-                return tuple(to_observation_dto(session, row) for row in rows)
+                return observations_from_rows(session, rows)
         except Exception:
             session.rollback()
             raise
@@ -231,13 +263,21 @@ class _ObservationSqlStoreMixin:
         try:
             with session.begin():
                 rows = session.scalars(
-                    operation_observation_select().where(
-                        ObservationOperationORM.input_digests_json.contains(
-                            f'"{input_digest}"'
+                    operation_observation_select()
+                    .join(
+                        ObservationOperationInputORM,
+                        (
+                            ObservationOperationInputORM.frame_id
+                            == ObservationOperationORM.frame_id
                         )
+                        & (
+                            ObservationOperationInputORM.operation_index
+                            == ObservationOperationORM.operation_index
+                        ),
                     )
+                    .where(ObservationOperationInputORM.input_digest == input_digest)
                 ).all()
-                return tuple(to_observation_dto(session, row) for row in rows)
+                return observations_from_rows(session, rows)
         except Exception:
             session.rollback()
             raise
@@ -250,15 +290,24 @@ class _ObservationSqlStoreMixin:
         observations: Sequence[MaterializedObservationDTO],
     ) -> tuple[ObservationDTO, ...]:
         existing = self._preflight_observations(session, observations)
+        inserted_frame_ids: set[str] = set()
+        operation_inputs: list[ObservationOperationInputORM] = []
         for item in observations:
             observation = item.observation
-            if observation.frame_id in existing:
+            if (
+                observation.frame_id in existing
+                or observation.frame_id in inserted_frame_ids
+            ):
                 continue
             if item.matrix_blob is not None:
                 self._save_matrix_blob_in_session(session, item.matrix_blob)
             session.add(to_observation_orm(observation))
             session.add(to_operation_chain_orm(observation))
             session.add_all(to_operation_orms(observation))
+            operation_inputs.extend(to_operation_input_orms(observation))
+            inserted_frame_ids.add(observation.frame_id)
+        session.flush()
+        session.add_all(operation_inputs)
         return tuple(
             existing.get(item.observation.frame_id, item.observation)
             for item in observations
@@ -607,7 +656,7 @@ class SqlAlchemyVideoActionSetStore(_ObservationSqlStoreMixin, VideoActionSetSto
             or row.source_row_id != dto.source_row_id
             or row.secondary_row_id != dto.secondary_row_id
             or row.derived_seed_identity != dto.derived_seed_identity
-            or row.episode_seed != dto.episode_seed
+            or _episode_seed_from_hex(row.episode_seed_hex) != dto.episode_seed
             or row.frame_count != dto.frame_count
         ):
             raise VPMValidationError("episode plan digest mismatch")
@@ -631,7 +680,7 @@ class SqlAlchemyVideoActionSetStore(_ObservationSqlStoreMixin, VideoActionSetSto
             source_row_id=plan.source_row_id,
             secondary_row_id=plan.secondary_row_id,
             derived_seed_identity=plan.derived_seed_identity,
-            episode_seed=plan.episode_seed,
+            episode_seed_hex=_episode_seed_hex(plan.episode_seed),
             frame_count=plan.frame_count,
             payload_json=canonical_json_text(plan.to_dict()),
         )
@@ -710,6 +759,18 @@ def _json_mapping(text: str, message: str) -> Mapping[str, object]:
     if not isinstance(value, Mapping):
         raise VPMValidationError(message)
     return cast(Mapping[str, object], value)
+
+
+def _episode_seed_hex(seed: int) -> str:
+    if seed < 0 or seed >= 2**64:
+        raise VPMValidationError("episode plan root seed lineage mismatch")
+    return f"{seed:016x}"
+
+
+def _episode_seed_from_hex(value: str) -> int:
+    if len(value) != 16 or any(item not in "0123456789abcdef" for item in value):
+        raise VPMValidationError("episode plan digest mismatch")
+    return int(value, 16)
 
 
 __all__ = ["SqlAlchemyVideoActionSetStore"]

--- a/zeromodel/db/stores/video_action_set_observation.py
+++ b/zeromodel/db/stores/video_action_set_observation.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from typing import cast
 
 from sqlalchemy import select
@@ -12,6 +13,7 @@ from ...domains.video_action_set.canonical_json import canonical_json_text
 from ...domains.video_action_set.contracts import BENCHMARK_VERSION, GENERATOR_VERSION
 from ...domains.video_action_set.dto import CanonicalJsonDTO
 from ...domains.video_action_set.observation_dto import (
+    MaterializedObservationDTO,
     ObservationDTO,
     ObservationOperationChainDTO,
     ObservationOperationDTO,
@@ -20,9 +22,11 @@ from ...domains.video_action_set.observation_dto import (
 from ...domains.video_action_set.store import raise_observation_sequence_conflict
 from ...matrix_blob import MatrixBlob
 from ..orm.video_action_set import (
+    EpisodePlanORM,
     MatrixBlobORM,
     ObservationORM,
     ObservationOperationChainORM,
+    ObservationOperationInputORM,
     ObservationOperationORM,
 )
 
@@ -42,6 +46,8 @@ def to_matrix_blob_orm(blob: MatrixBlob) -> MatrixBlobORM:
 
 
 def to_matrix_blob(row: MatrixBlobORM) -> MatrixBlob:
+    if row.byte_length != len(row.data):
+        raise VPMValidationError("matrix blob byte length mismatch")
     return MatrixBlob(
         dtype=row.dtype,
         shape=_json_value(row.shape_json, "matrix blob shape mismatch"),
@@ -84,7 +90,15 @@ def to_observation_orm(observation: ObservationDTO) -> ObservationORM:
     )
 
 
-def to_observation_dto(session: Session, row: ObservationORM) -> ObservationDTO:
+def to_observation_dto(
+    session: Session,
+    row: ObservationORM,
+    *,
+    chain: ObservationOperationChainDTO | None = None,
+    plan: EpisodePlanORM | None = None,
+) -> ObservationDTO:
+    chain = chain if chain is not None else chain_for_frame(session, row.frame_id)
+    validate_observation_row(session, row, chain, plan=plan)
     return ObservationDTO(
         benchmark_version=BENCHMARK_VERSION,
         generator_version=GENERATOR_VERSION,
@@ -113,9 +127,32 @@ def to_observation_dto(session: Session, row: ObservationORM) -> ObservationDTO:
             row.provider_descriptor_json
         ),
         provider_observation_digest=row.provider_observation_digest,
-        operation_chain=chain_for_frame(session, row.frame_id),
+        operation_chain=chain,
         metadata=CanonicalJsonDTO(row.metadata_json),
     )
+
+
+def validate_observation_row(
+    session: Session,
+    row: ObservationORM,
+    chain: ObservationOperationChainDTO,
+    *,
+    plan: EpisodePlanORM | None = None,
+) -> None:
+    if row.operation_chain_digest != chain.operation_chain_digest:
+        raise VPMValidationError("observation operation chain mismatch")
+    plan = plan if plan is not None else session.get(EpisodePlanORM, row.episode_id)
+    if plan is None:
+        raise VPMValidationError("observation references unknown episode plan")
+    if (
+        row.episode_plan_digest != plan.plan_digest
+        or row.benchmark_seed_digest != plan.benchmark_seed_digest
+        or row.split != plan.split
+        or row.episode_family != plan.family_label
+        or row.episode_disposition != plan.episode_disposition
+        or row.denominator_class != plan.denominator_class
+    ):
+        raise VPMValidationError("observation episode plan mismatch")
 
 
 def to_operation_chain_orm(
@@ -140,7 +177,6 @@ def to_operation_orms(
             operation_index=operation.index,
             operation=operation.operation,
             operation_version=operation.operation_version,
-            input_digests_json=canonical_json_text(list(operation.input_digests)),
             parameters_json=operation.parameters.canonical_text,
             parameter_digest=operation.parameter_digest,
             output_digest=operation.output_digest,
@@ -150,21 +186,27 @@ def to_operation_orms(
     )
 
 
+def to_operation_input_orms(
+    observation: ObservationDTO,
+) -> tuple[ObservationOperationInputORM, ...]:
+    return tuple(
+        ObservationOperationInputORM(
+            frame_id=observation.frame_id,
+            operation_index=operation.index,
+            input_index=input_index,
+            input_digest=input_digest,
+        )
+        for operation in observation.operation_chain.operations
+        for input_index, input_digest in enumerate(operation.input_digests)
+    )
+
+
 def to_operation_chain_dto(
     session: Session,
     row: ObservationOperationChainORM,
 ) -> ObservationOperationChainDTO:
     operations = operation_rows_for_frame(session, row.frame_id)
-    if row.operation_count != len(operations):
-        raise VPMValidationError("observation operation chain mismatch")
-    return ObservationOperationChainDTO.from_dict(
-        {
-            "version": row.version,
-            "operations": [operation.to_dict() for operation in operations],
-            "final_emitted_digest": row.final_emitted_digest,
-            "operation_chain_digest": row.operation_chain_digest,
-        }
-    )
+    return _operation_chain_from_rows(row, operations)
 
 
 def chain_for_frame(
@@ -186,7 +228,133 @@ def operation_rows_for_frame(
         .where(ObservationOperationORM.frame_id == frame_id)
         .order_by(ObservationOperationORM.operation_index)
     ).all()
-    return tuple(_to_operation_dto(row) for row in rows)
+    inputs_by_operation = _input_digests_by_operation(
+        session.scalars(
+            select(ObservationOperationInputORM)
+            .where(ObservationOperationInputORM.frame_id == frame_id)
+            .order_by(
+                ObservationOperationInputORM.operation_index,
+                ObservationOperationInputORM.input_index,
+            )
+        ).all()
+    )
+    return tuple(
+        _to_operation_dto(
+            row,
+            inputs_by_operation.get((row.frame_id, row.operation_index), ()),
+        )
+        for row in rows
+    )
+
+
+def observations_from_rows(
+    session: Session,
+    rows: Sequence[ObservationORM],
+) -> tuple[ObservationDTO, ...]:
+    if not rows:
+        return ()
+    frame_ids = [row.frame_id for row in rows]
+    episode_ids = {row.episode_id for row in rows}
+    chains = chains_for_frames(session, frame_ids)
+    plans = {
+        row.episode_id: row
+        for row in session.scalars(
+            select(EpisodePlanORM).where(EpisodePlanORM.episode_id.in_(episode_ids))
+        ).all()
+    }
+    return tuple(
+        to_observation_dto(
+            session,
+            row,
+            chain=chains[row.frame_id],
+            plan=plans.get(row.episode_id),
+        )
+        for row in rows
+    )
+
+
+def materialized_observations_from_rows(
+    session: Session,
+    rows: Sequence[ObservationORM],
+) -> tuple[MaterializedObservationDTO, ...]:
+    observations = observations_from_rows(session, rows)
+    blob_ids = {
+        observation.matrix_blob_id
+        for observation in observations
+        if observation.matrix_blob_id is not None
+    }
+    if not blob_ids:
+        return tuple(
+            MaterializedObservationDTO(observation, None)
+            for observation in observations
+        )
+    blobs = {
+        row.blob_id: to_matrix_blob(row)
+        for row in session.scalars(
+            select(MatrixBlobORM).where(MatrixBlobORM.blob_id.in_(blob_ids))
+        ).all()
+    }
+    return tuple(
+        MaterializedObservationDTO(
+            observation,
+            None
+            if observation.matrix_blob_id is None
+            else blobs.get(observation.matrix_blob_id),
+        )
+        for observation in observations
+    )
+
+
+def chains_for_frames(
+    session: Session,
+    frame_ids: Sequence[str],
+) -> dict[str, ObservationOperationChainDTO]:
+    if not frame_ids:
+        return {}
+    chain_rows = {
+        row.frame_id: row
+        for row in session.scalars(
+            select(ObservationOperationChainORM).where(
+                ObservationOperationChainORM.frame_id.in_(frame_ids)
+            )
+        ).all()
+    }
+    operation_rows = session.scalars(
+        select(ObservationOperationORM)
+        .where(ObservationOperationORM.frame_id.in_(frame_ids))
+        .order_by(
+            ObservationOperationORM.frame_id,
+            ObservationOperationORM.operation_index,
+        )
+    ).all()
+    input_rows = session.scalars(
+        select(ObservationOperationInputORM)
+        .where(ObservationOperationInputORM.frame_id.in_(frame_ids))
+        .order_by(
+            ObservationOperationInputORM.frame_id,
+            ObservationOperationInputORM.operation_index,
+            ObservationOperationInputORM.input_index,
+        )
+    ).all()
+    inputs_by_operation = _input_digests_by_operation(input_rows)
+    operations_by_frame: dict[str, list[ObservationOperationDTO]] = defaultdict(list)
+    for row in operation_rows:
+        operations_by_frame[row.frame_id].append(
+            _to_operation_dto(
+                row,
+                inputs_by_operation.get((row.frame_id, row.operation_index), ()),
+            )
+        )
+    chains: dict[str, ObservationOperationChainDTO] = {}
+    for frame_id in frame_ids:
+        chain_row = chain_rows.get(frame_id)
+        if chain_row is None:
+            raise VPMValidationError("observation operation chain mismatch")
+        chains[frame_id] = _operation_chain_from_rows(
+            chain_row,
+            tuple(operations_by_frame.get(frame_id, ())),
+        )
+    return chains
 
 
 def matrix_blob_for_observation(
@@ -298,16 +466,32 @@ def preflight_observation_sequence(
     seen_sequences[key] = observation.frame_id
 
 
-def _to_operation_dto(row: ObservationOperationORM) -> ObservationOperationDTO:
+def _operation_chain_from_rows(
+    row: ObservationOperationChainORM,
+    operations: tuple[ObservationOperationDTO, ...],
+) -> ObservationOperationChainDTO:
+    if row.operation_count != len(operations):
+        raise VPMValidationError("observation operation chain mismatch")
+    return ObservationOperationChainDTO.from_dict(
+        {
+            "version": row.version,
+            "operations": [operation.to_dict() for operation in operations],
+            "final_emitted_digest": row.final_emitted_digest,
+            "operation_chain_digest": row.operation_chain_digest,
+        }
+    )
+
+
+def _to_operation_dto(
+    row: ObservationOperationORM,
+    input_digests: Sequence[str | None],
+) -> ObservationOperationDTO:
     return ObservationOperationDTO.from_dict(
         {
             "index": row.operation_index,
             "operation": row.operation,
             "operation_version": row.operation_version,
-            "input_digests": _json_value(
-                row.input_digests_json,
-                "observation operation digest is not sha256",
-            ),
+            "input_digests": list(input_digests),
             "parameters": _json_value(
                 row.parameters_json,
                 "observation operation payload keys mismatch",
@@ -317,6 +501,25 @@ def _to_operation_dto(row: ObservationOperationORM) -> ObservationOperationDTO:
             "operation_digest": row.operation_digest,
         }
     )
+
+
+def _input_digests_by_operation(
+    rows: Sequence[ObservationOperationInputORM],
+) -> dict[tuple[str, int], tuple[str | None, ...]]:
+    indexed: dict[tuple[str, int], list[tuple[int, str | None]]] = defaultdict(list)
+    for row in rows:
+        indexed[(row.frame_id, row.operation_index)].append(
+            (row.input_index, row.input_digest)
+        )
+    grouped: dict[tuple[str, int], tuple[str | None, ...]] = {}
+    for key, values in indexed.items():
+        sorted_values = sorted(values)
+        if [index for index, _input_digest in sorted_values] != list(
+            range(len(sorted_values))
+        ):
+            raise VPMValidationError("observation operation payload keys mismatch")
+        grouped[key] = tuple(input_digest for _index, input_digest in sorted_values)
+    return grouped
 
 
 def _json_mapping(text: str, message: str) -> Mapping[str, object]:
@@ -361,8 +564,11 @@ def _provider_descriptor_from_json(
 
 __all__ = [
     "chain_for_frame",
+    "chains_for_frames",
+    "materialized_observations_from_rows",
     "matrix_blob_for_observation",
     "observation_select",
+    "observations_from_rows",
     "operation_observation_select",
     "optional_observation_predicates",
     "preflight_observation_sequence",
@@ -372,5 +578,7 @@ __all__ = [
     "to_observation_orm",
     "to_operation_chain_dto",
     "to_operation_chain_orm",
+    "to_operation_input_orms",
     "to_operation_orms",
+    "validate_observation_row",
 ]

--- a/zeromodel/db/stores/video_action_set_observation.py
+++ b/zeromodel/db/stores/video_action_set_observation.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ...artifact import VPMValidationError
+from ...domains.video_action_set.canonical_json import canonical_json_text
+from ...domains.video_action_set.contracts import BENCHMARK_VERSION, GENERATOR_VERSION
+from ...domains.video_action_set.dto import CanonicalJsonDTO
+from ...domains.video_action_set.observation_dto import (
+    ObservationDTO,
+    ObservationOperationChainDTO,
+    ObservationOperationDTO,
+    ProviderObservationDescriptorDTO,
+)
+from ...domains.video_action_set.store import raise_observation_sequence_conflict
+from ...matrix_blob import MatrixBlob
+from ..orm.video_action_set import (
+    MatrixBlobORM,
+    ObservationORM,
+    ObservationOperationChainORM,
+    ObservationOperationORM,
+)
+
+
+def to_matrix_blob_orm(blob: MatrixBlob) -> MatrixBlobORM:
+    return MatrixBlobORM(
+        blob_id=blob.blob_id,
+        version=blob.version,
+        dtype=blob.dtype,
+        shape_json=canonical_json_text(list(blob.shape)),
+        scale=blob.scale,
+        zero_point=blob.zero_point,
+        metadata_json=canonical_json_text(dict(blob.metadata)),
+        data=blob.data,
+        byte_length=len(blob.data),
+    )
+
+
+def to_matrix_blob(row: MatrixBlobORM) -> MatrixBlob:
+    return MatrixBlob(
+        dtype=row.dtype,
+        shape=_json_value(row.shape_json, "matrix blob shape mismatch"),
+        data=row.data,
+        scale=row.scale,
+        zero_point=row.zero_point,
+        metadata=_json_mapping(row.metadata_json, "matrix blob metadata mismatch"),
+        version=row.version,
+        blob_id=row.blob_id,
+    )
+
+
+def to_observation_orm(observation: ObservationDTO) -> ObservationORM:
+    return ObservationORM(
+        frame_id=observation.frame_id,
+        benchmark_seed_digest=observation.benchmark_seed_digest,
+        episode_id=observation.episode_id,
+        episode_plan_digest=observation.episode_plan_digest,
+        split=observation.split,
+        clip_id=observation.clip_id,
+        sequence_number=observation.sequence_number,
+        event_type=observation.event_type,
+        family=observation.family,
+        expected_disposition=observation.expected_disposition,
+        episode_family=observation.episode_family,
+        episode_disposition=observation.episode_disposition,
+        frame_disposition=observation.frame_disposition,
+        denominator_class=observation.denominator_class,
+        expected_row=observation.expected_row,
+        expected_action=observation.expected_action,
+        actual_executed_action=observation.actual_executed_action,
+        action_known=observation.action_known,
+        gap_declaration_json=_canonical_or_none(observation.gap_declaration),
+        observation_pixel_digest=observation.observation_pixel_digest,
+        matrix_blob_id=observation.matrix_blob_id,
+        provider_descriptor_json=_provider_descriptor_json(observation),
+        provider_observation_digest=observation.provider_observation_digest,
+        metadata_json=observation.metadata.canonical_text,
+        operation_chain_digest=observation.operation_chain.operation_chain_digest,
+    )
+
+
+def to_observation_dto(session: Session, row: ObservationORM) -> ObservationDTO:
+    return ObservationDTO(
+        benchmark_version=BENCHMARK_VERSION,
+        generator_version=GENERATOR_VERSION,
+        benchmark_seed_digest=row.benchmark_seed_digest,
+        episode_plan_digest=row.episode_plan_digest,
+        split=row.split,
+        episode_id=row.episode_id,
+        clip_id=row.clip_id,
+        frame_id=row.frame_id,
+        sequence_number=row.sequence_number,
+        event_type=row.event_type,
+        family=row.family,
+        expected_disposition=row.expected_disposition,
+        episode_family=row.episode_family,
+        episode_disposition=row.episode_disposition,
+        frame_disposition=row.frame_disposition,
+        denominator_class=row.denominator_class,
+        expected_row=row.expected_row,
+        expected_action=row.expected_action,
+        actual_executed_action=row.actual_executed_action,
+        action_known=row.action_known,
+        gap_declaration=_canonical_from_text_or_none(row.gap_declaration_json),
+        observation_pixel_digest=row.observation_pixel_digest,
+        matrix_blob_id=row.matrix_blob_id,
+        provider_observation_descriptor=_provider_descriptor_from_json(
+            row.provider_descriptor_json
+        ),
+        provider_observation_digest=row.provider_observation_digest,
+        operation_chain=chain_for_frame(session, row.frame_id),
+        metadata=CanonicalJsonDTO(row.metadata_json),
+    )
+
+
+def to_operation_chain_orm(
+    observation: ObservationDTO,
+) -> ObservationOperationChainORM:
+    chain = observation.operation_chain
+    return ObservationOperationChainORM(
+        frame_id=observation.frame_id,
+        version=chain.version,
+        final_emitted_digest=chain.final_emitted_digest,
+        operation_chain_digest=chain.operation_chain_digest,
+        operation_count=len(chain.operations),
+    )
+
+
+def to_operation_orms(
+    observation: ObservationDTO,
+) -> tuple[ObservationOperationORM, ...]:
+    return tuple(
+        ObservationOperationORM(
+            frame_id=observation.frame_id,
+            operation_index=operation.index,
+            operation=operation.operation,
+            operation_version=operation.operation_version,
+            input_digests_json=canonical_json_text(list(operation.input_digests)),
+            parameters_json=operation.parameters.canonical_text,
+            parameter_digest=operation.parameter_digest,
+            output_digest=operation.output_digest,
+            operation_digest=operation.operation_digest,
+        )
+        for operation in observation.operation_chain.operations
+    )
+
+
+def to_operation_chain_dto(
+    session: Session,
+    row: ObservationOperationChainORM,
+) -> ObservationOperationChainDTO:
+    operations = operation_rows_for_frame(session, row.frame_id)
+    if row.operation_count != len(operations):
+        raise VPMValidationError("observation operation chain mismatch")
+    return ObservationOperationChainDTO.from_dict(
+        {
+            "version": row.version,
+            "operations": [operation.to_dict() for operation in operations],
+            "final_emitted_digest": row.final_emitted_digest,
+            "operation_chain_digest": row.operation_chain_digest,
+        }
+    )
+
+
+def chain_for_frame(
+    session: Session,
+    frame_id: str,
+) -> ObservationOperationChainDTO:
+    row = session.get(ObservationOperationChainORM, frame_id)
+    if row is None:
+        raise VPMValidationError("observation operation chain mismatch")
+    return to_operation_chain_dto(session, row)
+
+
+def operation_rows_for_frame(
+    session: Session,
+    frame_id: str,
+) -> tuple[ObservationOperationDTO, ...]:
+    rows = session.scalars(
+        select(ObservationOperationORM)
+        .where(ObservationOperationORM.frame_id == frame_id)
+        .order_by(ObservationOperationORM.operation_index)
+    ).all()
+    return tuple(_to_operation_dto(row) for row in rows)
+
+
+def matrix_blob_for_observation(
+    session: Session,
+    observation: ObservationDTO,
+) -> MatrixBlob | None:
+    if observation.matrix_blob_id is None:
+        return None
+    row = session.get(MatrixBlobORM, observation.matrix_blob_id)
+    if row is None:
+        raise VPMValidationError("observation matrix blob mismatch")
+    return to_matrix_blob(row)
+
+
+def observation_select(
+    *,
+    benchmark_seed_digest: str | None,
+    split: str | None,
+    episode_id: str | None,
+    family: str | None,
+    event_type: str | None,
+    denominator_class: str | None,
+    has_pixels: bool | None,
+):
+    statement = select(ObservationORM)
+    predicates = optional_observation_predicates(
+        benchmark_seed_digest=benchmark_seed_digest,
+        split=split,
+        episode_id=episode_id,
+        family=family,
+        event_type=event_type,
+        denominator_class=denominator_class,
+        has_pixels=has_pixels,
+    )
+    if predicates:
+        statement = statement.where(*predicates)
+    return statement.order_by(
+        ObservationORM.split,
+        ObservationORM.episode_id,
+        ObservationORM.sequence_number,
+        ObservationORM.frame_id,
+    )
+
+
+def operation_observation_select():
+    return (
+        select(ObservationORM)
+        .join(
+            ObservationOperationORM,
+            ObservationORM.frame_id == ObservationOperationORM.frame_id,
+        )
+        .distinct()
+        .order_by(
+            ObservationORM.split,
+            ObservationORM.episode_id,
+            ObservationORM.sequence_number,
+            ObservationORM.frame_id,
+        )
+    )
+
+
+def optional_observation_predicates(
+    *,
+    benchmark_seed_digest: str | None = None,
+    split: str | None = None,
+    episode_id: str | None = None,
+    family: str | None = None,
+    event_type: str | None = None,
+    denominator_class: str | None = None,
+    has_pixels: bool | None = None,
+) -> tuple[object, ...]:
+    predicates: list[object] = []
+    if benchmark_seed_digest is not None:
+        predicates.append(ObservationORM.benchmark_seed_digest == benchmark_seed_digest)
+    if split is not None:
+        predicates.append(ObservationORM.split == split)
+    if episode_id is not None:
+        predicates.append(ObservationORM.episode_id == episode_id)
+    if family is not None:
+        predicates.append(ObservationORM.family == family)
+    if event_type is not None:
+        predicates.append(ObservationORM.event_type == event_type)
+    if denominator_class is not None:
+        predicates.append(ObservationORM.denominator_class == denominator_class)
+    if has_pixels is True:
+        predicates.append(ObservationORM.matrix_blob_id.is_not(None))
+    elif has_pixels is False:
+        predicates.append(ObservationORM.matrix_blob_id.is_(None))
+    return tuple(predicates)
+
+
+def preflight_observation_sequence(
+    session: Session,
+    observation: ObservationDTO,
+    seen_sequences: dict[tuple[str, int], str],
+) -> None:
+    key = (observation.episode_id, observation.sequence_number)
+    existing_frame_id = session.scalars(
+        select(ObservationORM.frame_id).where(
+            ObservationORM.episode_id == observation.episode_id,
+            ObservationORM.sequence_number == observation.sequence_number,
+        )
+    ).first()
+    if existing_frame_id is not None and existing_frame_id != observation.frame_id:
+        raise_observation_sequence_conflict()
+    seen_frame_id = seen_sequences.get(key)
+    if seen_frame_id is not None and seen_frame_id != observation.frame_id:
+        raise_observation_sequence_conflict()
+    seen_sequences[key] = observation.frame_id
+
+
+def _to_operation_dto(row: ObservationOperationORM) -> ObservationOperationDTO:
+    return ObservationOperationDTO.from_dict(
+        {
+            "index": row.operation_index,
+            "operation": row.operation,
+            "operation_version": row.operation_version,
+            "input_digests": _json_value(
+                row.input_digests_json,
+                "observation operation digest is not sha256",
+            ),
+            "parameters": _json_value(
+                row.parameters_json,
+                "observation operation payload keys mismatch",
+            ),
+            "parameter_digest": row.parameter_digest,
+            "output_digest": row.output_digest,
+            "operation_digest": row.operation_digest,
+        }
+    )
+
+
+def _json_mapping(text: str, message: str) -> Mapping[str, object]:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise VPMValidationError(message) from exc
+    if not isinstance(value, Mapping):
+        raise VPMValidationError(message)
+    return cast(Mapping[str, object], value)
+
+
+def _json_value(text: str, message: str) -> object:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise VPMValidationError(message) from exc
+
+
+def _canonical_or_none(dto: CanonicalJsonDTO | None) -> str | None:
+    return None if dto is None else dto.canonical_text
+
+
+def _canonical_from_text_or_none(text: str | None) -> CanonicalJsonDTO | None:
+    return None if text is None else CanonicalJsonDTO(text)
+
+
+def _provider_descriptor_json(observation: ObservationDTO) -> str | None:
+    descriptor = observation.provider_observation_descriptor
+    return None if descriptor is None else canonical_json_text(descriptor.to_dict())
+
+
+def _provider_descriptor_from_json(
+    text: str | None,
+) -> ProviderObservationDescriptorDTO | None:
+    if text is None:
+        return None
+    return ProviderObservationDescriptorDTO.from_dict(
+        _json_mapping(text, "provider observation descriptor keys mismatch")
+    )
+
+
+__all__ = [
+    "chain_for_frame",
+    "matrix_blob_for_observation",
+    "observation_select",
+    "operation_observation_select",
+    "optional_observation_predicates",
+    "preflight_observation_sequence",
+    "to_matrix_blob",
+    "to_matrix_blob_orm",
+    "to_observation_dto",
+    "to_observation_orm",
+    "to_operation_chain_dto",
+    "to_operation_chain_orm",
+    "to_operation_orms",
+]

--- a/zeromodel/domains/video_action_set/__init__.py
+++ b/zeromodel/domains/video_action_set/__init__.py
@@ -10,6 +10,14 @@ from .dto import (
 )
 from .episode_plan_service import EpisodePlanService
 from .facade import VideoActionSetFacade
+from .observation_dto import (
+    MaterializedObservationDTO,
+    ObservationDTO,
+    ObservationOperationChainDTO,
+    ObservationOperationDTO,
+    ProviderObservationDescriptorDTO,
+)
+from .observation_service import ObservationService
 from .store import VideoActionSetStore
 
 __all__ = [
@@ -19,6 +27,12 @@ __all__ = [
     "EpisodeIdsByFamilyDTO",
     "EpisodePlanDTO",
     "EpisodePlanService",
+    "MaterializedObservationDTO",
+    "ObservationDTO",
+    "ObservationOperationChainDTO",
+    "ObservationOperationDTO",
+    "ObservationService",
+    "ProviderObservationDescriptorDTO",
     "SealedSplitPlanDTO",
     "VideoActionSetFacade",
     "VideoActionSetStore",

--- a/zeromodel/domains/video_action_set/contracts.py
+++ b/zeromodel/domains/video_action_set/contracts.py
@@ -2,7 +2,12 @@
 
 BENCHMARK_VERSION = "zeromodel-video-action-set-reachability-benchmark/v1"
 EPISODE_PLAN_VERSION = "zeromodel-video-action-set-sealed-episode-plan/v1"
+FRAME_SHAPE = (16, 28)
 GENERATOR_VERSION = "zeromodel-video-action-set-reachability-generator/v1"
+OBSERVATION_OPERATION_CHAIN_VERSION = "zeromodel-video-observation-operation-chain/v1"
+PROVIDER_OBSERVATION_BOUNDARY_VERSION = (
+    "zeromodel-video-action-set-provider-observation-boundary/v1"
+)
 REACHABILITY_TILE_DIGEST = (
     "sha256:fef2bc5fd795bb92d3bd564bccdc2d32e1b23319aba55dffed5e0391e795a5df"
 )
@@ -12,7 +17,10 @@ SEED_DERIVATION_VERSION = "zeromodel-video-action-set-seed-derivation/v1"
 __all__ = [
     "BENCHMARK_VERSION",
     "EPISODE_PLAN_VERSION",
+    "FRAME_SHAPE",
     "GENERATOR_VERSION",
+    "OBSERVATION_OPERATION_CHAIN_VERSION",
+    "PROVIDER_OBSERVATION_BOUNDARY_VERSION",
     "REACHABILITY_TILE_DIGEST",
     "REACHABILITY_TILE_VERSION",
     "SEED_DERIVATION_VERSION",

--- a/zeromodel/domains/video_action_set/engine.py
+++ b/zeromodel/domains/video_action_set/engine.py
@@ -115,6 +115,27 @@ class VideoActionSetEngine:
     ) -> MaterializedObservationDTO | None:
         return self.observation_service.get_materialized(frame_id)
 
+    def list_materialized_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[MaterializedObservationDTO, ...]:
+        return self.observation_service.list_materialized(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+        )
+
     def get_observation_record(
         self,
         frame_id: str,

--- a/zeromodel/domains/video_action_set/engine.py
+++ b/zeromodel/domains/video_action_set/engine.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from ...matrix_blob import MatrixBlob
 from .dto import BenchmarkIdentityDTO, EpisodePlanDTO, SealedSplitPlanDTO
 from .episode_plan_service import EpisodePlanService
 from .identity_service import IdentityService
+from .observation_dto import (
+    MaterializedObservationDTO,
+    ObservationDTO,
+    ObservationOperationChainDTO,
+)
+from .observation_service import ObservationService
 
 
 @dataclass(frozen=True, slots=True)
 class VideoActionSetEngine:
     identity_service: IdentityService
     episode_plan_service: EpisodePlanService
+    observation_service: ObservationService
 
     def load_identity(self, repo_root: Path) -> BenchmarkIdentityDTO:
         return self.identity_service.load_identity(repo_root)
@@ -73,6 +81,125 @@ class VideoActionSetEngine:
             seed_commitment=seed_commitment,
             split=split,
         )
+
+    def save_matrix_blob(self, blob: MatrixBlob) -> MatrixBlob:
+        return self.observation_service.save_matrix_blob(blob)
+
+    def get_matrix_blob(self, blob_id: str) -> MatrixBlob | None:
+        return self.observation_service.get_matrix_blob(blob_id)
+
+    def save_observation_record(
+        self,
+        record: Mapping[str, object],
+    ) -> ObservationDTO:
+        return self.observation_service.save_record(record)
+
+    def save_observation_records(
+        self,
+        records: Sequence[Mapping[str, object]],
+    ) -> tuple[ObservationDTO, ...]:
+        return self.observation_service.save_records(records)
+
+    def save_materialized_observation(
+        self,
+        item: MaterializedObservationDTO,
+    ) -> ObservationDTO:
+        return self.observation_service.save_materialized(item)
+
+    def get_observation(self, frame_id: str) -> ObservationDTO | None:
+        return self.observation_service.get_observation(frame_id)
+
+    def get_materialized_observation(
+        self,
+        frame_id: str,
+    ) -> MaterializedObservationDTO | None:
+        return self.observation_service.get_materialized(frame_id)
+
+    def get_observation_record(
+        self,
+        frame_id: str,
+        *,
+        include_pixels: bool = True,
+    ) -> dict[str, object] | None:
+        return self.observation_service.get_record(
+            frame_id,
+            include_pixels=include_pixels,
+        )
+
+    def list_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.observation_service.list_observations(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+        )
+
+    def list_observation_records(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+        include_pixels: bool = False,
+    ) -> tuple[dict[str, object], ...]:
+        return self.observation_service.list_records(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+            include_pixels=include_pixels,
+        )
+
+    def get_observation_operation_chain(
+        self,
+        frame_id: str,
+    ) -> ObservationOperationChainDTO | None:
+        return self.observation_service.get_operation_chain(frame_id)
+
+    def list_observations_by_operation(
+        self,
+        *,
+        operation: str,
+        split: str | None = None,
+        family: str | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.observation_service.list_by_operation(
+            operation=operation,
+            split=split,
+            family=family,
+        )
+
+    def list_observations_by_output_digest(
+        self,
+        output_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.observation_service.list_by_output_digest(output_digest)
+
+    def list_observation_consumers_of_digest(
+        self,
+        input_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.observation_service.list_consumers_of_digest(input_digest)
 
 
 __all__ = ["VideoActionSetEngine"]

--- a/zeromodel/domains/video_action_set/facade.py
+++ b/zeromodel/domains/video_action_set/facade.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from ...matrix_blob import MatrixBlob
 from .dto import BenchmarkIdentityDTO, EpisodePlanDTO, SealedSplitPlanDTO
 from .engine import VideoActionSetEngine
+from .observation_dto import (
+    MaterializedObservationDTO,
+    ObservationDTO,
+    ObservationOperationChainDTO,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,6 +77,125 @@ class VideoActionSetFacade:
             seed_commitment=seed_commitment,
             split=split,
         )
+
+    def save_matrix_blob(self, blob: MatrixBlob) -> MatrixBlob:
+        return self.engine.save_matrix_blob(blob)
+
+    def get_matrix_blob(self, blob_id: str) -> MatrixBlob | None:
+        return self.engine.get_matrix_blob(blob_id)
+
+    def save_observation_record(
+        self,
+        record: Mapping[str, object],
+    ) -> ObservationDTO:
+        return self.engine.save_observation_record(record)
+
+    def save_observation_records(
+        self,
+        records: Sequence[Mapping[str, object]],
+    ) -> tuple[ObservationDTO, ...]:
+        return self.engine.save_observation_records(records)
+
+    def save_materialized_observation(
+        self,
+        item: MaterializedObservationDTO,
+    ) -> ObservationDTO:
+        return self.engine.save_materialized_observation(item)
+
+    def get_observation(self, frame_id: str) -> ObservationDTO | None:
+        return self.engine.get_observation(frame_id)
+
+    def get_materialized_observation(
+        self,
+        frame_id: str,
+    ) -> MaterializedObservationDTO | None:
+        return self.engine.get_materialized_observation(frame_id)
+
+    def get_observation_record(
+        self,
+        frame_id: str,
+        *,
+        include_pixels: bool = True,
+    ) -> dict[str, object] | None:
+        return self.engine.get_observation_record(
+            frame_id,
+            include_pixels=include_pixels,
+        )
+
+    def list_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.engine.list_observations(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+        )
+
+    def list_observation_records(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+        include_pixels: bool = False,
+    ) -> tuple[dict[str, object], ...]:
+        return self.engine.list_observation_records(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+            include_pixels=include_pixels,
+        )
+
+    def get_observation_operation_chain(
+        self,
+        frame_id: str,
+    ) -> ObservationOperationChainDTO | None:
+        return self.engine.get_observation_operation_chain(frame_id)
+
+    def list_observations_by_operation(
+        self,
+        *,
+        operation: str,
+        split: str | None = None,
+        family: str | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.engine.list_observations_by_operation(
+            operation=operation,
+            split=split,
+            family=family,
+        )
+
+    def list_observations_by_output_digest(
+        self,
+        output_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.engine.list_observations_by_output_digest(output_digest)
+
+    def list_observation_consumers_of_digest(
+        self,
+        input_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.engine.list_observation_consumers_of_digest(input_digest)
 
 
 __all__ = ["VideoActionSetFacade"]

--- a/zeromodel/domains/video_action_set/facade.py
+++ b/zeromodel/domains/video_action_set/facade.py
@@ -111,6 +111,27 @@ class VideoActionSetFacade:
     ) -> MaterializedObservationDTO | None:
         return self.engine.get_materialized_observation(frame_id)
 
+    def list_materialized_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[MaterializedObservationDTO, ...]:
+        return self.engine.list_materialized_observations(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+        )
+
     def get_observation_record(
         self,
         frame_id: str,

--- a/zeromodel/domains/video_action_set/observation_common.py
+++ b/zeromodel/domains/video_action_set/observation_common.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from ...artifact import VPMValidationError
+from .dto import CanonicalJsonDTO
+
+
+def is_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and value.startswith("sha256:")
+        and len(value) == 71
+        and all(item in "0123456789abcdef" for item in value[7:])
+    )
+
+
+def sha256(value: object, message: str) -> str:
+    if not is_sha256(value):
+        raise VPMValidationError(message)
+    return str(value)
+
+
+def optional_sha256(value: object, message: str) -> str | None:
+    if value is None:
+        return None
+    return sha256(value, message)
+
+
+def require_keys(
+    payload: Mapping[str, object],
+    keys: tuple[str, ...],
+    message: str,
+) -> None:
+    if set(payload) != set(keys):
+        raise VPMValidationError(message)
+
+
+def mapping(value: object, message: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise VPMValidationError(message)
+    return cast(Mapping[str, object], value)
+
+
+def sequence(value: object, message: str) -> Sequence[object]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise VPMValidationError(message)
+    return cast(Sequence[object], value)
+
+
+def string(payload: Mapping[str, object], key: str, message: str) -> str:
+    value = payload[key]
+    if not isinstance(value, str) or not value:
+        raise VPMValidationError(message)
+    return value
+
+
+def optional_string(
+    payload: Mapping[str, object],
+    key: str,
+    message: str,
+) -> str | None:
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise VPMValidationError(message)
+    return value
+
+
+def integer(payload: Mapping[str, object], key: str, message: str) -> int:
+    value = payload[key]
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise VPMValidationError(message)
+    return value
+
+
+def boolean(payload: Mapping[str, object], key: str, message: str) -> bool:
+    value = payload[key]
+    if not isinstance(value, bool):
+        raise VPMValidationError(message)
+    return value
+
+
+def string_tuple(value: object, message: str) -> tuple[str | None, ...]:
+    items = sequence(value, message)
+    result: list[str | None] = []
+    for item in items:
+        result.append(None if item is None else sha256(item, message))
+    return tuple(result)
+
+
+def json_mapping(dto: CanonicalJsonDTO, message: str) -> Mapping[str, object]:
+    return mapping(dto.to_value(), message)
+
+
+__all__ = [
+    "boolean",
+    "integer",
+    "is_sha256",
+    "json_mapping",
+    "mapping",
+    "optional_sha256",
+    "optional_string",
+    "require_keys",
+    "sequence",
+    "sha256",
+    "string",
+    "string_tuple",
+]

--- a/zeromodel/domains/video_action_set/observation_dto.py
+++ b/zeromodel/domains/video_action_set/observation_dto.py
@@ -1,24 +1,34 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
-import hashlib
-from typing import cast
-
-import numpy as np
 
 from ...artifact import VPMValidationError
 from ...matrix_blob import MatrixBlob
-from ...visual_address import IMAGE_OBSERVATION_VERSION
-from .canonical_json import canonical_json_bytes, canonical_sha256
-from .contracts import (
-    BENCHMARK_VERSION,
-    FRAME_SHAPE,
-    GENERATOR_VERSION,
-    OBSERVATION_OPERATION_CHAIN_VERSION,
-    PROVIDER_OBSERVATION_BOUNDARY_VERSION,
-)
+from .contracts import BENCHMARK_VERSION, GENERATOR_VERSION
 from .dto import CanonicalJsonDTO, SPLITS
+from .observation_common import (
+    boolean,
+    integer,
+    json_mapping,
+    mapping,
+    optional_sha256,
+    optional_string,
+    sha256,
+    string,
+)
+from .observation_materialization import (
+    MaterializedObservationDTO,
+    blob_from_record,
+    register_materialized_observation_loader,
+    validate_observation_matrix_blob,
+)
+from .observation_provenance_dto import (
+    ObservationOperationChainDTO,
+    ObservationOperationDTO,
+)
+from .provider_observation_dto import ProviderObservationDescriptorDTO
+
 
 OBSERVATION_RECORD_KEYS = (
     "benchmark_version",
@@ -43,385 +53,6 @@ OBSERVATION_RECORD_KEYS = (
     "observation_pixel_digest",
     "metadata",
 )
-STRUCTURED_METADATA_KEYS = (
-    "observation_operation_chain",
-    "provider_observation_descriptor",
-    "provider_observation_digest",
-)
-PROVIDER_DESCRIPTOR_KEYS = (
-    "version",
-    "raw_digest",
-    "shape",
-    "timestamp",
-    "source_id",
-    "metadata",
-)
-OPERATION_KEYS = (
-    "index",
-    "operation",
-    "operation_version",
-    "input_digests",
-    "parameters",
-    "parameter_digest",
-    "output_digest",
-    "operation_digest",
-)
-OPERATION_CHAIN_KEYS = (
-    "version",
-    "operations",
-    "final_emitted_digest",
-    "operation_chain_digest",
-)
-
-
-def _is_sha256(value: object) -> bool:
-    return (
-        isinstance(value, str)
-        and value.startswith("sha256:")
-        and len(value) == 71
-        and all(item in "0123456789abcdef" for item in value[7:])
-    )
-
-
-def _sha256(value: object, message: str) -> str:
-    if not _is_sha256(value):
-        raise VPMValidationError(message)
-    return str(value)
-
-
-def _optional_sha256(value: object, message: str) -> str | None:
-    if value is None:
-        return None
-    return _sha256(value, message)
-
-
-def _require_keys(
-    payload: Mapping[str, object],
-    keys: tuple[str, ...],
-    message: str,
-) -> None:
-    if set(payload) != set(keys):
-        raise VPMValidationError(message)
-
-
-def _record_keys(payload: Mapping[str, object]) -> None:
-    allowed = {
-        frozenset(OBSERVATION_RECORD_KEYS),
-        frozenset((*OBSERVATION_RECORD_KEYS, "pixels")),
-    }
-    if frozenset(payload) not in allowed:
-        raise VPMValidationError("observation record keys mismatch")
-
-
-def _mapping(value: object, message: str) -> Mapping[str, object]:
-    if not isinstance(value, Mapping):
-        raise VPMValidationError(message)
-    return cast(Mapping[str, object], value)
-
-
-def _sequence(value: object, message: str) -> Sequence[object]:
-    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
-        raise VPMValidationError(message)
-    return cast(Sequence[object], value)
-
-
-def _string(payload: Mapping[str, object], key: str, message: str) -> str:
-    value = payload[key]
-    if not isinstance(value, str) or not value:
-        raise VPMValidationError(message)
-    return value
-
-
-def _optional_string(
-    payload: Mapping[str, object],
-    key: str,
-    message: str,
-) -> str | None:
-    value = payload[key]
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise VPMValidationError(message)
-    return value
-
-
-def _integer(payload: Mapping[str, object], key: str, message: str) -> int:
-    value = payload[key]
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise VPMValidationError(message)
-    return value
-
-
-def _boolean(payload: Mapping[str, object], key: str, message: str) -> bool:
-    value = payload[key]
-    if not isinstance(value, bool):
-        raise VPMValidationError(message)
-    return value
-
-
-def _string_tuple(value: object, message: str) -> tuple[str | None, ...]:
-    items = _sequence(value, message)
-    result: list[str | None] = []
-    for item in items:
-        result.append(None if item is None else _sha256(item, message))
-    return tuple(result)
-
-
-def _json_mapping(dto: CanonicalJsonDTO, message: str) -> Mapping[str, object]:
-    return _mapping(dto.to_value(), message)
-
-
-def _pixel_digest_from_bytes(data: bytes) -> str:
-    return "sha256:" + hashlib.sha256(data).hexdigest()
-
-
-def _pixel_digest_from_array(pixels: object) -> str:
-    return _pixel_digest_from_bytes(
-        np.ascontiguousarray(pixels, dtype=np.uint8).tobytes(order="C")
-    )
-
-
-def _provider_raw_digest(blob: MatrixBlob) -> str:
-    payload = (
-        b"zeromodel.image-observation.raw.v1\0"
-        + canonical_json_bytes(list(blob.shape))
-        + blob.data
-    )
-    return "sha256:" + hashlib.sha256(payload).hexdigest()
-
-
-@dataclass(frozen=True, slots=True)
-class ProviderObservationDescriptorDTO:
-    version: str
-    raw_digest: str
-    shape: tuple[int, ...]
-    timestamp: str | None
-    source_id: str
-    metadata: CanonicalJsonDTO
-
-    def __post_init__(self) -> None:
-        if self.version != IMAGE_OBSERVATION_VERSION:
-            raise VPMValidationError("unsupported provider observation version")
-        _sha256(self.raw_digest, "provider observation raw digest is not sha256")
-        if not self.shape or any(dimension <= 0 for dimension in self.shape):
-            raise VPMValidationError("provider observation shape mismatch")
-        if not self.source_id:
-            raise VPMValidationError("provider observation source mismatch")
-        _json_mapping(self.metadata, "provider observation metadata mismatch")
-
-    @classmethod
-    def from_dict(
-        cls,
-        payload: Mapping[str, object],
-    ) -> ProviderObservationDescriptorDTO:
-        _require_keys(
-            payload,
-            PROVIDER_DESCRIPTOR_KEYS,
-            "provider observation descriptor keys mismatch",
-        )
-        return cls(
-            version=_string(
-                payload, "version", "unsupported provider observation version"
-            ),
-            raw_digest=_sha256(
-                payload["raw_digest"],
-                "provider observation raw digest is not sha256",
-            ),
-            shape=tuple(
-                int(str(item))
-                for item in _sequence(
-                    payload["shape"], "provider observation shape mismatch"
-                )
-            ),
-            timestamp=_optional_string(
-                payload,
-                "timestamp",
-                "provider observation timestamp mismatch",
-            ),
-            source_id=_string(
-                payload,
-                "source_id",
-                "provider observation source mismatch",
-            ),
-            metadata=CanonicalJsonDTO.from_value(payload["metadata"]),
-        )
-
-    @property
-    def descriptor_digest(self) -> str:
-        return canonical_sha256(
-            {
-                "version": PROVIDER_OBSERVATION_BOUNDARY_VERSION,
-                "descriptor": self.to_dict(),
-            }
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "version": self.version,
-            "raw_digest": self.raw_digest,
-            "shape": list(self.shape),
-            "timestamp": self.timestamp,
-            "source_id": self.source_id,
-            "metadata": self.metadata.to_value(),
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class ObservationOperationDTO:
-    index: int
-    operation: str
-    operation_version: str
-    input_digests: tuple[str | None, ...]
-    parameters: CanonicalJsonDTO
-    parameter_digest: str
-    output_digest: str | None
-    operation_digest: str
-
-    def __post_init__(self) -> None:
-        if self.index < 0:
-            raise VPMValidationError("observation operation index cannot be negative")
-        if not self.operation or not self.operation_version:
-            raise VPMValidationError("observation operation payload keys mismatch")
-        if self.parameter_digest != canonical_sha256(self.parameters.to_value()):
-            raise VPMValidationError("observation operation parameter digest mismatch")
-        for digest in (*self.input_digests, self.output_digest):
-            _optional_sha256(digest, "observation operation digest is not sha256")
-        _sha256(self.operation_digest, "observation operation digest is not sha256")
-        if canonical_sha256(self._payload_without_digest()) != self.operation_digest:
-            raise VPMValidationError("observation operation digest mismatch")
-
-    @classmethod
-    def from_dict(cls, payload: Mapping[str, object]) -> ObservationOperationDTO:
-        _require_keys(
-            payload,
-            OPERATION_KEYS,
-            "observation operation payload keys mismatch",
-        )
-        return cls(
-            index=_integer(
-                payload,
-                "index",
-                "observation operation index cannot be negative",
-            ),
-            operation=_string(
-                payload,
-                "operation",
-                "observation operation payload keys mismatch",
-            ),
-            operation_version=_string(
-                payload,
-                "operation_version",
-                "observation operation payload keys mismatch",
-            ),
-            input_digests=_string_tuple(
-                payload["input_digests"],
-                "observation operation digest is not sha256",
-            ),
-            parameters=CanonicalJsonDTO.from_value(payload["parameters"]),
-            parameter_digest=_sha256(
-                payload["parameter_digest"],
-                "observation operation parameter digest mismatch",
-            ),
-            output_digest=_optional_sha256(
-                payload["output_digest"],
-                "observation operation digest is not sha256",
-            ),
-            operation_digest=_sha256(
-                payload["operation_digest"],
-                "observation operation digest is not sha256",
-            ),
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        return self._payload_without_digest() | {
-            "operation_digest": self.operation_digest
-        }
-
-    def _payload_without_digest(self) -> dict[str, object]:
-        return {
-            "index": self.index,
-            "operation": self.operation,
-            "operation_version": self.operation_version,
-            "input_digests": list(self.input_digests),
-            "parameters": self.parameters.to_value(),
-            "parameter_digest": self.parameter_digest,
-            "output_digest": self.output_digest,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class ObservationOperationChainDTO:
-    version: str
-    operations: tuple[ObservationOperationDTO, ...]
-    final_emitted_digest: str | None
-    operation_chain_digest: str
-
-    def __post_init__(self) -> None:
-        if self.version != OBSERVATION_OPERATION_CHAIN_VERSION:
-            raise VPMValidationError("unsupported observation operation chain version")
-        if not self.operations:
-            raise VPMValidationError("observation operation indexes are not contiguous")
-        for expected, operation in enumerate(self.operations):
-            if operation.index != expected:
-                raise VPMValidationError(
-                    "observation operation indexes are not contiguous"
-                )
-        _optional_sha256(
-            self.final_emitted_digest,
-            "observation operation chain final digest mismatch",
-        )
-        if self.operations[-1].output_digest != self.final_emitted_digest:
-            raise VPMValidationError(
-                "observation operation chain final digest mismatch"
-            )
-        if (
-            canonical_sha256(self._payload_without_digest())
-            != self.operation_chain_digest
-        ):
-            raise VPMValidationError("observation operation chain digest mismatch")
-
-    @classmethod
-    def from_dict(
-        cls,
-        payload: Mapping[str, object],
-    ) -> ObservationOperationChainDTO:
-        _require_keys(payload, OPERATION_CHAIN_KEYS, "operation chain keys mismatch")
-        return cls(
-            version=_string(
-                payload,
-                "version",
-                "unsupported observation operation chain version",
-            ),
-            operations=tuple(
-                ObservationOperationDTO.from_dict(
-                    _mapping(item, "observation operation payload keys mismatch")
-                )
-                for item in _sequence(
-                    payload["operations"],
-                    "observation operation payload keys mismatch",
-                )
-            ),
-            final_emitted_digest=_optional_sha256(
-                payload["final_emitted_digest"],
-                "observation operation chain final digest mismatch",
-            ),
-            operation_chain_digest=_sha256(
-                payload["operation_chain_digest"],
-                "observation operation chain digest mismatch",
-            ),
-        )
-
-    def to_dict(self) -> dict[str, object]:
-        return self._payload_without_digest() | {
-            "operation_chain_digest": self.operation_chain_digest
-        }
-
-    def _payload_without_digest(self) -> dict[str, object]:
-        return {
-            "version": self.version,
-            "operations": [operation.to_dict() for operation in self.operations],
-            "final_emitted_digest": self.final_emitted_digest,
-        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -458,15 +89,15 @@ class ObservationDTO:
         self._validate_ids()
         if self.action_known != (self.actual_executed_action is not None):
             raise VPMValidationError("observation action_known mismatch")
-        _sha256(self.benchmark_seed_digest, "observation seed digest mismatch")
-        _sha256(self.episode_plan_digest, "observation episode plan digest mismatch")
-        _optional_sha256(
+        sha256(self.benchmark_seed_digest, "observation seed digest mismatch")
+        sha256(self.episode_plan_digest, "observation episode plan digest mismatch")
+        optional_sha256(
             self.observation_pixel_digest,
             "observation pixel digest mismatch",
         )
         self._validate_materialization_contract()
         self._validate_provider_descriptor()
-        _json_mapping(self.metadata, "observation metadata mismatch")
+        json_mapping(self.metadata, "observation metadata mismatch")
 
     @classmethod
     def from_record(
@@ -474,82 +105,80 @@ class ObservationDTO:
         record: Mapping[str, object],
     ) -> MaterializedObservationDTO:
         _record_keys(record)
-        metadata = dict(_mapping(record["metadata"], "observation metadata mismatch"))
+        metadata = dict(mapping(record["metadata"], "observation metadata mismatch"))
         chain = ObservationOperationChainDTO.from_dict(
-            _mapping(
+            mapping(
                 metadata.pop("observation_operation_chain", None),
                 "observation operation chain mismatch",
             )
         )
         descriptor = _provider_descriptor_from_metadata(metadata)
-        provider_digest = _optional_sha256(
+        provider_digest = optional_sha256(
             metadata.pop("provider_observation_digest", None),
             "provider observation digest mismatch",
         )
-        pixel_digest = _optional_sha256(
+        pixel_digest = optional_sha256(
             record["observation_pixel_digest"],
             "observation pixel digest mismatch",
         )
-        blob = _blob_from_record(record, pixel_digest)
+        blob = blob_from_record(record, pixel_digest)
         dto = cls(
-            benchmark_version=_string(
+            benchmark_version=string(
                 record,
                 "benchmark_version",
                 "unsupported observation benchmark version",
             ),
-            generator_version=_string(
+            generator_version=string(
                 record,
                 "generator_version",
                 "unsupported observation generator version",
             ),
-            benchmark_seed_digest=_sha256(
+            benchmark_seed_digest=sha256(
                 metadata.get("seed_digest"),
                 "observation seed digest mismatch",
             ),
-            episode_plan_digest=_sha256(
+            episode_plan_digest=sha256(
                 metadata.get("episode_plan_digest"),
                 "observation episode plan digest mismatch",
             ),
-            split=_string(record, "split", "observation split mismatch"),
-            episode_id=_string(record, "episode_id", "observation split mismatch"),
-            clip_id=_string(record, "clip_id", "observation clip id mismatch"),
-            frame_id=_string(record, "frame_id", "observation frame id mismatch"),
-            sequence_number=_integer(
+            split=string(record, "split", "observation split mismatch"),
+            episode_id=string(record, "episode_id", "observation split mismatch"),
+            clip_id=string(record, "clip_id", "observation clip id mismatch"),
+            frame_id=string(record, "frame_id", "observation frame id mismatch"),
+            sequence_number=integer(
                 record,
                 "sequence_number",
                 "observation sequence number cannot be negative",
             ),
-            event_type=_string(
-                record, "event_type", "observation record keys mismatch"
-            ),
-            family=_string(record, "family", "observation record keys mismatch"),
-            expected_disposition=_string(
+            event_type=string(record, "event_type", "observation record keys mismatch"),
+            family=string(record, "family", "observation record keys mismatch"),
+            expected_disposition=string(
                 record,
                 "expected_disposition",
                 "observation record keys mismatch",
             ),
-            episode_family=_string(
+            episode_family=string(
                 record, "episode_family", "observation record keys mismatch"
             ),
-            episode_disposition=_string(
+            episode_disposition=string(
                 record, "episode_disposition", "observation record keys mismatch"
             ),
-            frame_disposition=_string(
+            frame_disposition=string(
                 record, "frame_disposition", "observation record keys mismatch"
             ),
-            denominator_class=_string(
+            denominator_class=string(
                 record, "denominator_class", "observation record keys mismatch"
             ),
-            expected_row=_optional_string(
+            expected_row=optional_string(
                 record, "expected_row", "observation record keys mismatch"
             ),
-            expected_action=_optional_string(
+            expected_action=optional_string(
                 record, "expected_action", "observation record keys mismatch"
             ),
-            actual_executed_action=_optional_string(
+            actual_executed_action=optional_string(
                 record, "actual_executed_action", "observation record keys mismatch"
             ),
-            action_known=_boolean(
+            action_known=boolean(
                 record, "action_known", "observation action_known mismatch"
             ),
             gap_declaration=_canonical_optional(record["gap_declaration"]),
@@ -570,7 +199,7 @@ class ObservationDTO:
     ) -> dict[str, object]:
         if include_pixels:
             self._validate_record_blob(matrix_blob)
-        metadata = dict(_json_mapping(self.metadata, "observation metadata mismatch"))
+        metadata = dict(json_mapping(self.metadata, "observation metadata mismatch"))
         self._restore_structured_metadata(metadata)
         payload = {
             "benchmark_version": self.benchmark_version,
@@ -632,7 +261,7 @@ class ObservationDTO:
             raise VPMValidationError("observation frame id mismatch")
 
     def _is_reordered_frame_id(self, frame_index: int) -> bool:
-        metadata = _json_mapping(self.metadata, "observation metadata mismatch")
+        metadata = json_mapping(self.metadata, "observation metadata mismatch")
         return (
             metadata.get("original_frame_index") == frame_index
             and "materialized_order" in metadata
@@ -687,65 +316,13 @@ class ObservationDTO:
             metadata["provider_observation_digest"] = self.provider_observation_digest
 
 
-@dataclass(frozen=True, slots=True)
-class MaterializedObservationDTO:
-    observation: ObservationDTO
-    matrix_blob: MatrixBlob | None
-
-    def __post_init__(self) -> None:
-        if self.observation.split == "final":
-            raise VPMValidationError(
-                "final split observation materialization is prohibited"
-            )
-        if self.matrix_blob is None:
-            if self.observation.matrix_blob_id is not None:
-                raise VPMValidationError("observation matrix blob mismatch")
-            return
-        if self.observation.matrix_blob_id != self.matrix_blob.blob_id:
-            raise VPMValidationError("observation matrix blob mismatch")
-        validate_observation_matrix_blob(self.observation, self.matrix_blob)
-
-    @classmethod
-    def from_record(
-        cls,
-        record: Mapping[str, object],
-    ) -> MaterializedObservationDTO:
-        return ObservationDTO.from_record(record)
-
-    def to_record(self, *, include_pixels: bool = True) -> dict[str, object]:
-        return self.observation.to_record(
-            matrix_blob=self.matrix_blob,
-            include_pixels=include_pixels,
-        )
-
-
-def validate_observation_matrix_blob(
-    observation: ObservationDTO,
-    blob: MatrixBlob,
-) -> None:
-    if blob.dtype != "uint8" or tuple(blob.shape) != FRAME_SHAPE:
-        raise VPMValidationError(
-            "observation matrix blob does not match declared pixels"
-        )
-    if _pixel_digest_from_bytes(blob.data) != observation.observation_pixel_digest:
-        raise VPMValidationError(
-            "observation matrix blob does not match declared pixels"
-        )
-    metadata = dict(blob.metadata)
-    if metadata != {
-        "kind": "video_action_set_frame_pixels",
-        "pixel_digest": observation.observation_pixel_digest,
-    }:
-        raise VPMValidationError(
-            "observation matrix blob does not match declared pixels"
-        )
-    descriptor = observation.provider_observation_descriptor
-    if descriptor is None:
-        raise VPMValidationError("provider observation descriptor mismatch")
-    if descriptor.shape != tuple(
-        blob.shape
-    ) or descriptor.raw_digest != _provider_raw_digest(blob):
-        raise VPMValidationError("provider observation descriptor mismatch")
+def _record_keys(payload: Mapping[str, object]) -> None:
+    allowed = {
+        frozenset(OBSERVATION_RECORD_KEYS),
+        frozenset((*OBSERVATION_RECORD_KEYS, "pixels")),
+    }
+    if frozenset(payload) not in allowed:
+        raise VPMValidationError("observation record keys mismatch")
 
 
 def _provider_descriptor_from_metadata(
@@ -755,26 +332,7 @@ def _provider_descriptor_from_metadata(
     if value is None:
         return None
     return ProviderObservationDescriptorDTO.from_dict(
-        _mapping(value, "provider observation descriptor keys mismatch")
-    )
-
-
-def _blob_from_record(
-    record: Mapping[str, object],
-    pixel_digest: str | None,
-) -> MatrixBlob | None:
-    pixels = record.get("pixels")
-    if pixels is None:
-        return None
-    if pixel_digest is None or _pixel_digest_from_array(pixels) != pixel_digest:
-        raise VPMValidationError("observation pixel digest mismatch")
-    return MatrixBlob.from_array(
-        np.ascontiguousarray(pixels, dtype=np.uint8),
-        dtype="uint8",
-        metadata={
-            "kind": "video_action_set_frame_pixels",
-            "pixel_digest": pixel_digest,
-        },
+        mapping(value, "provider observation descriptor keys mismatch")
     )
 
 
@@ -782,6 +340,9 @@ def _canonical_optional(value: object) -> CanonicalJsonDTO | None:
     if value is None:
         return None
     return CanonicalJsonDTO.from_value(value)
+
+
+register_materialized_observation_loader(ObservationDTO.from_record)
 
 
 __all__ = [

--- a/zeromodel/domains/video_action_set/observation_dto.py
+++ b/zeromodel/domains/video_action_set/observation_dto.py
@@ -1,0 +1,794 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+from typing import cast
+
+import numpy as np
+
+from ...artifact import VPMValidationError
+from ...matrix_blob import MatrixBlob
+from ...visual_address import IMAGE_OBSERVATION_VERSION
+from .canonical_json import canonical_json_bytes, canonical_sha256
+from .contracts import (
+    BENCHMARK_VERSION,
+    FRAME_SHAPE,
+    GENERATOR_VERSION,
+    OBSERVATION_OPERATION_CHAIN_VERSION,
+    PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+)
+from .dto import CanonicalJsonDTO, SPLITS
+
+OBSERVATION_RECORD_KEYS = (
+    "benchmark_version",
+    "generator_version",
+    "split",
+    "episode_id",
+    "clip_id",
+    "frame_id",
+    "sequence_number",
+    "event_type",
+    "family",
+    "expected_disposition",
+    "episode_family",
+    "episode_disposition",
+    "frame_disposition",
+    "denominator_class",
+    "expected_row",
+    "expected_action",
+    "actual_executed_action",
+    "action_known",
+    "gap_declaration",
+    "observation_pixel_digest",
+    "metadata",
+)
+STRUCTURED_METADATA_KEYS = (
+    "observation_operation_chain",
+    "provider_observation_descriptor",
+    "provider_observation_digest",
+)
+PROVIDER_DESCRIPTOR_KEYS = (
+    "version",
+    "raw_digest",
+    "shape",
+    "timestamp",
+    "source_id",
+    "metadata",
+)
+OPERATION_KEYS = (
+    "index",
+    "operation",
+    "operation_version",
+    "input_digests",
+    "parameters",
+    "parameter_digest",
+    "output_digest",
+    "operation_digest",
+)
+OPERATION_CHAIN_KEYS = (
+    "version",
+    "operations",
+    "final_emitted_digest",
+    "operation_chain_digest",
+)
+
+
+def _is_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and value.startswith("sha256:")
+        and len(value) == 71
+        and all(item in "0123456789abcdef" for item in value[7:])
+    )
+
+
+def _sha256(value: object, message: str) -> str:
+    if not _is_sha256(value):
+        raise VPMValidationError(message)
+    return str(value)
+
+
+def _optional_sha256(value: object, message: str) -> str | None:
+    if value is None:
+        return None
+    return _sha256(value, message)
+
+
+def _require_keys(
+    payload: Mapping[str, object],
+    keys: tuple[str, ...],
+    message: str,
+) -> None:
+    if set(payload) != set(keys):
+        raise VPMValidationError(message)
+
+
+def _record_keys(payload: Mapping[str, object]) -> None:
+    allowed = {
+        frozenset(OBSERVATION_RECORD_KEYS),
+        frozenset((*OBSERVATION_RECORD_KEYS, "pixels")),
+    }
+    if frozenset(payload) not in allowed:
+        raise VPMValidationError("observation record keys mismatch")
+
+
+def _mapping(value: object, message: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise VPMValidationError(message)
+    return cast(Mapping[str, object], value)
+
+
+def _sequence(value: object, message: str) -> Sequence[object]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise VPMValidationError(message)
+    return cast(Sequence[object], value)
+
+
+def _string(payload: Mapping[str, object], key: str, message: str) -> str:
+    value = payload[key]
+    if not isinstance(value, str) or not value:
+        raise VPMValidationError(message)
+    return value
+
+
+def _optional_string(
+    payload: Mapping[str, object],
+    key: str,
+    message: str,
+) -> str | None:
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise VPMValidationError(message)
+    return value
+
+
+def _integer(payload: Mapping[str, object], key: str, message: str) -> int:
+    value = payload[key]
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise VPMValidationError(message)
+    return value
+
+
+def _boolean(payload: Mapping[str, object], key: str, message: str) -> bool:
+    value = payload[key]
+    if not isinstance(value, bool):
+        raise VPMValidationError(message)
+    return value
+
+
+def _string_tuple(value: object, message: str) -> tuple[str | None, ...]:
+    items = _sequence(value, message)
+    result: list[str | None] = []
+    for item in items:
+        result.append(None if item is None else _sha256(item, message))
+    return tuple(result)
+
+
+def _json_mapping(dto: CanonicalJsonDTO, message: str) -> Mapping[str, object]:
+    return _mapping(dto.to_value(), message)
+
+
+def _pixel_digest_from_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _pixel_digest_from_array(pixels: object) -> str:
+    return _pixel_digest_from_bytes(
+        np.ascontiguousarray(pixels, dtype=np.uint8).tobytes(order="C")
+    )
+
+
+def _provider_raw_digest(blob: MatrixBlob) -> str:
+    payload = (
+        b"zeromodel.image-observation.raw.v1\0"
+        + canonical_json_bytes(list(blob.shape))
+        + blob.data
+    )
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderObservationDescriptorDTO:
+    version: str
+    raw_digest: str
+    shape: tuple[int, ...]
+    timestamp: str | None
+    source_id: str
+    metadata: CanonicalJsonDTO
+
+    def __post_init__(self) -> None:
+        if self.version != IMAGE_OBSERVATION_VERSION:
+            raise VPMValidationError("unsupported provider observation version")
+        _sha256(self.raw_digest, "provider observation raw digest is not sha256")
+        if not self.shape or any(dimension <= 0 for dimension in self.shape):
+            raise VPMValidationError("provider observation shape mismatch")
+        if not self.source_id:
+            raise VPMValidationError("provider observation source mismatch")
+        _json_mapping(self.metadata, "provider observation metadata mismatch")
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Mapping[str, object],
+    ) -> ProviderObservationDescriptorDTO:
+        _require_keys(
+            payload,
+            PROVIDER_DESCRIPTOR_KEYS,
+            "provider observation descriptor keys mismatch",
+        )
+        return cls(
+            version=_string(
+                payload, "version", "unsupported provider observation version"
+            ),
+            raw_digest=_sha256(
+                payload["raw_digest"],
+                "provider observation raw digest is not sha256",
+            ),
+            shape=tuple(
+                int(str(item))
+                for item in _sequence(
+                    payload["shape"], "provider observation shape mismatch"
+                )
+            ),
+            timestamp=_optional_string(
+                payload,
+                "timestamp",
+                "provider observation timestamp mismatch",
+            ),
+            source_id=_string(
+                payload,
+                "source_id",
+                "provider observation source mismatch",
+            ),
+            metadata=CanonicalJsonDTO.from_value(payload["metadata"]),
+        )
+
+    @property
+    def descriptor_digest(self) -> str:
+        return canonical_sha256(
+            {
+                "version": PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+                "descriptor": self.to_dict(),
+            }
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "raw_digest": self.raw_digest,
+            "shape": list(self.shape),
+            "timestamp": self.timestamp,
+            "source_id": self.source_id,
+            "metadata": self.metadata.to_value(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationOperationDTO:
+    index: int
+    operation: str
+    operation_version: str
+    input_digests: tuple[str | None, ...]
+    parameters: CanonicalJsonDTO
+    parameter_digest: str
+    output_digest: str | None
+    operation_digest: str
+
+    def __post_init__(self) -> None:
+        if self.index < 0:
+            raise VPMValidationError("observation operation index cannot be negative")
+        if not self.operation or not self.operation_version:
+            raise VPMValidationError("observation operation payload keys mismatch")
+        if self.parameter_digest != canonical_sha256(self.parameters.to_value()):
+            raise VPMValidationError("observation operation parameter digest mismatch")
+        for digest in (*self.input_digests, self.output_digest):
+            _optional_sha256(digest, "observation operation digest is not sha256")
+        _sha256(self.operation_digest, "observation operation digest is not sha256")
+        if canonical_sha256(self._payload_without_digest()) != self.operation_digest:
+            raise VPMValidationError("observation operation digest mismatch")
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> ObservationOperationDTO:
+        _require_keys(
+            payload,
+            OPERATION_KEYS,
+            "observation operation payload keys mismatch",
+        )
+        return cls(
+            index=_integer(
+                payload,
+                "index",
+                "observation operation index cannot be negative",
+            ),
+            operation=_string(
+                payload,
+                "operation",
+                "observation operation payload keys mismatch",
+            ),
+            operation_version=_string(
+                payload,
+                "operation_version",
+                "observation operation payload keys mismatch",
+            ),
+            input_digests=_string_tuple(
+                payload["input_digests"],
+                "observation operation digest is not sha256",
+            ),
+            parameters=CanonicalJsonDTO.from_value(payload["parameters"]),
+            parameter_digest=_sha256(
+                payload["parameter_digest"],
+                "observation operation parameter digest mismatch",
+            ),
+            output_digest=_optional_sha256(
+                payload["output_digest"],
+                "observation operation digest is not sha256",
+            ),
+            operation_digest=_sha256(
+                payload["operation_digest"],
+                "observation operation digest is not sha256",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return self._payload_without_digest() | {
+            "operation_digest": self.operation_digest
+        }
+
+    def _payload_without_digest(self) -> dict[str, object]:
+        return {
+            "index": self.index,
+            "operation": self.operation,
+            "operation_version": self.operation_version,
+            "input_digests": list(self.input_digests),
+            "parameters": self.parameters.to_value(),
+            "parameter_digest": self.parameter_digest,
+            "output_digest": self.output_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationOperationChainDTO:
+    version: str
+    operations: tuple[ObservationOperationDTO, ...]
+    final_emitted_digest: str | None
+    operation_chain_digest: str
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVATION_OPERATION_CHAIN_VERSION:
+            raise VPMValidationError("unsupported observation operation chain version")
+        if not self.operations:
+            raise VPMValidationError("observation operation indexes are not contiguous")
+        for expected, operation in enumerate(self.operations):
+            if operation.index != expected:
+                raise VPMValidationError(
+                    "observation operation indexes are not contiguous"
+                )
+        _optional_sha256(
+            self.final_emitted_digest,
+            "observation operation chain final digest mismatch",
+        )
+        if self.operations[-1].output_digest != self.final_emitted_digest:
+            raise VPMValidationError(
+                "observation operation chain final digest mismatch"
+            )
+        if (
+            canonical_sha256(self._payload_without_digest())
+            != self.operation_chain_digest
+        ):
+            raise VPMValidationError("observation operation chain digest mismatch")
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Mapping[str, object],
+    ) -> ObservationOperationChainDTO:
+        _require_keys(payload, OPERATION_CHAIN_KEYS, "operation chain keys mismatch")
+        return cls(
+            version=_string(
+                payload,
+                "version",
+                "unsupported observation operation chain version",
+            ),
+            operations=tuple(
+                ObservationOperationDTO.from_dict(
+                    _mapping(item, "observation operation payload keys mismatch")
+                )
+                for item in _sequence(
+                    payload["operations"],
+                    "observation operation payload keys mismatch",
+                )
+            ),
+            final_emitted_digest=_optional_sha256(
+                payload["final_emitted_digest"],
+                "observation operation chain final digest mismatch",
+            ),
+            operation_chain_digest=_sha256(
+                payload["operation_chain_digest"],
+                "observation operation chain digest mismatch",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return self._payload_without_digest() | {
+            "operation_chain_digest": self.operation_chain_digest
+        }
+
+    def _payload_without_digest(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "operations": [operation.to_dict() for operation in self.operations],
+            "final_emitted_digest": self.final_emitted_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationDTO:
+    benchmark_version: str
+    generator_version: str
+    benchmark_seed_digest: str
+    episode_plan_digest: str
+    split: str
+    episode_id: str
+    clip_id: str
+    frame_id: str
+    sequence_number: int
+    event_type: str
+    family: str
+    expected_disposition: str
+    episode_family: str
+    episode_disposition: str
+    frame_disposition: str
+    denominator_class: str
+    expected_row: str | None
+    expected_action: str | None
+    actual_executed_action: str | None
+    action_known: bool
+    gap_declaration: CanonicalJsonDTO | None
+    observation_pixel_digest: str | None
+    matrix_blob_id: str | None
+    provider_observation_descriptor: ProviderObservationDescriptorDTO | None
+    provider_observation_digest: str | None
+    operation_chain: ObservationOperationChainDTO
+    metadata: CanonicalJsonDTO
+
+    def __post_init__(self) -> None:
+        self._validate_ids()
+        if self.action_known != (self.actual_executed_action is not None):
+            raise VPMValidationError("observation action_known mismatch")
+        _sha256(self.benchmark_seed_digest, "observation seed digest mismatch")
+        _sha256(self.episode_plan_digest, "observation episode plan digest mismatch")
+        _optional_sha256(
+            self.observation_pixel_digest,
+            "observation pixel digest mismatch",
+        )
+        self._validate_materialization_contract()
+        self._validate_provider_descriptor()
+        _json_mapping(self.metadata, "observation metadata mismatch")
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+    ) -> MaterializedObservationDTO:
+        _record_keys(record)
+        metadata = dict(_mapping(record["metadata"], "observation metadata mismatch"))
+        chain = ObservationOperationChainDTO.from_dict(
+            _mapping(
+                metadata.pop("observation_operation_chain", None),
+                "observation operation chain mismatch",
+            )
+        )
+        descriptor = _provider_descriptor_from_metadata(metadata)
+        provider_digest = _optional_sha256(
+            metadata.pop("provider_observation_digest", None),
+            "provider observation digest mismatch",
+        )
+        pixel_digest = _optional_sha256(
+            record["observation_pixel_digest"],
+            "observation pixel digest mismatch",
+        )
+        blob = _blob_from_record(record, pixel_digest)
+        dto = cls(
+            benchmark_version=_string(
+                record,
+                "benchmark_version",
+                "unsupported observation benchmark version",
+            ),
+            generator_version=_string(
+                record,
+                "generator_version",
+                "unsupported observation generator version",
+            ),
+            benchmark_seed_digest=_sha256(
+                metadata.get("seed_digest"),
+                "observation seed digest mismatch",
+            ),
+            episode_plan_digest=_sha256(
+                metadata.get("episode_plan_digest"),
+                "observation episode plan digest mismatch",
+            ),
+            split=_string(record, "split", "observation split mismatch"),
+            episode_id=_string(record, "episode_id", "observation split mismatch"),
+            clip_id=_string(record, "clip_id", "observation clip id mismatch"),
+            frame_id=_string(record, "frame_id", "observation frame id mismatch"),
+            sequence_number=_integer(
+                record,
+                "sequence_number",
+                "observation sequence number cannot be negative",
+            ),
+            event_type=_string(
+                record, "event_type", "observation record keys mismatch"
+            ),
+            family=_string(record, "family", "observation record keys mismatch"),
+            expected_disposition=_string(
+                record,
+                "expected_disposition",
+                "observation record keys mismatch",
+            ),
+            episode_family=_string(
+                record, "episode_family", "observation record keys mismatch"
+            ),
+            episode_disposition=_string(
+                record, "episode_disposition", "observation record keys mismatch"
+            ),
+            frame_disposition=_string(
+                record, "frame_disposition", "observation record keys mismatch"
+            ),
+            denominator_class=_string(
+                record, "denominator_class", "observation record keys mismatch"
+            ),
+            expected_row=_optional_string(
+                record, "expected_row", "observation record keys mismatch"
+            ),
+            expected_action=_optional_string(
+                record, "expected_action", "observation record keys mismatch"
+            ),
+            actual_executed_action=_optional_string(
+                record, "actual_executed_action", "observation record keys mismatch"
+            ),
+            action_known=_boolean(
+                record, "action_known", "observation action_known mismatch"
+            ),
+            gap_declaration=_canonical_optional(record["gap_declaration"]),
+            observation_pixel_digest=pixel_digest,
+            matrix_blob_id=None if blob is None else blob.blob_id,
+            provider_observation_descriptor=descriptor,
+            provider_observation_digest=provider_digest,
+            operation_chain=chain,
+            metadata=CanonicalJsonDTO.from_value(metadata),
+        )
+        return MaterializedObservationDTO(observation=dto, matrix_blob=blob)
+
+    def to_record(
+        self,
+        *,
+        matrix_blob: MatrixBlob | None = None,
+        include_pixels: bool = True,
+    ) -> dict[str, object]:
+        if include_pixels:
+            self._validate_record_blob(matrix_blob)
+        metadata = dict(_json_mapping(self.metadata, "observation metadata mismatch"))
+        self._restore_structured_metadata(metadata)
+        payload = {
+            "benchmark_version": self.benchmark_version,
+            "generator_version": self.generator_version,
+            "split": self.split,
+            "episode_id": self.episode_id,
+            "clip_id": self.clip_id,
+            "frame_id": self.frame_id,
+            "sequence_number": self.sequence_number,
+            "event_type": self.event_type,
+            "family": self.family,
+            "expected_disposition": self.expected_disposition,
+            "episode_family": self.episode_family,
+            "episode_disposition": self.episode_disposition,
+            "frame_disposition": self.frame_disposition,
+            "denominator_class": self.denominator_class,
+            "expected_row": self.expected_row,
+            "expected_action": self.expected_action,
+            "actual_executed_action": self.actual_executed_action,
+            "action_known": self.action_known,
+            "gap_declaration": (
+                None
+                if self.gap_declaration is None
+                else self.gap_declaration.to_value()
+            ),
+            "observation_pixel_digest": self.observation_pixel_digest,
+            "metadata": metadata,
+        }
+        if include_pixels:
+            payload["pixels"] = None if matrix_blob is None else matrix_blob.to_array()
+        return payload
+
+    @property
+    def has_pixels(self) -> bool:
+        return self.matrix_blob_id is not None
+
+    def _validate_ids(self) -> None:
+        if self.benchmark_version != BENCHMARK_VERSION:
+            raise VPMValidationError("unsupported observation benchmark version")
+        if self.generator_version != GENERATOR_VERSION:
+            raise VPMValidationError("unsupported observation generator version")
+        if self.split not in SPLITS:
+            raise VPMValidationError("observation split mismatch")
+        if not self.episode_id.startswith(f"{self.split}:"):
+            raise VPMValidationError("observation split mismatch")
+        if self.clip_id != f"{self.split}:{self.episode_id}:clip":
+            raise VPMValidationError("observation clip id mismatch")
+        frame_prefix = f"{self.split}:{self.episode_id}:frame-"
+        if not self.frame_id.startswith(frame_prefix):
+            raise VPMValidationError("observation frame id mismatch")
+        if self.sequence_number < 0:
+            raise VPMValidationError("observation sequence number cannot be negative")
+        suffix = self.frame_id.removeprefix(frame_prefix)
+        if not suffix.isdecimal():
+            raise VPMValidationError("observation frame id mismatch")
+        if int(suffix) != self.sequence_number and not self._is_reordered_frame_id(
+            int(suffix)
+        ):
+            raise VPMValidationError("observation frame id mismatch")
+
+    def _is_reordered_frame_id(self, frame_index: int) -> bool:
+        metadata = _json_mapping(self.metadata, "observation metadata mismatch")
+        return (
+            metadata.get("original_frame_index") == frame_index
+            and "materialized_order" in metadata
+        )
+
+    def _validate_materialization_contract(self) -> None:
+        if self.split == "final" and (
+            self.matrix_blob_id is not None or self.observation_pixel_digest is not None
+        ):
+            raise VPMValidationError(
+                "final split observation materialization is prohibited"
+            )
+        if self.event_type == "gap_unknown":
+            if (
+                self.matrix_blob_id is not None
+                or self.observation_pixel_digest is not None
+                or self.provider_observation_descriptor is not None
+                or self.provider_observation_digest is not None
+            ):
+                raise VPMValidationError("observation typed gap mismatch")
+        elif self.matrix_blob_id is None or self.observation_pixel_digest is None:
+            raise VPMValidationError("observation materialized pixel mismatch")
+        if self.operation_chain.final_emitted_digest != self.observation_pixel_digest:
+            raise VPMValidationError("observation operation chain mismatch")
+
+    def _validate_provider_descriptor(self) -> None:
+        if self.provider_observation_descriptor is None:
+            if self.provider_observation_digest is not None:
+                raise VPMValidationError("provider observation digest mismatch")
+            return
+        if (
+            self.provider_observation_descriptor.descriptor_digest
+            != self.provider_observation_digest
+        ):
+            raise VPMValidationError("provider observation digest mismatch")
+
+    def _validate_record_blob(self, matrix_blob: MatrixBlob | None) -> None:
+        if self.matrix_blob_id is None:
+            if matrix_blob is not None:
+                raise VPMValidationError("observation matrix blob mismatch")
+            return
+        if matrix_blob is None or matrix_blob.blob_id != self.matrix_blob_id:
+            raise VPMValidationError("observation matrix blob mismatch")
+        validate_observation_matrix_blob(self, matrix_blob)
+
+    def _restore_structured_metadata(self, metadata: dict[str, object]) -> None:
+        metadata["observation_operation_chain"] = self.operation_chain.to_dict()
+        if self.provider_observation_descriptor is not None:
+            metadata["provider_observation_descriptor"] = (
+                self.provider_observation_descriptor.to_dict()
+            )
+            metadata["provider_observation_digest"] = self.provider_observation_digest
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedObservationDTO:
+    observation: ObservationDTO
+    matrix_blob: MatrixBlob | None
+
+    def __post_init__(self) -> None:
+        if self.observation.split == "final":
+            raise VPMValidationError(
+                "final split observation materialization is prohibited"
+            )
+        if self.matrix_blob is None:
+            if self.observation.matrix_blob_id is not None:
+                raise VPMValidationError("observation matrix blob mismatch")
+            return
+        if self.observation.matrix_blob_id != self.matrix_blob.blob_id:
+            raise VPMValidationError("observation matrix blob mismatch")
+        validate_observation_matrix_blob(self.observation, self.matrix_blob)
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+    ) -> MaterializedObservationDTO:
+        return ObservationDTO.from_record(record)
+
+    def to_record(self, *, include_pixels: bool = True) -> dict[str, object]:
+        return self.observation.to_record(
+            matrix_blob=self.matrix_blob,
+            include_pixels=include_pixels,
+        )
+
+
+def validate_observation_matrix_blob(
+    observation: ObservationDTO,
+    blob: MatrixBlob,
+) -> None:
+    if blob.dtype != "uint8" or tuple(blob.shape) != FRAME_SHAPE:
+        raise VPMValidationError(
+            "observation matrix blob does not match declared pixels"
+        )
+    if _pixel_digest_from_bytes(blob.data) != observation.observation_pixel_digest:
+        raise VPMValidationError(
+            "observation matrix blob does not match declared pixels"
+        )
+    metadata = dict(blob.metadata)
+    if metadata != {
+        "kind": "video_action_set_frame_pixels",
+        "pixel_digest": observation.observation_pixel_digest,
+    }:
+        raise VPMValidationError(
+            "observation matrix blob does not match declared pixels"
+        )
+    descriptor = observation.provider_observation_descriptor
+    if descriptor is None:
+        raise VPMValidationError("provider observation descriptor mismatch")
+    if descriptor.shape != tuple(
+        blob.shape
+    ) or descriptor.raw_digest != _provider_raw_digest(blob):
+        raise VPMValidationError("provider observation descriptor mismatch")
+
+
+def _provider_descriptor_from_metadata(
+    metadata: dict[str, object],
+) -> ProviderObservationDescriptorDTO | None:
+    value = metadata.pop("provider_observation_descriptor", None)
+    if value is None:
+        return None
+    return ProviderObservationDescriptorDTO.from_dict(
+        _mapping(value, "provider observation descriptor keys mismatch")
+    )
+
+
+def _blob_from_record(
+    record: Mapping[str, object],
+    pixel_digest: str | None,
+) -> MatrixBlob | None:
+    pixels = record.get("pixels")
+    if pixels is None:
+        return None
+    if pixel_digest is None or _pixel_digest_from_array(pixels) != pixel_digest:
+        raise VPMValidationError("observation pixel digest mismatch")
+    return MatrixBlob.from_array(
+        np.ascontiguousarray(pixels, dtype=np.uint8),
+        dtype="uint8",
+        metadata={
+            "kind": "video_action_set_frame_pixels",
+            "pixel_digest": pixel_digest,
+        },
+    )
+
+
+def _canonical_optional(value: object) -> CanonicalJsonDTO | None:
+    if value is None:
+        return None
+    return CanonicalJsonDTO.from_value(value)
+
+
+__all__ = [
+    "MaterializedObservationDTO",
+    "ObservationDTO",
+    "ObservationOperationChainDTO",
+    "ObservationOperationDTO",
+    "ProviderObservationDescriptorDTO",
+    "validate_observation_matrix_blob",
+]

--- a/zeromodel/domains/video_action_set/observation_legacy_adapters.py
+++ b/zeromodel/domains/video_action_set/observation_legacy_adapters.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .canonical_json import canonical_sha256
+from .contracts import OBSERVATION_OPERATION_CHAIN_VERSION
+from .observation_provenance_dto import (
+    ObservationOperationChainDTO,
+    ObservationOperationDTO,
+)
+
+
+def operation_record(
+    *,
+    index: int,
+    operation: str,
+    operation_version: str,
+    input_digests: Sequence[str | None],
+    parameters: Mapping[str, Any],
+    output_digest: str | None,
+) -> dict[str, Any]:
+    payload = {
+        "index": int(index),
+        "operation": str(operation),
+        "operation_version": str(operation_version),
+        "input_digests": [
+            None if item is None else str(item) for item in input_digests
+        ],
+        "parameters": dict(parameters),
+        "parameter_digest": canonical_sha256(parameters),
+        "output_digest": output_digest,
+    }
+    payload["operation_digest"] = canonical_sha256(payload)
+    return ObservationOperationDTO.from_dict(payload).to_dict()
+
+
+def operation_chain(
+    operations: Sequence[Mapping[str, Any]],
+    final_emitted_digest: str | None,
+) -> dict[str, Any]:
+    payload = {
+        "version": OBSERVATION_OPERATION_CHAIN_VERSION,
+        "operations": [dict(item) for item in operations],
+        "final_emitted_digest": final_emitted_digest,
+    }
+    payload["operation_chain_digest"] = canonical_sha256(payload)
+    return ObservationOperationChainDTO.from_dict(payload).to_dict()
+
+
+__all__ = ["operation_chain", "operation_record"]

--- a/zeromodel/domains/video_action_set/observation_materialization.py
+++ b/zeromodel/domains/video_action_set/observation_materialization.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+from typing import Any, Callable
+
+import numpy as np
+
+from ...artifact import VPMValidationError
+from ...matrix_blob import MatrixBlob
+from .canonical_json import canonical_json_bytes
+from .contracts import FRAME_SHAPE
+
+_record_loader: Callable[[Mapping[str, object]], "MaterializedObservationDTO"] | None
+_record_loader = None
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedObservationDTO:
+    observation: Any
+    matrix_blob: MatrixBlob | None
+
+    def __post_init__(self) -> None:
+        if self.observation.split == "final":
+            raise VPMValidationError(
+                "final split observation materialization is prohibited"
+            )
+        if self.matrix_blob is None:
+            if self.observation.matrix_blob_id is not None:
+                raise VPMValidationError("observation matrix blob mismatch")
+            return
+        if self.observation.matrix_blob_id != self.matrix_blob.blob_id:
+            raise VPMValidationError("observation matrix blob mismatch")
+        validate_observation_matrix_blob(self.observation, self.matrix_blob)
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+    ) -> MaterializedObservationDTO:
+        if _record_loader is None:
+            raise VPMValidationError("observation record loader is not registered")
+        return _record_loader(record)
+
+    def to_record(self, *, include_pixels: bool = True) -> dict[str, object]:
+        return self.observation.to_record(
+            matrix_blob=self.matrix_blob,
+            include_pixels=include_pixels,
+        )
+
+
+def validate_observation_matrix_blob(
+    observation: Any,
+    blob: MatrixBlob,
+) -> None:
+    if blob.dtype != "uint8" or tuple(blob.shape) != FRAME_SHAPE:
+        raise VPMValidationError(
+            "observation matrix blob does not match declared pixels"
+        )
+    if _pixel_digest_from_bytes(blob.data) != observation.observation_pixel_digest:
+        raise VPMValidationError(
+            "observation matrix blob does not match declared pixels"
+        )
+    metadata = dict(blob.metadata)
+    if metadata != {
+        "kind": "video_action_set_frame_pixels",
+        "pixel_digest": observation.observation_pixel_digest,
+    }:
+        raise VPMValidationError(
+            "observation matrix blob does not match declared pixels"
+        )
+    descriptor = observation.provider_observation_descriptor
+    if descriptor is None:
+        raise VPMValidationError("provider observation descriptor mismatch")
+    if descriptor.shape != tuple(
+        blob.shape
+    ) or descriptor.raw_digest != _provider_raw_digest(blob):
+        raise VPMValidationError("provider observation descriptor mismatch")
+
+
+def blob_from_record(
+    record: Mapping[str, object],
+    pixel_digest: str | None,
+) -> MatrixBlob | None:
+    pixels = record.get("pixels")
+    if pixels is None:
+        return None
+    if pixel_digest is None or _pixel_digest_from_array(pixels) != pixel_digest:
+        raise VPMValidationError("observation pixel digest mismatch")
+    return MatrixBlob.from_array(
+        np.ascontiguousarray(pixels, dtype=np.uint8),
+        dtype="uint8",
+        metadata={
+            "kind": "video_action_set_frame_pixels",
+            "pixel_digest": pixel_digest,
+        },
+    )
+
+
+def register_materialized_observation_loader(
+    loader: Callable[[Mapping[str, object]], MaterializedObservationDTO],
+) -> None:
+    global _record_loader
+    _record_loader = loader
+
+
+def _pixel_digest_from_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _pixel_digest_from_array(pixels: object) -> str:
+    return _pixel_digest_from_bytes(
+        np.ascontiguousarray(pixels, dtype=np.uint8).tobytes(order="C")
+    )
+
+
+def _provider_raw_digest(blob: MatrixBlob) -> str:
+    payload = (
+        b"zeromodel.image-observation.raw.v1\0"
+        + canonical_json_bytes(list(blob.shape))
+        + blob.data
+    )
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+__all__ = [
+    "MaterializedObservationDTO",
+    "blob_from_record",
+    "register_materialized_observation_loader",
+    "validate_observation_matrix_blob",
+]

--- a/zeromodel/domains/video_action_set/observation_provenance_dto.py
+++ b/zeromodel/domains/video_action_set/observation_provenance_dto.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from ...artifact import VPMValidationError
+from .canonical_json import canonical_sha256
+from .contracts import OBSERVATION_OPERATION_CHAIN_VERSION
+from .dto import CanonicalJsonDTO
+from .observation_common import (
+    integer,
+    mapping,
+    optional_sha256,
+    require_keys,
+    sequence,
+    sha256,
+    string,
+    string_tuple,
+)
+
+
+OPERATION_KEYS = (
+    "index",
+    "operation",
+    "operation_version",
+    "input_digests",
+    "parameters",
+    "parameter_digest",
+    "output_digest",
+    "operation_digest",
+)
+OPERATION_CHAIN_KEYS = (
+    "version",
+    "operations",
+    "final_emitted_digest",
+    "operation_chain_digest",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationOperationDTO:
+    index: int
+    operation: str
+    operation_version: str
+    input_digests: tuple[str | None, ...]
+    parameters: CanonicalJsonDTO
+    parameter_digest: str
+    output_digest: str | None
+    operation_digest: str
+
+    def __post_init__(self) -> None:
+        if self.index < 0:
+            raise VPMValidationError("observation operation index cannot be negative")
+        if not self.operation or not self.operation_version:
+            raise VPMValidationError("observation operation payload keys mismatch")
+        if self.parameter_digest != canonical_sha256(self.parameters.to_value()):
+            raise VPMValidationError("observation operation parameter digest mismatch")
+        for digest in (*self.input_digests, self.output_digest):
+            optional_sha256(digest, "observation operation digest is not sha256")
+        sha256(self.operation_digest, "observation operation digest is not sha256")
+        if canonical_sha256(self._payload_without_digest()) != self.operation_digest:
+            raise VPMValidationError("observation operation digest mismatch")
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> ObservationOperationDTO:
+        require_keys(
+            payload,
+            OPERATION_KEYS,
+            "observation operation payload keys mismatch",
+        )
+        return cls(
+            index=integer(
+                payload,
+                "index",
+                "observation operation index cannot be negative",
+            ),
+            operation=string(
+                payload,
+                "operation",
+                "observation operation payload keys mismatch",
+            ),
+            operation_version=string(
+                payload,
+                "operation_version",
+                "observation operation payload keys mismatch",
+            ),
+            input_digests=string_tuple(
+                payload["input_digests"],
+                "observation operation digest is not sha256",
+            ),
+            parameters=CanonicalJsonDTO.from_value(payload["parameters"]),
+            parameter_digest=sha256(
+                payload["parameter_digest"],
+                "observation operation parameter digest mismatch",
+            ),
+            output_digest=optional_sha256(
+                payload["output_digest"],
+                "observation operation digest is not sha256",
+            ),
+            operation_digest=sha256(
+                payload["operation_digest"],
+                "observation operation digest is not sha256",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return self._payload_without_digest() | {
+            "operation_digest": self.operation_digest
+        }
+
+    def _payload_without_digest(self) -> dict[str, object]:
+        return {
+            "index": self.index,
+            "operation": self.operation,
+            "operation_version": self.operation_version,
+            "input_digests": list(self.input_digests),
+            "parameters": self.parameters.to_value(),
+            "parameter_digest": self.parameter_digest,
+            "output_digest": self.output_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationOperationChainDTO:
+    version: str
+    operations: tuple[ObservationOperationDTO, ...]
+    final_emitted_digest: str | None
+    operation_chain_digest: str
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVATION_OPERATION_CHAIN_VERSION:
+            raise VPMValidationError("unsupported observation operation chain version")
+        if not self.operations:
+            raise VPMValidationError("observation operation indexes are not contiguous")
+        for expected, operation in enumerate(self.operations):
+            if operation.index != expected:
+                raise VPMValidationError(
+                    "observation operation indexes are not contiguous"
+                )
+        optional_sha256(
+            self.final_emitted_digest,
+            "observation operation chain final digest mismatch",
+        )
+        if self.operations[-1].output_digest != self.final_emitted_digest:
+            raise VPMValidationError(
+                "observation operation chain final digest mismatch"
+            )
+        if (
+            canonical_sha256(self._payload_without_digest())
+            != self.operation_chain_digest
+        ):
+            raise VPMValidationError("observation operation chain digest mismatch")
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Mapping[str, object],
+    ) -> ObservationOperationChainDTO:
+        require_keys(payload, OPERATION_CHAIN_KEYS, "operation chain keys mismatch")
+        return cls(
+            version=string(
+                payload,
+                "version",
+                "unsupported observation operation chain version",
+            ),
+            operations=tuple(
+                ObservationOperationDTO.from_dict(
+                    mapping(item, "observation operation payload keys mismatch")
+                )
+                for item in sequence(
+                    payload["operations"],
+                    "observation operation payload keys mismatch",
+                )
+            ),
+            final_emitted_digest=optional_sha256(
+                payload["final_emitted_digest"],
+                "observation operation chain final digest mismatch",
+            ),
+            operation_chain_digest=sha256(
+                payload["operation_chain_digest"],
+                "observation operation chain digest mismatch",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return self._payload_without_digest() | {
+            "operation_chain_digest": self.operation_chain_digest
+        }
+
+    def _payload_without_digest(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "operations": [operation.to_dict() for operation in self.operations],
+            "final_emitted_digest": self.final_emitted_digest,
+        }
+
+
+__all__ = ["ObservationOperationChainDTO", "ObservationOperationDTO"]

--- a/zeromodel/domains/video_action_set/observation_service.py
+++ b/zeromodel/domains/video_action_set/observation_service.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from ...matrix_blob import MatrixBlob
+from .observation_dto import (
+    MaterializedObservationDTO,
+    ObservationDTO,
+    ObservationOperationChainDTO,
+)
+from .store import VideoActionSetStore
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationService:
+    store: VideoActionSetStore
+
+    def save_matrix_blob(self, blob: MatrixBlob) -> MatrixBlob:
+        return self.store.save_matrix_blob(blob)
+
+    def get_matrix_blob(self, blob_id: str) -> MatrixBlob | None:
+        return self.store.get_matrix_blob(blob_id)
+
+    def save_record(self, record: Mapping[str, object]) -> ObservationDTO:
+        item = MaterializedObservationDTO.from_record(record)
+        return self.save_materialized(item)
+
+    def save_records(
+        self,
+        records: Sequence[Mapping[str, object]],
+    ) -> tuple[ObservationDTO, ...]:
+        return self.store.save_observations(
+            tuple(MaterializedObservationDTO.from_record(record) for record in records)
+        )
+
+    def save_materialized(self, item: MaterializedObservationDTO) -> ObservationDTO:
+        return self.store.save_observation(
+            item.observation,
+            matrix_blob=item.matrix_blob,
+        )
+
+    def get_observation(self, frame_id: str) -> ObservationDTO | None:
+        return self.store.get_observation(frame_id)
+
+    def get_materialized(
+        self,
+        frame_id: str,
+    ) -> MaterializedObservationDTO | None:
+        return self.store.get_materialized_observation(frame_id)
+
+    def get_record(
+        self,
+        frame_id: str,
+        *,
+        include_pixels: bool = True,
+    ) -> dict[str, object] | None:
+        if include_pixels:
+            item = self.store.get_materialized_observation(frame_id)
+            return None if item is None else item.to_record(include_pixels=True)
+        observation = self.store.get_observation(frame_id)
+        return (
+            None if observation is None else observation.to_record(include_pixels=False)
+        )
+
+    def list_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.store.list_observations(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+        )
+
+    def list_records(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+        include_pixels: bool = False,
+    ) -> tuple[dict[str, object], ...]:
+        observations = self.list_observations(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+        )
+        return tuple(
+            self._record_for_observation(
+                observation,
+                include_pixels=include_pixels,
+            )
+            for observation in observations
+        )
+
+    def get_operation_chain(
+        self,
+        frame_id: str,
+    ) -> ObservationOperationChainDTO | None:
+        return self.store.get_operation_chain(frame_id)
+
+    def list_by_operation(
+        self,
+        *,
+        operation: str,
+        split: str | None = None,
+        family: str | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.store.list_observations_by_operation(
+            operation=operation,
+            split=split,
+            family=family,
+        )
+
+    def list_by_output_digest(
+        self,
+        output_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.store.list_observations_by_output_digest(output_digest)
+
+    def list_consumers_of_digest(
+        self,
+        input_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        return self.store.list_observation_consumers_of_digest(input_digest)
+
+    def _record_for_observation(
+        self,
+        observation: ObservationDTO,
+        *,
+        include_pixels: bool,
+    ) -> dict[str, object]:
+        if not include_pixels:
+            return observation.to_record(include_pixels=False)
+        item = self.store.get_materialized_observation(observation.frame_id)
+        if item is None:
+            return observation.to_record(include_pixels=True, matrix_blob=None)
+        return item.to_record(include_pixels=True)
+
+
+__all__ = ["ObservationService"]

--- a/zeromodel/domains/video_action_set/observation_service.py
+++ b/zeromodel/domains/video_action_set/observation_service.py
@@ -49,6 +49,27 @@ class ObservationService:
     ) -> MaterializedObservationDTO | None:
         return self.store.get_materialized_observation(frame_id)
 
+    def list_materialized(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[MaterializedObservationDTO, ...]:
+        return self.store.list_materialized_observations(
+            benchmark_seed_digest=benchmark_seed_digest,
+            split=split,
+            episode_id=episode_id,
+            family=family,
+            event_type=event_type,
+            denominator_class=denominator_class,
+            has_pixels=has_pixels,
+        )
+
     def get_record(
         self,
         frame_id: str,
@@ -96,6 +117,19 @@ class ObservationService:
         has_pixels: bool | None = None,
         include_pixels: bool = False,
     ) -> tuple[dict[str, object], ...]:
+        if include_pixels:
+            return tuple(
+                item.to_record(include_pixels=True)
+                for item in self.list_materialized(
+                    benchmark_seed_digest=benchmark_seed_digest,
+                    split=split,
+                    episode_id=episode_id,
+                    family=family,
+                    event_type=event_type,
+                    denominator_class=denominator_class,
+                    has_pixels=has_pixels,
+                )
+            )
         observations = self.list_observations(
             benchmark_seed_digest=benchmark_seed_digest,
             split=split,
@@ -108,7 +142,7 @@ class ObservationService:
         return tuple(
             self._record_for_observation(
                 observation,
-                include_pixels=include_pixels,
+                include_pixels=False,
             )
             for observation in observations
         )

--- a/zeromodel/domains/video_action_set/provider_observation_dto.py
+++ b/zeromodel/domains/video_action_set/provider_observation_dto.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from ...artifact import VPMValidationError
+from ...visual_address import IMAGE_OBSERVATION_VERSION
+from .canonical_json import canonical_sha256
+from .contracts import PROVIDER_OBSERVATION_BOUNDARY_VERSION
+from .dto import CanonicalJsonDTO
+from .observation_common import (
+    json_mapping,
+    optional_string,
+    require_keys,
+    sequence,
+    sha256,
+    string,
+)
+
+
+PROVIDER_DESCRIPTOR_KEYS = (
+    "version",
+    "raw_digest",
+    "shape",
+    "timestamp",
+    "source_id",
+    "metadata",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderObservationDescriptorDTO:
+    version: str
+    raw_digest: str
+    shape: tuple[int, ...]
+    timestamp: str | None
+    source_id: str
+    metadata: CanonicalJsonDTO
+
+    def __post_init__(self) -> None:
+        if self.version != IMAGE_OBSERVATION_VERSION:
+            raise VPMValidationError("unsupported provider observation version")
+        sha256(self.raw_digest, "provider observation raw digest is not sha256")
+        if not self.shape or any(dimension <= 0 for dimension in self.shape):
+            raise VPMValidationError("provider observation shape mismatch")
+        if not self.source_id:
+            raise VPMValidationError("provider observation source mismatch")
+        json_mapping(self.metadata, "provider observation metadata mismatch")
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Mapping[str, object],
+    ) -> ProviderObservationDescriptorDTO:
+        require_keys(
+            payload,
+            PROVIDER_DESCRIPTOR_KEYS,
+            "provider observation descriptor keys mismatch",
+        )
+        return cls(
+            version=string(
+                payload, "version", "unsupported provider observation version"
+            ),
+            raw_digest=sha256(
+                payload["raw_digest"],
+                "provider observation raw digest is not sha256",
+            ),
+            shape=tuple(
+                int(str(item))
+                for item in sequence(
+                    payload["shape"], "provider observation shape mismatch"
+                )
+            ),
+            timestamp=optional_string(
+                payload,
+                "timestamp",
+                "provider observation timestamp mismatch",
+            ),
+            source_id=string(
+                payload,
+                "source_id",
+                "provider observation source mismatch",
+            ),
+            metadata=CanonicalJsonDTO.from_value(payload["metadata"]),
+        )
+
+    @property
+    def descriptor_digest(self) -> str:
+        return canonical_sha256(
+            {
+                "version": PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+                "descriptor": self.to_dict(),
+            }
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "raw_digest": self.raw_digest,
+            "shape": list(self.shape),
+            "timestamp": self.timestamp,
+            "source_id": self.source_id,
+            "metadata": self.metadata.to_value(),
+        }
+
+
+__all__ = ["ProviderObservationDescriptorDTO"]

--- a/zeromodel/domains/video_action_set/store.py
+++ b/zeromodel/domains/video_action_set/store.py
@@ -108,6 +108,18 @@ class VideoActionSetStore(Protocol):
         frame_id: str,
     ) -> MaterializedObservationDTO | None: ...
 
+    def list_materialized_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[MaterializedObservationDTO, ...]: ...
+
     def list_observations(
         self,
         *,

--- a/zeromodel/domains/video_action_set/store.py
+++ b/zeromodel/domains/video_action_set/store.py
@@ -4,7 +4,13 @@ from collections.abc import Sequence
 from typing import NoReturn, Protocol
 
 from ...artifact import VPMValidationError
+from ...matrix_blob import MatrixBlob
 from .dto import BenchmarkIdentityDTO, EpisodePlanDTO, SealedSplitPlanDTO
+from .observation_dto import (
+    MaterializedObservationDTO,
+    ObservationDTO,
+    ObservationOperationChainDTO,
+)
 
 
 BENCHMARK_IDENTITY_CONFLICT_MESSAGE = "benchmark identity conflict for seed digest"
@@ -15,6 +21,14 @@ SEALED_SPLIT_PLAN_CONFLICT_MESSAGE = (
 UNKNOWN_BENCHMARK_IDENTITY_MESSAGE = (
     "episode plan references unknown benchmark identity"
 )
+MATRIX_BLOB_CONFLICT_MESSAGE = "matrix blob conflict for blob id"
+OBSERVATION_CONFLICT_MESSAGE = "observation conflict for frame id"
+OBSERVATION_SEQUENCE_CONFLICT_MESSAGE = "observation conflict for episode sequence"
+OBSERVATION_BLOB_MISMATCH_MESSAGE = (
+    "observation matrix blob does not match declared pixels"
+)
+OPERATION_CHAIN_CONFLICT_MESSAGE = "observation operation chain conflict for frame id"
+UNKNOWN_EPISODE_PLAN_MESSAGE = "observation references unknown episode plan"
 
 
 class VideoActionSetStore(Protocol):
@@ -62,6 +76,73 @@ class VideoActionSetStore(Protocol):
         split: str,
     ) -> SealedSplitPlanDTO | None: ...
 
+    def save_matrix_blob(
+        self,
+        blob: MatrixBlob,
+    ) -> MatrixBlob: ...
+
+    def get_matrix_blob(
+        self,
+        blob_id: str,
+    ) -> MatrixBlob | None: ...
+
+    def save_observation(
+        self,
+        observation: ObservationDTO,
+        *,
+        matrix_blob: MatrixBlob | None,
+    ) -> ObservationDTO: ...
+
+    def save_observations(
+        self,
+        observations: Sequence[MaterializedObservationDTO],
+    ) -> tuple[ObservationDTO, ...]: ...
+
+    def get_observation(
+        self,
+        frame_id: str,
+    ) -> ObservationDTO | None: ...
+
+    def get_materialized_observation(
+        self,
+        frame_id: str,
+    ) -> MaterializedObservationDTO | None: ...
+
+    def list_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[ObservationDTO, ...]: ...
+
+    def get_operation_chain(
+        self,
+        frame_id: str,
+    ) -> ObservationOperationChainDTO | None: ...
+
+    def list_observations_by_operation(
+        self,
+        *,
+        operation: str,
+        split: str | None = None,
+        family: str | None = None,
+    ) -> tuple[ObservationDTO, ...]: ...
+
+    def list_observations_by_output_digest(
+        self,
+        output_digest: str,
+    ) -> tuple[ObservationDTO, ...]: ...
+
+    def list_observation_consumers_of_digest(
+        self,
+        input_digest: str,
+    ) -> tuple[ObservationDTO, ...]: ...
+
 
 def raise_identity_conflict() -> NoReturn:
     raise VPMValidationError(BENCHMARK_IDENTITY_CONFLICT_MESSAGE)
@@ -79,14 +160,50 @@ def raise_unknown_benchmark_identity() -> NoReturn:
     raise VPMValidationError(UNKNOWN_BENCHMARK_IDENTITY_MESSAGE)
 
 
+def raise_matrix_blob_conflict() -> NoReturn:
+    raise VPMValidationError(MATRIX_BLOB_CONFLICT_MESSAGE)
+
+
+def raise_observation_conflict() -> NoReturn:
+    raise VPMValidationError(OBSERVATION_CONFLICT_MESSAGE)
+
+
+def raise_observation_sequence_conflict() -> NoReturn:
+    raise VPMValidationError(OBSERVATION_SEQUENCE_CONFLICT_MESSAGE)
+
+
+def raise_observation_blob_mismatch() -> NoReturn:
+    raise VPMValidationError(OBSERVATION_BLOB_MISMATCH_MESSAGE)
+
+
+def raise_operation_chain_conflict() -> NoReturn:
+    raise VPMValidationError(OPERATION_CHAIN_CONFLICT_MESSAGE)
+
+
+def raise_unknown_episode_plan() -> NoReturn:
+    raise VPMValidationError(UNKNOWN_EPISODE_PLAN_MESSAGE)
+
+
 __all__ = [
     "BENCHMARK_IDENTITY_CONFLICT_MESSAGE",
     "EPISODE_PLAN_CONFLICT_MESSAGE",
+    "MATRIX_BLOB_CONFLICT_MESSAGE",
+    "OBSERVATION_BLOB_MISMATCH_MESSAGE",
+    "OBSERVATION_CONFLICT_MESSAGE",
+    "OPERATION_CHAIN_CONFLICT_MESSAGE",
+    "OBSERVATION_SEQUENCE_CONFLICT_MESSAGE",
     "SEALED_SPLIT_PLAN_CONFLICT_MESSAGE",
     "UNKNOWN_BENCHMARK_IDENTITY_MESSAGE",
+    "UNKNOWN_EPISODE_PLAN_MESSAGE",
     "VideoActionSetStore",
     "raise_episode_plan_conflict",
     "raise_identity_conflict",
+    "raise_matrix_blob_conflict",
+    "raise_observation_blob_mismatch",
+    "raise_observation_conflict",
+    "raise_observation_sequence_conflict",
+    "raise_operation_chain_conflict",
     "raise_sealed_split_plan_conflict",
     "raise_unknown_benchmark_identity",
+    "raise_unknown_episode_plan",
 ]

--- a/zeromodel/runtime.py
+++ b/zeromodel/runtime.py
@@ -6,6 +6,7 @@ from .domains.video_action_set.engine import VideoActionSetEngine
 from .domains.video_action_set.episode_plan_service import EpisodePlanService
 from .domains.video_action_set.facade import VideoActionSetFacade
 from .domains.video_action_set.identity_service import IdentityService
+from .domains.video_action_set.observation_service import ObservationService
 from .domains.video_action_set.store import VideoActionSetStore
 from .stores.video_action_set_memory import InMemoryVideoActionSetStore
 
@@ -22,9 +23,11 @@ def build_runtime(
     store = video_action_set_store or InMemoryVideoActionSetStore()
     identity_service = IdentityService(store=store)
     episode_plan_service = EpisodePlanService(store=store)
+    observation_service = ObservationService(store=store)
     engine = VideoActionSetEngine(
         identity_service=identity_service,
         episode_plan_service=episode_plan_service,
+        observation_service=observation_service,
     )
     facade = VideoActionSetFacade(engine=engine)
     return ZeroModelRuntime(video_action_set=facade)

--- a/zeromodel/stores/video_action_set_memory.py
+++ b/zeromodel/stores/video_action_set_memory.py
@@ -7,13 +7,23 @@ from ..domains.video_action_set.dto import (
     EpisodePlanDTO,
     SealedSplitPlanDTO,
 )
+from ..domains.video_action_set.observation_dto import (
+    MaterializedObservationDTO,
+    ObservationDTO,
+    ObservationOperationChainDTO,
+)
 from ..domains.video_action_set.store import (
     VideoActionSetStore,
     raise_episode_plan_conflict,
     raise_identity_conflict,
+    raise_matrix_blob_conflict,
+    raise_observation_conflict,
+    raise_observation_sequence_conflict,
     raise_sealed_split_plan_conflict,
     raise_unknown_benchmark_identity,
+    raise_unknown_episode_plan,
 )
+from ..matrix_blob import MatrixBlob
 
 
 class InMemoryVideoActionSetStore(VideoActionSetStore):
@@ -21,6 +31,9 @@ class InMemoryVideoActionSetStore(VideoActionSetStore):
         self._identities: dict[str, BenchmarkIdentityDTO] = {}
         self._episode_plans: dict[str, EpisodePlanDTO] = {}
         self._sealed_split_plans: dict[tuple[str, str], SealedSplitPlanDTO] = {}
+        self._matrix_blobs: dict[str, MatrixBlob] = {}
+        self._observations: dict[str, ObservationDTO] = {}
+        self._observation_sequence_index: dict[tuple[str, int], str] = {}
 
     def save_identity(self, identity: BenchmarkIdentityDTO) -> BenchmarkIdentityDTO:
         existing = self._identities.get(identity.seed_digest)
@@ -94,6 +107,148 @@ class InMemoryVideoActionSetStore(VideoActionSetStore):
     ) -> SealedSplitPlanDTO | None:
         return self._sealed_split_plans.get((seed_commitment, split))
 
+    def save_matrix_blob(self, blob: MatrixBlob) -> MatrixBlob:
+        existing = self._matrix_blobs.get(blob.blob_id)
+        if existing is not None:
+            if existing != blob:
+                raise_matrix_blob_conflict()
+            return existing
+        self._matrix_blobs[blob.blob_id] = blob
+        return blob
+
+    def get_matrix_blob(self, blob_id: str) -> MatrixBlob | None:
+        return self._matrix_blobs.get(blob_id)
+
+    def save_observation(
+        self,
+        observation: ObservationDTO,
+        *,
+        matrix_blob: MatrixBlob | None,
+    ) -> ObservationDTO:
+        return self.save_observations(
+            (MaterializedObservationDTO(observation, matrix_blob),)
+        )[0]
+
+    def save_observations(
+        self,
+        observations: Sequence[MaterializedObservationDTO],
+    ) -> tuple[ObservationDTO, ...]:
+        observation_tuple = tuple(observations)
+        existing = self._preflight_observations(observation_tuple)
+        for item in observation_tuple:
+            if item.observation.frame_id in existing:
+                continue
+            if item.matrix_blob is not None:
+                self._matrix_blobs.setdefault(
+                    item.matrix_blob.blob_id,
+                    item.matrix_blob,
+                )
+            self._observations[item.observation.frame_id] = item.observation
+            self._observation_sequence_index[_sequence_key(item.observation)] = (
+                item.observation.frame_id
+            )
+        return tuple(
+            existing.get(item.observation.frame_id, item.observation)
+            for item in observation_tuple
+        )
+
+    def get_observation(self, frame_id: str) -> ObservationDTO | None:
+        return self._observations.get(frame_id)
+
+    def get_materialized_observation(
+        self,
+        frame_id: str,
+    ) -> MaterializedObservationDTO | None:
+        observation = self._observations.get(frame_id)
+        if observation is None:
+            return None
+        blob = (
+            None
+            if observation.matrix_blob_id is None
+            else self._matrix_blobs.get(observation.matrix_blob_id)
+        )
+        return MaterializedObservationDTO(observation, blob)
+
+    def list_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        return tuple(
+            sorted(
+                (
+                    observation
+                    for observation in self._observations.values()
+                    if _matches_observation(
+                        observation,
+                        benchmark_seed_digest=benchmark_seed_digest,
+                        split=split,
+                        episode_id=episode_id,
+                        family=family,
+                        event_type=event_type,
+                        denominator_class=denominator_class,
+                        has_pixels=has_pixels,
+                    )
+                ),
+                key=_observation_sort_key,
+            )
+        )
+
+    def get_operation_chain(
+        self,
+        frame_id: str,
+    ) -> ObservationOperationChainDTO | None:
+        observation = self._observations.get(frame_id)
+        return None if observation is None else observation.operation_chain
+
+    def list_observations_by_operation(
+        self,
+        *,
+        operation: str,
+        split: str | None = None,
+        family: str | None = None,
+    ) -> tuple[ObservationDTO, ...]:
+        return tuple(
+            observation
+            for observation in self.list_observations(split=split, family=family)
+            if any(
+                item.operation == operation
+                for item in observation.operation_chain.operations
+            )
+        )
+
+    def list_observations_by_output_digest(
+        self,
+        output_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        return tuple(
+            observation
+            for observation in self.list_observations()
+            if any(
+                item.output_digest == output_digest
+                for item in observation.operation_chain.operations
+            )
+        )
+
+    def list_observation_consumers_of_digest(
+        self,
+        input_digest: str,
+    ) -> tuple[ObservationDTO, ...]:
+        return tuple(
+            observation
+            for observation in self.list_observations()
+            if any(
+                input_digest in item.input_digests
+                for item in observation.operation_chain.operations
+            )
+        )
+
     def _preflight_episode_plans(self, plans: Sequence[EpisodePlanDTO]) -> None:
         seen_ids: dict[str, EpisodePlanDTO] = {}
         seen_ordinals: dict[tuple[str, str, int], EpisodePlanDTO] = {}
@@ -129,6 +284,135 @@ class InMemoryVideoActionSetStore(VideoActionSetStore):
             ):
                 return plan
         return None
+
+    def _preflight_observations(
+        self,
+        observations: Sequence[MaterializedObservationDTO],
+    ) -> dict[str, ObservationDTO]:
+        existing_observations: dict[str, ObservationDTO] = {}
+        seen_observations: dict[str, ObservationDTO] = {}
+        seen_sequences: dict[tuple[str, int], str] = {}
+        seen_blobs: dict[str, MatrixBlob] = {}
+        for item in observations:
+            observation = item.observation
+            self._preflight_observation_ownership(observation)
+            self._preflight_observation_identity(
+                observation,
+                existing_observations,
+                seen_observations,
+                seen_sequences,
+            )
+            self._preflight_blob(item.matrix_blob, seen_blobs)
+        return existing_observations
+
+    def _preflight_observation_ownership(
+        self,
+        observation: ObservationDTO,
+    ) -> None:
+        if observation.benchmark_seed_digest not in self._identities:
+            raise_unknown_benchmark_identity()
+        episode = self._episode_plans.get(observation.episode_id)
+        if episode is None:
+            raise_unknown_episode_plan()
+        if (
+            episode.plan_digest != observation.episode_plan_digest
+            or episode.benchmark_seed_digest != observation.benchmark_seed_digest
+            or episode.split != observation.split
+        ):
+            raise_unknown_episode_plan()
+
+    def _preflight_observation_identity(
+        self,
+        observation: ObservationDTO,
+        existing_observations: dict[str, ObservationDTO],
+        seen_observations: dict[str, ObservationDTO],
+        seen_sequences: dict[tuple[str, int], str],
+    ) -> None:
+        existing = self._observations.get(observation.frame_id)
+        if existing is not None:
+            if existing != observation:
+                raise_observation_conflict()
+            existing_observations[observation.frame_id] = existing
+        seen = seen_observations.get(observation.frame_id)
+        if seen is not None and seen != observation:
+            raise_observation_conflict()
+        seen_observations[observation.frame_id] = observation
+        self._preflight_sequence(observation, seen_sequences)
+
+    def _preflight_sequence(
+        self,
+        observation: ObservationDTO,
+        seen_sequences: dict[tuple[str, int], str],
+    ) -> None:
+        sequence_key = _sequence_key(observation)
+        existing_frame_id = self._observation_sequence_index.get(sequence_key)
+        if existing_frame_id is not None and existing_frame_id != observation.frame_id:
+            raise_observation_sequence_conflict()
+        seen_frame_id = seen_sequences.get(sequence_key)
+        if seen_frame_id is not None and seen_frame_id != observation.frame_id:
+            raise_observation_sequence_conflict()
+        seen_sequences[sequence_key] = observation.frame_id
+
+    def _preflight_blob(
+        self,
+        blob: MatrixBlob | None,
+        seen_blobs: dict[str, MatrixBlob],
+    ) -> None:
+        if blob is None:
+            return
+        existing = self._matrix_blobs.get(blob.blob_id)
+        if existing is not None and existing != blob:
+            raise_matrix_blob_conflict()
+        seen = seen_blobs.get(blob.blob_id)
+        if seen is not None and seen != blob:
+            raise_matrix_blob_conflict()
+        seen_blobs[blob.blob_id] = blob
+
+
+def _sequence_key(observation: ObservationDTO) -> tuple[str, int]:
+    return (observation.episode_id, observation.sequence_number)
+
+
+def _observation_sort_key(observation: ObservationDTO) -> tuple[str, str, int, str]:
+    return (
+        observation.split,
+        observation.episode_id,
+        observation.sequence_number,
+        observation.frame_id,
+    )
+
+
+def _matches_observation(
+    observation: ObservationDTO,
+    *,
+    benchmark_seed_digest: str | None,
+    split: str | None,
+    episode_id: str | None,
+    family: str | None,
+    event_type: str | None,
+    denominator_class: str | None,
+    has_pixels: bool | None,
+) -> bool:
+    if benchmark_seed_digest is not None and (
+        observation.benchmark_seed_digest != benchmark_seed_digest
+    ):
+        return False
+    if split is not None and observation.split != split:
+        return False
+    if episode_id is not None and observation.episode_id != episode_id:
+        return False
+    if family is not None and observation.family != family:
+        return False
+    if event_type is not None and observation.event_type != event_type:
+        return False
+    if (
+        denominator_class is not None
+        and observation.denominator_class != denominator_class
+    ):
+        return False
+    if has_pixels is not None and observation.has_pixels != has_pixels:
+        return False
+    return True
 
 
 __all__ = ["InMemoryVideoActionSetStore"]

--- a/zeromodel/stores/video_action_set_memory.py
+++ b/zeromodel/stores/video_action_set_memory.py
@@ -135,8 +135,12 @@ class InMemoryVideoActionSetStore(VideoActionSetStore):
     ) -> tuple[ObservationDTO, ...]:
         observation_tuple = tuple(observations)
         existing = self._preflight_observations(observation_tuple)
+        inserted_frame_ids: set[str] = set()
         for item in observation_tuple:
-            if item.observation.frame_id in existing:
+            if (
+                item.observation.frame_id in existing
+                or item.observation.frame_id in inserted_frame_ids
+            ):
                 continue
             if item.matrix_blob is not None:
                 self._matrix_blobs.setdefault(
@@ -147,6 +151,7 @@ class InMemoryVideoActionSetStore(VideoActionSetStore):
             self._observation_sequence_index[_sequence_key(item.observation)] = (
                 item.observation.frame_id
             )
+            inserted_frame_ids.add(item.observation.frame_id)
         return tuple(
             existing.get(item.observation.frame_id, item.observation)
             for item in observation_tuple
@@ -168,6 +173,35 @@ class InMemoryVideoActionSetStore(VideoActionSetStore):
             else self._matrix_blobs.get(observation.matrix_blob_id)
         )
         return MaterializedObservationDTO(observation, blob)
+
+    def list_materialized_observations(
+        self,
+        *,
+        benchmark_seed_digest: str | None = None,
+        split: str | None = None,
+        episode_id: str | None = None,
+        family: str | None = None,
+        event_type: str | None = None,
+        denominator_class: str | None = None,
+        has_pixels: bool | None = None,
+    ) -> tuple[MaterializedObservationDTO, ...]:
+        return tuple(
+            MaterializedObservationDTO(
+                observation,
+                None
+                if observation.matrix_blob_id is None
+                else self._matrix_blobs.get(observation.matrix_blob_id),
+            )
+            for observation in self.list_observations(
+                benchmark_seed_digest=benchmark_seed_digest,
+                split=split,
+                episode_id=episode_id,
+                family=family,
+                event_type=event_type,
+                denominator_class=denominator_class,
+                has_pixels=has_pixels,
+            )
+        )
 
     def list_observations(
         self,

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -24,7 +24,13 @@ from .domains.video_action_set.contracts import (
     SEED_DERIVATION_VERSION,
 )
 from .domains.video_action_set.dto import BenchmarkIdentityDTO, EpisodePlanDTO
-from .domains.video_action_set.observation_dto import ObservationOperationChainDTO, ObservationOperationDTO
+from .domains.video_action_set.observation_legacy_adapters import (
+    operation_chain as _operation_chain,
+    operation_record as _operation_record,
+)
+from .domains.video_action_set.observation_provenance_dto import (
+    ObservationOperationChainDTO,
+)
 from .policy_lookup import VPMPolicyLookup
 from .runtime import build_runtime
 from .video_complete_row_evidence import (
@@ -123,7 +129,13 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def _build_durable_runtime(output_dir: Path):
-    from .db.runtime import build_sqlite_runtime
+    try:
+        from .db.runtime import build_sqlite_runtime
+    except ImportError as exc:
+        raise VPMValidationError(
+            "SQLite benchmark persistence requires the optional database extra: "
+            'pip install "zeromodel[persistence]"'
+        ) from exc
 
     output_dir.mkdir(parents=True, exist_ok=True)
     database_url = f"sqlite:///{(output_dir / 'benchmark.sqlite3').as_posix()}"
@@ -528,6 +540,7 @@ def _renderer_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, Any
     return payload | {"renderer_identity_digest": _sha256(payload)}
 
 
+
 def _valid_transformation_parameter_key(params: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "dx": int(params["dx"]),
@@ -536,6 +549,7 @@ def _valid_transformation_parameter_key(params: Mapping[str, Any]) -> dict[str, 
         "offset": int(params["offset"]),
         "occlusion": None if params.get("occlusion") is None else dict(params["occlusion"]),
     }
+
 
 
 def _valid_transformation_parameter_universe() -> dict[str, Any]:
@@ -575,6 +589,7 @@ def _valid_transformation_parameter_universe() -> dict[str, Any]:
     payload["parameter_universe_digest"] = _sha256(payload)
     _valid_transformation_parameter_universe._cache = payload  # type: ignore[attr-defined]
     return payload
+
 
 
 def _valid_transformed_observation_digest_index(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
@@ -642,6 +657,7 @@ def _valid_transformed_observation_digest_index(config: ShooterConfig = ShooterC
     return payload
 
 
+
 def valid_observation_universe(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
     canonical = canonical_observation_universe(config)
     transformed = _valid_transformed_observation_digest_index(config)
@@ -701,6 +717,7 @@ def _target_slot_signal_coordinates(slot: int, *, width: int = 7) -> tuple[tuple
     return tuple([(2, centre - 1), (2, centre), (2, centre + 1), (3, centre - 1), (3, centre), (3, centre + 1), (4, centre)])
 
 
+
 def _detect_visible_target_slots(pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()) -> list[int]:
     array = np.ascontiguousarray(pixels, dtype=np.uint8)
     slots = []
@@ -710,6 +727,7 @@ def _detect_visible_target_slots(pixels: np.ndarray, *, config: ShooterConfig = 
         if all(value == TARGET_VALUE for value in values):
             slots.append(slot)
     return slots
+
 
 
 def _detect_tank_slot(pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()) -> int | None:
@@ -722,6 +740,7 @@ def _detect_tank_slot(pixels: np.ndarray, *, config: ShooterConfig = ShooterConf
     return None
 
 
+
 def _detect_cooldown_state(pixels: np.ndarray) -> int | None:
     block = np.ascontiguousarray(pixels, dtype=np.uint8)[7:9, -3:-1]
     values = {int(item) for item in block.reshape(-1)}
@@ -730,6 +749,7 @@ def _detect_cooldown_state(pixels: np.ndarray) -> int | None:
     if values == {COOLDOWN_BLOCKED_VALUE}:
         return 1
     return None
+
 
 
 def _final_visible_target_action_evidence(pixels: np.ndarray, row_actions: Mapping[str, str], *, config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
@@ -755,6 +775,7 @@ def _final_visible_target_action_evidence(pixels: np.ndarray, row_actions: Mappi
     return payload
 
 
+
 def _splice_pair_has_final_visible_action_conflict(primary_row_id: str, secondary_row_id: str, row_actions: Mapping[str, str]) -> bool:
     tank, primary_target, cooldown = parse_state_row_id(str(primary_row_id))
     _secondary_tank, secondary_target, _secondary_cooldown = parse_state_row_id(str(secondary_row_id))
@@ -767,6 +788,7 @@ def _splice_pair_has_final_visible_action_conflict(primary_row_id: str, secondar
     return len(implied) >= 2
 
 
+
 def _family_schedule() -> tuple[str, ...]:
     return (
         "exact",
@@ -776,6 +798,7 @@ def _family_schedule() -> tuple[str, ...]:
         "bounded_translation_occlusion",
         "compound_bounded",
     )
+
 
 
 def _episode_disposition(family_label: str, mutation_kind: str | None = None) -> str:
@@ -790,6 +813,7 @@ def _episode_disposition(family_label: str, mutation_kind: str | None = None) ->
     return str(mutation_kind or family_label)
 
 
+
 def _denominator_class(family_label: str, mutation_kind: str | None = None) -> str:
     if family_label == "valid":
         return "valid_denominator"
@@ -802,6 +826,7 @@ def _denominator_class(family_label: str, mutation_kind: str | None = None) -> s
     return str(mutation_kind or family_label)
 
 
+
 def _frame_disposition_for_episode(family_label: str, mutation_kind: str | None = None) -> str:
     if family_label == "valid":
         return "valid"
@@ -812,6 +837,7 @@ def _frame_disposition_for_episode(family_label: str, mutation_kind: str | None 
     if family_label == "temporal_negative":
         return "valid_frame_payload"
     return str(mutation_kind or family_label)
+
 
 
 def expected_frame_disposition(
@@ -846,8 +872,10 @@ def expected_frame_disposition(
     return "valid_frame_payload"
 
 
+
 def _transition_config_payload(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
     return {"width": int(config.width), "wave": [int(item) for item in config.wave], "max_steps": int(config.max_steps)}
+
 
 
 def _transition_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
@@ -858,6 +886,7 @@ def _transition_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, A
         "config": _transition_config_payload(config),
     }
     return payload | {"transition_identity_digest": _sha256(payload)}
+
 
 
 def _transition_input_digest(predecessor_row_id: str, action: str, *, config: ShooterConfig = ShooterConfig()) -> str:
@@ -871,6 +900,7 @@ def _transition_input_digest(predecessor_row_id: str, action: str, *, config: Sh
             "config_digest": _sha256(_transition_config_payload(config)),
         }
     )
+
 
 
 def _transition_result_digest(
@@ -894,6 +924,7 @@ def _transition_result_digest(
             "config_digest": _sha256(_transition_config_payload(config)),
         }
     )
+
 
 
 def _normalized_control_causal_tuple(
@@ -921,6 +952,7 @@ def _normalized_control_causal_tuple(
             config=config,
         ),
     }
+
 
 
 def _grounded_control_history(
@@ -961,6 +993,7 @@ def _grounded_control_history(
     return payload
 
 
+
 def _reconstructed_control_causal_tuple_digest(history: Mapping[str, Any], *, config: ShooterConfig = ShooterConfig()) -> str:
     if history.get("version") != GROUNDED_CONTROL_HISTORY_VERSION:
         raise VPMValidationError("unsupported grounded control history version")
@@ -993,6 +1026,7 @@ def _reconstructed_control_causal_tuple_digest(history: Mapping[str, Any], *, co
     if history.get("normalized_causal_tuple_digest") != tuple_digest:
         raise VPMValidationError("control history causal tuple digest mismatch")
     return tuple_digest
+
 
 
 def _grounded_control_histories_for_current_row(
@@ -1034,6 +1068,7 @@ def _grounded_control_histories_for_current_row(
             int(item["transition_choice_index"]),
         ),
     )
+
 
 
 def _select_grounded_control_histories(
@@ -1091,6 +1126,7 @@ def _select_grounded_control_histories(
     ]
 
 
+
 def _control_source_rows(row_ids: Sequence[str], *, count: int, frame_count: int, config: ShooterConfig = ShooterConfig()) -> list[str]:
     selected = []
     for row_id in row_ids:
@@ -1102,8 +1138,10 @@ def _control_source_rows(row_ids: Sequence[str], *, count: int, frame_count: int
     raise VPMValidationError("unable to select enough grounded information-control rows")
 
 
+
 def _provider_observation_digest(descriptor: Mapping[str, Any]) -> str:
     return _sha256({"version": PROVIDER_OBSERVATION_BOUNDARY_VERSION, "descriptor": descriptor})
+
 
 
 def _control_provider_source_id(record: Mapping[str, Any]) -> str:
@@ -1112,6 +1150,7 @@ def _control_provider_source_id(record: Mapping[str, Any]) -> str:
     if not group_id:
         raise VPMValidationError("information control record lacks a control group id")
     return str(metadata.get("provider_observation_source_id") or f"control:{group_id}")
+
 
 
 def provider_observation_for_record(record: Mapping[str, Any]) -> ImageObservation:
@@ -1128,6 +1167,7 @@ def provider_observation_for_record(record: Mapping[str, Any]) -> ImageObservati
         timestamp = metadata.get("provider_observation_timestamp") if "provider_observation_timestamp" in metadata else None
         visible_metadata = metadata.get("provider_observation_metadata", {}) if "provider_observation_metadata" in metadata else {}
     return ImageObservation(pixels, timestamp=None if timestamp is None else str(timestamp), source_id=source_id, metadata=visible_metadata)
+
 
 
 def provider_observation_descriptor_for_record(record: Mapping[str, Any]) -> dict[str, Any]:
@@ -1161,6 +1201,7 @@ def provider_observation_descriptor_for_record(record: Mapping[str, Any]) -> dic
         "source_id": source_id,
         "metadata": _json_ready(visible_metadata),
     }
+
 
 
 def _final_observation_provenance(split: str) -> dict[str, Any]:
@@ -1919,38 +1960,6 @@ def _apply_critical_corruption(source_pixels: np.ndarray, coordinate_manifest: M
     return output, manifest
 
 
-def _operation_record(
-    *,
-    index: int,
-    operation: str,
-    operation_version: str,
-    input_digests: Sequence[str | None],
-    parameters: Mapping[str, Any],
-    output_digest: str | None,
-) -> dict[str, Any]:
-    payload = {
-        "index": int(index),
-        "operation": str(operation),
-        "operation_version": str(operation_version),
-        "input_digests": [None if item is None else str(item) for item in input_digests],
-        "parameters": dict(parameters),
-        "parameter_digest": _sha256(parameters),
-        "output_digest": output_digest,
-    }
-    payload["operation_digest"] = _sha256(payload)
-    return ObservationOperationDTO.from_dict(payload).to_dict()
-
-
-def _operation_chain(operations: Sequence[Mapping[str, Any]], final_emitted_digest: str | None) -> dict[str, Any]:
-    payload = {
-        "version": OBSERVATION_OPERATION_CHAIN_VERSION,
-        "operations": [dict(item) for item in operations],
-        "final_emitted_digest": final_emitted_digest,
-    }
-    payload["operation_chain_digest"] = _sha256(payload)
-    return ObservationOperationChainDTO.from_dict(payload).to_dict()
-
-
 def _valid_frame_operation_chain(row_id: str, transformation_parameters: Mapping[str, Any]) -> dict[str, Any]:
     source = _render_row_frame(row_id)
     transformed, trace = _apply_transformation(source, transformation_parameters)
@@ -1983,6 +1992,7 @@ def _valid_frame_operation_chain(row_id: str, transformation_parameters: Mapping
         ),
     ]
     return _operation_chain(operations, output_digest)
+
 
 
 def _conflicting_splice_operation_chain(
@@ -2034,6 +2044,7 @@ def _conflicting_splice_operation_chain(
     return _operation_chain(operations, output_digest)
 
 
+
 def _critical_corruption_operation_chain(row_id: str, transformation_parameters: Mapping[str, Any], coordinate_manifest: Mapping[str, Any]) -> dict[str, Any]:
     source = _render_row_frame(row_id)
     transformed, transform_trace = _apply_transformation(source, transformation_parameters)
@@ -2048,6 +2059,7 @@ def _critical_corruption_operation_chain(row_id: str, transformation_parameters:
         _operation_record(index=3, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[output_digest], parameters={"event_type": "frame"}, output_digest=output_digest),
     ]
     return _operation_chain(operations, output_digest)
+
 
 
 def _stale_repeat_operation_chain(destination_before: Mapping[str, Any], replacement_source: Mapping[str, Any], repeat: Mapping[str, Any]) -> dict[str, Any]:
@@ -2080,6 +2092,7 @@ def _stale_repeat_operation_chain(destination_before: Mapping[str, Any], replace
     return _operation_chain(operations, replacement_digest)
 
 
+
 def _impossible_transition_operation_chain(destination_before: Mapping[str, Any], transition_plan: Mapping[str, Any]) -> dict[str, Any]:
     dest_params = destination_before.get("metadata", {}).get("transformation_parameters", {})
     ordinary_row = str(destination_before.get("expected_row"))
@@ -2104,12 +2117,14 @@ def _impossible_transition_operation_chain(destination_before: Mapping[str, Any]
     return _operation_chain(operations, unreachable_digest)
 
 
+
 def _gap_event_operation_chain(gap_event: Mapping[str, Any]) -> dict[str, Any]:
     operations = [
         _operation_record(index=0, operation="emit_typed_gap_event", operation_version="zeromodel-video-action-set-gap-event/v1", input_digests=[], parameters=dict(gap_event), output_digest=None),
         _operation_record(index=1, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[None], parameters={"event_type": "gap_unknown"}, output_digest=None),
     ]
     return _operation_chain(operations, None)
+
 
 
 def _information_control_operation_chain(current_row_id: str) -> dict[str, Any]:
@@ -2123,6 +2138,7 @@ def _information_control_operation_chain(current_row_id: str) -> dict[str, Any]:
     return _operation_chain(operations, current_digest)
 
 
+
 def _refresh_provider_observation_metadata(record: dict[str, Any]) -> None:
     metadata = record.setdefault("metadata", {})
     for key in ("provider_observation_boundary_version", "provider_observation_descriptor", "provider_observation_digest"):
@@ -2133,6 +2149,7 @@ def _refresh_provider_observation_metadata(record: dict[str, Any]) -> None:
     metadata["provider_observation_boundary_version"] = PROVIDER_OBSERVATION_BOUNDARY_VERSION
     metadata["provider_observation_descriptor"] = descriptor
     metadata["provider_observation_digest"] = _provider_observation_digest(descriptor)
+
 
 
 def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, Any]:
@@ -2250,6 +2267,7 @@ def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, An
     return {"pixels": current_pixels, "final_emitted_digest": current_digest, "typed_gap": typed_gap, "operation_count": len(operations)}
 
 
+
 def validate_observation_operation_chain(record: Mapping[str, Any]) -> str:
     chain = record.get("metadata", {}).get("observation_operation_chain")
     if not isinstance(chain, Mapping):
@@ -2269,6 +2287,7 @@ def validate_observation_operation_chain(record: Mapping[str, Any]) -> str:
     if pixels is not None and replay["pixels"] is not None and _array_digest(np.ascontiguousarray(pixels, dtype=np.uint8)) != replay["final_emitted_digest"]:
         return "final_observation_provenance_mismatch"
     return "ok"
+
 
 
 def _frame_descriptor(
@@ -2885,6 +2904,8 @@ def _record_regeneration_view(record: Mapping[str, Any]) -> dict[str, Any]:
         "sequence_digest": record.get("metadata", {}).get("sequence_digest"),
         "episode_plan_digest": record.get("metadata", {}).get("episode_plan_digest"),
     }
+
+
 
 
 def _frame_invalid_closure_summary(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -15,12 +15,16 @@ from .domains.video_action_set.canonical_json import canonical_json_bytes, canon
 from .domains.video_action_set.contracts import (
     BENCHMARK_VERSION,
     EPISODE_PLAN_VERSION,
+    FRAME_SHAPE,
     GENERATOR_VERSION,
+    OBSERVATION_OPERATION_CHAIN_VERSION,
+    PROVIDER_OBSERVATION_BOUNDARY_VERSION,
     REACHABILITY_TILE_DIGEST,
     REACHABILITY_TILE_VERSION,
     SEED_DERIVATION_VERSION,
 )
 from .domains.video_action_set.dto import BenchmarkIdentityDTO, EpisodePlanDTO
+from .domains.video_action_set.observation_dto import ObservationOperationChainDTO, ObservationOperationDTO
 from .policy_lookup import VPMPolicyLookup
 from .runtime import build_runtime
 from .video_complete_row_evidence import (
@@ -70,9 +74,6 @@ INFORMATION_CONTROL_VERSION = "zeromodel-video-action-set-family-information-con
 INFORMATION_CONTROL_AMBIGUITY_VERSION = "zeromodel-video-action-set-information-control-ambiguity/v2"
 GROUNDED_CONTROL_HISTORY_VERSION = "zeromodel-video-action-set-grounded-control-history/v1"
 AUTHORITATIVE_TRANSITION_FUNCTION_VERSION = "zeromodel-arcade-shooter-next-rows/v1"
-PROVIDER_OBSERVATION_BOUNDARY_VERSION = "zeromodel-video-action-set-provider-observation-boundary/v1"
-OBSERVATION_OPERATION_CHAIN_VERSION = "zeromodel-video-observation-operation-chain/v1"
-FRAME_SHAPE = (16, 28)
 CRITICAL_REGION_ID = "cooldown_indicator"
 TARGET_REGION_ID = "target_band"
 
@@ -119,6 +120,14 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _build_durable_runtime(output_dir: Path):
+    from .db.runtime import build_sqlite_runtime
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    database_url = f"sqlite:///{(output_dir / 'benchmark.sqlite3').as_posix()}"
+    return build_sqlite_runtime(database_url, initialize_schema=True)
 
 
 def _provider_version(provider_id: str) -> str:
@@ -519,7 +528,6 @@ def _renderer_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, Any
     return payload | {"renderer_identity_digest": _sha256(payload)}
 
 
-
 def _valid_transformation_parameter_key(params: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "dx": int(params["dx"]),
@@ -528,7 +536,6 @@ def _valid_transformation_parameter_key(params: Mapping[str, Any]) -> dict[str, 
         "offset": int(params["offset"]),
         "occlusion": None if params.get("occlusion") is None else dict(params["occlusion"]),
     }
-
 
 
 def _valid_transformation_parameter_universe() -> dict[str, Any]:
@@ -568,7 +575,6 @@ def _valid_transformation_parameter_universe() -> dict[str, Any]:
     payload["parameter_universe_digest"] = _sha256(payload)
     _valid_transformation_parameter_universe._cache = payload  # type: ignore[attr-defined]
     return payload
-
 
 
 def _valid_transformed_observation_digest_index(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
@@ -636,7 +642,6 @@ def _valid_transformed_observation_digest_index(config: ShooterConfig = ShooterC
     return payload
 
 
-
 def valid_observation_universe(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
     canonical = canonical_observation_universe(config)
     transformed = _valid_transformed_observation_digest_index(config)
@@ -696,7 +701,6 @@ def _target_slot_signal_coordinates(slot: int, *, width: int = 7) -> tuple[tuple
     return tuple([(2, centre - 1), (2, centre), (2, centre + 1), (3, centre - 1), (3, centre), (3, centre + 1), (4, centre)])
 
 
-
 def _detect_visible_target_slots(pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()) -> list[int]:
     array = np.ascontiguousarray(pixels, dtype=np.uint8)
     slots = []
@@ -706,7 +710,6 @@ def _detect_visible_target_slots(pixels: np.ndarray, *, config: ShooterConfig = 
         if all(value == TARGET_VALUE for value in values):
             slots.append(slot)
     return slots
-
 
 
 def _detect_tank_slot(pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()) -> int | None:
@@ -719,7 +722,6 @@ def _detect_tank_slot(pixels: np.ndarray, *, config: ShooterConfig = ShooterConf
     return None
 
 
-
 def _detect_cooldown_state(pixels: np.ndarray) -> int | None:
     block = np.ascontiguousarray(pixels, dtype=np.uint8)[7:9, -3:-1]
     values = {int(item) for item in block.reshape(-1)}
@@ -728,7 +730,6 @@ def _detect_cooldown_state(pixels: np.ndarray) -> int | None:
     if values == {COOLDOWN_BLOCKED_VALUE}:
         return 1
     return None
-
 
 
 def _final_visible_target_action_evidence(pixels: np.ndarray, row_actions: Mapping[str, str], *, config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
@@ -754,7 +755,6 @@ def _final_visible_target_action_evidence(pixels: np.ndarray, row_actions: Mappi
     return payload
 
 
-
 def _splice_pair_has_final_visible_action_conflict(primary_row_id: str, secondary_row_id: str, row_actions: Mapping[str, str]) -> bool:
     tank, primary_target, cooldown = parse_state_row_id(str(primary_row_id))
     _secondary_tank, secondary_target, _secondary_cooldown = parse_state_row_id(str(secondary_row_id))
@@ -767,7 +767,6 @@ def _splice_pair_has_final_visible_action_conflict(primary_row_id: str, secondar
     return len(implied) >= 2
 
 
-
 def _family_schedule() -> tuple[str, ...]:
     return (
         "exact",
@@ -777,7 +776,6 @@ def _family_schedule() -> tuple[str, ...]:
         "bounded_translation_occlusion",
         "compound_bounded",
     )
-
 
 
 def _episode_disposition(family_label: str, mutation_kind: str | None = None) -> str:
@@ -792,7 +790,6 @@ def _episode_disposition(family_label: str, mutation_kind: str | None = None) ->
     return str(mutation_kind or family_label)
 
 
-
 def _denominator_class(family_label: str, mutation_kind: str | None = None) -> str:
     if family_label == "valid":
         return "valid_denominator"
@@ -805,7 +802,6 @@ def _denominator_class(family_label: str, mutation_kind: str | None = None) -> s
     return str(mutation_kind or family_label)
 
 
-
 def _frame_disposition_for_episode(family_label: str, mutation_kind: str | None = None) -> str:
     if family_label == "valid":
         return "valid"
@@ -816,7 +812,6 @@ def _frame_disposition_for_episode(family_label: str, mutation_kind: str | None 
     if family_label == "temporal_negative":
         return "valid_frame_payload"
     return str(mutation_kind or family_label)
-
 
 
 def expected_frame_disposition(
@@ -851,10 +846,8 @@ def expected_frame_disposition(
     return "valid_frame_payload"
 
 
-
 def _transition_config_payload(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
     return {"width": int(config.width), "wave": [int(item) for item in config.wave], "max_steps": int(config.max_steps)}
-
 
 
 def _transition_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
@@ -865,7 +858,6 @@ def _transition_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, A
         "config": _transition_config_payload(config),
     }
     return payload | {"transition_identity_digest": _sha256(payload)}
-
 
 
 def _transition_input_digest(predecessor_row_id: str, action: str, *, config: ShooterConfig = ShooterConfig()) -> str:
@@ -879,7 +871,6 @@ def _transition_input_digest(predecessor_row_id: str, action: str, *, config: Sh
             "config_digest": _sha256(_transition_config_payload(config)),
         }
     )
-
 
 
 def _transition_result_digest(
@@ -903,7 +894,6 @@ def _transition_result_digest(
             "config_digest": _sha256(_transition_config_payload(config)),
         }
     )
-
 
 
 def _normalized_control_causal_tuple(
@@ -931,7 +921,6 @@ def _normalized_control_causal_tuple(
             config=config,
         ),
     }
-
 
 
 def _grounded_control_history(
@@ -972,7 +961,6 @@ def _grounded_control_history(
     return payload
 
 
-
 def _reconstructed_control_causal_tuple_digest(history: Mapping[str, Any], *, config: ShooterConfig = ShooterConfig()) -> str:
     if history.get("version") != GROUNDED_CONTROL_HISTORY_VERSION:
         raise VPMValidationError("unsupported grounded control history version")
@@ -1005,7 +993,6 @@ def _reconstructed_control_causal_tuple_digest(history: Mapping[str, Any], *, co
     if history.get("normalized_causal_tuple_digest") != tuple_digest:
         raise VPMValidationError("control history causal tuple digest mismatch")
     return tuple_digest
-
 
 
 def _grounded_control_histories_for_current_row(
@@ -1047,7 +1034,6 @@ def _grounded_control_histories_for_current_row(
             int(item["transition_choice_index"]),
         ),
     )
-
 
 
 def _select_grounded_control_histories(
@@ -1105,7 +1091,6 @@ def _select_grounded_control_histories(
     ]
 
 
-
 def _control_source_rows(row_ids: Sequence[str], *, count: int, frame_count: int, config: ShooterConfig = ShooterConfig()) -> list[str]:
     selected = []
     for row_id in row_ids:
@@ -1117,10 +1102,8 @@ def _control_source_rows(row_ids: Sequence[str], *, count: int, frame_count: int
     raise VPMValidationError("unable to select enough grounded information-control rows")
 
 
-
 def _provider_observation_digest(descriptor: Mapping[str, Any]) -> str:
     return _sha256({"version": PROVIDER_OBSERVATION_BOUNDARY_VERSION, "descriptor": descriptor})
-
 
 
 def _control_provider_source_id(record: Mapping[str, Any]) -> str:
@@ -1129,7 +1112,6 @@ def _control_provider_source_id(record: Mapping[str, Any]) -> str:
     if not group_id:
         raise VPMValidationError("information control record lacks a control group id")
     return str(metadata.get("provider_observation_source_id") or f"control:{group_id}")
-
 
 
 def provider_observation_for_record(record: Mapping[str, Any]) -> ImageObservation:
@@ -1146,7 +1128,6 @@ def provider_observation_for_record(record: Mapping[str, Any]) -> ImageObservati
         timestamp = metadata.get("provider_observation_timestamp") if "provider_observation_timestamp" in metadata else None
         visible_metadata = metadata.get("provider_observation_metadata", {}) if "provider_observation_metadata" in metadata else {}
     return ImageObservation(pixels, timestamp=None if timestamp is None else str(timestamp), source_id=source_id, metadata=visible_metadata)
-
 
 
 def provider_observation_descriptor_for_record(record: Mapping[str, Any]) -> dict[str, Any]:
@@ -1180,7 +1161,6 @@ def provider_observation_descriptor_for_record(record: Mapping[str, Any]) -> dic
         "source_id": source_id,
         "metadata": _json_ready(visible_metadata),
     }
-
 
 
 def _final_observation_provenance(split: str) -> dict[str, Any]:
@@ -1958,8 +1938,7 @@ def _operation_record(
         "output_digest": output_digest,
     }
     payload["operation_digest"] = _sha256(payload)
-    return payload
-
+    return ObservationOperationDTO.from_dict(payload).to_dict()
 
 
 def _operation_chain(operations: Sequence[Mapping[str, Any]], final_emitted_digest: str | None) -> dict[str, Any]:
@@ -1969,8 +1948,7 @@ def _operation_chain(operations: Sequence[Mapping[str, Any]], final_emitted_dige
         "final_emitted_digest": final_emitted_digest,
     }
     payload["operation_chain_digest"] = _sha256(payload)
-    return payload
-
+    return ObservationOperationChainDTO.from_dict(payload).to_dict()
 
 
 def _valid_frame_operation_chain(row_id: str, transformation_parameters: Mapping[str, Any]) -> dict[str, Any]:
@@ -2005,7 +1983,6 @@ def _valid_frame_operation_chain(row_id: str, transformation_parameters: Mapping
         ),
     ]
     return _operation_chain(operations, output_digest)
-
 
 
 def _conflicting_splice_operation_chain(
@@ -2057,7 +2034,6 @@ def _conflicting_splice_operation_chain(
     return _operation_chain(operations, output_digest)
 
 
-
 def _critical_corruption_operation_chain(row_id: str, transformation_parameters: Mapping[str, Any], coordinate_manifest: Mapping[str, Any]) -> dict[str, Any]:
     source = _render_row_frame(row_id)
     transformed, transform_trace = _apply_transformation(source, transformation_parameters)
@@ -2072,7 +2048,6 @@ def _critical_corruption_operation_chain(row_id: str, transformation_parameters:
         _operation_record(index=3, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[output_digest], parameters={"event_type": "frame"}, output_digest=output_digest),
     ]
     return _operation_chain(operations, output_digest)
-
 
 
 def _stale_repeat_operation_chain(destination_before: Mapping[str, Any], replacement_source: Mapping[str, Any], repeat: Mapping[str, Any]) -> dict[str, Any]:
@@ -2105,7 +2080,6 @@ def _stale_repeat_operation_chain(destination_before: Mapping[str, Any], replace
     return _operation_chain(operations, replacement_digest)
 
 
-
 def _impossible_transition_operation_chain(destination_before: Mapping[str, Any], transition_plan: Mapping[str, Any]) -> dict[str, Any]:
     dest_params = destination_before.get("metadata", {}).get("transformation_parameters", {})
     ordinary_row = str(destination_before.get("expected_row"))
@@ -2130,14 +2104,12 @@ def _impossible_transition_operation_chain(destination_before: Mapping[str, Any]
     return _operation_chain(operations, unreachable_digest)
 
 
-
 def _gap_event_operation_chain(gap_event: Mapping[str, Any]) -> dict[str, Any]:
     operations = [
         _operation_record(index=0, operation="emit_typed_gap_event", operation_version="zeromodel-video-action-set-gap-event/v1", input_digests=[], parameters=dict(gap_event), output_digest=None),
         _operation_record(index=1, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[None], parameters={"event_type": "gap_unknown"}, output_digest=None),
     ]
     return _operation_chain(operations, None)
-
 
 
 def _information_control_operation_chain(current_row_id: str) -> dict[str, Any]:
@@ -2149,7 +2121,6 @@ def _information_control_operation_chain(current_row_id: str) -> dict[str, Any]:
         _operation_record(index=2, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[current_digest], parameters={"event_type": "frame"}, output_digest=current_digest),
     ]
     return _operation_chain(operations, current_digest)
-
 
 
 def _refresh_provider_observation_metadata(record: dict[str, Any]) -> None:
@@ -2164,8 +2135,8 @@ def _refresh_provider_observation_metadata(record: dict[str, Any]) -> None:
     metadata["provider_observation_digest"] = _provider_observation_digest(descriptor)
 
 
-
 def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, Any]:
+    chain = ObservationOperationChainDTO.from_dict(chain).to_dict()
     if chain.get("version") != OBSERVATION_OPERATION_CHAIN_VERSION:
         raise VPMValidationError("unsupported observation operation chain version")
     operations = list(chain.get("operations", []))
@@ -2279,7 +2250,6 @@ def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, An
     return {"pixels": current_pixels, "final_emitted_digest": current_digest, "typed_gap": typed_gap, "operation_count": len(operations)}
 
 
-
 def validate_observation_operation_chain(record: Mapping[str, Any]) -> str:
     chain = record.get("metadata", {}).get("observation_operation_chain")
     if not isinstance(chain, Mapping):
@@ -2299,7 +2269,6 @@ def validate_observation_operation_chain(record: Mapping[str, Any]) -> str:
     if pixels is not None and replay["pixels"] is not None and _array_digest(np.ascontiguousarray(pixels, dtype=np.uint8)) != replay["final_emitted_digest"]:
         return "final_observation_provenance_mismatch"
     return "ok"
-
 
 
 def _frame_descriptor(
@@ -2739,7 +2708,7 @@ def _control_episode(
 
 
 def freeze_benchmark(output_dir: Path, repo_root: Path) -> dict[str, Any]:
-    runtime = build_runtime()
+    runtime = _build_durable_runtime(output_dir)
     identity = runtime.video_action_set.load_identity(repo_root)
     policy = compile_policy_artifact()
     lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
@@ -2916,8 +2885,6 @@ def _record_regeneration_view(record: Mapping[str, Any]) -> dict[str, Any]:
         "sequence_digest": record.get("metadata", {}).get("sequence_digest"),
         "episode_plan_digest": record.get("metadata", {}).get("episode_plan_digest"),
     }
-
-
 
 
 def _frame_invalid_closure_summary(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
@@ -3583,8 +3550,8 @@ def _score_record(
 
 def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]:
     split_dir = output_dir / split
-    records = _materialize_records(split, repo_root)
-    identity = load_identity(repo_root)
+    runtime = _build_durable_runtime(output_dir)
+    identity = runtime.video_action_set.load_identity(repo_root)
     prototypes = canonical_prototypes()
     policy = compile_policy_artifact()
     lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
@@ -3592,6 +3559,11 @@ def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]
     policy_artifact_id = policy.artifact_id
     reachability_tile = _load_reachability_tile(repo_root)
     plans = _episode_plans_for_split(identity, split, [str(row_id) for row_id in policy.source.row_ids], row_actions)
+    saved_plans = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in plans))
+    plans = [dto.to_dict() for dto in saved_plans]
+    records = _materialize_records(split, repo_root)
+    runtime.video_action_set.save_observation_records(records)
+    records = list(runtime.video_action_set.list_observation_records(benchmark_seed_digest=identity.seed_digest, split=split, include_pixels=True))
     reachability_state: dict[str, Mapping[str, Any] | None] = {"P1": None, "P2": None, "P3": None}
     scored_rows: list[dict[str, Any]] = []
     for record in records:


### PR DESCRIPTION
## What changed

- added observation, operation, operation-chain, and provider descriptor RMDTOs;
- added MatrixBlob persistence and content-addressed deduplication;
- added in-memory and SQL observation ledger Store methods;
- routed durable split materialization through Runtime/Facade/Engine/Service/Store boundaries;
- added focused fast tests and authored SQL integration coverage without executing it.

## Scope boundary

Audit-Exempt: behavior-preserving observation and provenance RMDTO extraction; no claim status, benchmark evidence, scientific semantics, observation identity, digest semantics, or conclusions changed.

Integration tests were authored but not executed per Stage 2C instructions.