### PR TITLE
refactor: extract canonical and valid observation universes

### DIFF
--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -9,7 +9,7 @@ maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
 reason = "Stage 3 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 5812
+maximum_lines = 5614
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -12,8 +12,16 @@ VIDEO_ACTION_SET_BENCHMARK_MODULE = "zeromodel.video_action_set_benchmark"
 DOMAIN_VIDEO_ACTION_SET_PREFIX = "zeromodel.domains.video_action_set"
 DB_ORM_PREFIX = "zeromodel.db.orm"
 DB_STORES_PREFIX = "zeromodel.db.stores"
+ARCADE_OBSERVATION_MODULE = "zeromodel.domains.video_action_set.arcade_observation"
+OBSERVATION_UNIVERSE_MODULE = "zeromodel.domains.video_action_set.observation_universe"
 PIXEL_DIGEST_MODULE = "zeromodel.domains.video_action_set.pixel_digest"
 TRANSFORMATIONS_MODULE = "zeromodel.domains.video_action_set.transformations"
+VIDEO_OBSERVATION_KERNEL_MODULES = {
+    ARCADE_OBSERVATION_MODULE,
+    OBSERVATION_UNIVERSE_MODULE,
+    PIXEL_DIGEST_MODULE,
+    TRANSFORMATIONS_MODULE,
+}
 VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
     "zeromodel.domains.video_action_set.episode_plan_service",
     "zeromodel.domains.video_action_set.identity_service",
@@ -23,6 +31,7 @@ VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
     "zeromodel.runtime",
 }
 VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
+    ARCADE_OBSERVATION_MODULE,
     "zeromodel.domains.video_action_set.canonical_json",
     "zeromodel.domains.video_action_set.contracts",
     "zeromodel.domains.video_action_set.dto",
@@ -33,6 +42,7 @@ VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
     "zeromodel.domains.video_action_set.observation_materialization",
     "zeromodel.domains.video_action_set.observation_provenance_dto",
     "zeromodel.domains.video_action_set.observation_service",
+    OBSERVATION_UNIVERSE_MODULE,
     PIXEL_DIGEST_MODULE,
     "zeromodel.domains.video_action_set.provider_observation_dto",
     TRANSFORMATIONS_MODULE,
@@ -364,7 +374,37 @@ def transformation_kernel_forbidden_edge_violations(
                 edge,
             )
         )
-    if edge.importer in {PIXEL_DIGEST_MODULE, TRANSFORMATIONS_MODULE} and (
+    if edge.importer == PIXEL_DIGEST_MODULE and edge.imported in {
+        ARCADE_OBSERVATION_MODULE,
+        OBSERVATION_UNIVERSE_MODULE,
+    }:
+        violations.append(
+            edge_violation(
+                "pixel_digest must not import arcade_observation or observation_universe",
+                edge,
+            )
+        )
+    if edge.importer == TRANSFORMATIONS_MODULE and edge.imported in {
+        ARCADE_OBSERVATION_MODULE,
+        OBSERVATION_UNIVERSE_MODULE,
+    }:
+        violations.append(
+            edge_violation(
+                "transformations must not import arcade_observation or observation_universe",
+                edge,
+            )
+        )
+    if (
+        edge.importer == ARCADE_OBSERVATION_MODULE
+        and edge.imported == OBSERVATION_UNIVERSE_MODULE
+    ):
+        violations.append(
+            edge_violation(
+                "arcade_observation must not import observation_universe",
+                edge,
+            )
+        )
+    if edge.importer in VIDEO_OBSERVATION_KERNEL_MODULES and (
         is_module_under(edge.imported, DB_ORM_PREFIX)
         or is_module_under(edge.imported, DB_STORES_PREFIX)
         or is_module_under(edge.imported, "zeromodel.db.session")
@@ -374,16 +414,16 @@ def transformation_kernel_forbidden_edge_violations(
     ):
         violations.append(
             edge_violation(
-                "video transformation kernel modules must not import persistence or runtime layers",
+                "video observation kernel modules must not import persistence or runtime layers",
                 edge,
             )
         )
-    if edge.importer == TRANSFORMATIONS_MODULE and (
-        edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+    if edge.importer in VIDEO_OBSERVATION_KERNEL_MODULES and edge.imported == (
+        VIDEO_ACTION_SET_BENCHMARK_MODULE
     ):
         violations.append(
             edge_violation(
-                "transformations must not import legacy benchmark facade",
+                "video observation kernel modules must not import legacy benchmark facade",
                 edge,
             )
         )

--- a/tests/test_video_observation_universe_kernel.py
+++ b/tests/test_video_observation_universe_kernel.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import numpy as np
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.arcade_policy import ShooterConfig, compile_policy_artifact
+from zeromodel.domains.video_action_set import arcade_observation
+from zeromodel.domains.video_action_set import observation_universe as universe
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+from zeromodel.domains.video_action_set.contracts import (
+    ARCADE_RENDERER_CONTRACT_VERSION,
+    ARCADE_RENDERER_IDENTITY_VERSION,
+    CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+    FRAME_SHAPE,
+    TRANSFORMATION_FAMILY_VERSION,
+    VALID_OBSERVATION_UNIVERSE_VERSION,
+    VALID_TRANSFORMATION_PARAMETER_UNIVERSE_VERSION,
+)
+from zeromodel.domains.video_action_set.pixel_digest import array_digest
+from zeromodel.visual_address import ImageObservation
+
+
+DEFAULT_CONFIG_PAYLOAD = {"width": 7, "wave": [0, 6, 1, 5], "max_steps": 32}
+DEFAULT_CONFIG_DIGEST = (
+    "sha256:9189c6aab306713893497c99f190ab9d6c84392033a628db0a96b371af9dbddd"
+)
+CUSTOM_CONFIG = ShooterConfig(width=5, wave=(4, 2, 0), max_steps=9)
+CUSTOM_CONFIG_PAYLOAD = {"width": 5, "wave": [4, 2, 0], "max_steps": 9}
+CUSTOM_CONFIG_DIGEST = (
+    "sha256:c38ddd39e4e5f24c35d1b4f23589a46f3859938c783f6a1cf0dfa81720e508c0"
+)
+
+DEFAULT_RENDERER_IDENTITY = {
+    "version": "zeromodel-arcade-shooter-renderer-identity/v1",
+    "function": "zeromodel.arcade_policy.render_state_frame",
+    "frame_shape": [16, 28],
+    "cell_pixels": 4,
+    "target_value": 220,
+    "tank_value": 255,
+    "cooldown_ready_value": 40,
+    "cooldown_blocked_value": 160,
+    "config": DEFAULT_CONFIG_PAYLOAD,
+    "renderer_identity_digest": (
+        "sha256:a08e75ed50d080b6944a9caf5e64674f3c3cb91c91aab1d8679d93ee2f121c16"
+    ),
+}
+CUSTOM_RENDERER_DIGEST = (
+    "sha256:2ef9610c1918d15a2303fcc9502dbf72275632ebe87ae2d3174e51fd26b52f72"
+)
+
+ROW_FRAME_DIGESTS = {
+    "tank=0|target=0|cooldown=0": (
+        "sha256:49e46341a170608e2bf8db63064e3d2235727a64ceddafa0cf9970c2707fe443"
+    ),
+    "tank=0|target=none|cooldown=0": (
+        "sha256:76d6b55ab164806fa6d621e669de37b60b9cbd8f8fff2bbb610b6b0e034461f0"
+    ),
+    "tank=0|target=0|cooldown=1": (
+        "sha256:fbd8cdf59131334bec00f39063847f869da54f963f81ac6c0b8c9e36c8a23df6"
+    ),
+    "tank=6|target=6|cooldown=0": (
+        "sha256:63280c3c42468851dfe637431e33721faefaa30924a1fcf7bdf8aba4b38859bf"
+    ),
+    "tank=6|target=none|cooldown=1": (
+        "sha256:7b71bf932b093ad9b6ebebb1ef50e8a43cda8ca35e5640f1edffe756f5ab71f5"
+    ),
+}
+
+SELECTED_PROTOTYPES = {
+    "prototype:tank=0|target=none|cooldown=0": (
+        "tank=0|target=none|cooldown=0",
+        "STAY",
+        "sha256:3e3dc2d6661c710405e00ee6448c3966fa27a875ab7430d00f6bad2ab358d668",
+        "sha256:76d6b55ab164806fa6d621e669de37b60b9cbd8f8fff2bbb610b6b0e034461f0",
+    ),
+    "prototype:tank=0|target=none|cooldown=1": (
+        "tank=0|target=none|cooldown=1",
+        "STAY",
+        "sha256:ae08a24f369ba051a162349c04962dc1948a0c8901f726564ebd9ade70d365a7",
+        "sha256:6170d693f571210bb02918cb4dba8be19dcc91ad842383e3c531fd7f2210bb2f",
+    ),
+    "prototype:tank=6|target=6|cooldown=0": (
+        "tank=6|target=6|cooldown=0",
+        "FIRE",
+        "sha256:34f49182fe9701b001821e903af4b278ded06c741f659100c23e33e372f29f8d",
+        "sha256:63280c3c42468851dfe637431e33721faefaa30924a1fcf7bdf8aba4b38859bf",
+    ),
+    "prototype:tank=6|target=6|cooldown=1": (
+        "tank=6|target=6|cooldown=1",
+        "STAY",
+        "sha256:58ae1f648dfb98fbf9a10d9ff80cdd29eeb289b6eeb0e9a0c7c2e945b6bd0009",
+        "sha256:ed6867cf59a01b51467bc540ce8e7e16474222386c8ceb0f31ad697741f47e8b",
+    ),
+}
+
+CANONICAL_UNIVERSE_DIGEST = (
+    "sha256:8fd3073bb511894d71d369610885e69d796cf686255e240e1407f5f7c7653385"
+)
+SELECTED_CANONICAL_ROWS = [
+    {
+        "prototype_id": "prototype:tank=0|target=none|cooldown=0",
+        "row_id": "tank=0|target=none|cooldown=0",
+        "action_id": "STAY",
+        "image_observation_raw_digest": (
+            "sha256:3e3dc2d6661c710405e00ee6448c3966fa27a875ab7430d00f6bad2ab358d668"
+        ),
+        "observation_pixel_digest": (
+            "sha256:76d6b55ab164806fa6d621e669de37b60b9cbd8f8fff2bbb610b6b0e034461f0"
+        ),
+    },
+    {
+        "prototype_id": "prototype:tank=0|target=none|cooldown=1",
+        "row_id": "tank=0|target=none|cooldown=1",
+        "action_id": "STAY",
+        "image_observation_raw_digest": (
+            "sha256:ae08a24f369ba051a162349c04962dc1948a0c8901f726564ebd9ade70d365a7"
+        ),
+        "observation_pixel_digest": (
+            "sha256:6170d693f571210bb02918cb4dba8be19dcc91ad842383e3c531fd7f2210bb2f"
+        ),
+    },
+    {
+        "prototype_id": "prototype:tank=6|target=6|cooldown=0",
+        "row_id": "tank=6|target=6|cooldown=0",
+        "action_id": "FIRE",
+        "image_observation_raw_digest": (
+            "sha256:34f49182fe9701b001821e903af4b278ded06c741f659100c23e33e372f29f8d"
+        ),
+        "observation_pixel_digest": (
+            "sha256:63280c3c42468851dfe637431e33721faefaa30924a1fcf7bdf8aba4b38859bf"
+        ),
+    },
+    {
+        "prototype_id": "prototype:tank=6|target=6|cooldown=1",
+        "row_id": "tank=6|target=6|cooldown=1",
+        "action_id": "STAY",
+        "image_observation_raw_digest": (
+            "sha256:58ae1f648dfb98fbf9a10d9ff80cdd29eeb289b6eeb0e9a0c7c2e945b6bd0009"
+        ),
+        "observation_pixel_digest": (
+            "sha256:ed6867cf59a01b51467bc540ce8e7e16474222386c8ceb0f31ad697741f47e8b"
+        ),
+    },
+]
+
+FIRST_PARAMETER = {
+    "version": "zeromodel-video-action-set-transformation-family/v1",
+    "family": "compound_bounded",
+    "seed": 0,
+    "dx": 1,
+    "dy": 0,
+    "scale_percent": 97,
+    "offset": 5,
+    "occlusion": {"top": 2, "left": 1, "height": 2, "width": 3, "value": 64},
+    "parameter_digest": (
+        "sha256:3a909e187b05e0fd0298d83e4fdcc62aa000dd6c0531c479b269218def4b7df8"
+    ),
+}
+NON_OCCLUDED_PARAMETER = {
+    "version": "zeromodel-video-action-set-transformation-family/v1",
+    "family": "bounded_translation_photometric",
+    "seed": 0,
+    "dx": 1,
+    "dy": -1,
+    "scale_percent": 92,
+    "offset": 2,
+    "occlusion": None,
+    "parameter_digest": (
+        "sha256:007adfa53503b6d64cca245a64f0a6c3df0e7a10bd0b00360f87c2930032a759"
+    ),
+}
+LAST_PARAMETER = {
+    "version": "zeromodel-video-action-set-transformation-family/v1",
+    "family": "compound_bounded",
+    "seed": 0,
+    "dx": -1,
+    "dy": 1,
+    "scale_percent": 100,
+    "offset": 5,
+    "occlusion": {"top": 2, "left": 1, "height": 2, "width": 3, "value": 64},
+    "parameter_digest": (
+        "sha256:8b5710759ab0d4499e2ee17cedf6bddfd8bd516b2003e1a29294dc079eab01b2"
+    ),
+}
+
+
+def test_shooter_config_payload_is_frozen() -> None:
+    assert arcade_observation.shooter_config_payload() == DEFAULT_CONFIG_PAYLOAD
+    assert canonical_sha256(DEFAULT_CONFIG_PAYLOAD) == DEFAULT_CONFIG_DIGEST
+    assert arcade_observation.shooter_config_payload(CUSTOM_CONFIG) == (
+        CUSTOM_CONFIG_PAYLOAD
+    )
+    assert canonical_sha256(CUSTOM_CONFIG_PAYLOAD) == CUSTOM_CONFIG_DIGEST
+
+
+@pytest.mark.parametrize(("row_id", "digest"), list(ROW_FRAME_DIGESTS.items()))
+def test_render_row_frame_bytes_are_frozen(row_id: str, digest: str) -> None:
+    frame = arcade_observation.render_row_frame(row_id)
+
+    assert frame.shape == FRAME_SHAPE
+    assert frame.dtype == np.uint8
+    assert frame.flags.c_contiguous
+    assert array_digest(frame) == digest
+
+
+def test_renderer_identity_is_frozen_and_config_bound() -> None:
+    assert ARCADE_RENDERER_IDENTITY_VERSION == (
+        "zeromodel-arcade-shooter-renderer-identity/v1"
+    )
+    assert ARCADE_RENDERER_CONTRACT_VERSION == (
+        "zeromodel-arcade-shooter-render-state-frame/v1"
+    )
+    assert arcade_observation.renderer_identity() == DEFAULT_RENDERER_IDENTITY
+    assert (
+        arcade_observation.renderer_identity(CUSTOM_CONFIG)["renderer_identity_digest"]
+        == CUSTOM_RENDERER_DIGEST
+    )
+    assert (
+        arcade_observation.renderer_identity(CUSTOM_CONFIG)["renderer_identity_digest"]
+        != DEFAULT_RENDERER_IDENTITY["renderer_identity_digest"]
+    )
+
+
+def test_canonical_prototypes_are_frozen() -> None:
+    prototypes = universe.canonical_prototypes()
+    keys = list(prototypes)
+
+    assert len(prototypes) == 112
+    assert keys[:3] == [
+        "prototype:tank=0|target=none|cooldown=0",
+        "prototype:tank=0|target=none|cooldown=1",
+        "prototype:tank=0|target=0|cooldown=0",
+    ]
+    assert keys[-3:] == [
+        "prototype:tank=6|target=5|cooldown=1",
+        "prototype:tank=6|target=6|cooldown=0",
+        "prototype:tank=6|target=6|cooldown=1",
+    ]
+    for key, expected in SELECTED_PROTOTYPES.items():
+        row_id, action_id, raw_digest, observation = prototypes[key]
+        assert (row_id, action_id, raw_digest, array_digest(observation.pixels)) == (
+            expected
+        )
+        assert raw_digest != array_digest(observation.pixels)
+
+
+def test_canonical_observation_universe_is_frozen() -> None:
+    payload = universe.canonical_observation_universe()
+
+    assert payload["version"] == CANONICAL_OBSERVATION_UNIVERSE_VERSION
+    assert payload["digest_semantics"] == (
+        "raw rendered uint8 bytes, excluding ImageObservation namespace"
+    )
+    assert payload["frame_shape"] == [16, 28]
+    assert payload["row_count"] == 112
+    assert payload["duplicate_digest_group_count"] == 0
+    assert payload["duplicate_digest_groups"] == []
+    assert payload["universe_digest"] == CANONICAL_UNIVERSE_DIGEST
+    assert [
+        payload["rows"][0],
+        payload["rows"][1],
+        payload["rows"][-2],
+        payload["rows"][-1],
+    ] == (SELECTED_CANONICAL_ROWS)
+    for row in SELECTED_CANONICAL_ROWS:
+        assert payload["digest_to_rows"][row["observation_pixel_digest"]] == [
+            {"row_id": row["row_id"], "action_id": row["action_id"]}
+        ]
+        assert row["image_observation_raw_digest"] != row["observation_pixel_digest"]
+
+
+def test_canonical_universe_preserves_default_call_semantics(monkeypatch) -> None:
+    calls: list[tuple[object, ...]] = []
+    pixels = np.zeros(FRAME_SHAPE, dtype=np.uint8)
+    observation = ImageObservation(pixels, source_id="canonical:test")
+
+    def fake_prototypes(*args: object) -> dict[str, tuple[str, str, str, Any]]:
+        calls.append(args)
+        return {
+            "prototype:test": (
+                "test",
+                "STAY",
+                observation.raw_digest,
+                observation,
+            )
+        }
+
+    monkeypatch.setattr(universe, "canonical_prototypes", fake_prototypes)
+
+    universe.canonical_observation_universe()
+    universe.canonical_observation_universe(CUSTOM_CONFIG)
+
+    assert calls == [(), (CUSTOM_CONFIG,)]
+
+
+def test_parameter_key_includes_only_declared_fields() -> None:
+    base = deepcopy(NON_OCCLUDED_PARAMETER)
+    base_key = universe._valid_transformation_parameter_key(base)
+    base_digest = canonical_sha256(base_key)
+    assert base_key == {
+        "dx": 1,
+        "dy": -1,
+        "scale_percent": 92,
+        "offset": 2,
+        "occlusion": None,
+    }
+    for field, value in {
+        "dx": -1,
+        "dy": 0,
+        "scale_percent": 93,
+        "offset": 3,
+        "occlusion": {"top": 0, "left": 0, "height": 2, "width": 3, "value": 64},
+    }.items():
+        mutated = deepcopy(base)
+        mutated[field] = value
+        assert canonical_sha256(
+            universe._valid_transformation_parameter_key(mutated)
+        ) != (base_digest)
+    for field, value in {
+        "version": "changed-version",
+        "family": "compound_bounded",
+        "seed": 99,
+        "parameter_digest": "sha256:" + "0" * 64,
+    }.items():
+        mutated = deepcopy(base)
+        mutated[field] = value
+        assert universe._valid_transformation_parameter_key(mutated) == base_key
+
+
+def test_valid_transformation_parameter_universe_is_frozen() -> None:
+    payload = universe._valid_transformation_parameter_universe()
+
+    assert payload is universe._valid_transformation_parameter_universe()
+    assert payload["version"] == VALID_TRANSFORMATION_PARAMETER_UNIVERSE_VERSION
+    assert payload["transformation_contract_version"] == TRANSFORMATION_FAMILY_VERSION
+    assert payload["parameter_count"] == 8640
+    assert payload["parameter_universe_digest"] == (
+        "sha256:9fc78f73b196125e2723871f61fe6b5ee9614ac83a5768d91031c4b9b2780ac2"
+    )
+    assert payload["parameters"][0] == FIRST_PARAMETER
+    assert payload["parameters"][21] == NON_OCCLUDED_PARAMETER
+    assert payload["parameters"][-1] == LAST_PARAMETER
+    key_digests = [
+        canonical_sha256(universe._valid_transformation_parameter_key(params))
+        for params in payload["parameters"]
+    ]
+    assert len(key_digests) == len(set(key_digests))
+
+
+def _fake_parameter(index: int) -> dict[str, Any]:
+    return {
+        "version": TRANSFORMATION_FAMILY_VERSION,
+        "family": "bounded_translation_photometric",
+        "seed": 0,
+        "dx": 0,
+        "dy": 0,
+        "scale_percent": 100,
+        "offset": index,
+        "occlusion": None,
+        "parameter_digest": "sha256:" + f"{index:064x}",
+    }
+
+
+def test_transformed_index_mechanics_with_bounded_fixture(monkeypatch) -> None:
+    config = ShooterConfig(width=2, wave=(0,), max_steps=3)
+    params = [_fake_parameter(index) for index in range(22)]
+    canonical = {
+        "rows": [
+            {"row_id": "row:a", "action_id": "LEFT"},
+            {"row_id": "row:b", "action_id": "RIGHT"},
+        ],
+        "digest_to_rows": {
+            "sha256:canonical-a": [{"row_id": "row:a", "action_id": "LEFT"}],
+            "sha256:canonical-b": [{"row_id": "row:b", "action_id": "RIGHT"}],
+        },
+        "universe_digest": "sha256:canonical",
+    }
+    render_calls: list[str] = []
+
+    def fake_render(row_id: str, *, config: ShooterConfig) -> np.ndarray:
+        render_calls.append(row_id)
+        return np.array([[1 if row_id == "row:a" else 2]], dtype=np.uint8)
+
+    def fake_apply(_source: np.ndarray, _params: dict[str, Any]):
+        return np.array([[7]], dtype=np.uint8), {}
+
+    monkeypatch.setattr(
+        universe, "canonical_observation_universe", lambda _config: canonical
+    )
+    monkeypatch.setattr(
+        universe,
+        "_valid_transformation_parameter_universe",
+        lambda: {
+            "parameter_universe_digest": "sha256:params",
+            "parameter_count": len(params),
+            "parameters": params,
+        },
+    )
+    monkeypatch.setattr(universe, "render_row_frame", fake_render)
+    monkeypatch.setattr(universe, "_apply_transformation", fake_apply)
+    monkeypatch.setattr(
+        universe._valid_transformed_observation_digest_index,
+        "_cache",
+        {},
+        raising=False,
+    )
+
+    result = universe._valid_transformed_observation_digest_index(config)
+    summary = result["summary"]
+    output_digest = array_digest(np.array([[7]], dtype=np.uint8))
+    first_provenance = {
+        "row_id": "row:a",
+        "parameter_digest": params[0]["parameter_digest"],
+        "parameter_key_digest": canonical_sha256(
+            universe._valid_transformation_parameter_key(params[0])
+        ),
+    }
+
+    assert result["digest_index"] == {output_digest}
+    assert render_calls == ["row:a", "row:b"]
+    assert summary["version"] == VALID_OBSERVATION_UNIVERSE_VERSION
+    assert summary["policy_artifact_id"] == compile_policy_artifact(config).artifact_id
+    assert summary["renderer_contract_version"] == ARCADE_RENDERER_CONTRACT_VERSION
+    assert summary["renderer_identity"] == arcade_observation.renderer_identity(config)
+    assert summary["shooter_config"] == arcade_observation.shooter_config_payload(
+        config
+    )
+    assert summary["shooter_config_digest"] == canonical_sha256(
+        arcade_observation.shooter_config_payload(config)
+    )
+    assert summary["parameter_universe_digest"] == "sha256:params"
+    assert summary["parameter_universe_count"] == 22
+    assert summary["canonical_universe_digest"] == "sha256:canonical"
+    assert summary["exact_canonical_digest_count"] == 2
+    assert summary["transformed_valid_digest_count"] == 1
+    assert summary["transformed_valid_output_count"] == 44
+    assert summary["duplicate_transformed_digest_count"] == 43
+    assert len(summary["duplicate_transformed_digest_examples"]) == 20
+    assert summary["duplicate_transformed_digest_examples"][0] == {
+        "observation_pixel_digest": output_digest,
+        "first": first_provenance,
+        "duplicate": {
+            "row_id": "row:a",
+            "parameter_digest": params[1]["parameter_digest"],
+            "parameter_key_digest": canonical_sha256(
+                universe._valid_transformation_parameter_key(params[1])
+            ),
+        },
+    }
+    assert summary["transformed_valid_digest_set_digest"] == canonical_sha256(
+        [output_digest]
+    )
+    assert summary["universe_digest"] == canonical_sha256(
+        {key: value for key, value in summary.items() if key != "universe_digest"}
+    )
+    assert universe._valid_transformed_observation_digest_index(config) is result
+
+
+def test_valid_universe_assembly_replaces_inherited_digest(monkeypatch) -> None:
+    canonical = {
+        "version": CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+        "digest_to_rows": {
+            "sha256:canonical-a": [{"row_id": "row:a", "action_id": "LEFT"}]
+        },
+    }
+    transformed_summary = {
+        "version": VALID_OBSERVATION_UNIVERSE_VERSION,
+        "policy_artifact_id": "artifact:test",
+        "universe_digest": "sha256:inherited",
+    }
+
+    monkeypatch.setattr(
+        universe, "canonical_observation_universe", lambda _config: canonical
+    )
+    monkeypatch.setattr(
+        universe,
+        "_valid_transformed_observation_digest_index",
+        lambda _config: {
+            "digest_index": {"sha256:bounded"},
+            "summary": transformed_summary,
+        },
+    )
+
+    payload = universe.valid_observation_universe()
+
+    assert payload["valid_categories"] == [
+        "canonical_exact",
+        "bounded_transformation_family",
+    ]
+    assert (
+        payload["canonical_universe_version"] == CANONICAL_OBSERVATION_UNIVERSE_VERSION
+    )
+    assert payload["exact_canonical_digest_to_rows"] == canonical["digest_to_rows"]
+    assert payload["bounded_transformation_contract_version"] == (
+        TRANSFORMATION_FAMILY_VERSION
+    )
+    assert payload["universe_digest"] != "sha256:inherited"
+    assert payload["universe_digest"] == canonical_sha256(
+        {key: value for key, value in payload.items() if key != "universe_digest"}
+    )
+
+
+def test_canonical_collision_lookup_normalizes_and_returns_copies() -> None:
+    prototype = universe.canonical_prototypes()[
+        "prototype:tank=0|target=none|cooldown=0"
+    ][3]
+    expected = [{"row_id": "tank=0|target=none|cooldown=0", "action_id": "STAY"}]
+
+    assert universe._canonical_collision_rows(prototype.pixels) == expected
+    assert universe._canonical_collision_rows(
+        np.array(prototype.pixels, copy=True)
+    ) == (expected)
+    assert universe._canonical_collision_rows(prototype.pixels.astype(np.int16)) == (
+        expected
+    )
+    assert universe._canonical_collision_rows(prototype.pixels.tolist()) == expected
+    assert universe._canonical_collision_rows(np.zeros_like(prototype.pixels)) == []
+
+    returned = universe._canonical_observation_digest_index()[
+        array_digest(prototype.pixels)
+    ]
+    returned[0]["row_id"] = "mutated"
+    assert universe._canonical_observation_digest_index()[
+        array_digest(prototype.pixels)
+    ] == (expected)
+
+
+def test_legacy_benchmark_facade_exposes_moved_universe_symbols() -> None:
+    assert benchmark._transition_config_payload is (
+        arcade_observation.shooter_config_payload
+    )
+    assert benchmark._render_row_frame is arcade_observation.render_row_frame
+    assert benchmark._renderer_identity is arcade_observation.renderer_identity
+    assert benchmark.canonical_prototypes is universe.canonical_prototypes
+    assert benchmark.canonical_observation_universe is (
+        universe.canonical_observation_universe
+    )
+    assert benchmark.valid_observation_universe is universe.valid_observation_universe
+    assert benchmark._valid_transformation_parameter_key is (
+        universe._valid_transformation_parameter_key
+    )
+    assert benchmark._valid_transformation_parameter_universe is (
+        universe._valid_transformation_parameter_universe
+    )
+    assert benchmark._valid_transformed_observation_digest_index is (
+        universe._valid_transformed_observation_digest_index
+    )
+    assert benchmark._canonical_observation_digest_index is (
+        universe._canonical_observation_digest_index
+    )
+    assert benchmark._canonical_collision_rows is universe._canonical_collision_rows
+    assert benchmark.CANONICAL_OBSERVATION_UNIVERSE_VERSION == (
+        CANONICAL_OBSERVATION_UNIVERSE_VERSION
+    )
+    assert benchmark.VALID_OBSERVATION_UNIVERSE_VERSION == (
+        VALID_OBSERVATION_UNIVERSE_VERSION
+    )
+    assert benchmark._transition_config_payload() == DEFAULT_CONFIG_PAYLOAD
+    assert (
+        array_digest(benchmark._render_row_frame("tank=0|target=0|cooldown=0"))
+        == ROW_FRAME_DIGESTS["tank=0|target=0|cooldown=0"]
+    )

--- a/zeromodel/domains/video_action_set/arcade_observation.py
+++ b/zeromodel/domains/video_action_set/arcade_observation.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from ...arcade_policy import (
+    CELL_PIXELS,
+    COOLDOWN_BLOCKED_VALUE,
+    COOLDOWN_READY_VALUE,
+    TANK_VALUE,
+    TARGET_VALUE,
+    ShooterConfig,
+    parse_state_row_id,
+    render_state_frame,
+)
+from .canonical_json import canonical_sha256
+from .contracts import (
+    ARCADE_RENDERER_IDENTITY_VERSION,
+    FRAME_SHAPE,
+)
+
+
+def shooter_config_payload(
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    return {
+        "width": int(config.width),
+        "wave": [int(item) for item in config.wave],
+        "max_steps": int(config.max_steps),
+    }
+
+
+def render_row_frame(
+    row_id: str,
+    *,
+    config: ShooterConfig = ShooterConfig(),
+) -> np.ndarray:
+    tank, target, cooldown = parse_state_row_id(str(row_id))
+    return render_state_frame(tank, target, cooldown, width=config.width)
+
+
+def renderer_identity(
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    payload = {
+        "version": ARCADE_RENDERER_IDENTITY_VERSION,
+        "function": "zeromodel.arcade_policy.render_state_frame",
+        "frame_shape": list(FRAME_SHAPE),
+        "cell_pixels": int(CELL_PIXELS),
+        "target_value": int(TARGET_VALUE),
+        "tank_value": int(TANK_VALUE),
+        "cooldown_ready_value": int(COOLDOWN_READY_VALUE),
+        "cooldown_blocked_value": int(COOLDOWN_BLOCKED_VALUE),
+        "config": shooter_config_payload(config),
+    }
+    return payload | {"renderer_identity_digest": canonical_sha256(payload)}
+
+
+__all__ = [
+    "render_row_frame",
+    "renderer_identity",
+    "shooter_config_payload",
+]

--- a/zeromodel/domains/video_action_set/contracts.py
+++ b/zeromodel/domains/video_action_set/contracts.py
@@ -1,6 +1,11 @@
 """Identity-owned video action-set contracts."""
 
+ARCADE_RENDERER_CONTRACT_VERSION = "zeromodel-arcade-shooter-render-state-frame/v1"
+ARCADE_RENDERER_IDENTITY_VERSION = "zeromodel-arcade-shooter-renderer-identity/v1"
 BENCHMARK_VERSION = "zeromodel-video-action-set-reachability-benchmark/v1"
+CANONICAL_OBSERVATION_UNIVERSE_VERSION = (
+    "zeromodel-video-action-set-canonical-observation-universe/v1"
+)
 EPISODE_PLAN_VERSION = "zeromodel-video-action-set-sealed-episode-plan/v1"
 FRAME_SHAPE = (16, 28)
 GENERATOR_VERSION = "zeromodel-video-action-set-reachability-generator/v1"
@@ -14,9 +19,18 @@ REACHABILITY_TILE_DIGEST = (
 REACHABILITY_TILE_VERSION = "zeromodel-video-policy-reachability-tile/v1"
 SEED_DERIVATION_VERSION = "zeromodel-video-action-set-seed-derivation/v1"
 TRANSFORMATION_FAMILY_VERSION = "zeromodel-video-action-set-transformation-family/v1"
+VALID_OBSERVATION_UNIVERSE_VERSION = (
+    "zeromodel-video-action-set-valid-observation-universe/v2"
+)
+VALID_TRANSFORMATION_PARAMETER_UNIVERSE_VERSION = (
+    "zeromodel-video-action-set-valid-transformation-parameter-universe/v1"
+)
 
 __all__ = [
+    "ARCADE_RENDERER_CONTRACT_VERSION",
+    "ARCADE_RENDERER_IDENTITY_VERSION",
     "BENCHMARK_VERSION",
+    "CANONICAL_OBSERVATION_UNIVERSE_VERSION",
     "EPISODE_PLAN_VERSION",
     "FRAME_SHAPE",
     "GENERATOR_VERSION",
@@ -26,4 +40,6 @@ __all__ = [
     "REACHABILITY_TILE_VERSION",
     "SEED_DERIVATION_VERSION",
     "TRANSFORMATION_FAMILY_VERSION",
+    "VALID_OBSERVATION_UNIVERSE_VERSION",
+    "VALID_TRANSFORMATION_PARAMETER_UNIVERSE_VERSION",
 ]

--- a/zeromodel/domains/video_action_set/observation_universe.py
+++ b/zeromodel/domains/video_action_set/observation_universe.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+from ...arcade_policy import ACTIONS, ShooterConfig, compile_policy_artifact
+from ...policy_lookup import VPMPolicyLookup
+from ...visual_address import ImageObservation
+from .arcade_observation import (
+    render_row_frame,
+    renderer_identity,
+    shooter_config_payload,
+)
+from .canonical_json import canonical_sha256
+from .contracts import (
+    ARCADE_RENDERER_CONTRACT_VERSION,
+    CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+    FRAME_SHAPE,
+    TRANSFORMATION_FAMILY_VERSION,
+    VALID_OBSERVATION_UNIVERSE_VERSION,
+    VALID_TRANSFORMATION_PARAMETER_UNIVERSE_VERSION,
+)
+from .pixel_digest import array_digest
+from .transformations import _apply_transformation
+
+
+def canonical_prototypes(
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, tuple[str, str, str, ImageObservation]]:
+    policy = compile_policy_artifact(config)
+    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
+    prototypes = {}
+    for row_id in policy.source.row_ids:
+        frame = render_row_frame(str(row_id), config=config)
+        observation = ImageObservation(frame, source_id=f"canonical:{row_id}")
+        prototypes[f"prototype:{row_id}"] = (
+            str(row_id),
+            lookup.choose(str(row_id)),
+            observation.raw_digest,
+            observation,
+        )
+    return prototypes
+
+
+def canonical_observation_universe(
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    digest_to_rows: dict[str, list[dict[str, str]]] = {}
+    prototypes = (
+        canonical_prototypes()
+        if config == ShooterConfig()
+        else canonical_prototypes(config)
+    )
+    for prototype_id, (
+        row_id,
+        action_id,
+        observation_raw_digest,
+        observation,
+    ) in prototypes.items():
+        pixel_digest = array_digest(observation.pixels)
+        entry = {
+            "prototype_id": prototype_id,
+            "row_id": row_id,
+            "action_id": action_id,
+            "image_observation_raw_digest": observation_raw_digest,
+            "observation_pixel_digest": pixel_digest,
+        }
+        rows.append(entry)
+        digest_to_rows.setdefault(pixel_digest, []).append(
+            {"row_id": row_id, "action_id": action_id}
+        )
+    duplicate_groups = [
+        {"observation_pixel_digest": digest, "rows": grouped}
+        for digest, grouped in sorted(digest_to_rows.items())
+        if len(grouped) > 1
+    ]
+    payload = {
+        "version": CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+        "digest_semantics": "raw rendered uint8 bytes, excluding ImageObservation namespace",
+        "frame_shape": list(FRAME_SHAPE),
+        "row_count": len(rows),
+        "rows": rows,
+        "digest_to_rows": digest_to_rows,
+        "duplicate_digest_group_count": len(duplicate_groups),
+        "duplicate_digest_groups": duplicate_groups,
+    }
+    payload["universe_digest"] = canonical_sha256(payload)
+    return payload
+
+
+def _valid_transformation_parameter_key(params: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "dx": int(params["dx"]),
+        "dy": int(params["dy"]),
+        "scale_percent": int(params["scale_percent"]),
+        "offset": int(params["offset"]),
+        "occlusion": None
+        if params.get("occlusion") is None
+        else dict(params["occlusion"]),
+    }
+
+
+def _valid_transformation_parameter_universe() -> dict[str, Any]:
+    if hasattr(_valid_transformation_parameter_universe, "_cache"):
+        return _valid_transformation_parameter_universe._cache  # type: ignore[attr-defined]
+    by_key: dict[str, dict[str, Any]] = {}
+    for dx in range(-1, 2):
+        for dy in range(-1, 2):
+            for scale in range(90, 106):
+                for offset in range(0, 6):
+                    params = {
+                        "version": TRANSFORMATION_FAMILY_VERSION,
+                        "family": "bounded_translation_photometric",
+                        "seed": 0,
+                        "dx": dx,
+                        "dy": dy,
+                        "scale_percent": scale,
+                        "offset": offset,
+                        "occlusion": None,
+                    }
+                    params["parameter_digest"] = canonical_sha256(
+                        {
+                            key: value
+                            for key, value in params.items()
+                            if key != "parameter_digest"
+                        }
+                    )
+                    by_key[
+                        canonical_sha256(_valid_transformation_parameter_key(params))
+                    ] = params
+                    for top in range(0, 3):
+                        for left in range(0, 3):
+                            occluded = dict(params)
+                            occluded["family"] = "compound_bounded"
+                            occluded["occlusion"] = {
+                                "top": top,
+                                "left": left,
+                                "height": 2,
+                                "width": 3,
+                                "value": 64,
+                            }
+                            occluded["parameter_digest"] = canonical_sha256(
+                                {
+                                    key: value
+                                    for key, value in occluded.items()
+                                    if key != "parameter_digest"
+                                }
+                            )
+                            by_key[
+                                canonical_sha256(
+                                    _valid_transformation_parameter_key(occluded)
+                                )
+                            ] = occluded
+    parameters = [by_key[key] for key in sorted(by_key)]
+    payload = {
+        "version": VALID_TRANSFORMATION_PARAMETER_UNIVERSE_VERSION,
+        "transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
+        "parameter_count": len(parameters),
+        "parameters": parameters,
+    }
+    payload["parameter_universe_digest"] = canonical_sha256(payload)
+    _valid_transformation_parameter_universe._cache = payload  # type: ignore[attr-defined]
+    return payload
+
+
+def _valid_transformed_observation_digest_index(
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    cache_key = canonical_sha256(
+        {
+            "config": shooter_config_payload(config),
+            "transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
+        }
+    )
+    if not hasattr(_valid_transformed_observation_digest_index, "_cache"):
+        _valid_transformed_observation_digest_index._cache = {}  # type: ignore[attr-defined]
+    cache: dict[str, dict[str, Any]] = getattr(
+        _valid_transformed_observation_digest_index,
+        "_cache",
+    )
+    if cache_key in cache:
+        return cache[cache_key]
+    canonical = canonical_observation_universe(config)
+    parameter_universe = _valid_transformation_parameter_universe()
+    digest_to_first: dict[str, dict[str, Any]] = {}
+    duplicate_count = 0
+    duplicate_examples: list[dict[str, Any]] = []
+    for canonical_row in canonical["rows"]:
+        row_id = str(canonical_row["row_id"])
+        source_pixels = render_row_frame(row_id, config=config)
+        for params in parameter_universe["parameters"]:
+            output, _trace = _apply_transformation(source_pixels, params)
+            digest = array_digest(output)
+            provenance = {
+                "row_id": row_id,
+                "parameter_digest": params["parameter_digest"],
+                "parameter_key_digest": canonical_sha256(
+                    _valid_transformation_parameter_key(params)
+                ),
+            }
+            previous = digest_to_first.get(digest)
+            if previous is None:
+                digest_to_first[digest] = provenance
+            else:
+                duplicate_count += 1
+                if len(duplicate_examples) < 20:
+                    duplicate_examples.append(
+                        {
+                            "observation_pixel_digest": digest,
+                            "first": previous,
+                            "duplicate": provenance,
+                        }
+                    )
+    digest_set = sorted(digest_to_first)
+    summary: dict[str, Any] = {
+        "version": VALID_OBSERVATION_UNIVERSE_VERSION,
+        "policy_artifact_id": compile_policy_artifact(config).artifact_id,
+        "row_action_universe_digest": canonical_sha256(
+            {
+                "row_action": [
+                    {"row_id": row["row_id"], "action_id": row["action_id"]}
+                    for row in canonical["rows"]
+                ]
+            }
+        ),
+        "renderer_contract_version": ARCADE_RENDERER_CONTRACT_VERSION,
+        "renderer_identity": renderer_identity(config),
+        "shooter_config": shooter_config_payload(config),
+        "shooter_config_digest": canonical_sha256(shooter_config_payload(config)),
+        "transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
+        "parameter_universe_digest": parameter_universe["parameter_universe_digest"],
+        "parameter_universe_count": parameter_universe["parameter_count"],
+        "canonical_universe_digest": canonical["universe_digest"],
+        "exact_canonical_digest_count": len(canonical["digest_to_rows"]),
+        "transformed_valid_digest_count": len(digest_set),
+        "transformed_valid_output_count": len(canonical["rows"])
+        * int(parameter_universe["parameter_count"]),
+        "duplicate_transformed_digest_count": duplicate_count,
+        "duplicate_transformed_digest_examples": duplicate_examples,
+        "transformed_valid_digest_set_digest": canonical_sha256(digest_set),
+    }
+    payload: dict[str, Any] = {"digest_index": set(digest_set), "summary": summary}
+    summary["universe_digest"] = canonical_sha256(summary)
+    cache[cache_key] = payload
+    return payload
+
+
+def valid_observation_universe(
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    canonical = canonical_observation_universe(config)
+    transformed = _valid_transformed_observation_digest_index(config)
+    payload = {
+        **transformed["summary"],
+        "canonical_universe_version": canonical["version"],
+        "valid_categories": ["canonical_exact", "bounded_transformation_family"],
+        "exact_canonical_digest_to_rows": canonical["digest_to_rows"],
+        "bounded_transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
+    }
+    payload["universe_digest"] = canonical_sha256(
+        {key: value for key, value in payload.items() if key != "universe_digest"}
+    )
+    return payload
+
+
+def _canonical_observation_digest_index(
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, list[dict[str, str]]]:
+    return {
+        str(digest): [dict(item) for item in rows]
+        for digest, rows in canonical_observation_universe(config)[
+            "digest_to_rows"
+        ].items()
+    }
+
+
+def _canonical_collision_rows(
+    pixels: np.ndarray,
+    *,
+    config: ShooterConfig = ShooterConfig(),
+) -> list[dict[str, str]]:
+    return _canonical_observation_digest_index(config).get(
+        array_digest(np.ascontiguousarray(pixels, dtype=np.uint8)),
+        [],
+    )
+
+
+__all__ = [
+    "_canonical_collision_rows",
+    "_canonical_observation_digest_index",
+    "_valid_transformation_parameter_key",
+    "_valid_transformation_parameter_universe",
+    "_valid_transformed_observation_digest_index",
+    "canonical_observation_universe",
+    "canonical_prototypes",
+    "valid_observation_universe",
+]

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -12,7 +12,9 @@ from .arcade_policy import ACTIONS, CELL_PIXELS, COOLDOWN_BLOCKED_VALUE, COOLDOW
 from .artifact import VPMValidationError
 from .domains.video_action_set.canonical_json import canonical_json_bytes, canonical_json_value, canonical_sha256
 from .domains.video_action_set.contracts import (
+    ARCADE_RENDERER_CONTRACT_VERSION,
     BENCHMARK_VERSION,
+    CANONICAL_OBSERVATION_UNIVERSE_VERSION,
     EPISODE_PLAN_VERSION,
     FRAME_SHAPE,
     GENERATOR_VERSION,
@@ -22,6 +24,7 @@ from .domains.video_action_set.contracts import (
     REACHABILITY_TILE_VERSION,
     SEED_DERIVATION_VERSION,
     TRANSFORMATION_FAMILY_VERSION,
+    VALID_OBSERVATION_UNIVERSE_VERSION,
 )
 from .domains.video_action_set.dto import BenchmarkIdentityDTO, EpisodePlanDTO
 from .domains.video_action_set.observation_legacy_adapters import (
@@ -34,6 +37,21 @@ from .domains.video_action_set.observation_provenance_dto import (
 from .domains.video_action_set.pixel_digest import (
     array_digest as _array_digest,
     pixel_digest as _pixel_digest,
+)
+from .domains.video_action_set.arcade_observation import (
+    render_row_frame as _render_row_frame,
+    renderer_identity as _renderer_identity,
+    shooter_config_payload as _transition_config_payload,
+)
+from .domains.video_action_set.observation_universe import (
+    _canonical_collision_rows,
+    _canonical_observation_digest_index,
+    _valid_transformation_parameter_key,
+    _valid_transformation_parameter_universe,
+    _valid_transformed_observation_digest_index,
+    canonical_observation_universe,
+    canonical_prototypes,
+    valid_observation_universe,
 )
 from .domains.video_action_set.transformations import (
     _apply_transformation,
@@ -80,8 +98,6 @@ CLOSURE_REPORT_VERSION = "zeromodel-video-action-set-reference-closure/v1"
 MUTATION_MATRIX_VERSION = "zeromodel-video-action-set-reference-mutation-matrix/v3"
 SOURCE_SCOPE = "zeromodel-video-action-set-reachability-benchmark-v1"
 SEMANTIC_OUTCOME_VERSION = VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION
-CANONICAL_OBSERVATION_UNIVERSE_VERSION = "zeromodel-video-action-set-canonical-observation-universe/v1"
-VALID_OBSERVATION_UNIVERSE_VERSION = "zeromodel-video-action-set-valid-observation-universe/v2"
 FRAME_INVALID_CLOSURE_VERSION = "zeromodel-video-action-set-frame-invalid-closure/v1"
 FAMILY_INTERVENTION_VERSION = "zeromodel-video-action-set-family-intervention/v3"
 CONFLICTING_ACTION_SPLICE_VERSION = "zeromodel-video-action-set-family-conflicting-action-splice/v3"
@@ -341,210 +357,6 @@ def _derived_seed(
     return payload | {"seed_digest": digest, "seed_int64": _seed_int_from_digest(digest)}
 
 
-def canonical_prototypes(config: ShooterConfig = ShooterConfig()) -> dict[str, tuple[str, str, str, ImageObservation]]:
-    policy = compile_policy_artifact(config)
-    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
-    prototypes = {}
-    for row_id in policy.source.row_ids:
-        tank, target, cooldown = parse_state_row_id(str(row_id))
-        frame = render_state_frame(tank, target, cooldown, width=config.width)
-        observation = ImageObservation(frame, source_id=f"canonical:{row_id}")
-        prototypes[f"prototype:{row_id}"] = (str(row_id), lookup.choose(str(row_id)), observation.raw_digest, observation)
-    return prototypes
-
-
-def canonical_observation_universe(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
-    rows: list[dict[str, Any]] = []
-    digest_to_rows: dict[str, list[dict[str, str]]] = {}
-    prototypes = canonical_prototypes() if config == ShooterConfig() else canonical_prototypes(config)
-    for prototype_id, (row_id, action_id, observation_raw_digest, observation) in prototypes.items():
-        pixel_digest = _array_digest(observation.pixels)
-        entry = {
-            "prototype_id": prototype_id,
-            "row_id": row_id,
-            "action_id": action_id,
-            "image_observation_raw_digest": observation_raw_digest,
-            "observation_pixel_digest": pixel_digest,
-        }
-        rows.append(entry)
-        digest_to_rows.setdefault(pixel_digest, []).append({"row_id": row_id, "action_id": action_id})
-    duplicate_groups = [
-        {"observation_pixel_digest": digest, "rows": grouped}
-        for digest, grouped in sorted(digest_to_rows.items())
-        if len(grouped) > 1
-    ]
-    payload = {
-        "version": CANONICAL_OBSERVATION_UNIVERSE_VERSION,
-        "digest_semantics": "raw rendered uint8 bytes, excluding ImageObservation namespace",
-        "frame_shape": list(FRAME_SHAPE),
-        "row_count": len(rows),
-        "rows": rows,
-        "digest_to_rows": digest_to_rows,
-        "duplicate_digest_group_count": len(duplicate_groups),
-        "duplicate_digest_groups": duplicate_groups,
-    }
-    payload["universe_digest"] = _sha256(payload)
-    return payload
-
-
-def _renderer_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
-    payload = {
-        "version": "zeromodel-arcade-shooter-renderer-identity/v1",
-        "function": "zeromodel.arcade_policy.render_state_frame",
-        "frame_shape": list(FRAME_SHAPE),
-        "cell_pixels": int(CELL_PIXELS),
-        "target_value": int(TARGET_VALUE),
-        "tank_value": int(TANK_VALUE),
-        "cooldown_ready_value": int(COOLDOWN_READY_VALUE),
-        "cooldown_blocked_value": int(COOLDOWN_BLOCKED_VALUE),
-        "config": _transition_config_payload(config),
-    }
-    return payload | {"renderer_identity_digest": _sha256(payload)}
-
-
-
-def _valid_transformation_parameter_key(params: Mapping[str, Any]) -> dict[str, Any]:
-    return {
-        "dx": int(params["dx"]),
-        "dy": int(params["dy"]),
-        "scale_percent": int(params["scale_percent"]),
-        "offset": int(params["offset"]),
-        "occlusion": None if params.get("occlusion") is None else dict(params["occlusion"]),
-    }
-
-
-
-def _valid_transformation_parameter_universe() -> dict[str, Any]:
-    if hasattr(_valid_transformation_parameter_universe, "_cache"):
-        return _valid_transformation_parameter_universe._cache  # type: ignore[attr-defined]
-    by_key: dict[str, dict[str, Any]] = {}
-    for dx in range(-1, 2):
-        for dy in range(-1, 2):
-            for scale in range(90, 106):
-                for offset in range(0, 6):
-                    params = {
-                        "version": TRANSFORMATION_FAMILY_VERSION,
-                        "family": "bounded_translation_photometric",
-                        "seed": 0,
-                        "dx": dx,
-                        "dy": dy,
-                        "scale_percent": scale,
-                        "offset": offset,
-                        "occlusion": None,
-                    }
-                    params["parameter_digest"] = _sha256({key: value for key, value in params.items() if key != "parameter_digest"})
-                    by_key[_sha256(_valid_transformation_parameter_key(params))] = params
-                    for top in range(0, 3):
-                        for left in range(0, 3):
-                            occluded = dict(params)
-                            occluded["family"] = "compound_bounded"
-                            occluded["occlusion"] = {"top": top, "left": left, "height": 2, "width": 3, "value": 64}
-                            occluded["parameter_digest"] = _sha256({key: value for key, value in occluded.items() if key != "parameter_digest"})
-                            by_key[_sha256(_valid_transformation_parameter_key(occluded))] = occluded
-    parameters = [by_key[key] for key in sorted(by_key)]
-    payload = {
-        "version": "zeromodel-video-action-set-valid-transformation-parameter-universe/v1",
-        "transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
-        "parameter_count": len(parameters),
-        "parameters": parameters,
-    }
-    payload["parameter_universe_digest"] = _sha256(payload)
-    _valid_transformation_parameter_universe._cache = payload  # type: ignore[attr-defined]
-    return payload
-
-
-
-def _valid_transformed_observation_digest_index(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
-    cache_key = _sha256({"config": _transition_config_payload(config), "transformation_contract_version": TRANSFORMATION_FAMILY_VERSION})
-    if not hasattr(_valid_transformed_observation_digest_index, "_cache"):
-        _valid_transformed_observation_digest_index._cache = {}  # type: ignore[attr-defined]
-    cache: dict[str, dict[str, Any]] = _valid_transformed_observation_digest_index._cache  # type: ignore[attr-defined]
-    if cache_key in cache:
-        return cache[cache_key]
-    canonical = canonical_observation_universe(config)
-    parameter_universe = _valid_transformation_parameter_universe()
-    digest_to_first: dict[str, dict[str, Any]] = {}
-    duplicate_count = 0
-    duplicate_examples = []
-    for canonical_row in canonical["rows"]:
-        row_id = str(canonical_row["row_id"])
-        source_pixels = _render_row_frame(row_id, config=config)
-        for params in parameter_universe["parameters"]:
-            output, _trace = _apply_transformation(source_pixels, params)
-            digest = _array_digest(output)
-            provenance = {
-                "row_id": row_id,
-                "parameter_digest": params["parameter_digest"],
-                "parameter_key_digest": _sha256(_valid_transformation_parameter_key(params)),
-            }
-            previous = digest_to_first.get(digest)
-            if previous is None:
-                digest_to_first[digest] = provenance
-            else:
-                duplicate_count += 1
-                if len(duplicate_examples) < 20:
-                    duplicate_examples.append({"observation_pixel_digest": digest, "first": previous, "duplicate": provenance})
-    digest_set = sorted(digest_to_first)
-    payload = {
-        "digest_index": set(digest_set),
-        "summary": {
-            "version": VALID_OBSERVATION_UNIVERSE_VERSION,
-            "policy_artifact_id": compile_policy_artifact(config).artifact_id,
-            "row_action_universe_digest": _sha256(
-                {
-                    "row_action": [
-                        {"row_id": row["row_id"], "action_id": row["action_id"]}
-                        for row in canonical["rows"]
-                    ]
-                }
-            ),
-            "renderer_contract_version": "zeromodel-arcade-shooter-render-state-frame/v1",
-            "renderer_identity": _renderer_identity(config),
-            "shooter_config": _transition_config_payload(config),
-            "shooter_config_digest": _sha256(_transition_config_payload(config)),
-            "transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
-            "parameter_universe_digest": parameter_universe["parameter_universe_digest"],
-            "parameter_universe_count": parameter_universe["parameter_count"],
-            "canonical_universe_digest": canonical["universe_digest"],
-            "exact_canonical_digest_count": len(canonical["digest_to_rows"]),
-            "transformed_valid_digest_count": len(digest_set),
-            "transformed_valid_output_count": len(canonical["rows"]) * int(parameter_universe["parameter_count"]),
-            "duplicate_transformed_digest_count": duplicate_count,
-            "duplicate_transformed_digest_examples": duplicate_examples,
-            "transformed_valid_digest_set_digest": _sha256(digest_set),
-        },
-    }
-    payload["summary"]["universe_digest"] = _sha256(payload["summary"])
-    cache[cache_key] = payload
-    return payload
-
-
-
-def valid_observation_universe(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
-    canonical = canonical_observation_universe(config)
-    transformed = _valid_transformed_observation_digest_index(config)
-    payload = {
-        **transformed["summary"],
-        "canonical_universe_version": canonical["version"],
-        "valid_categories": ["canonical_exact", "bounded_transformation_family"],
-        "exact_canonical_digest_to_rows": canonical["digest_to_rows"],
-        "bounded_transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
-    }
-    payload["universe_digest"] = _sha256({key: value for key, value in payload.items() if key != "universe_digest"})
-    return payload
-
-
-def _canonical_observation_digest_index(config: ShooterConfig = ShooterConfig()) -> dict[str, list[dict[str, str]]]:
-    return {
-        str(digest): [dict(item) for item in rows]
-        for digest, rows in canonical_observation_universe(config)["digest_to_rows"].items()
-    }
-
-
-def _canonical_collision_rows(pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()) -> list[dict[str, str]]:
-    return _canonical_observation_digest_index(config).get(_array_digest(np.ascontiguousarray(pixels, dtype=np.uint8)), [])
-
-
 def _target_signal_coordinates(width: int = FRAME_SHAPE[1]) -> tuple[tuple[int, int], ...]:
     return tuple((y, x) for y in range(2, 5) for x in range(int(width)))
 
@@ -732,11 +544,6 @@ def expected_frame_disposition(
         gap = intervention.get("gap_event", {})
         return "declared_gap_or_unknown_action" if index == int(gap.get("position", -1)) else "valid_frame_payload"
     return "valid_frame_payload"
-
-
-
-def _transition_config_payload(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
-    return {"width": int(config.width), "wave": [int(item) for item in config.wave], "max_steps": int(config.max_steps)}
 
 
 
@@ -1685,11 +1492,6 @@ def _apply_frame_plan(frame: np.ndarray, frame_plan: Mapping[str, Any]) -> tuple
     return _apply_transformation(frame, params)
 
 
-def _render_row_frame(row_id: str, *, config: ShooterConfig = ShooterConfig()) -> np.ndarray:
-    tank, target, cooldown = parse_state_row_id(str(row_id))
-    return render_state_frame(tank, target, cooldown, width=config.width)
-
-
 def _apply_conflicting_splice(
     *,
     primary_pixels: np.ndarray,
@@ -1831,7 +1633,7 @@ def _valid_frame_operation_chain(row_id: str, transformation_parameters: Mapping
         _operation_record(
             index=0,
             operation="render_canonical_row",
-            operation_version="zeromodel-arcade-shooter-render-state-frame/v1",
+            operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
             input_digests=[],
             parameters={"row_id": str(row_id), "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()},
             output_digest=source_digest,
@@ -1883,9 +1685,9 @@ def _conflicting_splice_operation_chain(
     secondary_digest = _array_digest(secondary)
     output_digest = _array_digest(output)
     operations = [
-        _operation_record(index=0, operation="render_canonical_row", operation_version="zeromodel-arcade-shooter-render-state-frame/v1", input_digests=[], parameters={"row_id": primary_row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=primary_base_digest),
+        _operation_record(index=0, operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": primary_row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=primary_base_digest),
         _operation_record(index=1, operation="apply_bounded_transformation", operation_version=TRANSFORMATION_FAMILY_VERSION, input_digests=[primary_base_digest], parameters={"transformation_parameters": dict(primary_transformation_parameters)}, output_digest=primary_transformed_digest),
-        _operation_record(index=2, operation="render_canonical_row", operation_version="zeromodel-arcade-shooter-render-state-frame/v1", input_digests=[], parameters={"row_id": secondary_row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=secondary_digest),
+        _operation_record(index=2, operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": secondary_row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=secondary_digest),
         _operation_record(
             index=3,
             operation="compose_simultaneous_target_evidence",
@@ -1915,7 +1717,7 @@ def _critical_corruption_operation_chain(row_id: str, transformation_parameters:
     transformed_digest = transform_trace["transformed_observation_digest"]
     output_digest = _array_digest(corrupted)
     operations = [
-        _operation_record(index=0, operation="render_canonical_row", operation_version="zeromodel-arcade-shooter-render-state-frame/v1", input_digests=[], parameters={"row_id": row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=source_digest),
+        _operation_record(index=0, operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=source_digest),
         _operation_record(index=1, operation="apply_bounded_transformation", operation_version=TRANSFORMATION_FAMILY_VERSION, input_digests=[source_digest], parameters={"transformation_parameters": dict(transformation_parameters)}, output_digest=transformed_digest),
         _operation_record(index=2, operation="apply_critical_coordinate_corruption", operation_version="zeromodel-video-action-set-family-critical-evidence-corruption/v1", input_digests=[transformed_digest], parameters={"critical_coordinates": dict(coordinate_manifest), "critical_corruption_digest": corruption_trace["critical_corruption_digest"]}, output_digest=output_digest),
         _operation_record(index=3, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[output_digest], parameters={"event_type": "frame"}, output_digest=output_digest),
@@ -1964,7 +1766,7 @@ def _impossible_transition_operation_chain(destination_before: Mapping[str, Any]
     unreachable_pixels = _render_row_frame(unreachable_row)
     unreachable_digest = _array_digest(unreachable_pixels)
     operations = list(ordinary_chain["operations"][:-1])
-    operations.append(_operation_record(index=len(operations), operation="render_canonical_row", operation_version="zeromodel-arcade-shooter-render-state-frame/v1", input_digests=[], parameters={"row_id": unreachable_row, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=unreachable_digest))
+    operations.append(_operation_record(index=len(operations), operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": unreachable_row, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=unreachable_digest))
     operations.append(
         _operation_record(
             index=len(operations),
@@ -1993,7 +1795,7 @@ def _information_control_operation_chain(current_row_id: str) -> dict[str, Any]:
     current = _render_row_frame(current_row_id)
     current_digest = _array_digest(current)
     operations = [
-        _operation_record(index=0, operation="render_canonical_row", operation_version="zeromodel-arcade-shooter-render-state-frame/v1", input_digests=[], parameters={"row_id": str(current_row_id), "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=current_digest),
+        _operation_record(index=0, operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": str(current_row_id), "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=current_digest),
         _operation_record(index=1, operation="emit_provider_identical_control_observation", operation_version=INFORMATION_CONTROL_VERSION, input_digests=[current_digest], parameters={"current_row_id": str(current_row_id), "provider_observation_boundary_version": PROVIDER_OBSERVATION_BOUNDARY_VERSION}, output_digest=current_digest),
         _operation_record(index=2, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[current_digest], parameters={"event_type": "frame"}, output_digest=current_digest),
     ]


### PR DESCRIPTION
## Summary

- Extract canonical and valid observation-universe compilation into `zeromodel.domains.video_action_set.observation_universe`.
- Extract deterministic arcade row rendering, shooter config payloads, and renderer identity into `zeromodel.domains.video_action_set.arcade_observation`.
- Move observation-universe and renderer version constants into `contracts.py` without changing values.
- Preserve the legacy benchmark compatibility facade for all moved public and private helper names.
- Deliberately leave invalid-family mechanics, frame-invalid closure, episode-family code, reachability, persistence, and reporting in the legacy benchmark.
- Reduce the legacy benchmark quality ceiling from 5812 to 5614 lines.

Audit-Exempt: behavior-preserving extraction of deterministic arcade
observation rendering and canonical/valid observation-universe compilation.
No scientific semantics, policy identities, rendered bytes, transformation
parameters, pixel digests, universe membership, universe digests, cache
semantics, benchmark evidence, or conclusions changed.

## Validation

- `python -m pytest -q tests/test_video_observation_universe_kernel.py tests/test_video_transformation_kernel.py` - 40 passed in 0.61s
- `python scripts/check_architecture.py` - passed
- `python scripts/check_quality.py` - passed
- `python scripts/run_fast_tests.py` - passed in 25.69s
- `python -m build` - passed; existing setuptools license deprecation warnings only

Integration tests were not run. The full transformed universe was not executed outside the existing integration/slow test tier, which remains skipped by default.