### PR TITLE
refactor: extract observation provenance replay kernel

### DIFF
--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -9,7 +9,7 @@ maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
 reason = "Stage 3 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 5614
+maximum_lines = 5456
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -13,14 +13,38 @@ DOMAIN_VIDEO_ACTION_SET_PREFIX = "zeromodel.domains.video_action_set"
 DB_ORM_PREFIX = "zeromodel.db.orm"
 DB_STORES_PREFIX = "zeromodel.db.stores"
 ARCADE_OBSERVATION_MODULE = "zeromodel.domains.video_action_set.arcade_observation"
+CANONICAL_JSON_MODULE = "zeromodel.domains.video_action_set.canonical_json"
+CONTRACTS_MODULE = "zeromodel.domains.video_action_set.contracts"
+OBSERVATION_LEGACY_ADAPTERS_MODULE = (
+    "zeromodel.domains.video_action_set.observation_legacy_adapters"
+)
+OBSERVATION_PROVENANCE_DTO_MODULE = (
+    "zeromodel.domains.video_action_set.observation_provenance_dto"
+)
+OBSERVATION_PROVENANCE_MODULE = (
+    "zeromodel.domains.video_action_set.observation_provenance"
+)
+OBSERVATION_REPLAY_MODULE = "zeromodel.domains.video_action_set.observation_replay"
 OBSERVATION_UNIVERSE_MODULE = "zeromodel.domains.video_action_set.observation_universe"
 PIXEL_DIGEST_MODULE = "zeromodel.domains.video_action_set.pixel_digest"
 TRANSFORMATIONS_MODULE = "zeromodel.domains.video_action_set.transformations"
 VIDEO_OBSERVATION_KERNEL_MODULES = {
     ARCADE_OBSERVATION_MODULE,
+    OBSERVATION_PROVENANCE_MODULE,
+    OBSERVATION_REPLAY_MODULE,
     OBSERVATION_UNIVERSE_MODULE,
     PIXEL_DIGEST_MODULE,
     TRANSFORMATIONS_MODULE,
+}
+LOWER_OBSERVATION_MODULES = {
+    CANONICAL_JSON_MODULE,
+    CONTRACTS_MODULE,
+    PIXEL_DIGEST_MODULE,
+    TRANSFORMATIONS_MODULE,
+    ARCADE_OBSERVATION_MODULE,
+    OBSERVATION_UNIVERSE_MODULE,
+    OBSERVATION_PROVENANCE_DTO_MODULE,
+    OBSERVATION_LEGACY_ADAPTERS_MODULE,
 }
 VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
     "zeromodel.domains.video_action_set.episode_plan_service",
@@ -32,15 +56,17 @@ VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
 }
 VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
     ARCADE_OBSERVATION_MODULE,
-    "zeromodel.domains.video_action_set.canonical_json",
-    "zeromodel.domains.video_action_set.contracts",
+    CANONICAL_JSON_MODULE,
+    CONTRACTS_MODULE,
     "zeromodel.domains.video_action_set.dto",
     "zeromodel.domains.video_action_set.episode_plan_service",
     "zeromodel.domains.video_action_set.observation_common",
     "zeromodel.domains.video_action_set.observation_dto",
-    "zeromodel.domains.video_action_set.observation_legacy_adapters",
+    OBSERVATION_LEGACY_ADAPTERS_MODULE,
     "zeromodel.domains.video_action_set.observation_materialization",
-    "zeromodel.domains.video_action_set.observation_provenance_dto",
+    OBSERVATION_PROVENANCE_DTO_MODULE,
+    OBSERVATION_PROVENANCE_MODULE,
+    OBSERVATION_REPLAY_MODULE,
     "zeromodel.domains.video_action_set.observation_service",
     OBSERVATION_UNIVERSE_MODULE,
     PIXEL_DIGEST_MODULE,
@@ -430,6 +456,74 @@ def transformation_kernel_forbidden_edge_violations(
     return violations
 
 
+def observation_provenance_replay_forbidden_edge_violations(
+    edge: ImportEdge,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if (
+        edge.importer == OBSERVATION_PROVENANCE_MODULE
+        and edge.imported == OBSERVATION_REPLAY_MODULE
+    ):
+        violations.append(
+            edge_violation(
+                "observation_provenance must not import observation_replay",
+                edge,
+            )
+        )
+    if (
+        edge.importer == OBSERVATION_REPLAY_MODULE
+        and edge.imported == OBSERVATION_PROVENANCE_MODULE
+    ):
+        violations.append(
+            edge_violation(
+                "observation_replay must not import observation_provenance",
+                edge,
+            )
+        )
+    if (
+        edge.importer
+        in {
+            OBSERVATION_PROVENANCE_MODULE,
+            OBSERVATION_REPLAY_MODULE,
+        }
+        and edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+    ):
+        violations.append(
+            edge_violation(
+                "observation provenance/replay modules must not import legacy benchmark",
+                edge,
+            )
+        )
+    if edge.importer in {
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+    } and (
+        is_module_under(edge.imported, DB_ORM_PREFIX)
+        or is_module_under(edge.imported, DB_STORES_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db.session")
+        or is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+        or is_sqlalchemy_import(edge.imported)
+    ):
+        violations.append(
+            edge_violation(
+                "observation provenance/replay modules must not import persistence or runtime layers",
+                edge,
+            )
+        )
+    if edge.importer in LOWER_OBSERVATION_MODULES and edge.imported in {
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+    }:
+        violations.append(
+            edge_violation(
+                "lower observation modules must not import observation provenance/replay",
+                edge,
+            )
+        )
+    return violations
+
+
 def rmdto_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
     violations: list[Violation] = []
     if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
@@ -513,6 +607,7 @@ def forbidden_edge_violations(edges: list[ImportEdge]) -> list[Violation]:
     for edge in edges:
         violations.extend(legacy_forbidden_edge_violations(edge))
         violations.extend(transformation_kernel_forbidden_edge_violations(edge))
+        violations.extend(observation_provenance_replay_forbidden_edge_violations(edge))
         violations.extend(rmdto_forbidden_edge_violations(edge))
     return violations
 

--- a/tests/test_video_observation_provenance_kernel.py
+++ b/tests/test_video_observation_provenance_kernel.py
@@ -1,0 +1,792 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import numpy as np
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.arcade_observation import (
+    render_row_frame,
+    shooter_config_payload,
+)
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+from zeromodel.domains.video_action_set.contracts import (
+    ARCADE_RENDERER_CONTRACT_VERSION,
+    GAP_EVENT_VERSION,
+    OBSERVATION_OPERATION_CHAIN_VERSION,
+)
+from zeromodel.domains.video_action_set.observation_legacy_adapters import (
+    operation_chain,
+    operation_record,
+)
+from zeromodel.domains.video_action_set.observation_provenance import (
+    gap_event_operation_chain,
+    valid_frame_operation_chain,
+)
+from zeromodel.domains.video_action_set.observation_provenance_dto import (
+    ObservationOperationChainDTO,
+    ObservationOperationDTO,
+)
+from zeromodel.domains.video_action_set.observation_replay import (
+    replay_observation_operation_chain,
+    validate_observation_operation_chain,
+)
+from zeromodel.domains.video_action_set.pixel_digest import array_digest
+from zeromodel.domains.video_action_set.transformations import (
+    _transformation_parameters,
+)
+
+
+ROW_ID = "tank=0|target=0|cooldown=0"
+OTHER_ROW_ID = "tank=1|target=1|cooldown=0"
+THIRD_ROW_ID = "tank=2|target=2|cooldown=0"
+EXACT_PARAMS = _transformation_parameters("exact", 12345)
+TRANSFORMED_PARAMS = _transformation_parameters(
+    "bounded_translation_photometric",
+    12345,
+)
+SOURCE_DIGEST = (
+    "sha256:49e46341a170608e2bf8db63064e3d2235727a64ceddafa0cf9970c2707fe443"
+)
+TRANSFORMED_DIGEST = (
+    "sha256:c173cfaa13d5f8d5da8ba4d72e129416d733f383219bbb44897608c321a7a86f"
+)
+FAKE_DIGEST = "sha256:" + "a" * 64
+OTHER_FAKE_DIGEST = "sha256:" + "b" * 64
+
+EXPECTED_EXACT_CHAIN = {
+    "version": "zeromodel-video-observation-operation-chain/v1",
+    "final_emitted_digest": SOURCE_DIGEST,
+    "operation_chain_digest": (
+        "sha256:a90cd05c48b2a6232b53ba8ac0b0b6e90596ad7aa127273a629b60a5dd3affce"
+    ),
+    "operations": [
+        {
+            "index": 0,
+            "operation": "render_canonical_row",
+            "operation_version": "zeromodel-arcade-shooter-render-state-frame/v1",
+            "input_digests": [],
+            "parameters": {
+                "row_id": ROW_ID,
+                "renderer": "zeromodel.arcade_policy.render_state_frame",
+                "config": {"width": 7, "wave": [0, 6, 1, 5], "max_steps": 32},
+            },
+            "parameter_digest": (
+                "sha256:7a0435e38e07209f4cf9fcf4707057ac9afb33a727090d5d72f985176326a9b4"
+            ),
+            "output_digest": SOURCE_DIGEST,
+            "operation_digest": (
+                "sha256:01390f67c13d6959645fb2fd4506e085f768c21c71766a288daa2e4c638a1239"
+            ),
+        },
+        {
+            "index": 1,
+            "operation": "apply_bounded_transformation",
+            "operation_version": "zeromodel-video-action-set-transformation-family/v1",
+            "input_digests": [SOURCE_DIGEST],
+            "parameters": {"transformation_parameters": EXACT_PARAMS},
+            "parameter_digest": (
+                "sha256:ef5f3d6d9500db5c270da6edb3a88362fc66c42d10bb50b78b18aded9cc49a8a"
+            ),
+            "output_digest": SOURCE_DIGEST,
+            "operation_digest": (
+                "sha256:a72a385b4979dc924a3e3f0c162e56340d1edc4a01eeb9cee7f26ccc2a396c7c"
+            ),
+        },
+        {
+            "index": 2,
+            "operation": "emit_observation",
+            "operation_version": "zeromodel-video-observation-operation-chain/v1",
+            "input_digests": [SOURCE_DIGEST],
+            "parameters": {"event_type": "frame"},
+            "parameter_digest": (
+                "sha256:45da9ed29fdf87e86e95196cd98a172ff3684a40cdf31ca52775f6acd5d18d75"
+            ),
+            "output_digest": SOURCE_DIGEST,
+            "operation_digest": (
+                "sha256:99e9f654442d6a8d5ba183b40b649c2f52640202c827d45cbf9f8c84c1fcf415"
+            ),
+        },
+    ],
+}
+
+EXPECTED_TRANSFORMED_CHAIN = {
+    "version": "zeromodel-video-observation-operation-chain/v1",
+    "final_emitted_digest": TRANSFORMED_DIGEST,
+    "operation_chain_digest": (
+        "sha256:4662c45b549809a86b23fff8460d8acd78fd294259308d21e0c77a2e33da46c0"
+    ),
+    "operations": [
+        EXPECTED_EXACT_CHAIN["operations"][0],
+        {
+            "index": 1,
+            "operation": "apply_bounded_transformation",
+            "operation_version": "zeromodel-video-action-set-transformation-family/v1",
+            "input_digests": [SOURCE_DIGEST],
+            "parameters": {"transformation_parameters": TRANSFORMED_PARAMS},
+            "parameter_digest": (
+                "sha256:0af58c5b5cba4915da08e9c0682d91fa9278bded80aaed33bf504e0d16e01a32"
+            ),
+            "output_digest": TRANSFORMED_DIGEST,
+            "operation_digest": (
+                "sha256:fd58511e161772c6a5b6fbeb239ab0bc41ab19a47d44adeaa7de70cab93640cc"
+            ),
+        },
+        {
+            "index": 2,
+            "operation": "emit_observation",
+            "operation_version": "zeromodel-video-observation-operation-chain/v1",
+            "input_digests": [TRANSFORMED_DIGEST],
+            "parameters": {"event_type": "frame"},
+            "parameter_digest": (
+                "sha256:45da9ed29fdf87e86e95196cd98a172ff3684a40cdf31ca52775f6acd5d18d75"
+            ),
+            "output_digest": TRANSFORMED_DIGEST,
+            "operation_digest": (
+                "sha256:e8ce74e554289ee256562e56d13339fa024f368f9dd9023d870ab4f081010c9c"
+            ),
+        },
+    ],
+}
+
+GAP_EVENT = {
+    "version": "zeromodel-video-action-set-gap-event/v1",
+    "position": 2,
+    "duration_frames": 1,
+    "reason": "declared_gap_or_unknown_action",
+    "event_id": "sha256:" + "1" * 64,
+}
+
+EXPECTED_GAP_CHAIN = {
+    "version": "zeromodel-video-observation-operation-chain/v1",
+    "final_emitted_digest": None,
+    "operation_chain_digest": (
+        "sha256:89e78eb86fc3a2d309d68cc6be92c22644986381eb207b80b6c1fb77608e0e6f"
+    ),
+    "operations": [
+        {
+            "index": 0,
+            "operation": "emit_typed_gap_event",
+            "operation_version": "zeromodel-video-action-set-gap-event/v1",
+            "input_digests": [],
+            "parameters": GAP_EVENT,
+            "parameter_digest": (
+                "sha256:0b286cba80ad09f1fb1740a05ef971076deccf8759f63a21c8eb2295584af3eb"
+            ),
+            "output_digest": None,
+            "operation_digest": (
+                "sha256:275e275a07b57387510d4dc6b821d6988819dc64baf36b6eccb7fba6aaa1e3d9"
+            ),
+        },
+        {
+            "index": 1,
+            "operation": "emit_observation",
+            "operation_version": "zeromodel-video-observation-operation-chain/v1",
+            "input_digests": [None],
+            "parameters": {"event_type": "gap_unknown"},
+            "parameter_digest": (
+                "sha256:bd3805cfc593ddc0c885e000683fff8a80d6a8df665f2859aa33afff5537c305"
+            ),
+            "output_digest": None,
+            "operation_digest": (
+                "sha256:6657e267f5280e620fecc26e946f35c5f2ad6db862db04c37c0b644087720758"
+            ),
+        },
+    ],
+}
+
+
+def _unused_conflicting_splice_executor(**_kwargs: Any) -> tuple[np.ndarray, dict]:
+    raise AssertionError("conflicting-splice executor must not be used")
+
+
+def _unused_critical_corruption_executor(
+    _source: np.ndarray,
+    _coordinate_manifest: dict,
+) -> tuple[np.ndarray, dict]:
+    raise AssertionError("critical-corruption executor must not be used")
+
+
+def _replay(chain: dict[str, Any]) -> dict[str, Any]:
+    return replay_observation_operation_chain(
+        chain,
+        conflicting_splice_executor=_unused_conflicting_splice_executor,
+        critical_corruption_executor=_unused_critical_corruption_executor,
+    )
+
+
+def _validate(record: dict[str, Any]) -> str:
+    return validate_observation_operation_chain(
+        record,
+        conflicting_splice_executor=_unused_conflicting_splice_executor,
+        critical_corruption_executor=_unused_critical_corruption_executor,
+    )
+
+
+def _render_op(index: int, row_id: str) -> dict[str, Any]:
+    pixels = render_row_frame(row_id)
+    return operation_record(
+        index=index,
+        operation="render_canonical_row",
+        operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
+        input_digests=[],
+        parameters={
+            "row_id": row_id,
+            "renderer": "zeromodel.arcade_policy.render_state_frame",
+            "config": shooter_config_payload(),
+        },
+        output_digest=array_digest(pixels),
+    )
+
+
+def _emit_op(index: int, digest: str | None, *, event_type: str = "frame") -> dict:
+    return operation_record(
+        index=index,
+        operation="emit_observation",
+        operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+        input_digests=[digest],
+        parameters={"event_type": event_type},
+        output_digest=digest,
+    )
+
+
+def _record(
+    chain: dict[str, Any],
+    pixels: object,
+    *,
+    event_type: str = "frame",
+    observation_pixel_digest: str | None | object = ...,
+) -> dict[str, Any]:
+    if observation_pixel_digest is ...:
+        observation_pixel_digest = chain["final_emitted_digest"]
+    return {
+        "metadata": {"observation_operation_chain": chain},
+        "observation_pixel_digest": observation_pixel_digest,
+        "event_type": event_type,
+        "pixels": pixels,
+    }
+
+
+def _array_with_digest_change(source: np.ndarray) -> np.ndarray:
+    output = np.array(source, copy=True)
+    output[0, 0] = 255 if int(output[0, 0]) != 255 else 0
+    return output
+
+
+def _stale_chain(
+    *,
+    operation: str = "stale_repeat_replace",
+    second_input_digest: str | None = None,
+    output_digest: str | None = None,
+) -> dict[str, Any]:
+    render_op = _render_op(0, OTHER_ROW_ID)
+    replacement_digest = str(render_op["output_digest"])
+    second_input_digest = (
+        replacement_digest if second_input_digest is None else second_input_digest
+    )
+    output_digest = replacement_digest if output_digest is None else output_digest
+    ops = [
+        render_op,
+        operation_record(
+            index=1,
+            operation=operation,
+            operation_version="zeromodel-video-action-set-family-temporal/v1",
+            input_digests=[FAKE_DIGEST, second_input_digest],
+            parameters={
+                "source_frame_index": 0,
+                "destination_frame_index": 1,
+                "maximum_stale_horizon": 1,
+            },
+            output_digest=output_digest,
+        ),
+        _emit_op(2, output_digest),
+    ]
+    return operation_chain(ops, output_digest)
+
+
+def _provider_control_chain() -> dict[str, Any]:
+    render_op = _render_op(0, ROW_ID)
+    digest = str(render_op["output_digest"])
+    ops = [
+        render_op,
+        operation_record(
+            index=1,
+            operation="emit_provider_identical_control_observation",
+            operation_version="zeromodel-video-action-set-family-information-control/v3",
+            input_digests=[digest],
+            parameters={
+                "current_row_id": ROW_ID,
+                "provider_observation_boundary_version": (
+                    "zeromodel-video-action-set-provider-observation-boundary/v1"
+                ),
+            },
+            output_digest=digest,
+        ),
+        _emit_op(2, digest),
+    ]
+    return operation_chain(ops, digest)
+
+
+def _splice_chain(
+    *,
+    second_input_digest: str | None = None,
+    output_digest: str | None = None,
+) -> tuple[dict[str, Any], np.ndarray]:
+    primary_op = _render_op(0, ROW_ID)
+    secondary_op = _render_op(1, OTHER_ROW_ID)
+    output = np.maximum(render_row_frame(ROW_ID), render_row_frame(OTHER_ROW_ID))
+    actual_output_digest = array_digest(output)
+    output_digest = actual_output_digest if output_digest is None else output_digest
+    second_input_digest = (
+        str(secondary_op["output_digest"])
+        if second_input_digest is None
+        else second_input_digest
+    )
+    ops = [
+        primary_op,
+        secondary_op,
+        operation_record(
+            index=2,
+            operation="compose_simultaneous_target_evidence",
+            operation_version="zeromodel-video-action-set-family-conflicting-action-splice/v3",
+            input_digests=[primary_op["output_digest"], second_input_digest],
+            parameters={
+                "primary_row_id": ROW_ID,
+                "secondary_row_id": OTHER_ROW_ID,
+                "primary_action_id": "left",
+                "secondary_action_id": "right",
+                "mask_manifest": {"version": "test"},
+            },
+            output_digest=output_digest,
+        ),
+        _emit_op(3, output_digest),
+    ]
+    return operation_chain(ops, output_digest), output
+
+
+def _critical_chain(
+    *,
+    input_digest: str | None = None,
+    output_digest: str | None = None,
+) -> tuple[dict[str, Any], np.ndarray]:
+    render_op = _render_op(0, ROW_ID)
+    output = _array_with_digest_change(render_row_frame(ROW_ID))
+    actual_output_digest = array_digest(output)
+    input_digest = (
+        str(render_op["output_digest"]) if input_digest is None else input_digest
+    )
+    output_digest = actual_output_digest if output_digest is None else output_digest
+    ops = [
+        render_op,
+        operation_record(
+            index=1,
+            operation="apply_critical_coordinate_corruption",
+            operation_version="zeromodel-video-action-set-family-critical-evidence-corruption/v1",
+            input_digests=[input_digest],
+            parameters={"critical_coordinates": {"coordinates": [[0, 0]]}},
+            output_digest=output_digest,
+        ),
+        _emit_op(2, output_digest),
+    ]
+    return operation_chain(ops, output_digest), output
+
+
+def _copy_with_operation(
+    chain: dict[str, Any],
+    index: int,
+    updates: dict[str, Any],
+) -> dict[str, Any]:
+    copied = deepcopy(chain)
+    copied["operations"][index].update(updates)
+    copied["operations"][index]["operation_digest"] = canonical_sha256(
+        {
+            key: value
+            for key, value in copied["operations"][index].items()
+            if key != "operation_digest"
+        },
+    )
+    copied["operation_chain_digest"] = canonical_sha256(
+        {
+            key: value
+            for key, value in copied.items()
+            if key != "operation_chain_digest"
+        },
+    )
+    return copied
+
+
+def test_valid_frame_operation_chains_are_frozen() -> None:
+    assert valid_frame_operation_chain(ROW_ID, EXACT_PARAMS) == EXPECTED_EXACT_CHAIN
+    assert (
+        valid_frame_operation_chain(ROW_ID, TRANSFORMED_PARAMS)
+        == EXPECTED_TRANSFORMED_CHAIN
+    )
+
+
+def test_gap_event_operation_chain_is_frozen_and_uses_contract_constant() -> None:
+    assert GAP_EVENT_VERSION == "zeromodel-video-action-set-gap-event/v1"
+    chain = gap_event_operation_chain(GAP_EVENT)
+
+    assert chain == EXPECTED_GAP_CHAIN
+    assert chain["operations"][0]["operation_version"] == GAP_EVENT_VERSION
+
+
+def test_benchmark_retains_direct_aliases_and_dto_backed_adapters() -> None:
+    digest = SOURCE_DIGEST
+    op = _emit_op(0, digest)
+    chain = operation_chain([op], digest)
+
+    assert benchmark._valid_frame_operation_chain is valid_frame_operation_chain
+    assert benchmark._gap_event_operation_chain is gap_event_operation_chain
+    assert ObservationOperationDTO.from_dict(op).to_dict() == op
+    assert ObservationOperationChainDTO.from_dict(chain).to_dict() == chain
+
+
+def test_valid_frame_replay_reconstructs_pixels_and_state() -> None:
+    replay = _replay(EXPECTED_TRANSFORMED_CHAIN)
+
+    assert replay["final_emitted_digest"] == TRANSFORMED_DIGEST
+    assert replay["typed_gap"] is False
+    assert replay["operation_count"] == 3
+    assert replay["pixels"].shape == (16, 28)
+    assert replay["pixels"].dtype == np.uint8
+    assert replay["pixels"].flags.c_contiguous
+    assert array_digest(replay["pixels"]) == TRANSFORMED_DIGEST
+
+
+def test_typed_gap_replay_emits_no_pixels() -> None:
+    replay = _replay(EXPECTED_GAP_CHAIN)
+
+    assert replay == {
+        "pixels": None,
+        "final_emitted_digest": None,
+        "typed_gap": True,
+        "operation_count": 2,
+    }
+
+
+@pytest.mark.parametrize(
+    ("operation", "missing_message", "mismatch_message"),
+    [
+        (
+            "stale_repeat_replace",
+            "stale repeat input digest missing",
+            "stale repeat output digest mismatch",
+        ),
+        (
+            "impossible_transition_replace",
+            "impossible transition input digest missing",
+            "impossible transition output digest mismatch",
+        ),
+    ],
+)
+def test_replacement_operations_require_only_second_input_digest(
+    operation: str,
+    missing_message: str,
+    mismatch_message: str,
+) -> None:
+    chain = _stale_chain(operation=operation)
+    replay = _replay(chain)
+
+    assert replay["final_emitted_digest"] == chain["final_emitted_digest"]
+    assert array_digest(replay["pixels"]) == chain["final_emitted_digest"]
+
+    with pytest.raises(VPMValidationError, match=missing_message):
+        _replay(_stale_chain(operation=operation, second_input_digest=FAKE_DIGEST))
+    with pytest.raises(VPMValidationError, match=mismatch_message):
+        _replay(_stale_chain(operation=operation, output_digest=OTHER_FAKE_DIGEST))
+
+
+def test_provider_identical_control_passes_through_pixels() -> None:
+    chain = _provider_control_chain()
+    replay = _replay(chain)
+
+    assert replay["typed_gap"] is False
+    assert replay["final_emitted_digest"] == SOURCE_DIGEST
+    assert array_digest(replay["pixels"]) == SOURCE_DIGEST
+
+
+def test_conflicting_splice_replay_uses_injected_executor() -> None:
+    chain, output = _splice_chain()
+    calls: list[dict[str, Any]] = []
+
+    def executor(**kwargs: Any) -> tuple[np.ndarray, dict[str, Any]]:
+        calls.append(kwargs)
+        np.testing.assert_array_equal(
+            kwargs["primary_pixels"], render_row_frame(ROW_ID)
+        )
+        np.testing.assert_array_equal(
+            kwargs["secondary_pixels"],
+            render_row_frame(OTHER_ROW_ID),
+        )
+        return output, {"trace": "test"}
+
+    replay = replay_observation_operation_chain(
+        chain,
+        conflicting_splice_executor=executor,
+        critical_corruption_executor=_unused_critical_corruption_executor,
+    )
+
+    assert len(calls) == 1
+    assert array_digest(replay["pixels"]) == chain["final_emitted_digest"]
+
+    with pytest.raises(VPMValidationError, match="splice input digest missing"):
+        replay_observation_operation_chain(
+            _splice_chain(second_input_digest=FAKE_DIGEST)[0],
+            conflicting_splice_executor=executor,
+            critical_corruption_executor=_unused_critical_corruption_executor,
+        )
+    with pytest.raises(VPMValidationError, match="splice output digest mismatch"):
+        replay_observation_operation_chain(
+            _splice_chain(output_digest=FAKE_DIGEST)[0],
+            conflicting_splice_executor=executor,
+            critical_corruption_executor=_unused_critical_corruption_executor,
+        )
+
+
+def test_critical_corruption_replay_uses_injected_executor() -> None:
+    chain, output = _critical_chain()
+    calls: list[dict[str, Any]] = []
+
+    def executor(
+        source: np.ndarray, coordinate_manifest: dict
+    ) -> tuple[np.ndarray, dict]:
+        calls.append({"source": source, "coordinate_manifest": coordinate_manifest})
+        np.testing.assert_array_equal(source, render_row_frame(ROW_ID))
+        assert coordinate_manifest == {"coordinates": [[0, 0]]}
+        return output, {"trace": "test"}
+
+    replay = replay_observation_operation_chain(
+        chain,
+        conflicting_splice_executor=_unused_conflicting_splice_executor,
+        critical_corruption_executor=executor,
+    )
+
+    assert len(calls) == 1
+    assert array_digest(replay["pixels"]) == chain["final_emitted_digest"]
+
+    with pytest.raises(
+        VPMValidationError,
+        match="critical corruption input digest missing",
+    ):
+        replay_observation_operation_chain(
+            _critical_chain(input_digest=FAKE_DIGEST)[0],
+            conflicting_splice_executor=_unused_conflicting_splice_executor,
+            critical_corruption_executor=executor,
+        )
+    with pytest.raises(
+        VPMValidationError,
+        match="critical corruption output digest mismatch",
+    ):
+        replay_observation_operation_chain(
+            _critical_chain(output_digest=FAKE_DIGEST)[0],
+            conflicting_splice_executor=_unused_conflicting_splice_executor,
+            critical_corruption_executor=executor,
+        )
+
+
+@pytest.mark.parametrize(
+    ("chain", "message"),
+    [
+        (
+            operation_chain(
+                [
+                    operation_record(
+                        index=0,
+                        operation="unsupported",
+                        operation_version="test/v1",
+                        input_digests=[],
+                        parameters={},
+                        output_digest=SOURCE_DIGEST,
+                    ),
+                ],
+                SOURCE_DIGEST,
+            ),
+            "unsupported operation chain operation",
+        ),
+        (
+            operation_chain(
+                [
+                    operation_record(
+                        index=0,
+                        operation="emit_typed_gap_event",
+                        operation_version=GAP_EVENT_VERSION,
+                        input_digests=[],
+                        parameters=GAP_EVENT,
+                        output_digest=SOURCE_DIGEST,
+                    ),
+                ],
+                SOURCE_DIGEST,
+            ),
+            "typed gap operation must not emit pixels",
+        ),
+        (
+            operation_chain(
+                [
+                    operation_record(
+                        index=0,
+                        operation="emit_observation",
+                        operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+                        input_digests=[],
+                        parameters={"event_type": "gap_unknown"},
+                        output_digest=None,
+                    ),
+                ],
+                None,
+            ),
+            "no-pixel emit input mismatch",
+        ),
+    ],
+)
+def test_replay_rejects_unsupported_and_emit_mismatches(
+    chain: dict[str, Any],
+    message: str,
+) -> None:
+    with pytest.raises(VPMValidationError, match=message):
+        _replay(chain)
+
+
+def test_replay_rejects_emit_digest_mismatch() -> None:
+    chain = operation_chain(
+        [
+            _render_op(0, ROW_ID),
+            operation_record(
+                index=1,
+                operation="emit_observation",
+                operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+                input_digests=[FAKE_DIGEST],
+                parameters={"event_type": "frame"},
+                output_digest=SOURCE_DIGEST,
+            ),
+        ],
+        SOURCE_DIGEST,
+    )
+
+    with pytest.raises(
+        VPMValidationError, match="emit operation input/output mismatch"
+    ):
+        _replay(chain)
+
+
+def test_replay_rejects_render_and_transformation_digest_mismatches() -> None:
+    with pytest.raises(
+        VPMValidationError,
+        match="render operation output digest mismatch",
+    ):
+        _replay(
+            _copy_with_operation(
+                EXPECTED_EXACT_CHAIN, 0, {"output_digest": FAKE_DIGEST}
+            )
+        )
+
+    bad_input = deepcopy(EXPECTED_EXACT_CHAIN)
+    bad_input["operations"][1] = operation_record(
+        index=1,
+        operation="apply_bounded_transformation",
+        operation_version=bad_input["operations"][1]["operation_version"],
+        input_digests=[FAKE_DIGEST],
+        parameters=bad_input["operations"][1]["parameters"],
+        output_digest=SOURCE_DIGEST,
+    )
+    bad_input["operation_chain_digest"] = canonical_sha256(
+        {
+            key: value
+            for key, value in bad_input.items()
+            if key != "operation_chain_digest"
+        },
+    )
+    with pytest.raises(VPMValidationError, match="transformation input digest missing"):
+        _replay(bad_input)
+
+    bad_output = deepcopy(EXPECTED_EXACT_CHAIN)
+    bad_output["operations"][1] = operation_record(
+        index=1,
+        operation="apply_bounded_transformation",
+        operation_version=bad_output["operations"][1]["operation_version"],
+        input_digests=[SOURCE_DIGEST],
+        parameters=bad_output["operations"][1]["parameters"],
+        output_digest=FAKE_DIGEST,
+    )
+    bad_output["operations"][2] = _emit_op(2, FAKE_DIGEST)
+    bad_output["final_emitted_digest"] = FAKE_DIGEST
+    bad_output["operation_chain_digest"] = canonical_sha256(
+        {
+            key: value
+            for key, value in bad_output.items()
+            if key != "operation_chain_digest"
+        },
+    )
+    with pytest.raises(
+        VPMValidationError,
+        match="transformation output digest mismatch",
+    ):
+        _replay(bad_output)
+
+
+def test_validate_observation_operation_chain_record_contract() -> None:
+    pixels = render_row_frame(ROW_ID)
+
+    assert _validate(_record(EXPECTED_EXACT_CHAIN, pixels)) == "ok"
+    assert (
+        _validate(_record(EXPECTED_GAP_CHAIN, None, event_type="gap_unknown")) == "ok"
+    )
+    assert _validate({"metadata": {}, "event_type": "frame"}) == (
+        "final_observation_provenance_mismatch"
+    )
+    assert _validate(
+        _record(EXPECTED_EXACT_CHAIN, pixels, observation_pixel_digest=FAKE_DIGEST)
+    ) == ("final_observation_provenance_mismatch")
+    assert _validate(_record(EXPECTED_GAP_CHAIN, None, event_type="frame")) == (
+        "final_observation_provenance_mismatch"
+    )
+    bad_pixels = np.array(pixels, copy=True)
+    bad_pixels[0, 0] = 255 if int(bad_pixels[0, 0]) != 255 else 0
+    assert _validate(_record(EXPECTED_EXACT_CHAIN, bad_pixels)) == (
+        "final_observation_provenance_mismatch"
+    )
+
+
+def test_validate_observation_pixels_are_normalized_to_uint8_contiguous() -> None:
+    pixels = render_row_frame(ROW_ID)
+    wide = np.zeros((16, 56), dtype=np.uint8)
+    wide[:, ::2] = pixels
+    non_contiguous = wide[:, ::2]
+    assert not non_contiguous.flags.c_contiguous
+
+    for value in (pixels.tolist(), pixels.astype(np.int16), non_contiguous):
+        assert _validate(_record(EXPECTED_EXACT_CHAIN, value)) == "ok"
+
+
+def test_legacy_wrappers_delegate_to_core_and_real_family_executors() -> None:
+    replay = benchmark.replay_observation_operation_chain(EXPECTED_EXACT_CHAIN)
+
+    assert replay["final_emitted_digest"] == SOURCE_DIGEST
+    assert array_digest(replay["pixels"]) == SOURCE_DIGEST
+    assert (
+        benchmark.validate_observation_operation_chain(
+            _record(EXPECTED_EXACT_CHAIN, replay["pixels"]),
+        )
+        == "ok"
+    )
+    assert (
+        benchmark.validate_observation_operation_chain(
+            _record(EXPECTED_GAP_CHAIN, None, event_type="gap_unknown"),
+        )
+        == "ok"
+    )
+
+    critical_chain = benchmark._critical_corruption_operation_chain(
+        ROW_ID,
+        EXACT_PARAMS,
+        benchmark._critical_coordinate_manifest(),
+    )
+    critical_replay = benchmark.replay_observation_operation_chain(critical_chain)
+    assert (
+        benchmark.validate_observation_operation_chain(
+            _record(critical_chain, critical_replay["pixels"]),
+        )
+        == "ok"
+    )

--- a/zeromodel/domains/video_action_set/contracts.py
+++ b/zeromodel/domains/video_action_set/contracts.py
@@ -8,6 +8,7 @@ CANONICAL_OBSERVATION_UNIVERSE_VERSION = (
 )
 EPISODE_PLAN_VERSION = "zeromodel-video-action-set-sealed-episode-plan/v1"
 FRAME_SHAPE = (16, 28)
+GAP_EVENT_VERSION = "zeromodel-video-action-set-gap-event/v1"
 GENERATOR_VERSION = "zeromodel-video-action-set-reachability-generator/v1"
 OBSERVATION_OPERATION_CHAIN_VERSION = "zeromodel-video-observation-operation-chain/v1"
 PROVIDER_OBSERVATION_BOUNDARY_VERSION = (
@@ -33,6 +34,7 @@ __all__ = [
     "CANONICAL_OBSERVATION_UNIVERSE_VERSION",
     "EPISODE_PLAN_VERSION",
     "FRAME_SHAPE",
+    "GAP_EVENT_VERSION",
     "GENERATOR_VERSION",
     "OBSERVATION_OPERATION_CHAIN_VERSION",
     "PROVIDER_OBSERVATION_BOUNDARY_VERSION",

--- a/zeromodel/domains/video_action_set/observation_provenance.py
+++ b/zeromodel/domains/video_action_set/observation_provenance.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .arcade_observation import render_row_frame, shooter_config_payload
+from .contracts import (
+    ARCADE_RENDERER_CONTRACT_VERSION,
+    GAP_EVENT_VERSION,
+    OBSERVATION_OPERATION_CHAIN_VERSION,
+    TRANSFORMATION_FAMILY_VERSION,
+)
+from .observation_legacy_adapters import operation_chain, operation_record
+from .transformations import _apply_transformation
+
+
+def valid_frame_operation_chain(
+    row_id: str,
+    transformation_parameters: Mapping[str, Any],
+) -> dict[str, Any]:
+    source = render_row_frame(row_id)
+    _transformed, trace = _apply_transformation(source, transformation_parameters)
+    source_digest = trace["source_observation_digest"]
+    output_digest = trace["transformed_observation_digest"]
+    operations = [
+        operation_record(
+            index=0,
+            operation="render_canonical_row",
+            operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
+            input_digests=[],
+            parameters={
+                "row_id": str(row_id),
+                "renderer": "zeromodel.arcade_policy.render_state_frame",
+                "config": shooter_config_payload(),
+            },
+            output_digest=source_digest,
+        ),
+        operation_record(
+            index=1,
+            operation="apply_bounded_transformation",
+            operation_version=TRANSFORMATION_FAMILY_VERSION,
+            input_digests=[source_digest],
+            parameters={
+                "transformation_parameters": dict(transformation_parameters),
+            },
+            output_digest=output_digest,
+        ),
+        operation_record(
+            index=2,
+            operation="emit_observation",
+            operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+            input_digests=[output_digest],
+            parameters={"event_type": "frame"},
+            output_digest=output_digest,
+        ),
+    ]
+    return operation_chain(operations, output_digest)
+
+
+def gap_event_operation_chain(gap_event: Mapping[str, Any]) -> dict[str, Any]:
+    operations = [
+        operation_record(
+            index=0,
+            operation="emit_typed_gap_event",
+            operation_version=GAP_EVENT_VERSION,
+            input_digests=[],
+            parameters=dict(gap_event),
+            output_digest=None,
+        ),
+        operation_record(
+            index=1,
+            operation="emit_observation",
+            operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+            input_digests=[None],
+            parameters={"event_type": "gap_unknown"},
+            output_digest=None,
+        ),
+    ]
+    return operation_chain(operations, None)
+
+
+__all__ = ["gap_event_operation_chain", "valid_frame_operation_chain"]

--- a/zeromodel/domains/video_action_set/observation_replay.py
+++ b/zeromodel/domains/video_action_set/observation_replay.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol, cast
+
+import numpy as np
+
+from ...artifact import VPMValidationError
+from .arcade_observation import render_row_frame
+from .canonical_json import canonical_sha256
+from .contracts import OBSERVATION_OPERATION_CHAIN_VERSION
+from .observation_provenance_dto import ObservationOperationChainDTO
+from .pixel_digest import array_digest
+from .transformations import _apply_transformation
+
+
+class ConflictingSpliceExecutor(Protocol):
+    def __call__(
+        self,
+        *,
+        primary_pixels: np.ndarray,
+        secondary_pixels: np.ndarray,
+        primary_row_id: str,
+        secondary_row_id: str,
+        primary_action_id: str,
+        secondary_action_id: str,
+        mask_manifest: Mapping[str, Any],
+    ) -> tuple[np.ndarray, Mapping[str, Any]]: ...
+
+
+class CriticalCorruptionExecutor(Protocol):
+    def __call__(
+        self,
+        source: np.ndarray,
+        coordinate_manifest: Mapping[str, Any],
+    ) -> tuple[np.ndarray, Mapping[str, Any]]: ...
+
+
+def _operation_parts(
+    op: Mapping[str, Any],
+) -> tuple[list[str | None], str, Mapping[str, Any], str | None]:
+    expected_param_digest = canonical_sha256(op.get("parameters", {}))
+    if op.get("parameter_digest") != expected_param_digest:
+        raise VPMValidationError("operation parameter digest mismatch")
+    if op.get("operation_digest") != canonical_sha256(
+        {key: value for key, value in op.items() if key != "operation_digest"}
+    ):
+        raise VPMValidationError("operation digest mismatch")
+    input_digests = [
+        None if item is None else str(item) for item in op.get("input_digests", [])
+    ]
+    output_digest = op.get("output_digest")
+    return (
+        input_digests,
+        str(op.get("operation")),
+        cast(Mapping[str, Any], op.get("parameters", {})),
+        None if output_digest is None else str(output_digest),
+    )
+
+
+def _replay_pixel_operation(
+    operation: str,
+    input_digests: list[str | None],
+    parameters: Mapping[str, Any],
+    output_digest: str | None,
+    pixels_by_digest: dict[str, np.ndarray],
+    conflicting_splice_executor: ConflictingSpliceExecutor,
+    critical_corruption_executor: CriticalCorruptionExecutor,
+) -> tuple[str, np.ndarray] | None:
+    if operation == "render_canonical_row":
+        pixels = render_row_frame(str(parameters["row_id"]))
+        digest = array_digest(pixels)
+        mismatch = "render operation output digest mismatch"
+    elif operation == "apply_bounded_transformation":
+        if len(input_digests) != 1 or input_digests[0] not in pixels_by_digest:
+            raise VPMValidationError("transformation input digest missing")
+        pixels, trace = _apply_transformation(
+            pixels_by_digest[str(input_digests[0])],
+            parameters["transformation_parameters"],
+        )
+        digest = trace["transformed_observation_digest"]
+        mismatch = "transformation output digest mismatch"
+    elif operation == "compose_simultaneous_target_evidence":
+        if (
+            len(input_digests) != 2
+            or input_digests[0] not in pixels_by_digest
+            or input_digests[1] not in pixels_by_digest
+        ):
+            raise VPMValidationError("splice input digest missing")
+        pixels, _trace = conflicting_splice_executor(
+            primary_pixels=pixels_by_digest[str(input_digests[0])],
+            secondary_pixels=pixels_by_digest[str(input_digests[1])],
+            primary_row_id=str(parameters["primary_row_id"]),
+            secondary_row_id=str(parameters["secondary_row_id"]),
+            primary_action_id=str(parameters["primary_action_id"]),
+            secondary_action_id=str(parameters["secondary_action_id"]),
+            mask_manifest=parameters["mask_manifest"],
+        )
+        digest = array_digest(pixels)
+        mismatch = "splice output digest mismatch"
+    elif operation == "apply_critical_coordinate_corruption":
+        if len(input_digests) != 1 or input_digests[0] not in pixels_by_digest:
+            raise VPMValidationError("critical corruption input digest missing")
+        pixels, _trace = critical_corruption_executor(
+            pixels_by_digest[str(input_digests[0])],
+            parameters["critical_coordinates"],
+        )
+        digest = array_digest(pixels)
+        mismatch = "critical corruption output digest mismatch"
+    elif operation in {"stale_repeat_replace", "impossible_transition_replace"}:
+        if len(input_digests) != 2 or input_digests[1] not in pixels_by_digest:
+            if operation == "stale_repeat_replace":
+                raise VPMValidationError("stale repeat input digest missing")
+            raise VPMValidationError("impossible transition input digest missing")
+        pixels = np.array(pixels_by_digest[str(input_digests[1])], copy=True)
+        digest = array_digest(pixels)
+        mismatch = (
+            "stale repeat output digest mismatch"
+            if operation == "stale_repeat_replace"
+            else "impossible transition output digest mismatch"
+        )
+    else:
+        return None
+    if digest != output_digest:
+        raise VPMValidationError(mismatch)
+    pixels_by_digest[digest] = pixels
+    return digest, pixels
+
+
+def _replay_emit(
+    input_digests: list[str | None],
+    output_digest: str | None,
+    pixels_by_digest: dict[str, np.ndarray],
+) -> tuple[str | None, np.ndarray | None]:
+    if output_digest is None:
+        if input_digests != [None]:
+            raise VPMValidationError("no-pixel emit input mismatch")
+        return None, None
+    if (
+        len(input_digests) != 1
+        or input_digests[0] != output_digest
+        or str(output_digest) not in pixels_by_digest
+    ):
+        raise VPMValidationError("emit operation input/output mismatch")
+    return str(output_digest), pixels_by_digest[str(output_digest)]
+
+
+def _checked_chain_operations(chain: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    if chain.get("version") != OBSERVATION_OPERATION_CHAIN_VERSION:
+        raise VPMValidationError("unsupported observation operation chain version")
+    operations = cast(list[Mapping[str, Any]], list(chain.get("operations", [])))
+    if [int(op.get("index", -1)) for op in operations] != list(range(len(operations))):
+        raise VPMValidationError("operation chain indices are not ordered")
+    stored_chain_digest = chain.get("operation_chain_digest")
+    if stored_chain_digest != canonical_sha256(
+        {key: value for key, value in chain.items() if key != "operation_chain_digest"}
+    ):
+        raise VPMValidationError("operation chain digest mismatch")
+    return operations
+
+
+def replay_observation_operation_chain(
+    chain: Mapping[str, Any],
+    *,
+    conflicting_splice_executor: ConflictingSpliceExecutor,
+    critical_corruption_executor: CriticalCorruptionExecutor,
+) -> dict[str, Any]:
+    chain = ObservationOperationChainDTO.from_dict(chain).to_dict()
+    chain = cast(dict[str, Any], chain)
+    operations = _checked_chain_operations(chain)
+    pixels_by_digest: dict[str, np.ndarray] = {}
+    current_digest: str | None = None
+    current_pixels: np.ndarray | None = None
+    typed_gap = False
+    for op in operations:
+        input_digests, operation, parameters, output_digest = _operation_parts(op)
+        replay_pixels = _replay_pixel_operation(
+            operation,
+            input_digests,
+            parameters,
+            output_digest,
+            pixels_by_digest,
+            conflicting_splice_executor,
+            critical_corruption_executor,
+        )
+        if replay_pixels is not None:
+            current_digest, current_pixels = replay_pixels
+            continue
+        if operation == "emit_typed_gap_event":
+            if output_digest is not None:
+                raise VPMValidationError("typed gap operation must not emit pixels")
+            typed_gap = True
+            current_digest = None
+            current_pixels = None
+            continue
+        if operation in {
+            "emit_provider_identical_control_observation",
+            "emit_observation",
+        }:
+            current_digest, current_pixels = _replay_emit(
+                input_digests,
+                output_digest,
+                pixels_by_digest,
+            )
+            continue
+        raise VPMValidationError("unsupported operation chain operation")
+    if chain.get("final_emitted_digest") != current_digest:
+        raise VPMValidationError("operation chain final digest mismatch")
+    return {
+        "pixels": current_pixels,
+        "final_emitted_digest": current_digest,
+        "typed_gap": typed_gap,
+        "operation_count": len(operations),
+    }
+
+
+def validate_observation_operation_chain(
+    record: Mapping[str, Any],
+    *,
+    conflicting_splice_executor: ConflictingSpliceExecutor,
+    critical_corruption_executor: CriticalCorruptionExecutor,
+) -> str:
+    chain = record.get("metadata", {}).get("observation_operation_chain")
+    if not isinstance(chain, Mapping):
+        return "final_observation_provenance_mismatch"
+    try:
+        replay = replay_observation_operation_chain(
+            chain,
+            conflicting_splice_executor=conflicting_splice_executor,
+            critical_corruption_executor=critical_corruption_executor,
+        )
+    except (KeyError, TypeError, ValueError, VPMValidationError):
+        return "final_observation_provenance_mismatch"
+    if replay["final_emitted_digest"] != record.get("observation_pixel_digest"):
+        return "final_observation_provenance_mismatch"
+    if record.get("event_type") == "gap_unknown":
+        if (
+            replay["final_emitted_digest"] is not None
+            or replay["typed_gap"] is not True
+        ):
+            return "final_observation_provenance_mismatch"
+    elif replay["final_emitted_digest"] is None:
+        return "final_observation_provenance_mismatch"
+    pixels = record.get("pixels")
+    if (
+        pixels is not None
+        and replay["pixels"] is not None
+        and array_digest(np.ascontiguousarray(pixels, dtype=np.uint8))
+        != replay["final_emitted_digest"]
+    ):
+        return "final_observation_provenance_mismatch"
+    return "ok"
+
+
+__all__ = [
+    "ConflictingSpliceExecutor",
+    "CriticalCorruptionExecutor",
+    "replay_observation_operation_chain",
+    "validate_observation_operation_chain",
+]

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -17,6 +17,7 @@ from .domains.video_action_set.contracts import (
     CANONICAL_OBSERVATION_UNIVERSE_VERSION,
     EPISODE_PLAN_VERSION,
     FRAME_SHAPE,
+    GAP_EVENT_VERSION,
     GENERATOR_VERSION,
     OBSERVATION_OPERATION_CHAIN_VERSION,
     PROVIDER_OBSERVATION_BOUNDARY_VERSION,
@@ -31,8 +32,13 @@ from .domains.video_action_set.observation_legacy_adapters import (
     operation_chain as _operation_chain,
     operation_record as _operation_record,
 )
-from .domains.video_action_set.observation_provenance_dto import (
-    ObservationOperationChainDTO,
+from .domains.video_action_set.observation_provenance import (
+    gap_event_operation_chain as _gap_event_operation_chain,
+    valid_frame_operation_chain as _valid_frame_operation_chain,
+)
+from .domains.video_action_set.observation_replay import (
+    replay_observation_operation_chain as _replay_observation_operation_chain_core,
+    validate_observation_operation_chain as _validate_observation_operation_chain_core,
 )
 from .domains.video_action_set.pixel_digest import (
     array_digest as _array_digest,
@@ -1058,7 +1064,7 @@ def _family_intervention_plan(
         payload |= {
             "event_type": "typed_gap_sequence",
             "gap_event": {
-                "version": "zeromodel-video-action-set-gap-event/v1",
+                "version": GAP_EVENT_VERSION,
                 "position": 2,
                 "duration_frames": 1,
                 "reason": "declared_gap_or_unknown_action",
@@ -1624,41 +1630,6 @@ def _apply_critical_corruption(source_pixels: np.ndarray, coordinate_manifest: M
     return output, manifest
 
 
-def _valid_frame_operation_chain(row_id: str, transformation_parameters: Mapping[str, Any]) -> dict[str, Any]:
-    source = _render_row_frame(row_id)
-    transformed, trace = _apply_transformation(source, transformation_parameters)
-    source_digest = trace["source_observation_digest"]
-    output_digest = trace["transformed_observation_digest"]
-    operations = [
-        _operation_record(
-            index=0,
-            operation="render_canonical_row",
-            operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
-            input_digests=[],
-            parameters={"row_id": str(row_id), "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()},
-            output_digest=source_digest,
-        ),
-        _operation_record(
-            index=1,
-            operation="apply_bounded_transformation",
-            operation_version=TRANSFORMATION_FAMILY_VERSION,
-            input_digests=[source_digest],
-            parameters={"transformation_parameters": dict(transformation_parameters)},
-            output_digest=output_digest,
-        ),
-        _operation_record(
-            index=2,
-            operation="emit_observation",
-            operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
-            input_digests=[output_digest],
-            parameters={"event_type": "frame"},
-            output_digest=output_digest,
-        ),
-    ]
-    return _operation_chain(operations, output_digest)
-
-
-
 def _conflicting_splice_operation_chain(
     *,
     primary_row_id: str,
@@ -1782,15 +1753,6 @@ def _impossible_transition_operation_chain(destination_before: Mapping[str, Any]
 
 
 
-def _gap_event_operation_chain(gap_event: Mapping[str, Any]) -> dict[str, Any]:
-    operations = [
-        _operation_record(index=0, operation="emit_typed_gap_event", operation_version="zeromodel-video-action-set-gap-event/v1", input_digests=[], parameters=dict(gap_event), output_digest=None),
-        _operation_record(index=1, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[None], parameters={"event_type": "gap_unknown"}, output_digest=None),
-    ]
-    return _operation_chain(operations, None)
-
-
-
 def _information_control_operation_chain(current_row_id: str) -> dict[str, Any]:
     current = _render_row_frame(current_row_id)
     current_digest = _array_digest(current)
@@ -1817,140 +1779,20 @@ def _refresh_provider_observation_metadata(record: dict[str, Any]) -> None:
 
 
 def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, Any]:
-    chain = ObservationOperationChainDTO.from_dict(chain).to_dict()
-    if chain.get("version") != OBSERVATION_OPERATION_CHAIN_VERSION:
-        raise VPMValidationError("unsupported observation operation chain version")
-    operations = list(chain.get("operations", []))
-    if [int(op.get("index", -1)) for op in operations] != list(range(len(operations))):
-        raise VPMValidationError("operation chain indices are not ordered")
-    stored_chain_digest = chain.get("operation_chain_digest")
-    if stored_chain_digest != _sha256({key: value for key, value in chain.items() if key != "operation_chain_digest"}):
-        raise VPMValidationError("operation chain digest mismatch")
-    pixels_by_digest: dict[str, np.ndarray] = {}
-    current_digest: str | None = None
-    current_pixels: np.ndarray | None = None
-    typed_gap = False
-    for op in operations:
-        expected_param_digest = _sha256(op.get("parameters", {}))
-        if op.get("parameter_digest") != expected_param_digest:
-            raise VPMValidationError("operation parameter digest mismatch")
-        if op.get("operation_digest") != _sha256({key: value for key, value in op.items() if key != "operation_digest"}):
-            raise VPMValidationError("operation digest mismatch")
-        input_digests = [None if item is None else str(item) for item in op.get("input_digests", [])]
-        operation = str(op.get("operation"))
-        parameters = op.get("parameters", {})
-        output_digest = op.get("output_digest")
-        if operation == "render_canonical_row":
-            row_id = str(parameters["row_id"])
-            pixels = _render_row_frame(row_id)
-            digest = _array_digest(pixels)
-            if digest != output_digest:
-                raise VPMValidationError("render operation output digest mismatch")
-            pixels_by_digest[digest] = pixels
-            current_digest = digest
-            current_pixels = pixels
-        elif operation == "apply_bounded_transformation":
-            if len(input_digests) != 1 or input_digests[0] not in pixels_by_digest:
-                raise VPMValidationError("transformation input digest missing")
-            pixels, trace = _apply_transformation(pixels_by_digest[str(input_digests[0])], parameters["transformation_parameters"])
-            digest = trace["transformed_observation_digest"]
-            if digest != output_digest:
-                raise VPMValidationError("transformation output digest mismatch")
-            pixels_by_digest[digest] = pixels
-            current_digest = digest
-            current_pixels = pixels
-        elif operation == "compose_simultaneous_target_evidence":
-            if len(input_digests) != 2 or input_digests[0] not in pixels_by_digest or input_digests[1] not in pixels_by_digest:
-                raise VPMValidationError("splice input digest missing")
-            pixels, _trace = _apply_conflicting_splice(
-                primary_pixels=pixels_by_digest[str(input_digests[0])],
-                secondary_pixels=pixels_by_digest[str(input_digests[1])],
-                primary_row_id=str(parameters["primary_row_id"]),
-                secondary_row_id=str(parameters["secondary_row_id"]),
-                primary_action_id=str(parameters["primary_action_id"]),
-                secondary_action_id=str(parameters["secondary_action_id"]),
-                mask_manifest=parameters["mask_manifest"],
-            )
-            digest = _array_digest(pixels)
-            if digest != output_digest:
-                raise VPMValidationError("splice output digest mismatch")
-            pixels_by_digest[digest] = pixels
-            current_digest = digest
-            current_pixels = pixels
-        elif operation == "apply_critical_coordinate_corruption":
-            if len(input_digests) != 1 or input_digests[0] not in pixels_by_digest:
-                raise VPMValidationError("critical corruption input digest missing")
-            pixels, _trace = _apply_critical_corruption(pixels_by_digest[str(input_digests[0])], parameters["critical_coordinates"])
-            digest = _array_digest(pixels)
-            if digest != output_digest:
-                raise VPMValidationError("critical corruption output digest mismatch")
-            pixels_by_digest[digest] = pixels
-            current_digest = digest
-            current_pixels = pixels
-        elif operation == "stale_repeat_replace":
-            if len(input_digests) != 2 or input_digests[1] not in pixels_by_digest:
-                raise VPMValidationError("stale repeat input digest missing")
-            pixels = np.array(pixels_by_digest[str(input_digests[1])], copy=True)
-            digest = _array_digest(pixels)
-            if digest != output_digest:
-                raise VPMValidationError("stale repeat output digest mismatch")
-            pixels_by_digest[digest] = pixels
-            current_digest = digest
-            current_pixels = pixels
-        elif operation == "impossible_transition_replace":
-            if len(input_digests) != 2 or input_digests[1] not in pixels_by_digest:
-                raise VPMValidationError("impossible transition input digest missing")
-            pixels = np.array(pixels_by_digest[str(input_digests[1])], copy=True)
-            digest = _array_digest(pixels)
-            if digest != output_digest:
-                raise VPMValidationError("impossible transition output digest mismatch")
-            pixels_by_digest[digest] = pixels
-            current_digest = digest
-            current_pixels = pixels
-        elif operation == "emit_typed_gap_event":
-            if output_digest is not None:
-                raise VPMValidationError("typed gap operation must not emit pixels")
-            typed_gap = True
-            current_digest = None
-            current_pixels = None
-        elif operation in {"emit_provider_identical_control_observation", "emit_observation"}:
-            if output_digest is None:
-                if input_digests != [None]:
-                    raise VPMValidationError("no-pixel emit input mismatch")
-                current_digest = None
-                current_pixels = None
-            else:
-                if len(input_digests) != 1 or input_digests[0] != output_digest or str(output_digest) not in pixels_by_digest:
-                    raise VPMValidationError("emit operation input/output mismatch")
-                current_digest = str(output_digest)
-                current_pixels = pixels_by_digest[str(output_digest)]
-        else:
-            raise VPMValidationError("unsupported operation chain operation")
-    if chain.get("final_emitted_digest") != current_digest:
-        raise VPMValidationError("operation chain final digest mismatch")
-    return {"pixels": current_pixels, "final_emitted_digest": current_digest, "typed_gap": typed_gap, "operation_count": len(operations)}
+    return _replay_observation_operation_chain_core(
+        chain,
+        conflicting_splice_executor=_apply_conflicting_splice,
+        critical_corruption_executor=_apply_critical_corruption,
+    )
 
 
 
 def validate_observation_operation_chain(record: Mapping[str, Any]) -> str:
-    chain = record.get("metadata", {}).get("observation_operation_chain")
-    if not isinstance(chain, Mapping):
-        return "final_observation_provenance_mismatch"
-    try:
-        replay = replay_observation_operation_chain(chain)
-    except (KeyError, TypeError, ValueError, VPMValidationError):
-        return "final_observation_provenance_mismatch"
-    if replay["final_emitted_digest"] != record.get("observation_pixel_digest"):
-        return "final_observation_provenance_mismatch"
-    if record.get("event_type") == "gap_unknown":
-        if replay["final_emitted_digest"] is not None or replay["typed_gap"] is not True:
-            return "final_observation_provenance_mismatch"
-    elif replay["final_emitted_digest"] is None:
-        return "final_observation_provenance_mismatch"
-    pixels = record.get("pixels")
-    if pixels is not None and replay["pixels"] is not None and _array_digest(np.ascontiguousarray(pixels, dtype=np.uint8)) != replay["final_emitted_digest"]:
-        return "final_observation_provenance_mismatch"
-    return "ok"
+    return _validate_observation_operation_chain_core(
+        record,
+        conflicting_splice_executor=_apply_conflicting_splice,
+        critical_corruption_executor=_apply_critical_corruption,
+    )
 
 
 


### PR DESCRIPTION
## Summary

- Extract valid-frame and typed-gap operation-chain construction into `observation_provenance.py`.
- Extract operation-chain replay and record validation into `observation_replay.py` with explicit conflicting-splice and critical-corruption executor protocols.
- Keep legacy benchmark aliases/wrappers intact and add architecture/quality ratchets plus focused fast tests.

Audit-Exempt: behavior-preserving observation provenance construction and replay extraction; no claim status, benchmark evidence, scientific semantics, observation identities, provider identities, digest semantics, materialization policy, or conclusions changed.

## Validation

- `python -m pytest -q tests/test_video_observation_provenance_kernel.py tests/test_video_observation_rmdto.py tests/test_video_transformation_kernel.py`
- `python scripts/check_architecture.py`
- `python scripts/check_quality.py`
- `python scripts/run_fast_tests.py`
- `python -m build`

Integration/slow tests, complete episode materialization, and exhaustive transformed-universe runs were intentionally not run for this Stage 4A draft.