### PR TITLE
refactor: extract pure video transformation kernel

### DIFF
--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -9,7 +9,7 @@ maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
 reason = "Stage 3 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 5950
+maximum_lines = 5812
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -12,6 +12,8 @@ VIDEO_ACTION_SET_BENCHMARK_MODULE = "zeromodel.video_action_set_benchmark"
 DOMAIN_VIDEO_ACTION_SET_PREFIX = "zeromodel.domains.video_action_set"
 DB_ORM_PREFIX = "zeromodel.db.orm"
 DB_STORES_PREFIX = "zeromodel.db.stores"
+PIXEL_DIGEST_MODULE = "zeromodel.domains.video_action_set.pixel_digest"
+TRANSFORMATIONS_MODULE = "zeromodel.domains.video_action_set.transformations"
 VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
     "zeromodel.domains.video_action_set.episode_plan_service",
     "zeromodel.domains.video_action_set.identity_service",
@@ -31,7 +33,9 @@ VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
     "zeromodel.domains.video_action_set.observation_materialization",
     "zeromodel.domains.video_action_set.observation_provenance_dto",
     "zeromodel.domains.video_action_set.observation_service",
+    PIXEL_DIGEST_MODULE,
     "zeromodel.domains.video_action_set.provider_observation_dto",
+    TRANSFORMATIONS_MODULE,
 }
 VIDEO_ACTION_SET_POLICY_MODULES = {
     f"{VIDEO_ACTION_SET_PREFIX}.contracts",
@@ -349,6 +353,43 @@ def legacy_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
     return violations
 
 
+def transformation_kernel_forbidden_edge_violations(
+    edge: ImportEdge,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if edge.importer == PIXEL_DIGEST_MODULE and edge.imported == TRANSFORMATIONS_MODULE:
+        violations.append(
+            edge_violation(
+                "pixel_digest must not import transformations",
+                edge,
+            )
+        )
+    if edge.importer in {PIXEL_DIGEST_MODULE, TRANSFORMATIONS_MODULE} and (
+        is_module_under(edge.imported, DB_ORM_PREFIX)
+        or is_module_under(edge.imported, DB_STORES_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db.session")
+        or is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+        or is_sqlalchemy_import(edge.imported)
+    ):
+        violations.append(
+            edge_violation(
+                "video transformation kernel modules must not import persistence or runtime layers",
+                edge,
+            )
+        )
+    if edge.importer == TRANSFORMATIONS_MODULE and (
+        edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+    ):
+        violations.append(
+            edge_violation(
+                "transformations must not import legacy benchmark facade",
+                edge,
+            )
+        )
+    return violations
+
+
 def rmdto_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
     violations: list[Violation] = []
     if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
@@ -431,6 +472,7 @@ def forbidden_edge_violations(edges: list[ImportEdge]) -> list[Violation]:
     violations: list[Violation] = []
     for edge in edges:
         violations.extend(legacy_forbidden_edge_violations(edge))
+        violations.extend(transformation_kernel_forbidden_edge_violations(edge))
         violations.extend(rmdto_forbidden_edge_violations(edge))
     return violations
 

--- a/tests/test_video_transformation_kernel.py
+++ b/tests/test_video_transformation_kernel.py
@@ -189,6 +189,11 @@ OUTPUT_GOLDENS = {
         "digest": "sha256:772f6f803b902cef207fe455f849aad1c69f6880e9fce0f4c265664133176dd7",
         "changed": 20,
     },
+    "bounded_translation_photometric": {
+        "bytes": "050505050505060708090a0b0c0d0e0f10111213",
+        "digest": "sha256:ce88113f7db54c5dda0e5127290938d36ba9ef951e8046d18e7d50bdbb9b64c0",
+        "changed": 5,
+    },
     "bounded_translation_occlusion": {
         "bytes": "0000000000000140404005064040400a0b0c0d0e",
         "digest": "sha256:33b6b91a06ffd9ae0a6874f3ef6f825899c9d9b48c2126220fc2c62e7e9713b7",
@@ -338,6 +343,7 @@ def test_transformation_validation_rejects_occlusion_and_digest(
         "exact",
         "bounded_translation",
         "bounded_photometric",
+        "bounded_translation_photometric",
         "bounded_translation_occlusion",
         "compound_bounded",
     ],
@@ -424,4 +430,26 @@ def test_materialized_observation_uses_historical_pixel_digest() -> None:
     assert (
         item.to_record(include_pixels=False)["observation_pixel_digest"]
         == record["observation_pixel_digest"]
+    )
+
+
+@pytest.mark.parametrize("record_pixels_kind", ["list", "int16"])
+def test_materialized_observation_normalizes_record_pixels_to_uint8(
+    record_pixels_kind: str,
+) -> None:
+    pixels = _pixels()
+    record = sample_record(pixels=pixels)
+    if record_pixels_kind == "list":
+        record["pixels"] = pixels.tolist()
+    else:
+        record["pixels"] = pixels.astype(np.int16)
+
+    item = MaterializedObservationDTO.from_record(record)
+
+    assert item.matrix_blob is not None
+    restored = item.matrix_blob.to_array()
+    assert restored.dtype == np.uint8
+    np.testing.assert_array_equal(restored, pixels)
+    assert (
+        item.observation.observation_pixel_digest == record["observation_pixel_digest"]
     )

--- a/tests/test_video_transformation_kernel.py
+++ b/tests/test_video_transformation_kernel.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from test_video_observation_rmdto import _pixels, sample_record
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+from zeromodel.domains.video_action_set.contracts import TRANSFORMATION_FAMILY_VERSION
+from zeromodel.domains.video_action_set.observation_dto import (
+    MaterializedObservationDTO,
+)
+from zeromodel.domains.video_action_set.pixel_digest import (
+    array_digest,
+    pixel_digest,
+    pixel_digest_from_bytes,
+)
+from zeromodel.domains.video_action_set.transformations import (
+    _apply_transformation,
+    _transformation_contract,
+    _transformation_parameters,
+    _translation_values_for_seed,
+    _validate_transformation_parameters,
+)
+
+
+EXPECTED_TRANSFORMATION_CONTRACT = {
+    "version": "zeromodel-video-action-set-transformation-family/v1",
+    "families": {
+        "exact": {
+            "classification": "valid",
+            "dx": [0, 0],
+            "dy": [0, 0],
+            "scale_percent": [100, 100],
+            "offset": [0, 0],
+            "occlusion": False,
+        },
+        "bounded_translation": {
+            "classification": "valid",
+            "dx": [-1, 1],
+            "dy": [-1, 1],
+            "scale_percent": [100, 100],
+            "offset": [0, 0],
+            "occlusion": False,
+        },
+        "bounded_photometric": {
+            "classification": "valid",
+            "dx": [0, 0],
+            "dy": [0, 0],
+            "scale_percent": [90, 105],
+            "offset": [0, 5],
+            "occlusion": False,
+        },
+        "bounded_translation_photometric": {
+            "classification": "valid",
+            "dx": [-1, 1],
+            "dy": [-1, 1],
+            "scale_percent": [90, 105],
+            "offset": [0, 5],
+            "occlusion": False,
+        },
+        "bounded_translation_occlusion": {
+            "classification": "valid",
+            "dx": [-1, 1],
+            "dy": [-1, 1],
+            "scale_percent": [100, 100],
+            "offset": [0, 0],
+            "occlusion": True,
+        },
+        "compound_bounded": {
+            "classification": "valid",
+            "dx": [-1, 1],
+            "dy": [-1, 1],
+            "scale_percent": [90, 105],
+            "offset": [0, 5],
+            "occlusion": True,
+        },
+    },
+    "occlusion_bounds": {
+        "top": [0, 2],
+        "left": [0, 2],
+        "height": 2,
+        "width": 3,
+        "value": 64,
+    },
+}
+
+EXPECTED_CONTRACT_DIGEST = (
+    "sha256:b7159f26df7e721680edfe9d52948797a10afa0f4c7dafc7396baacaf3eb2450"
+)
+
+EXPECTED_PARAMETERS = {
+    "exact": {
+        "version": "zeromodel-video-action-set-transformation-family/v1",
+        "family": "exact",
+        "seed": 12345,
+        "dx": 0,
+        "dy": 0,
+        "scale_percent": 100,
+        "offset": 0,
+        "occlusion": None,
+        "parameter_digest": (
+            "sha256:7ad8100c9edae0dbbb370d41d6c2f04b9d95dab4ce2f0a371477649c62311c32"
+        ),
+    },
+    "bounded_translation": {
+        "version": "zeromodel-video-action-set-transformation-family/v1",
+        "family": "bounded_translation",
+        "seed": 12345,
+        "dx": 0,
+        "dy": 1,
+        "scale_percent": 100,
+        "offset": 0,
+        "occlusion": None,
+        "parameter_digest": (
+            "sha256:322ef2669264ea17418cc65b8657b39fa964b51ce53ef11949ee866e6d8a10ad"
+        ),
+    },
+    "bounded_photometric": {
+        "version": "zeromodel-video-action-set-transformation-family/v1",
+        "family": "bounded_photometric",
+        "seed": 12345,
+        "dx": 0,
+        "dy": 0,
+        "scale_percent": 103,
+        "offset": 5,
+        "occlusion": None,
+        "parameter_digest": (
+            "sha256:31331886c5f37c7326441bbf70c5d0b759b380f132cb6ae8e7394d351c6509c1"
+        ),
+    },
+    "bounded_translation_photometric": {
+        "version": "zeromodel-video-action-set-transformation-family/v1",
+        "family": "bounded_translation_photometric",
+        "seed": 12345,
+        "dx": 0,
+        "dy": 1,
+        "scale_percent": 103,
+        "offset": 5,
+        "occlusion": None,
+        "parameter_digest": (
+            "sha256:19f71181a4ed8077aff31a318c3033358c467667d382aa2351d06b7e6aae20ce"
+        ),
+    },
+    "bounded_translation_occlusion": {
+        "version": "zeromodel-video-action-set-transformation-family/v1",
+        "family": "bounded_translation_occlusion",
+        "seed": 12345,
+        "dx": 0,
+        "dy": 1,
+        "scale_percent": 100,
+        "offset": 0,
+        "occlusion": {"top": 1, "left": 2, "height": 2, "width": 3, "value": 64},
+        "parameter_digest": (
+            "sha256:c4d6388f784d81c8ad6286a703396719d2a9cb3016ff8cff894e94fc5c60dafe"
+        ),
+    },
+    "compound_bounded": {
+        "version": "zeromodel-video-action-set-transformation-family/v1",
+        "family": "compound_bounded",
+        "seed": 12345,
+        "dx": 0,
+        "dy": 1,
+        "scale_percent": 103,
+        "offset": 5,
+        "occlusion": {"top": 0, "left": 1, "height": 2, "width": 3, "value": 64},
+        "parameter_digest": (
+            "sha256:a2c0c56598a4c1666d05ca76c0782996a5183f2c2c726f26ef1246aabed1f8c3"
+        ),
+    },
+}
+
+OUTPUT_GOLDENS = {
+    "exact": {
+        "bytes": "000102030405060708090a0b0c0d0e0f10111213",
+        "digest": "sha256:e7aebf577f60412f0312d442c70a1fa6148c090bf5bab404caec29482ae779e8",
+        "changed": 0,
+    },
+    "bounded_translation": {
+        "bytes": "0000000000000102030405060708090a0b0c0d0e",
+        "digest": "sha256:debdac7459ccb5129c1580891fdb80f5e265122cc26db0b3b8e27aed95f78949",
+        "changed": 19,
+    },
+    "bounded_photometric": {
+        "bytes": "05060708090a0b0c0d0e0f101112131415171819",
+        "digest": "sha256:772f6f803b902cef207fe455f849aad1c69f6880e9fce0f4c265664133176dd7",
+        "changed": 20,
+    },
+    "bounded_translation_occlusion": {
+        "bytes": "0000000000000140404005064040400a0b0c0d0e",
+        "digest": "sha256:33b6b91a06ffd9ae0a6874f3ef6f825899c9d9b48c2126220fc2c62e7e9713b7",
+        "changed": 19,
+    },
+    "compound_bounded": {
+        "bytes": "054040400505404040090a0b0c0d0e0f10111213",
+        "digest": "sha256:bd98bb3cd4a51d1b76d380ea09669391507e49667f955234f0a26e4dc443e999",
+        "changed": 8,
+    },
+}
+
+SOURCE_DIGEST = (
+    "sha256:e7aebf577f60412f0312d442c70a1fa6148c090bf5bab404caec29482ae779e8"
+)
+
+
+def test_transformation_contract_payload_is_frozen() -> None:
+    contract = _transformation_contract()
+
+    assert TRANSFORMATION_FAMILY_VERSION == (
+        "zeromodel-video-action-set-transformation-family/v1"
+    )
+    assert contract == EXPECTED_TRANSFORMATION_CONTRACT
+    assert canonical_sha256(contract) == EXPECTED_CONTRACT_DIGEST
+    assert set(contract["families"]) == {
+        "exact",
+        "bounded_translation",
+        "bounded_photometric",
+        "bounded_translation_photometric",
+        "bounded_translation_occlusion",
+        "compound_bounded",
+    }
+    assert contract["occlusion_bounds"] == {
+        "top": [0, 2],
+        "left": [0, 2],
+        "height": 2,
+        "width": 3,
+        "value": 64,
+    }
+
+
+def test_transformation_parameters_are_frozen_for_fixed_seed() -> None:
+    assert _translation_values_for_seed(12345) == (0, 1)
+    for family, expected in EXPECTED_PARAMETERS.items():
+        assert _transformation_parameters(family, 12345) == expected
+
+    with pytest.raises(VPMValidationError, match="unsupported transformation family"):
+        _transformation_parameters("unsupported", 12345)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (
+            lambda item: item.__setitem__("family", "unsupported"),
+            "unsupported transformation family",
+        ),
+        (lambda item: item.__setitem__("dx", 2), "transformation dx out of bounds"),
+        (lambda item: item.__setitem__("dy", 2), "transformation dy out of bounds"),
+        (
+            lambda item: item.__setitem__("scale_percent", 106),
+            "transformation scale out of bounds",
+        ),
+        (
+            lambda item: item.__setitem__("offset", 6),
+            "transformation offset out of bounds",
+        ),
+    ],
+)
+def test_transformation_validation_rejects_scalar_bounds(mutator, message: str) -> None:
+    params = deepcopy(EXPECTED_PARAMETERS["bounded_translation_photometric"])
+    mutator(params)
+
+    with pytest.raises(VPMValidationError, match=message):
+        _validate_transformation_parameters(params)
+
+
+@pytest.mark.parametrize(
+    ("params", "message", "image_shape"),
+    [
+        (
+            EXPECTED_PARAMETERS["bounded_translation_occlusion"] | {"occlusion": None},
+            "occlusion parameters required",
+            (16, 28),
+        ),
+        (
+            EXPECTED_PARAMETERS["exact"]
+            | {
+                "occlusion": {"top": 0, "left": 0, "height": 2, "width": 3, "value": 64}
+            },
+            "occlusion parameters supplied for non-occlusion family",
+            (16, 28),
+        ),
+        (
+            {
+                **EXPECTED_PARAMETERS["bounded_translation_occlusion"],
+                "occlusion": {
+                    "top": 3,
+                    "left": 2,
+                    "height": 2,
+                    "width": 3,
+                    "value": 64,
+                },
+            },
+            "occlusion top out of bounds",
+            (16, 28),
+        ),
+        (
+            {
+                **EXPECTED_PARAMETERS["bounded_translation_occlusion"],
+                "occlusion": {
+                    "top": 1,
+                    "left": 2,
+                    "height": 3,
+                    "width": 3,
+                    "value": 64,
+                },
+            },
+            "occlusion dimensions or value out of bounds",
+            (16, 28),
+        ),
+        (
+            EXPECTED_PARAMETERS["bounded_translation_occlusion"],
+            "occlusion exceeds image bounds",
+            (2, 5),
+        ),
+        (
+            EXPECTED_PARAMETERS["exact"] | {"parameter_digest": "sha256:" + "0" * 64},
+            "foreign transformation parameter digest",
+            (16, 28),
+        ),
+    ],
+)
+def test_transformation_validation_rejects_occlusion_and_digest(
+    params: dict[str, object],
+    message: str,
+    image_shape: tuple[int, int],
+) -> None:
+    with pytest.raises(VPMValidationError, match=message):
+        _validate_transformation_parameters(deepcopy(params), image_shape=image_shape)
+
+
+@pytest.mark.parametrize(
+    "family",
+    [
+        "exact",
+        "bounded_translation",
+        "bounded_photometric",
+        "bounded_translation_occlusion",
+        "compound_bounded",
+    ],
+)
+def test_transformation_output_bytes_and_trace_are_frozen(family: str) -> None:
+    source = np.arange(20, dtype=np.uint8).reshape(4, 5)
+    result, trace = _apply_transformation(source, EXPECTED_PARAMETERS[family])
+    expected = OUTPUT_GOLDENS[family]
+    expected_bytes = bytes.fromhex(expected["bytes"])
+
+    assert result.dtype == np.uint8
+    assert result.flags.c_contiguous
+    assert result.shape == source.shape
+    assert result.tobytes(order="C") == expected_bytes
+    assert trace == {
+        "source_observation_digest": SOURCE_DIGEST,
+        "transformed_observation_digest": expected["digest"],
+        "transformation_parameter_digest": EXPECTED_PARAMETERS[family][
+            "parameter_digest"
+        ],
+        "changed_pixel_count": expected["changed"],
+    }
+    assert tuple(trace) == (
+        "source_observation_digest",
+        "transformed_observation_digest",
+        "transformation_parameter_digest",
+        "changed_pixel_count",
+    )
+    assert array_digest(source) == SOURCE_DIGEST
+    assert pixel_digest_from_bytes(expected_bytes) == expected["digest"]
+
+
+def test_pixel_digest_uses_contiguous_c_order_bytes_for_views() -> None:
+    view = np.arange(24, dtype=np.uint8).reshape(4, 6)[:, ::2]
+
+    assert not view.flags.c_contiguous
+    assert view.tolist() == [[0, 2, 4], [6, 8, 10], [12, 14, 16], [18, 20, 22]]
+    assert pixel_digest(None) is None
+    assert array_digest(view) == (
+        "sha256:eeab3b7b19f2560d5b64621880ab7f06559c9567526cd513a1ad0e4d55092335"
+    )
+    assert pixel_digest_from_bytes(bytes.fromhex("00020406080a0c0e10121416")) == (
+        "sha256:eeab3b7b19f2560d5b64621880ab7f06559c9567526cd513a1ad0e4d55092335"
+    )
+
+
+def test_legacy_benchmark_facade_exposes_moved_symbols() -> None:
+    source = np.arange(20, dtype=np.uint8).reshape(4, 5)
+
+    assert benchmark.TRANSFORMATION_FAMILY_VERSION == TRANSFORMATION_FAMILY_VERSION
+    assert benchmark._pixel_digest(source) == pixel_digest(source)
+    assert benchmark._array_digest(source) == array_digest(source)
+    assert benchmark._transformation_contract() == _transformation_contract()
+    assert benchmark._translation_values_for_seed(
+        12345
+    ) == _translation_values_for_seed(12345)
+    assert benchmark._transformation_parameters(
+        "compound_bounded", 12345
+    ) == _transformation_parameters("compound_bounded", 12345)
+    benchmark_output, benchmark_trace = benchmark._apply_transformation(
+        source,
+        EXPECTED_PARAMETERS["compound_bounded"],
+    )
+    output, trace = _apply_transformation(
+        source,
+        EXPECTED_PARAMETERS["compound_bounded"],
+    )
+    np.testing.assert_array_equal(benchmark_output, output)
+    assert benchmark_trace == trace
+
+
+def test_materialized_observation_uses_historical_pixel_digest() -> None:
+    record = sample_record(pixels=_pixels())
+
+    assert record["observation_pixel_digest"] == pixel_digest(record["pixels"])
+    item = MaterializedObservationDTO.from_record(record)
+
+    assert item.matrix_blob is not None
+    assert item.observation.observation_pixel_digest == pixel_digest(record["pixels"])
+    assert (
+        pixel_digest_from_bytes(item.matrix_blob.data)
+        == record["observation_pixel_digest"]
+    )
+    assert (
+        item.to_record(include_pixels=False)["observation_pixel_digest"]
+        == record["observation_pixel_digest"]
+    )

--- a/zeromodel/domains/video_action_set/contracts.py
+++ b/zeromodel/domains/video_action_set/contracts.py
@@ -13,6 +13,7 @@ REACHABILITY_TILE_DIGEST = (
 )
 REACHABILITY_TILE_VERSION = "zeromodel-video-policy-reachability-tile/v1"
 SEED_DERIVATION_VERSION = "zeromodel-video-action-set-seed-derivation/v1"
+TRANSFORMATION_FAMILY_VERSION = "zeromodel-video-action-set-transformation-family/v1"
 
 __all__ = [
     "BENCHMARK_VERSION",
@@ -24,4 +25,5 @@ __all__ = [
     "REACHABILITY_TILE_DIGEST",
     "REACHABILITY_TILE_VERSION",
     "SEED_DERIVATION_VERSION",
+    "TRANSFORMATION_FAMILY_VERSION",
 ]

--- a/zeromodel/domains/video_action_set/observation_materialization.py
+++ b/zeromodel/domains/video_action_set/observation_materialization.py
@@ -87,10 +87,11 @@ def blob_from_record(
     pixels = record.get("pixels")
     if pixels is None:
         return None
-    if pixel_digest is None or array_digest(pixels) != pixel_digest:
+    normalized_pixels = np.ascontiguousarray(pixels, dtype=np.uint8)
+    if pixel_digest is None or array_digest(normalized_pixels) != pixel_digest:
         raise VPMValidationError("observation pixel digest mismatch")
     return MatrixBlob.from_array(
-        np.ascontiguousarray(pixels, dtype=np.uint8),
+        normalized_pixels,
         dtype="uint8",
         metadata={
             "kind": "video_action_set_frame_pixels",

--- a/zeromodel/domains/video_action_set/observation_materialization.py
+++ b/zeromodel/domains/video_action_set/observation_materialization.py
@@ -11,6 +11,7 @@ from ...artifact import VPMValidationError
 from ...matrix_blob import MatrixBlob
 from .canonical_json import canonical_json_bytes
 from .contracts import FRAME_SHAPE
+from .pixel_digest import array_digest, pixel_digest_from_bytes
 
 _record_loader: Callable[[Mapping[str, object]], "MaterializedObservationDTO"] | None
 _record_loader = None
@@ -58,7 +59,7 @@ def validate_observation_matrix_blob(
         raise VPMValidationError(
             "observation matrix blob does not match declared pixels"
         )
-    if _pixel_digest_from_bytes(blob.data) != observation.observation_pixel_digest:
+    if pixel_digest_from_bytes(blob.data) != observation.observation_pixel_digest:
         raise VPMValidationError(
             "observation matrix blob does not match declared pixels"
         )
@@ -86,7 +87,7 @@ def blob_from_record(
     pixels = record.get("pixels")
     if pixels is None:
         return None
-    if pixel_digest is None or _pixel_digest_from_array(pixels) != pixel_digest:
+    if pixel_digest is None or array_digest(pixels) != pixel_digest:
         raise VPMValidationError("observation pixel digest mismatch")
     return MatrixBlob.from_array(
         np.ascontiguousarray(pixels, dtype=np.uint8),
@@ -103,16 +104,6 @@ def register_materialized_observation_loader(
 ) -> None:
     global _record_loader
     _record_loader = loader
-
-
-def _pixel_digest_from_bytes(data: bytes) -> str:
-    return "sha256:" + hashlib.sha256(data).hexdigest()
-
-
-def _pixel_digest_from_array(pixels: object) -> str:
-    return _pixel_digest_from_bytes(
-        np.ascontiguousarray(pixels, dtype=np.uint8).tobytes(order="C")
-    )
 
 
 def _provider_raw_digest(blob: MatrixBlob) -> str:

--- a/zeromodel/domains/video_action_set/pixel_digest.py
+++ b/zeromodel/domains/video_action_set/pixel_digest.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+
+from ...artifact import VPMValidationError
+
+
+def pixel_digest_from_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def pixel_digest(pixels: object | None) -> str | None:
+    if pixels is None:
+        return None
+    return pixel_digest_from_bytes(np.ascontiguousarray(pixels).tobytes(order="C"))
+
+
+def array_digest(pixels: object) -> str:
+    digest = pixel_digest(pixels)
+    if digest is None:
+        raise VPMValidationError("array digest requires pixels")
+    return digest
+
+
+__all__ = ["array_digest", "pixel_digest", "pixel_digest_from_bytes"]

--- a/zeromodel/domains/video_action_set/pixel_digest.py
+++ b/zeromodel/domains/video_action_set/pixel_digest.py
@@ -1,3 +1,9 @@
+"""Historical SHA-256 identity over contiguous array bytes.
+
+This helper preserves the supplied array dtype. Callers whose contracts declare
+uint8 pixels must normalize to uint8 before invoking it.
+"""
+
 from __future__ import annotations
 
 import hashlib

--- a/zeromodel/domains/video_action_set/transformations.py
+++ b/zeromodel/domains/video_action_set/transformations.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+from ...artifact import VPMValidationError
+from .canonical_json import canonical_json_value, canonical_sha256
+from .contracts import FRAME_SHAPE, TRANSFORMATION_FAMILY_VERSION
+from .pixel_digest import array_digest
+
+
+def _transformation_contract() -> dict[str, Any]:
+    return {
+        "version": TRANSFORMATION_FAMILY_VERSION,
+        "families": {
+            "exact": {
+                "classification": "valid",
+                "dx": [0, 0],
+                "dy": [0, 0],
+                "scale_percent": [100, 100],
+                "offset": [0, 0],
+                "occlusion": False,
+            },
+            "bounded_translation": {
+                "classification": "valid",
+                "dx": [-1, 1],
+                "dy": [-1, 1],
+                "scale_percent": [100, 100],
+                "offset": [0, 0],
+                "occlusion": False,
+            },
+            "bounded_photometric": {
+                "classification": "valid",
+                "dx": [0, 0],
+                "dy": [0, 0],
+                "scale_percent": [90, 105],
+                "offset": [0, 5],
+                "occlusion": False,
+            },
+            "bounded_translation_photometric": {
+                "classification": "valid",
+                "dx": [-1, 1],
+                "dy": [-1, 1],
+                "scale_percent": [90, 105],
+                "offset": [0, 5],
+                "occlusion": False,
+            },
+            "bounded_translation_occlusion": {
+                "classification": "valid",
+                "dx": [-1, 1],
+                "dy": [-1, 1],
+                "scale_percent": [100, 100],
+                "offset": [0, 0],
+                "occlusion": True,
+            },
+            "compound_bounded": {
+                "classification": "valid",
+                "dx": [-1, 1],
+                "dy": [-1, 1],
+                "scale_percent": [90, 105],
+                "offset": [0, 5],
+                "occlusion": True,
+            },
+        },
+        "occlusion_bounds": {
+            "top": [0, 2],
+            "left": [0, 2],
+            "height": 2,
+            "width": 3,
+            "value": 64,
+        },
+    }
+
+
+def _translation_values_for_seed(seed: int) -> tuple[int, int]:
+    rng = random.Random(int(seed))
+    return int(rng.choice((-1, 0, 1))), int(rng.choice((-1, 0, 1)))
+
+
+def _transformation_parameters(family: str, seed: int) -> dict[str, Any]:
+    contract = _transformation_contract()["families"]
+    if family not in contract:
+        raise VPMValidationError("unsupported transformation family")
+    rng = random.Random(int(seed))
+    spec = contract[family]
+    dx = dy = 0
+    if spec["dx"] != [0, 0] or spec["dy"] != [0, 0]:
+        dx, dy = _translation_values_for_seed(seed)
+    scale_percent = int(spec["scale_percent"][0])
+    offset = int(spec["offset"][0])
+    if spec["scale_percent"][0] != spec["scale_percent"][1]:
+        scale_percent = 90 + rng.randint(0, 15)
+    if spec["offset"][0] != spec["offset"][1]:
+        offset = rng.randint(0, 5)
+    params: dict[str, Any] = {
+        "version": TRANSFORMATION_FAMILY_VERSION,
+        "family": family,
+        "seed": int(seed),
+        "dx": dx,
+        "dy": dy,
+        "scale_percent": scale_percent,
+        "offset": offset,
+        "occlusion": None,
+    }
+    if bool(spec["occlusion"]):
+        occlusion = _transformation_contract()["occlusion_bounds"]
+        params["occlusion"] = {
+            "top": rng.randint(int(occlusion["top"][0]), int(occlusion["top"][1])),
+            "left": rng.randint(
+                int(occlusion["left"][0]),
+                int(occlusion["left"][1]),
+            ),
+            "height": int(occlusion["height"]),
+            "width": int(occlusion["width"]),
+            "value": int(occlusion["value"]),
+        }
+    params["parameter_digest"] = canonical_sha256(
+        {key: value for key, value in params.items() if key != "parameter_digest"}
+    )
+    return params
+
+
+def _validate_transformation_parameters(
+    params: Mapping[str, Any],
+    *,
+    image_shape: tuple[int, int] = FRAME_SHAPE,
+) -> None:
+    family = str(params["family"])
+    contract = _transformation_contract()
+    if family not in contract["families"]:
+        raise VPMValidationError("unsupported transformation family")
+    spec = contract["families"][family]
+    dx = int(params["dx"])
+    dy = int(params["dy"])
+    scale_percent = int(params["scale_percent"])
+    offset = int(params["offset"])
+    if not (int(spec["dx"][0]) <= dx <= int(spec["dx"][1])):
+        raise VPMValidationError("transformation dx out of bounds")
+    if not (int(spec["dy"][0]) <= dy <= int(spec["dy"][1])):
+        raise VPMValidationError("transformation dy out of bounds")
+    if not (
+        int(spec["scale_percent"][0]) <= scale_percent <= int(spec["scale_percent"][1])
+    ):
+        raise VPMValidationError("transformation scale out of bounds")
+    if not (int(spec["offset"][0]) <= offset <= int(spec["offset"][1])):
+        raise VPMValidationError("transformation offset out of bounds")
+    if bool(spec["occlusion"]):
+        occlusion = params.get("occlusion")
+        if not isinstance(occlusion, Mapping):
+            raise VPMValidationError("occlusion parameters required")
+        top = int(occlusion["top"])
+        left = int(occlusion["left"])
+        height = int(occlusion["height"])
+        width = int(occlusion["width"])
+        value = int(occlusion["value"])
+        bounds = contract["occlusion_bounds"]
+        if not (int(bounds["top"][0]) <= top <= int(bounds["top"][1])):
+            raise VPMValidationError("occlusion top out of bounds")
+        if not (int(bounds["left"][0]) <= left <= int(bounds["left"][1])):
+            raise VPMValidationError("occlusion left out of bounds")
+        if (
+            height != int(bounds["height"])
+            or width != int(bounds["width"])
+            or value != int(bounds["value"])
+        ):
+            raise VPMValidationError("occlusion dimensions or value out of bounds")
+        if top + height > image_shape[0] or left + width > image_shape[1]:
+            raise VPMValidationError("occlusion exceeds image bounds")
+    elif params.get("occlusion") is not None:
+        raise VPMValidationError(
+            "occlusion parameters supplied for non-occlusion family"
+        )
+    expected = canonical_sha256(
+        {
+            key: canonical_json_value(value)
+            for key, value in params.items()
+            if key != "parameter_digest"
+        }
+    )
+    if str(params.get("parameter_digest")) != expected:
+        raise VPMValidationError("foreign transformation parameter digest")
+
+
+def _apply_transformation(
+    frame: np.ndarray,
+    params: Mapping[str, Any],
+) -> tuple[np.ndarray, dict[str, Any]]:
+    source = np.ascontiguousarray(frame, dtype=np.uint8)
+    _validate_transformation_parameters(params, image_shape=tuple(source.shape))
+    result = np.array(source, copy=True)
+    dx = int(params["dx"])
+    dy = int(params["dy"])
+    if dx or dy:
+        translated = np.full_like(result, 0)
+        h, w = result.shape
+        x0, x1 = max(0, dx), min(w, w + dx)
+        y0, y1 = max(0, dy), min(h, h + dy)
+        if x1 > x0 and y1 > y0:
+            translated[y0:y1, x0:x1] = result[
+                y0 - dy : y1 - dy,
+                x0 - dx : x1 - dx,
+            ]
+        result = translated
+    if int(params["scale_percent"]) != 100 or int(params["offset"]) != 0:
+        result = np.clip(
+            np.round(result.astype(np.float32) * (int(params["scale_percent"]) / 100.0))
+            + int(params["offset"]),
+            0,
+            255,
+        ).astype(np.uint8)
+    if params.get("occlusion") is not None:
+        occlusion = params["occlusion"]
+        top = int(occlusion["top"])
+        left = int(occlusion["left"])
+        height = int(occlusion["height"])
+        width = int(occlusion["width"])
+        result[top : top + height, left : left + width] = int(occlusion["value"])
+    result = np.ascontiguousarray(result, dtype=np.uint8)
+    source_digest = array_digest(source)
+    output_digest = array_digest(result)
+    return result, {
+        "source_observation_digest": source_digest,
+        "transformed_observation_digest": output_digest,
+        "transformation_parameter_digest": params["parameter_digest"],
+        "changed_pixel_count": int(np.count_nonzero(source != result)),
+    }
+
+
+__all__ = [
+    "_apply_transformation",
+    "_transformation_contract",
+    "_transformation_parameters",
+    "_translation_values_for_seed",
+    "_validate_transformation_parameters",
+]

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import random
 import time
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -22,6 +21,7 @@ from .domains.video_action_set.contracts import (
     REACHABILITY_TILE_DIGEST,
     REACHABILITY_TILE_VERSION,
     SEED_DERIVATION_VERSION,
+    TRANSFORMATION_FAMILY_VERSION,
 )
 from .domains.video_action_set.dto import BenchmarkIdentityDTO, EpisodePlanDTO
 from .domains.video_action_set.observation_legacy_adapters import (
@@ -30,6 +30,17 @@ from .domains.video_action_set.observation_legacy_adapters import (
 )
 from .domains.video_action_set.observation_provenance_dto import (
     ObservationOperationChainDTO,
+)
+from .domains.video_action_set.pixel_digest import (
+    array_digest as _array_digest,
+    pixel_digest as _pixel_digest,
+)
+from .domains.video_action_set.transformations import (
+    _apply_transformation,
+    _transformation_contract,
+    _transformation_parameters,
+    _translation_values_for_seed,
+    _validate_transformation_parameters,
 )
 from .policy_lookup import VPMPolicyLookup
 from .runtime import build_runtime
@@ -59,7 +70,6 @@ from .visual_address import IMAGE_OBSERVATION_VERSION, ImageObservation
 
 EPISODE_SCHEMA_VERSION = "zeromodel-video-policy-episode/v1"
 EPISODE_FAMILY_REGISTRY_VERSION = "zeromodel-video-action-set-episode-family-registry/v4"
-TRANSFORMATION_FAMILY_VERSION = "zeromodel-video-action-set-transformation-family/v1"
 CRITICAL_COORDINATE_SET_VERSION = "zeromodel-video-action-set-critical-coordinate-set/v1"
 REACHABILITY_COMPOSITION_VERSION = "zeromodel-video-action-set-reachability-composition/v1"
 REACHABILITY_TRACE_VERSION = "zeromodel-video-action-set-reachability-trace/v1"
@@ -150,40 +160,12 @@ def _provider_version(provider_id: str) -> str:
     }[provider_id]
 
 
-def _pixel_digest(pixels: np.ndarray | None) -> str | None:
-    if pixels is None:
-        return None
-    return "sha256:" + hashlib.sha256(np.ascontiguousarray(pixels).tobytes(order="C")).hexdigest()
-
-
-def _array_digest(pixels: np.ndarray) -> str:
-    digest = _pixel_digest(pixels)
-    if digest is None:
-        raise VPMValidationError("array digest requires pixels")
-    return digest
-
-
 def _coordinate_set_digest(coordinates: Sequence[Sequence[int]]) -> str:
     return _sha256({"coordinates": [[int(y), int(x)] for y, x in coordinates]})
 
 
 def _load_reachability_tile(repo_root: Path) -> dict[str, Any]:
     return _read_json(repo_root / "docs" / "results" / "video-policy-reachability-tile-v1" / "reachability-tile.json")
-
-
-def _transformation_contract() -> dict[str, Any]:
-    return {
-        "version": TRANSFORMATION_FAMILY_VERSION,
-        "families": {
-            "exact": {"classification": "valid", "dx": [0, 0], "dy": [0, 0], "scale_percent": [100, 100], "offset": [0, 0], "occlusion": False},
-            "bounded_translation": {"classification": "valid", "dx": [-1, 1], "dy": [-1, 1], "scale_percent": [100, 100], "offset": [0, 0], "occlusion": False},
-            "bounded_photometric": {"classification": "valid", "dx": [0, 0], "dy": [0, 0], "scale_percent": [90, 105], "offset": [0, 5], "occlusion": False},
-            "bounded_translation_photometric": {"classification": "valid", "dx": [-1, 1], "dy": [-1, 1], "scale_percent": [90, 105], "offset": [0, 5], "occlusion": False},
-            "bounded_translation_occlusion": {"classification": "valid", "dx": [-1, 1], "dy": [-1, 1], "scale_percent": [100, 100], "offset": [0, 0], "occlusion": True},
-            "compound_bounded": {"classification": "valid", "dx": [-1, 1], "dy": [-1, 1], "scale_percent": [90, 105], "offset": [0, 5], "occlusion": True},
-        },
-        "occlusion_bounds": {"top": [0, 2], "left": [0, 2], "height": 2, "width": 3, "value": 64},
-    }
 
 
 def _episode_family_registry() -> dict[str, Any]:
@@ -321,126 +303,6 @@ def _family_contract(family_label: str, mutation_kind: str | None) -> dict[str, 
         if entry["family_id"] == family_id:
             return dict(entry)
     raise VPMValidationError("unknown episode family")
-
-
-def _translation_values_for_seed(seed: int) -> tuple[int, int]:
-    rng = random.Random(int(seed))
-    return int(rng.choice((-1, 0, 1))), int(rng.choice((-1, 0, 1)))
-
-
-def _transformation_parameters(family: str, seed: int) -> dict[str, Any]:
-    contract = _transformation_contract()["families"]
-    if family not in contract:
-        raise VPMValidationError("unsupported transformation family")
-    rng = random.Random(int(seed))
-    spec = contract[family]
-    dx = dy = 0
-    if spec["dx"] != [0, 0] or spec["dy"] != [0, 0]:
-        dx, dy = _translation_values_for_seed(seed)
-    scale_percent = int(spec["scale_percent"][0])
-    offset = int(spec["offset"][0])
-    if spec["scale_percent"][0] != spec["scale_percent"][1]:
-        scale_percent = 90 + rng.randint(0, 15)
-    if spec["offset"][0] != spec["offset"][1]:
-        offset = rng.randint(0, 5)
-    params: dict[str, Any] = {
-        "version": TRANSFORMATION_FAMILY_VERSION,
-        "family": family,
-        "seed": int(seed),
-        "dx": dx,
-        "dy": dy,
-        "scale_percent": scale_percent,
-        "offset": offset,
-        "occlusion": None,
-    }
-    if bool(spec["occlusion"]):
-        occlusion = _transformation_contract()["occlusion_bounds"]
-        params["occlusion"] = {
-            "top": rng.randint(int(occlusion["top"][0]), int(occlusion["top"][1])),
-            "left": rng.randint(int(occlusion["left"][0]), int(occlusion["left"][1])),
-            "height": int(occlusion["height"]),
-            "width": int(occlusion["width"]),
-            "value": int(occlusion["value"]),
-        }
-    params["parameter_digest"] = _sha256({key: value for key, value in params.items() if key != "parameter_digest"})
-    return params
-
-
-def _validate_transformation_parameters(params: Mapping[str, Any], *, image_shape: tuple[int, int] = FRAME_SHAPE) -> None:
-    family = str(params["family"])
-    contract = _transformation_contract()
-    if family not in contract["families"]:
-        raise VPMValidationError("unsupported transformation family")
-    spec = contract["families"][family]
-    dx = int(params["dx"])
-    dy = int(params["dy"])
-    scale_percent = int(params["scale_percent"])
-    offset = int(params["offset"])
-    if not (int(spec["dx"][0]) <= dx <= int(spec["dx"][1])):
-        raise VPMValidationError("transformation dx out of bounds")
-    if not (int(spec["dy"][0]) <= dy <= int(spec["dy"][1])):
-        raise VPMValidationError("transformation dy out of bounds")
-    if not (int(spec["scale_percent"][0]) <= scale_percent <= int(spec["scale_percent"][1])):
-        raise VPMValidationError("transformation scale out of bounds")
-    if not (int(spec["offset"][0]) <= offset <= int(spec["offset"][1])):
-        raise VPMValidationError("transformation offset out of bounds")
-    if bool(spec["occlusion"]):
-        occlusion = params.get("occlusion")
-        if not isinstance(occlusion, Mapping):
-            raise VPMValidationError("occlusion parameters required")
-        top = int(occlusion["top"])
-        left = int(occlusion["left"])
-        height = int(occlusion["height"])
-        width = int(occlusion["width"])
-        value = int(occlusion["value"])
-        bounds = contract["occlusion_bounds"]
-        if not (int(bounds["top"][0]) <= top <= int(bounds["top"][1])):
-            raise VPMValidationError("occlusion top out of bounds")
-        if not (int(bounds["left"][0]) <= left <= int(bounds["left"][1])):
-            raise VPMValidationError("occlusion left out of bounds")
-        if height != int(bounds["height"]) or width != int(bounds["width"]) or value != int(bounds["value"]):
-            raise VPMValidationError("occlusion dimensions or value out of bounds")
-        if top + height > image_shape[0] or left + width > image_shape[1]:
-            raise VPMValidationError("occlusion exceeds image bounds")
-    elif params.get("occlusion") is not None:
-        raise VPMValidationError("occlusion parameters supplied for non-occlusion family")
-    expected = _sha256({key: _json_ready(value) for key, value in params.items() if key != "parameter_digest"})
-    if str(params.get("parameter_digest")) != expected:
-        raise VPMValidationError("foreign transformation parameter digest")
-
-
-def _apply_transformation(frame: np.ndarray, params: Mapping[str, Any]) -> tuple[np.ndarray, dict[str, Any]]:
-    source = np.ascontiguousarray(frame, dtype=np.uint8)
-    _validate_transformation_parameters(params, image_shape=tuple(source.shape))
-    result = np.array(source, copy=True)
-    dx = int(params["dx"])
-    dy = int(params["dy"])
-    if dx or dy:
-        translated = np.full_like(result, 0)
-        h, w = result.shape
-        x0, x1 = max(0, dx), min(w, w + dx)
-        y0, y1 = max(0, dy), min(h, h + dy)
-        if x1 > x0 and y1 > y0:
-            translated[y0:y1, x0:x1] = result[y0 - dy : y1 - dy, x0 - dx : x1 - dx]
-        result = translated
-    if int(params["scale_percent"]) != 100 or int(params["offset"]) != 0:
-        result = np.clip(np.round(result.astype(np.float32) * (int(params["scale_percent"]) / 100.0)) + int(params["offset"]), 0, 255).astype(np.uint8)
-    if params.get("occlusion") is not None:
-        occlusion = params["occlusion"]
-        top = int(occlusion["top"])
-        left = int(occlusion["left"])
-        height = int(occlusion["height"])
-        width = int(occlusion["width"])
-        result[top : top + height, left : left + width] = int(occlusion["value"])
-    result = np.ascontiguousarray(result, dtype=np.uint8)
-    source_digest = _array_digest(source)
-    output_digest = _array_digest(result)
-    return result, {
-        "source_observation_digest": source_digest,
-        "transformed_observation_digest": output_digest,
-        "transformation_parameter_digest": params["parameter_digest"],
-        "changed_pixel_count": int(np.count_nonzero(source != result)),
-    }
 
 
 BenchmarkIdentity = BenchmarkIdentityDTO


### PR DESCRIPTION
## Summary

- Extract deterministic video transformation mechanics into `zeromodel.domains.video_action_set.transformations`.
- Extract historical raw-pixel digest helpers into `zeromodel.domains.video_action_set.pixel_digest`.
- Keep the legacy benchmark private facade names available and lower its quality ceiling from 5950 to 5812 lines.
- Add focused golden tests for contract payloads, parameter digests, output bytes, digest behavior, and legacy facade compatibility.
- Preserve the historical record-materialization boundary by normalizing record pixels to contiguous `uint8` before digest validation and MatrixBlob construction.

Audit-Exempt: behavior-preserving extraction of deterministic video
transformation mechanics and historical raw-pixel digest helpers.
No scientific semantics, identities, schemas, version strings, digest
behavior, observation universes, benchmark evidence, or conclusions changed.

## Validation

- `python -m pytest -q tests/test_video_transformation_kernel.py tests/test_video_observation_rmdto.py` - 34 passed in 0.48s
- `python scripts/check_architecture.py` - passed
- `python scripts/check_quality.py` - passed
- `python scripts/run_fast_tests.py` - passed in 25.55s
- `python -m build` - passed; existing setuptools license deprecation warnings only

Integration tests were not run per Stage 3A scope.
