### PR TITLE
refactor: extract episode-family science kernels

### DIFF
--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -9,7 +9,7 @@ maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
 reason = "Stage 3 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 5456
+maximum_lines = 4819
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -28,6 +28,16 @@ OBSERVATION_REPLAY_MODULE = "zeromodel.domains.video_action_set.observation_repl
 OBSERVATION_UNIVERSE_MODULE = "zeromodel.domains.video_action_set.observation_universe"
 PIXEL_DIGEST_MODULE = "zeromodel.domains.video_action_set.pixel_digest"
 TRANSFORMATIONS_MODULE = "zeromodel.domains.video_action_set.transformations"
+EPISODE_FAMILIES_MODULE = "zeromodel.domains.video_action_set.episode_families"
+FRAME_FAMILY_KERNELS_MODULE = "zeromodel.domains.video_action_set.frame_family_kernels"
+FAMILY_PROVENANCE_MODULE = "zeromodel.domains.video_action_set.family_provenance"
+FAMILY_VALIDATION_MODULE = "zeromodel.domains.video_action_set.family_validation"
+FAMILY_SCIENCE_MODULES = {
+    EPISODE_FAMILIES_MODULE,
+    FRAME_FAMILY_KERNELS_MODULE,
+    FAMILY_PROVENANCE_MODULE,
+    FAMILY_VALIDATION_MODULE,
+}
 VIDEO_OBSERVATION_KERNEL_MODULES = {
     ARCADE_OBSERVATION_MODULE,
     OBSERVATION_PROVENANCE_MODULE,
@@ -58,6 +68,10 @@ VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
     ARCADE_OBSERVATION_MODULE,
     CANONICAL_JSON_MODULE,
     CONTRACTS_MODULE,
+    EPISODE_FAMILIES_MODULE,
+    FAMILY_PROVENANCE_MODULE,
+    FAMILY_VALIDATION_MODULE,
+    FRAME_FAMILY_KERNELS_MODULE,
     "zeromodel.domains.video_action_set.dto",
     "zeromodel.domains.video_action_set.episode_plan_service",
     "zeromodel.domains.video_action_set.observation_common",
@@ -524,6 +538,96 @@ def observation_provenance_replay_forbidden_edge_violations(
     return violations
 
 
+def family_science_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
+    violations: list[Violation] = []
+    if edge.importer in FAMILY_SCIENCE_MODULES and (
+        edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+        or is_module_under(edge.imported, DB_ORM_PREFIX)
+        or is_module_under(edge.imported, DB_STORES_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db.session")
+        or is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+        or is_sqlalchemy_import(edge.imported)
+    ):
+        violations.append(
+            edge_violation(
+                "family science modules must not import legacy benchmark, persistence, or runtime",
+                edge,
+            )
+        )
+    if edge.importer == EPISODE_FAMILIES_MODULE and edge.imported in {
+        ARCADE_OBSERVATION_MODULE,
+        FAMILY_PROVENANCE_MODULE,
+        FAMILY_VALIDATION_MODULE,
+        FRAME_FAMILY_KERNELS_MODULE,
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+        OBSERVATION_UNIVERSE_MODULE,
+        TRANSFORMATIONS_MODULE,
+    }:
+        violations.append(
+            edge_violation(
+                "episode_families must not import higher family or observation kernels",
+                edge,
+            )
+        )
+    if edge.importer == FRAME_FAMILY_KERNELS_MODULE and edge.imported in {
+        FAMILY_PROVENANCE_MODULE,
+        FAMILY_VALIDATION_MODULE,
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+        "zeromodel.domains.video_action_set.dto",
+        "zeromodel.domains.video_action_set.episode_plan_service",
+    }:
+        violations.append(
+            edge_violation(
+                "frame_family_kernels must not import provenance, replay, validation, or planning",
+                edge,
+            )
+        )
+    if edge.importer == FAMILY_PROVENANCE_MODULE and edge.imported in {
+        FAMILY_VALIDATION_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+    }:
+        violations.append(
+            edge_violation(
+                "family_provenance must not import replay or validation",
+                edge,
+            )
+        )
+    if edge.importer == FAMILY_VALIDATION_MODULE and edge.imported in {
+        FAMILY_PROVENANCE_MODULE,
+        FRAME_FAMILY_KERNELS_MODULE,
+    }:
+        violations.append(
+            edge_violation(
+                "family_validation must not import family provenance or frame kernels",
+                edge,
+            )
+        )
+    if (
+        edge.importer == OBSERVATION_REPLAY_MODULE
+        and edge.imported in FAMILY_SCIENCE_MODULES
+    ):
+        violations.append(
+            edge_violation(
+                "observation_replay must not import family implementation modules",
+                edge,
+            )
+        )
+    if (
+        edge.importer in LOWER_OBSERVATION_MODULES
+        and edge.imported in FAMILY_SCIENCE_MODULES
+    ):
+        violations.append(
+            edge_violation(
+                "lower observation modules must not import family implementation modules",
+                edge,
+            )
+        )
+    return violations
+
+
 def rmdto_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
     violations: list[Violation] = []
     if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
@@ -608,6 +712,7 @@ def forbidden_edge_violations(edges: list[ImportEdge]) -> list[Violation]:
         violations.extend(legacy_forbidden_edge_violations(edge))
         violations.extend(transformation_kernel_forbidden_edge_violations(edge))
         violations.extend(observation_provenance_replay_forbidden_edge_violations(edge))
+        violations.extend(family_science_forbidden_edge_violations(edge))
         violations.extend(rmdto_forbidden_edge_violations(edge))
     return violations
 

--- a/tests/test_video_episode_family_kernel.py
+++ b/tests/test_video_episode_family_kernel.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set import episode_families as families
+from zeromodel.domains.video_action_set.contracts import (
+    CONFLICTING_ACTION_SPLICE_VERSION,
+    CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+    DECLARED_GAP_OR_UNKNOWN_VERSION,
+    EPISODE_FAMILY_REGISTRY_VERSION,
+    FAMILY_CLOSURE_VERSION,
+    FAMILY_INTERVENTION_VERSION,
+    FRAME_INVALID_CLOSURE_VERSION,
+    IMPOSSIBLE_TRANSITION_VERSION,
+    INFORMATION_CONTROL_VERSION,
+    REORDERED_FRAMES_VERSION,
+    SPLICE_MASK_VERSION,
+    STALE_REPEATED_FRAME_VERSION,
+    TRANSFORMATION_FAMILY_VERSION,
+    VALID_FAMILY_VERSION,
+)
+
+
+EXPECTED_FAMILY_IDS = [
+    "valid",
+    "conflicting_action_splice",
+    "critical_evidence_corruption",
+    "reordered_frames",
+    "stale_repeated_frame",
+    "impossible_transition",
+    "declared_gap_or_unknown_action",
+    "information_control",
+]
+EXPECTED_FAMILY_VERSIONS = [
+    "zeromodel-video-action-set-family-valid/v1",
+    "zeromodel-video-action-set-family-conflicting-action-splice/v3",
+    "zeromodel-video-action-set-family-critical-evidence-corruption/v1",
+    "zeromodel-video-action-set-family-reordered-frames/v1",
+    "zeromodel-video-action-set-family-stale-repeated-frame/v1",
+    "zeromodel-video-action-set-family-impossible-transition/v1",
+    "zeromodel-video-action-set-family-declared-gap-or-unknown/v1",
+    "zeromodel-video-action-set-family-information-control/v3",
+]
+EXPECTED_REGISTRY_DIGEST = (
+    "sha256:2d5777cbbe6839dfa866c5e95f4c62a70a402ee4dfe7191e099b8b5258681917"
+)
+
+
+def test_episode_family_registry_is_frozen_and_fresh() -> None:
+    registry = families.episode_family_registry()
+
+    assert registry["version"] == EPISODE_FAMILY_REGISTRY_VERSION
+    assert registry["transformation_contract_version"] == TRANSFORMATION_FAMILY_VERSION
+    assert registry["registry_digest"] == EXPECTED_REGISTRY_DIGEST
+    assert [item["family_id"] for item in registry["families"]] == EXPECTED_FAMILY_IDS
+    assert [item["family_version"] for item in registry["families"]] == (
+        EXPECTED_FAMILY_VERSIONS
+    )
+
+    registry["families"][0]["family_id"] = "mutated"
+    assert families.episode_family_registry()["families"][0]["family_id"] == "valid"
+
+
+def test_family_contract_lookup_returns_copies() -> None:
+    valid = families.family_contract("valid", None)
+    conflicting = families.family_contract("frame_invalid", "conflicting_action_splice")
+    control = families.family_contract("information_control", None)
+
+    assert valid["family_version"] == VALID_FAMILY_VERSION
+    assert conflicting["family_version"] == CONFLICTING_ACTION_SPLICE_VERSION
+    assert conflicting["classification"] == "invalid"
+    assert control["family_version"] == INFORMATION_CONTROL_VERSION
+    assert control["source_action_required"] is False
+
+    conflicting["family_id"] = "mutated"
+    assert (
+        families.family_contract("frame_invalid", "conflicting_action_splice")[
+            "family_id"
+        ]
+        == "conflicting_action_splice"
+    )
+    with pytest.raises(VPMValidationError, match="unknown episode family"):
+        families.family_contract("frame_invalid", "unsupported")
+
+
+def test_family_schedule_and_disposition_contracts_are_frozen() -> None:
+    assert families.family_schedule() == (
+        "exact",
+        "bounded_photometric",
+        "bounded_translation",
+        "bounded_translation_photometric",
+        "bounded_translation_occlusion",
+        "compound_bounded",
+    )
+    assert families.episode_disposition("valid") == "valid"
+    assert (
+        families.episode_disposition("frame_invalid") == "distinguishable_invalid_input"
+    )
+    assert (
+        families.episode_disposition("temporal_negative")
+        == "distinguishable_temporal_invalid"
+    )
+    assert (
+        families.episode_disposition("information_control")
+        == "information_theoretic_control"
+    )
+    assert families.episode_disposition("custom", "x") == "x"
+    assert families.denominator_class("valid") == "valid_denominator"
+    assert (
+        families.denominator_class("frame_invalid")
+        == "distinguishable_invalid_denominator"
+    )
+    assert (
+        families.denominator_class("temporal_negative")
+        == "temporal_negative_denominator"
+    )
+    assert (
+        families.denominator_class("information_control")
+        == "excluded_information_control"
+    )
+    assert families.frame_disposition_for_episode("temporal_negative") == (
+        "valid_frame_payload"
+    )
+
+
+def test_expected_frame_disposition_temporal_closure() -> None:
+    intervention = {
+        "stale_repeat": {"destination_frame_index": 1},
+        "impossible_transition": {"destination_frame_index": 2},
+        "gap_event": {"position": 3},
+    }
+
+    assert (
+        families.expected_frame_disposition(
+            "temporal_negative", "reordered_frames", 0, intervention
+        )
+        == "temporally_reordered_frame_payload"
+    )
+    assert (
+        families.expected_frame_disposition(
+            "temporal_negative", "stale_repeated_frame", 1, intervention
+        )
+        == "stale_repeated_frame_payload"
+    )
+    assert (
+        families.expected_frame_disposition(
+            "temporal_negative", "stale_repeated_frame", 0, intervention
+        )
+        == "valid_frame_payload"
+    )
+    assert (
+        families.expected_frame_disposition(
+            "temporal_negative", "impossible_transition", 2, intervention
+        )
+        == "unreachable_destination_frame_payload"
+    )
+    assert (
+        families.expected_frame_disposition(
+            "temporal_negative",
+            "declared_gap_or_unknown_action",
+            3,
+            intervention,
+        )
+        == "declared_gap_or_unknown_action"
+    )
+    assert (
+        families.expected_frame_disposition("information_control", None, 0)
+        == "information_theoretic_control"
+    )
+
+
+def test_legacy_benchmark_exposes_direct_family_aliases_and_contracts() -> None:
+    assert benchmark._episode_family_registry is families.episode_family_registry
+    assert benchmark._family_contract is families.family_contract
+    assert benchmark._family_schedule is families.family_schedule
+    assert benchmark._episode_disposition is families.episode_disposition
+    assert benchmark._denominator_class is families.denominator_class
+    assert (
+        benchmark._frame_disposition_for_episode
+        is families.frame_disposition_for_episode
+    )
+    assert benchmark.expected_frame_disposition is families.expected_frame_disposition
+
+    assert benchmark.EPISODE_FAMILY_REGISTRY_VERSION == EPISODE_FAMILY_REGISTRY_VERSION
+    assert benchmark.FAMILY_INTERVENTION_VERSION == FAMILY_INTERVENTION_VERSION
+    assert benchmark.CONFLICTING_ACTION_SPLICE_VERSION == (
+        CONFLICTING_ACTION_SPLICE_VERSION
+    )
+    assert benchmark.CRITICAL_EVIDENCE_CORRUPTION_VERSION == (
+        CRITICAL_EVIDENCE_CORRUPTION_VERSION
+    )
+    assert benchmark.REORDERED_FRAMES_VERSION == REORDERED_FRAMES_VERSION
+    assert benchmark.STALE_REPEATED_FRAME_VERSION == STALE_REPEATED_FRAME_VERSION
+    assert benchmark.IMPOSSIBLE_TRANSITION_VERSION == IMPOSSIBLE_TRANSITION_VERSION
+    assert benchmark.DECLARED_GAP_OR_UNKNOWN_VERSION == DECLARED_GAP_OR_UNKNOWN_VERSION
+    assert benchmark.INFORMATION_CONTROL_VERSION == INFORMATION_CONTROL_VERSION
+    assert benchmark.SPLICE_MASK_VERSION == SPLICE_MASK_VERSION
+    assert benchmark.FRAME_INVALID_CLOSURE_VERSION == FRAME_INVALID_CLOSURE_VERSION
+    assert benchmark.FAMILY_CLOSURE_VERSION == FAMILY_CLOSURE_VERSION

--- a/tests/test_video_family_provenance_kernel.py
+++ b/tests/test_video_family_provenance_kernel.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.arcade_observation import render_row_frame
+from zeromodel.domains.video_action_set import family_provenance as provenance
+from zeromodel.domains.video_action_set import family_validation as validation
+from zeromodel.domains.video_action_set import frame_family_kernels as kernels
+from zeromodel.domains.video_action_set.observation_replay import (
+    replay_observation_operation_chain,
+)
+from zeromodel.domains.video_action_set.contracts import (
+    CONFLICTING_ACTION_SPLICE_VERSION,
+    CRITICAL_COORDINATE_SET_VERSION,
+    CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+    CRITICAL_REGION_ID,
+    FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION,
+    FRAME_INVALID_CLOSURE_VERSION,
+    IMPOSSIBLE_TRANSITION_VERSION,
+    INFORMATION_CONTROL_VERSION,
+    SPLICE_MASK_VERSION,
+    STALE_REPEATED_FRAME_VERSION,
+    TARGET_REGION_ID,
+)
+from zeromodel.domains.video_action_set.pixel_digest import array_digest
+from zeromodel.domains.video_action_set.transformations import (
+    _transformation_parameters,
+)
+
+
+PRIMARY_ROW = "tank=0|target=0|cooldown=0"
+SECONDARY_ROW = "tank=0|target=1|cooldown=0"
+THIRD_ROW = "tank=0|target=2|cooldown=0"
+EXACT_PARAMS = _transformation_parameters("exact", 12345)
+PRIMARY_DIGEST = (
+    "sha256:49e46341a170608e2bf8db63064e3d2235727a64ceddafa0cf9970c2707fe443"
+)
+SECONDARY_DIGEST = (
+    "sha256:b72f28f8210df1a77c6bbb7f6486e9eabfe92b460f42a2d1c4f93e6d742a1bf6"
+)
+THIRD_DIGEST = "sha256:0c8dbd9bc06cceadda299372427a3ae57dfed9954a4955ba61270d53092266f5"
+SPLICE_DIGEST = (
+    "sha256:ca73312136f3875a09eba69d6372425ade15dcb2bbb31abeee8da75aeeef33cc"
+)
+CRITICAL_DIGEST = (
+    "sha256:0751a64fcfb6d18949aa5f75a202118ceaa465de25dc69e05e2b8ad5146a8ab6"
+)
+ROW_ACTIONS = {
+    PRIMARY_ROW: "FIRE",
+    SECONDARY_ROW: "RIGHT",
+    THIRD_ROW: "RIGHT",
+}
+
+
+def _spliced() -> tuple[np.ndarray, dict[str, Any]]:
+    return kernels.apply_conflicting_splice(
+        primary_pixels=render_row_frame(PRIMARY_ROW),
+        secondary_pixels=render_row_frame(SECONDARY_ROW),
+        primary_row_id=PRIMARY_ROW,
+        secondary_row_id=SECONDARY_ROW,
+        primary_action_id="FIRE",
+        secondary_action_id="RIGHT",
+        mask_manifest=kernels.splice_mask_manifest(),
+    )
+
+
+def _critical() -> tuple[np.ndarray, dict[str, Any]]:
+    return kernels.apply_critical_corruption(
+        render_row_frame(PRIMARY_ROW),
+        kernels.critical_coordinate_manifest(),
+    )
+
+
+def _splice_kwargs(**overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "primary_pixels": render_row_frame(PRIMARY_ROW),
+        "secondary_pixels": render_row_frame(SECONDARY_ROW),
+        "primary_row_id": PRIMARY_ROW,
+        "secondary_row_id": SECONDARY_ROW,
+        "primary_action_id": "FIRE",
+        "secondary_action_id": "RIGHT",
+        "mask_manifest": kernels.splice_mask_manifest(),
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _frame_record(
+    *,
+    family: str,
+    pixels: np.ndarray,
+    trace: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "family": family,
+        "expected_disposition": "distinguishable_invalid_input",
+        "event_type": "frame",
+        "observation_pixel_digest": array_digest(pixels),
+        "pixels": pixels,
+        "metadata": {"family_intervention_trace": trace},
+    }
+
+
+def _source_record(row_id: str, digest: str) -> dict[str, Any]:
+    return {
+        "expected_row": row_id,
+        "observation_pixel_digest": digest,
+        "metadata": {"transformation_parameters": EXACT_PARAMS},
+    }
+
+
+def _conflicting_chain() -> dict[str, Any]:
+    return provenance.conflicting_splice_operation_chain(
+        primary_row_id=PRIMARY_ROW,
+        secondary_row_id=SECONDARY_ROW,
+        primary_action_id="FIRE",
+        secondary_action_id="RIGHT",
+        primary_transformation_parameters=EXACT_PARAMS,
+        mask_manifest=kernels.splice_mask_manifest(),
+    )
+
+
+def _critical_chain() -> dict[str, Any]:
+    return provenance.critical_corruption_operation_chain(
+        PRIMARY_ROW,
+        EXACT_PARAMS,
+        kernels.critical_coordinate_manifest(),
+    )
+
+
+def test_frame_geometry_manifests_and_visible_evidence_are_frozen() -> None:
+    mask = kernels.splice_mask_manifest()
+    critical = kernels.critical_coordinate_manifest()
+    primary = render_row_frame(PRIMARY_ROW)
+
+    assert kernels.target_signal_coordinates()[0] == (2, 0)
+    assert kernels.target_signal_coordinates()[-1] == (4, 27)
+    assert len(kernels.target_signal_coordinates()) == 84
+    assert kernels.target_slot_signal_coordinates(0) == (
+        (2, 1),
+        (2, 2),
+        (2, 3),
+        (3, 1),
+        (3, 2),
+        (3, 3),
+        (4, 2),
+    )
+    assert kernels.critical_coordinates() == (
+        (7, 25),
+        (7, 26),
+        (8, 25),
+        (8, 26),
+    )
+    assert critical == {
+        "version": CRITICAL_COORDINATE_SET_VERSION,
+        "criticality_source": "tiny_arcade_shooter_rendering",
+        "criticality_region_id": CRITICAL_REGION_ID,
+        "coordinates": [[7, 25], [7, 26], [8, 25], [8, 26]],
+        "coordinate_set_digest": (
+            "sha256:bdb6fcb07eafaeb00978a0fecabb470886f2d5ced3dee9383274aaefaf6fb081"
+        ),
+    }
+    assert mask["version"] == SPLICE_MASK_VERSION
+    assert mask["target_region_id"] == TARGET_REGION_ID
+    assert mask["coordinate_count"] == 84
+    assert mask["mask_digest"] == (
+        "sha256:1850329620179f93ec0ddec778d559c16b7b5f9464b1ee8344e6c91b8b27e781"
+    )
+    assert kernels.final_visible_target_action_evidence(primary, ROW_ACTIONS) == {
+        "version": FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION,
+        "final_visible_target_slots": [0],
+        "final_tank_slot": 0,
+        "final_cooldown": 0,
+        "visible_target_action_map": {"0": "FIRE"},
+        "visible_action_set": ["FIRE"],
+        "conflicting_action_evidence_present": False,
+        "visible_action_evidence_digest": (
+            "sha256:2bd0d7336fa88ec919362ccdeb4bfc7474cc57d9e626d70796ba0972bf70835c"
+        ),
+    }
+
+
+def test_splice_and_critical_intervention_outputs_are_frozen() -> None:
+    spliced, splice_trace = _spliced()
+    corrupted, critical_trace = _critical()
+
+    assert array_digest(spliced) == SPLICE_DIGEST
+    assert splice_trace["splice_trace_digest"] == (
+        "sha256:0560f6990b65c67fc5f151fb1b2eb7c4fe34714dec11fb58a6b690ba2e8b9697"
+    )
+    assert splice_trace["visible_action_set"] == ["FIRE", "RIGHT"]
+    assert splice_trace["canonical_collision_count"] == 0
+    assert splice_trace["changed_pixel_count"] == 7
+    assert splice_trace["action_relevant_region_contribution_counts"] == {
+        "primary_target_pixel_count": 7,
+        "secondary_target_pixel_count": 7,
+        "secondary_additive_target_pixel_count": 7,
+        "target_overlap_pixel_count": 0,
+    }
+    assert array_digest(corrupted) == CRITICAL_DIGEST
+    assert critical_trace["critical_corruption_digest"] == (
+        "sha256:942ad2b962b0b05271abbbd3fb47d80cb6cdcc911fbe0b6281d4d19c6ca6c8bd"
+    )
+    assert critical_trace["changed_pixel_count"] == 4
+    assert [item["replacement"] for item in critical_trace["changes"]] == [
+        255,
+        255,
+        255,
+        255,
+    ]
+
+
+def test_conflicting_splice_validation_messages_and_precedence(monkeypatch) -> None:
+    def expect(message: str, **overrides: Any) -> None:
+        with pytest.raises(VPMValidationError, match=message):
+            kernels.apply_conflicting_splice(**_splice_kwargs(**overrides))
+
+    expect(
+        "conflicting splice requires different governed actions",
+        secondary_action_id="FIRE",
+        secondary_pixels=np.zeros((15, 28), dtype=np.uint8),
+    )
+    expect(
+        "splice sources must have the same shape",
+        secondary_pixels=np.zeros((15, 28), dtype=np.uint8),
+    )
+    expect(
+        "conflicting splice requires the canonical frame shape",
+        primary_pixels=np.zeros((15, 28), dtype=np.uint8),
+        secondary_pixels=np.zeros((15, 28), dtype=np.uint8),
+    )
+    expect(
+        "unsupported conflicting splice mask version",
+        mask_manifest=kernels.splice_mask_manifest() | {"version": "test/v0"},
+    )
+    expect(
+        "conflicting splice requires the simultaneous target-evidence mask",
+        mask_manifest=kernels.splice_mask_manifest() | {"mask_kind": "test"},
+    )
+    expect(
+        "conflicting splice target coordinates do not match the frozen renderer geometry",
+        mask_manifest=kernels.splice_mask_manifest() | {"coordinates": [[2, 0]]},
+    )
+    expect(
+        "splice requires visible target evidence from both sources",
+        primary_pixels=np.zeros((16, 28), dtype=np.uint8),
+    )
+    expect(
+        "splice requires distinct secondary target evidence",
+        secondary_pixels=render_row_frame(PRIMARY_ROW),
+    )
+    spliced, _trace = _spliced()
+    expect(
+        "splice output must not equal either source observation",
+        secondary_pixels=spliced,
+    )
+    expect(
+        "conflicting splice final visible target evidence does not imply conflicting actions",
+        primary_pixels=render_row_frame(SECONDARY_ROW),
+        secondary_pixels=render_row_frame(THIRD_ROW),
+        primary_row_id=SECONDARY_ROW,
+        secondary_row_id=THIRD_ROW,
+        primary_action_id="RIGHT",
+        secondary_action_id="FIRE",
+    )
+    with monkeypatch.context() as local_patch:
+        local_patch.setattr(
+            kernels,
+            "_canonical_collision_rows",
+            lambda _pixels: [{"row_id": PRIMARY_ROW, "action_id": "FIRE"}],
+        )
+        expect("conflicting splice output collides with a canonical valid observation")
+    with monkeypatch.context() as local_patch:
+        primary_mask = np.zeros((16, 28), dtype=bool)
+        primary_mask[2, 1] = True
+        secondary_mask = np.zeros((16, 28), dtype=bool)
+        secondary_mask[2, 2] = True
+        masks = iter([primary_mask, secondary_mask])
+        local_patch.setattr(kernels, "target_signal_mask", lambda _pixels: next(masks))
+        expect(
+            "splice requires nonzero effective contribution from both sources",
+            primary_pixels=np.zeros((16, 28), dtype=np.uint8),
+            secondary_pixels=np.zeros((16, 28), dtype=np.uint8),
+        )
+
+
+def test_critical_corruption_preserves_forged_manifest_identity() -> None:
+    forged_digest = "sha256:" + "a" * 64
+    forged = kernels.critical_coordinate_manifest() | {
+        "version": "forged-critical-manifest/v0",
+        "coordinate_set_digest": forged_digest,
+    }
+
+    corrupted, trace = kernels.apply_critical_corruption(
+        render_row_frame(PRIMARY_ROW),
+        forged,
+    )
+
+    assert array_digest(corrupted) == CRITICAL_DIGEST
+    assert trace["criticality_artifact_identity"] == CRITICAL_COORDINATE_SET_VERSION
+    assert trace["critical_coordinate_set_identity"] == forged_digest
+    assert trace["critical_corruption_digest"] == (
+        "sha256:09c05d930ea1eaf81554735e025cf722acd7f30fe013ac0011ab5ef0f050d4f6"
+    )
+
+
+def test_family_operation_chains_are_frozen() -> None:
+    stale_plan = {
+        "source_frame_index": 0,
+        "destination_frame_index": 1,
+        "maximum_stale_horizon": 1,
+    }
+    impossible_plan = {
+        "source_frame_index": 0,
+        "destination_frame_index": 1,
+        "source_row_id": PRIMARY_ROW,
+        "source_action_id": "FIRE",
+        "destination_row_id": THIRD_ROW,
+        "destination_action_id": "RIGHT",
+    }
+    chains = {
+        "conflicting": provenance.conflicting_splice_operation_chain(
+            primary_row_id=PRIMARY_ROW,
+            secondary_row_id=SECONDARY_ROW,
+            primary_action_id="FIRE",
+            secondary_action_id="RIGHT",
+            primary_transformation_parameters=EXACT_PARAMS,
+            mask_manifest=kernels.splice_mask_manifest(),
+        ),
+        "critical": provenance.critical_corruption_operation_chain(
+            PRIMARY_ROW,
+            EXACT_PARAMS,
+            kernels.critical_coordinate_manifest(),
+        ),
+        "stale": provenance.stale_repeat_operation_chain(
+            _source_record(PRIMARY_ROW, PRIMARY_DIGEST),
+            _source_record(SECONDARY_ROW, SECONDARY_DIGEST),
+            stale_plan,
+        ),
+        "impossible": provenance.impossible_transition_operation_chain(
+            _source_record(PRIMARY_ROW, PRIMARY_DIGEST),
+            impossible_plan,
+        ),
+        "control": provenance.information_control_operation_chain(PRIMARY_ROW),
+    }
+
+    assert chains["conflicting"]["operation_chain_digest"] == (
+        "sha256:ad903845d7542e69e0bee0fcca0fff929e6f7df4a2e6d7802dac095d5a3db999"
+    )
+    assert chains["critical"]["operation_chain_digest"] == (
+        "sha256:1a2432d0540542bdd2cd204aa0f36d33f17852aaea32fb283716d2f83da2a5ff"
+    )
+    assert chains["stale"]["operation_chain_digest"] == (
+        "sha256:1b176a60f36540c9d5c7e056c6f581141fd0d0eabd535d674dafcd75c7a045dd"
+    )
+    assert chains["impossible"]["operation_chain_digest"] == (
+        "sha256:46a1f450f665910e5fbef778e34b94a865b8adc9105083b6f2d2a5f4870ee683"
+    )
+    assert chains["control"]["operation_chain_digest"] == (
+        "sha256:fedc9cd54944fba25c6e0c4d93d30c024e4f49aa23da32e06dfef99bb54e8edb"
+    )
+    assert chains["conflicting"]["final_emitted_digest"] == SPLICE_DIGEST
+    assert chains["critical"]["final_emitted_digest"] == CRITICAL_DIGEST
+    assert chains["stale"]["final_emitted_digest"] == SECONDARY_DIGEST
+    assert chains["impossible"]["final_emitted_digest"] == THIRD_DIGEST
+    assert [op["operation_version"] for op in chains["conflicting"]["operations"]][
+        3
+    ] == CONFLICTING_ACTION_SPLICE_VERSION
+    assert [op["operation_version"] for op in chains["critical"]["operations"]][
+        2
+    ] == CRITICAL_EVIDENCE_CORRUPTION_VERSION
+    assert [op["operation_version"] for op in chains["stale"]["operations"]][
+        4
+    ] == STALE_REPEATED_FRAME_VERSION
+    assert [op["operation_version"] for op in chains["impossible"]["operations"]][
+        3
+    ] == IMPOSSIBLE_TRANSITION_VERSION
+    assert [op["operation_version"] for op in chains["control"]["operations"]][
+        1
+    ] == INFORMATION_CONTROL_VERSION
+
+
+def test_replay_core_uses_real_extracted_family_executors() -> None:
+    splice_replay = replay_observation_operation_chain(
+        _conflicting_chain(),
+        conflicting_splice_executor=kernels.apply_conflicting_splice,
+        critical_corruption_executor=kernels.apply_critical_corruption,
+    )
+    critical_replay = replay_observation_operation_chain(
+        _critical_chain(),
+        conflicting_splice_executor=kernels.apply_conflicting_splice,
+        critical_corruption_executor=kernels.apply_critical_corruption,
+    )
+
+    assert splice_replay["final_emitted_digest"] == SPLICE_DIGEST
+    assert array_digest(splice_replay["pixels"]) == SPLICE_DIGEST
+    assert critical_replay["final_emitted_digest"] == CRITICAL_DIGEST
+    assert array_digest(critical_replay["pixels"]) == CRITICAL_DIGEST
+
+
+def test_family_validation_statuses_and_closure_digest_are_frozen() -> None:
+    spliced, splice_trace = _spliced()
+    corrupted, critical_trace = _critical()
+    splice_record = _frame_record(
+        family="conflicting_action_splice",
+        pixels=spliced,
+        trace=splice_trace,
+    )
+    critical_record = _frame_record(
+        family="critical_evidence_corruption",
+        pixels=corrupted,
+        trace=critical_trace,
+    )
+
+    assert validation.validate_materialized_family_record(splice_record) == "ok"
+    assert (
+        validation.validate_materialized_family_record(
+            splice_record | {"observation_pixel_digest": CRITICAL_DIGEST}
+        )
+        == "stale_observation_digest"
+    )
+    assert (
+        validation.validate_materialized_family_record(
+            {
+                "metadata": {
+                    "family_intervention_trace": {
+                        "output_observation_digest": CRITICAL_DIGEST,
+                        "changed_pixel_count": 1,
+                    }
+                },
+                "observation_pixel_digest": SPLICE_DIGEST,
+            }
+        )
+        == "family_output_digest_mismatch"
+    )
+    assert (
+        validation.validate_materialized_family_record(
+            {
+                "metadata": {"family_intervention_trace": {"changed_pixel_count": 0}},
+                "observation_pixel_digest": SPLICE_DIGEST,
+            }
+        )
+        == "family_no_op"
+    )
+    assert (
+        validation.validate_materialized_family_record(
+            {
+                "expected_disposition": "distinguishable_invalid_input",
+                "observation_pixel_digest": PRIMARY_DIGEST,
+                "pixels": render_row_frame(PRIMARY_ROW),
+            }
+        )
+        == "invalid_family_valid_state_collision"
+    )
+    assert (
+        validation.validate_materialized_family_record(
+            {
+                "event_type": "gap_unknown",
+                "observation_pixel_digest": PRIMARY_DIGEST,
+                "pixels": render_row_frame(PRIMARY_ROW),
+            }
+        )
+        == "gap_event_has_pixels"
+    )
+
+    closure = validation.frame_invalid_closure_summary([splice_record, critical_record])
+    assert closure["version"] == FRAME_INVALID_CLOSURE_VERSION
+    assert closure["status"] == "passed"
+    assert closure["totals"] == {
+        "frame_count": 2,
+        "canonical_collision_count": 0,
+        "valid_decode_count": 0,
+        "no_op_count": 0,
+        "malformed_count": 0,
+    }
+    assert closure["closure_digest"] == (
+        "sha256:9c3feb21a81ee14b5206faf4a999dc650162ffc3c337b4995eba74fe52075766"
+    )
+
+
+@pytest.mark.parametrize("metadata", [None, [], "malformed"])
+def test_family_validation_preserves_non_mapping_metadata_failure(
+    metadata: object,
+) -> None:
+    with pytest.raises(AttributeError):
+        validation.validate_materialized_family_record({"metadata": metadata})
+
+
+def test_family_validation_status_precedence_is_frozen() -> None:
+    pixels = render_row_frame(PRIMARY_ROW)
+    collision_record = {
+        "expected_disposition": "distinguishable_invalid_input",
+        "event_type": "gap_unknown",
+        "observation_pixel_digest": PRIMARY_DIGEST,
+        "pixels": pixels,
+    }
+
+    assert (
+        validation.validate_materialized_family_record(
+            collision_record
+            | {
+                "observation_pixel_digest": SPLICE_DIGEST,
+                "metadata": {
+                    "family_intervention_trace": {
+                        "output_observation_digest": CRITICAL_DIGEST,
+                        "changed_pixel_count": 0,
+                    }
+                },
+            }
+        )
+        == "stale_observation_digest"
+    )
+    assert (
+        validation.validate_materialized_family_record(
+            {
+                "metadata": {
+                    "family_intervention_trace": {
+                        "output_observation_digest": CRITICAL_DIGEST,
+                        "changed_pixel_count": 0,
+                    }
+                },
+                "observation_pixel_digest": SPLICE_DIGEST,
+            }
+        )
+        == "family_output_digest_mismatch"
+    )
+    assert (
+        validation.validate_materialized_family_record(
+            collision_record
+            | {
+                "metadata": {
+                    "family_intervention_trace": {
+                        "output_observation_digest": PRIMARY_DIGEST,
+                        "changed_pixel_count": 0,
+                    }
+                }
+            }
+        )
+        == "family_no_op"
+    )
+    assert (
+        validation.validate_materialized_family_record(collision_record)
+        == "invalid_family_valid_state_collision"
+    )
+
+
+def test_legacy_benchmark_exposes_direct_family_kernel_aliases() -> None:
+    assert benchmark._target_signal_coordinates is kernels.target_signal_coordinates
+    assert benchmark._target_signal_mask is kernels.target_signal_mask
+    assert benchmark._splice_evidence_counts is kernels.splice_evidence_counts
+    assert (
+        benchmark._target_slot_signal_coordinates
+        is kernels.target_slot_signal_coordinates
+    )
+    assert benchmark._detect_visible_target_slots is kernels.detect_visible_target_slots
+    assert benchmark._detect_tank_slot is kernels.detect_tank_slot
+    assert benchmark._detect_cooldown_state is kernels.detect_cooldown_state
+    assert (
+        benchmark._final_visible_target_action_evidence
+        is kernels.final_visible_target_action_evidence
+    )
+    assert benchmark._critical_coordinates is kernels.critical_coordinates
+    assert (
+        benchmark._critical_coordinate_manifest is kernels.critical_coordinate_manifest
+    )
+    assert benchmark._splice_mask_manifest is kernels.splice_mask_manifest
+    assert benchmark._apply_conflicting_splice is kernels.apply_conflicting_splice
+    assert benchmark._apply_critical_corruption is kernels.apply_critical_corruption
+    assert (
+        benchmark._conflicting_splice_operation_chain
+        is provenance.conflicting_splice_operation_chain
+    )
+    assert (
+        benchmark._critical_corruption_operation_chain
+        is provenance.critical_corruption_operation_chain
+    )
+    assert benchmark._stale_repeat_operation_chain is (
+        provenance.stale_repeat_operation_chain
+    )
+    assert (
+        benchmark._impossible_transition_operation_chain
+        is provenance.impossible_transition_operation_chain
+    )
+    assert (
+        benchmark._information_control_operation_chain
+        is provenance.information_control_operation_chain
+    )
+    assert benchmark.validate_materialized_family_record is (
+        validation.validate_materialized_family_record
+    )
+    assert benchmark._frame_invalid_closure_summary is (
+        validation.frame_invalid_closure_summary
+    )

--- a/zeromodel/domains/video_action_set/contracts.py
+++ b/zeromodel/domains/video_action_set/contracts.py
@@ -6,10 +6,42 @@ BENCHMARK_VERSION = "zeromodel-video-action-set-reachability-benchmark/v1"
 CANONICAL_OBSERVATION_UNIVERSE_VERSION = (
     "zeromodel-video-action-set-canonical-observation-universe/v1"
 )
+CONFLICTING_ACTION_SPLICE_VERSION = (
+    "zeromodel-video-action-set-family-conflicting-action-splice/v3"
+)
+CRITICAL_COORDINATE_SET_VERSION = (
+    "zeromodel-video-action-set-critical-coordinate-set/v1"
+)
+CRITICAL_EVIDENCE_CORRUPTION_VERSION = (
+    "zeromodel-video-action-set-family-critical-evidence-corruption/v1"
+)
+CRITICAL_REGION_ID = "cooldown_indicator"
+DECLARED_GAP_OR_UNKNOWN_VERSION = (
+    "zeromodel-video-action-set-family-declared-gap-or-unknown/v1"
+)
+EPISODE_FAMILY_REGISTRY_VERSION = (
+    "zeromodel-video-action-set-episode-family-registry/v4"
+)
 EPISODE_PLAN_VERSION = "zeromodel-video-action-set-sealed-episode-plan/v1"
+FAMILY_CLOSURE_VERSION = "zeromodel-video-action-set-family-closure/v1"
+FAMILY_INTERVENTION_VERSION = "zeromodel-video-action-set-family-intervention/v3"
+FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION = (
+    "zeromodel-video-action-set-final-visible-target-action-evidence/v1"
+)
 FRAME_SHAPE = (16, 28)
+FRAME_INVALID_CLOSURE_VERSION = "zeromodel-video-action-set-frame-invalid-closure/v1"
 GAP_EVENT_VERSION = "zeromodel-video-action-set-gap-event/v1"
 GENERATOR_VERSION = "zeromodel-video-action-set-reachability-generator/v1"
+GROUNDED_CONTROL_HISTORY_VERSION = (
+    "zeromodel-video-action-set-grounded-control-history/v1"
+)
+IMPOSSIBLE_TRANSITION_VERSION = (
+    "zeromodel-video-action-set-family-impossible-transition/v1"
+)
+INFORMATION_CONTROL_AMBIGUITY_VERSION = (
+    "zeromodel-video-action-set-information-control-ambiguity/v2"
+)
+INFORMATION_CONTROL_VERSION = "zeromodel-video-action-set-family-information-control/v3"
 OBSERVATION_OPERATION_CHAIN_VERSION = "zeromodel-video-observation-operation-chain/v1"
 PROVIDER_OBSERVATION_BOUNDARY_VERSION = (
     "zeromodel-video-action-set-provider-observation-boundary/v1"
@@ -18,8 +50,15 @@ REACHABILITY_TILE_DIGEST = (
     "sha256:fef2bc5fd795bb92d3bd564bccdc2d32e1b23319aba55dffed5e0391e795a5df"
 )
 REACHABILITY_TILE_VERSION = "zeromodel-video-policy-reachability-tile/v1"
+REORDERED_FRAMES_VERSION = "zeromodel-video-action-set-family-reordered-frames/v1"
 SEED_DERIVATION_VERSION = "zeromodel-video-action-set-seed-derivation/v1"
+SPLICE_MASK_VERSION = "zeromodel-video-action-set-splice-mask/v2"
+STALE_REPEATED_FRAME_VERSION = (
+    "zeromodel-video-action-set-family-stale-repeated-frame/v1"
+)
+TARGET_REGION_ID = "target_band"
 TRANSFORMATION_FAMILY_VERSION = "zeromodel-video-action-set-transformation-family/v1"
+VALID_FAMILY_VERSION = "zeromodel-video-action-set-family-valid/v1"
 VALID_OBSERVATION_UNIVERSE_VERSION = (
     "zeromodel-video-action-set-valid-observation-universe/v2"
 )
@@ -32,16 +71,35 @@ __all__ = [
     "ARCADE_RENDERER_IDENTITY_VERSION",
     "BENCHMARK_VERSION",
     "CANONICAL_OBSERVATION_UNIVERSE_VERSION",
+    "CONFLICTING_ACTION_SPLICE_VERSION",
+    "CRITICAL_COORDINATE_SET_VERSION",
+    "CRITICAL_EVIDENCE_CORRUPTION_VERSION",
+    "CRITICAL_REGION_ID",
+    "DECLARED_GAP_OR_UNKNOWN_VERSION",
+    "EPISODE_FAMILY_REGISTRY_VERSION",
     "EPISODE_PLAN_VERSION",
+    "FAMILY_CLOSURE_VERSION",
+    "FAMILY_INTERVENTION_VERSION",
+    "FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION",
     "FRAME_SHAPE",
+    "FRAME_INVALID_CLOSURE_VERSION",
     "GAP_EVENT_VERSION",
     "GENERATOR_VERSION",
+    "GROUNDED_CONTROL_HISTORY_VERSION",
+    "IMPOSSIBLE_TRANSITION_VERSION",
+    "INFORMATION_CONTROL_AMBIGUITY_VERSION",
+    "INFORMATION_CONTROL_VERSION",
     "OBSERVATION_OPERATION_CHAIN_VERSION",
     "PROVIDER_OBSERVATION_BOUNDARY_VERSION",
     "REACHABILITY_TILE_DIGEST",
     "REACHABILITY_TILE_VERSION",
+    "REORDERED_FRAMES_VERSION",
     "SEED_DERIVATION_VERSION",
+    "SPLICE_MASK_VERSION",
+    "STALE_REPEATED_FRAME_VERSION",
+    "TARGET_REGION_ID",
     "TRANSFORMATION_FAMILY_VERSION",
+    "VALID_FAMILY_VERSION",
     "VALID_OBSERVATION_UNIVERSE_VERSION",
     "VALID_TRANSFORMATION_PARAMETER_UNIVERSE_VERSION",
 ]

--- a/zeromodel/domains/video_action_set/episode_families.py
+++ b/zeromodel/domains/video_action_set/episode_families.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ...artifact import VPMValidationError
+from .canonical_json import canonical_sha256
+from .contracts import (
+    CONFLICTING_ACTION_SPLICE_VERSION,
+    CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+    DECLARED_GAP_OR_UNKNOWN_VERSION,
+    EPISODE_FAMILY_REGISTRY_VERSION,
+    IMPOSSIBLE_TRANSITION_VERSION,
+    INFORMATION_CONTROL_VERSION,
+    REORDERED_FRAMES_VERSION,
+    STALE_REPEATED_FRAME_VERSION,
+    TRANSFORMATION_FAMILY_VERSION,
+    VALID_FAMILY_VERSION,
+)
+
+
+def _valid_family_entry() -> dict[str, Any]:
+    return {
+        "family_id": "valid",
+        "family_version": VALID_FAMILY_VERSION,
+        "classification": "valid",
+        "source_row_required": True,
+        "source_action_required": True,
+        "pixel_intervention": "bounded valid transformation only",
+        "sequence_intervention": "none",
+        "expected_semantic_effect": "row/action should remain admissible under complete evidence",
+        "distinguishability_status": "distinguishable_valid",
+        "denominator_treatment": "valid denominator",
+        "regeneration_requirements": [
+            "source row",
+            "sealed seed lineage",
+            "transformation parameters",
+            "pixel digest",
+        ],
+        "implementation_status": "implemented_bounded_scaffold",
+    }
+
+
+def _conflicting_splice_family_entry() -> dict[str, Any]:
+    return {
+        "family_id": "conflicting_action_splice",
+        "family_version": CONFLICTING_ACTION_SPLICE_VERSION,
+        "classification": "invalid",
+        "source_row_required": True,
+        "source_action_required": True,
+        "pixel_intervention": "primary target evidence plus additive secondary target evidence with valid-state collision closure",
+        "sequence_intervention": "none",
+        "expected_semantic_effect": "constructed multi-target visual evidence that cannot decode to a canonical valid state",
+        "distinguishability_status": "distinguishable_invalid_input",
+        "denominator_treatment": "distinguishable-invalid denominator",
+        "regeneration_requirements": [
+            "primary source",
+            "secondary source",
+            "target-evidence composition mask",
+            "source contribution counts",
+            "canonical byte-universe noncollision",
+            "output digest",
+        ],
+        "implementation_status": "implemented_bounded_scaffold",
+    }
+
+
+def _critical_corruption_family_entry() -> dict[str, Any]:
+    return {
+        "family_id": "critical_evidence_corruption",
+        "family_version": CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+        "classification": "invalid",
+        "source_row_required": True,
+        "source_action_required": True,
+        "pixel_intervention": "frozen critical coordinate replacement",
+        "sequence_intervention": "none",
+        "expected_semantic_effect": "critical evidence is no longer faithful to the source row",
+        "distinguishability_status": "distinguishable_invalid_input",
+        "denominator_treatment": "distinguishable-invalid denominator",
+        "regeneration_requirements": [
+            "critical coordinate set",
+            "original values",
+            "replacement values",
+            "output digest",
+        ],
+        "implementation_status": "implemented_bounded_scaffold",
+    }
+
+
+def _reordered_frames_family_entry() -> dict[str, Any]:
+    return {
+        "family_id": "reordered_frames",
+        "family_version": REORDERED_FRAMES_VERSION,
+        "classification": "temporal-negative",
+        "source_row_required": True,
+        "source_action_required": True,
+        "pixel_intervention": "none",
+        "sequence_intervention": "non-identity permutation of frame payload order",
+        "expected_semantic_effect": "sequence order evidence is invalid",
+        "distinguishability_status": "distinguishable_temporal_invalid",
+        "denominator_treatment": "temporal-negative denominator",
+        "regeneration_requirements": [
+            "original order",
+            "mutated order",
+            "sequence digest",
+        ],
+        "implementation_status": "implemented_bounded_scaffold",
+    }
+
+
+def _stale_repeat_family_entry() -> dict[str, Any]:
+    return {
+        "family_id": "stale_repeated_frame",
+        "family_version": STALE_REPEATED_FRAME_VERSION,
+        "classification": "temporal-negative",
+        "source_row_required": True,
+        "source_action_required": True,
+        "pixel_intervention": "later frame payload replaced by earlier payload",
+        "sequence_intervention": "explicit stale repeat horizon",
+        "expected_semantic_effect": "current frame evidence is stale",
+        "distinguishability_status": "distinguishable_temporal_invalid",
+        "denominator_treatment": "temporal-negative denominator",
+        "regeneration_requirements": [
+            "source frame index",
+            "destination frame index",
+            "original destination digest",
+            "replacement digest",
+        ],
+        "implementation_status": "implemented_bounded_scaffold",
+    }
+
+
+def _impossible_transition_family_entry() -> dict[str, Any]:
+    return {
+        "family_id": "impossible_transition",
+        "family_version": IMPOSSIBLE_TRANSITION_VERSION,
+        "classification": "temporal-negative",
+        "source_row_required": True,
+        "source_action_required": True,
+        "pixel_intervention": "destination frame set to a nonreachable policy row",
+        "sequence_intervention": "violates frozen reachability relation",
+        "expected_semantic_effect": "no admissible source-to-destination transition",
+        "distinguishability_status": "distinguishable_temporal_invalid",
+        "denominator_treatment": "temporal-negative denominator",
+        "regeneration_requirements": [
+            "transition relation identity",
+            "pairwise reachability audit",
+            "endpoint frame digests",
+        ],
+        "implementation_status": "implemented_bounded_scaffold",
+    }
+
+
+def _declared_gap_family_entry() -> dict[str, Any]:
+    return {
+        "family_id": "declared_gap_or_unknown_action",
+        "family_version": DECLARED_GAP_OR_UNKNOWN_VERSION,
+        "classification": "temporal-negative",
+        "source_row_required": True,
+        "source_action_required": False,
+        "pixel_intervention": "typed gap event with no ordinary pixels",
+        "sequence_intervention": "explicit gap/unknown event",
+        "expected_semantic_effect": "reader sees a deterministic non-frame event",
+        "distinguishability_status": "typed_temporal_event",
+        "denominator_treatment": "temporal-negative denominator",
+        "regeneration_requirements": [
+            "event identity",
+            "position",
+            "duration",
+            "sequence digest",
+        ],
+        "implementation_status": "implemented_bounded_scaffold",
+    }
+
+
+def _information_control_family_entry() -> dict[str, Any]:
+    return {
+        "family_id": "information_control",
+        "family_version": INFORMATION_CONTROL_VERSION,
+        "classification": "information-theoretic-control",
+        "source_row_required": True,
+        "source_action_required": False,
+        "pixel_intervention": "byte-identical control observations with multiple hidden source-history labels",
+        "sequence_intervention": "control-only grouping",
+        "expected_semantic_effect": "hidden distinction unavailable to providers",
+        "distinguishability_status": "information_theoretic_control",
+        "denominator_treatment": "excluded from distinguishable-invalid denominators",
+        "regeneration_requirements": [
+            "control group",
+            "byte identity digest",
+            "hidden history labels",
+            "hidden-label cardinality",
+            "provider-visible field closure",
+        ],
+        "implementation_status": "implemented_bounded_scaffold",
+    }
+
+
+def episode_family_registry() -> dict[str, Any]:
+    entries = [
+        _valid_family_entry(),
+        _conflicting_splice_family_entry(),
+        _critical_corruption_family_entry(),
+        _reordered_frames_family_entry(),
+        _stale_repeat_family_entry(),
+        _impossible_transition_family_entry(),
+        _declared_gap_family_entry(),
+        _information_control_family_entry(),
+    ]
+    return {
+        "version": EPISODE_FAMILY_REGISTRY_VERSION,
+        "transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
+        "families": entries,
+        "registry_digest": canonical_sha256(
+            {"version": EPISODE_FAMILY_REGISTRY_VERSION, "families": entries}
+        ),
+    }
+
+
+def family_contract(
+    family_label: str,
+    mutation_kind: str | None,
+) -> dict[str, Any]:
+    family_id = (
+        "valid" if family_label == "valid" else str(mutation_kind or family_label)
+    )
+    for entry in episode_family_registry()["families"]:
+        if entry["family_id"] == family_id:
+            return dict(entry)
+    raise VPMValidationError("unknown episode family")
+
+
+def family_schedule() -> tuple[str, ...]:
+    return (
+        "exact",
+        "bounded_photometric",
+        "bounded_translation",
+        "bounded_translation_photometric",
+        "bounded_translation_occlusion",
+        "compound_bounded",
+    )
+
+
+def episode_disposition(
+    family_label: str,
+    mutation_kind: str | None = None,
+) -> str:
+    if family_label == "valid":
+        return "valid"
+    if family_label == "frame_invalid":
+        return "distinguishable_invalid_input"
+    if family_label == "temporal_negative":
+        return "distinguishable_temporal_invalid"
+    if family_label == "information_control":
+        return "information_theoretic_control"
+    return str(mutation_kind or family_label)
+
+
+def denominator_class(
+    family_label: str,
+    mutation_kind: str | None = None,
+) -> str:
+    if family_label == "valid":
+        return "valid_denominator"
+    if family_label == "frame_invalid":
+        return "distinguishable_invalid_denominator"
+    if family_label == "temporal_negative":
+        return "temporal_negative_denominator"
+    if family_label == "information_control":
+        return "excluded_information_control"
+    return str(mutation_kind or family_label)
+
+
+def frame_disposition_for_episode(
+    family_label: str,
+    mutation_kind: str | None = None,
+) -> str:
+    if family_label == "valid":
+        return "valid"
+    if family_label == "frame_invalid":
+        return "distinguishable_invalid_input"
+    if family_label == "information_control":
+        return "information_theoretic_control"
+    if family_label == "temporal_negative":
+        return "valid_frame_payload"
+    return str(mutation_kind or family_label)
+
+
+def expected_frame_disposition(
+    episode_family: str,
+    mutation_kind: str | None,
+    frame_index: int,
+    intervention_plan: Mapping[str, Any] | None = None,
+) -> str:
+    family = str(episode_family)
+    kind = None if mutation_kind is None else str(mutation_kind)
+    index = int(frame_index)
+    intervention = dict(intervention_plan or {})
+    if family == "valid":
+        return "valid"
+    if family == "frame_invalid":
+        return "distinguishable_invalid_input"
+    if family == "information_control":
+        return "information_theoretic_control"
+    if family != "temporal_negative":
+        return str(kind or family)
+    if kind == "reordered_frames":
+        return "temporally_reordered_frame_payload"
+    if kind == "stale_repeated_frame":
+        repeat = intervention.get("stale_repeat", {})
+        return (
+            "stale_repeated_frame_payload"
+            if index == int(repeat.get("destination_frame_index", -1))
+            else "valid_frame_payload"
+        )
+    if kind == "impossible_transition":
+        transition = intervention.get("impossible_transition", {})
+        return (
+            "unreachable_destination_frame_payload"
+            if index == int(transition.get("destination_frame_index", -1))
+            else "valid_frame_payload"
+        )
+    if kind == "declared_gap_or_unknown_action":
+        gap = intervention.get("gap_event", {})
+        return (
+            "declared_gap_or_unknown_action"
+            if index == int(gap.get("position", -1))
+            else "valid_frame_payload"
+        )
+    return "valid_frame_payload"
+
+
+__all__ = [
+    "denominator_class",
+    "episode_disposition",
+    "episode_family_registry",
+    "expected_frame_disposition",
+    "family_contract",
+    "family_schedule",
+    "frame_disposition_for_episode",
+]

--- a/zeromodel/domains/video_action_set/family_provenance.py
+++ b/zeromodel/domains/video_action_set/family_provenance.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .arcade_observation import render_row_frame, shooter_config_payload
+from .canonical_json import canonical_sha256
+from .contracts import (
+    ARCADE_RENDERER_CONTRACT_VERSION,
+    CONFLICTING_ACTION_SPLICE_VERSION,
+    CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+    IMPOSSIBLE_TRANSITION_VERSION,
+    INFORMATION_CONTROL_VERSION,
+    OBSERVATION_OPERATION_CHAIN_VERSION,
+    PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+    STALE_REPEATED_FRAME_VERSION,
+    TRANSFORMATION_FAMILY_VERSION,
+)
+from .frame_family_kernels import apply_conflicting_splice, apply_critical_corruption
+from .observation_legacy_adapters import operation_chain, operation_record
+from .observation_provenance import valid_frame_operation_chain
+from .pixel_digest import array_digest
+from .transformations import _apply_transformation
+
+
+def conflicting_splice_operation_chain(
+    *,
+    primary_row_id: str,
+    secondary_row_id: str,
+    primary_action_id: str,
+    secondary_action_id: str,
+    primary_transformation_parameters: Mapping[str, Any],
+    mask_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    primary_base = render_row_frame(primary_row_id)
+    primary_transformed, primary_trace = _apply_transformation(
+        primary_base, primary_transformation_parameters
+    )
+    secondary = render_row_frame(secondary_row_id)
+    output, splice_trace = apply_conflicting_splice(
+        primary_pixels=primary_transformed,
+        secondary_pixels=secondary,
+        primary_row_id=primary_row_id,
+        secondary_row_id=secondary_row_id,
+        primary_action_id=primary_action_id,
+        secondary_action_id=secondary_action_id,
+        mask_manifest=mask_manifest,
+    )
+    primary_base_digest = primary_trace["source_observation_digest"]
+    primary_transformed_digest = primary_trace["transformed_observation_digest"]
+    secondary_digest = array_digest(secondary)
+    output_digest = array_digest(output)
+    operations = [
+        operation_record(
+            index=0,
+            operation="render_canonical_row",
+            operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
+            input_digests=[],
+            parameters={
+                "row_id": primary_row_id,
+                "renderer": "zeromodel.arcade_policy.render_state_frame",
+                "config": shooter_config_payload(),
+            },
+            output_digest=primary_base_digest,
+        ),
+        operation_record(
+            index=1,
+            operation="apply_bounded_transformation",
+            operation_version=TRANSFORMATION_FAMILY_VERSION,
+            input_digests=[primary_base_digest],
+            parameters={
+                "transformation_parameters": dict(primary_transformation_parameters)
+            },
+            output_digest=primary_transformed_digest,
+        ),
+        operation_record(
+            index=2,
+            operation="render_canonical_row",
+            operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
+            input_digests=[],
+            parameters={
+                "row_id": secondary_row_id,
+                "renderer": "zeromodel.arcade_policy.render_state_frame",
+                "config": shooter_config_payload(),
+            },
+            output_digest=secondary_digest,
+        ),
+        operation_record(
+            index=3,
+            operation="compose_simultaneous_target_evidence",
+            operation_version=CONFLICTING_ACTION_SPLICE_VERSION,
+            input_digests=[primary_transformed_digest, secondary_digest],
+            parameters={
+                "primary_row_id": primary_row_id,
+                "secondary_row_id": secondary_row_id,
+                "primary_action_id": primary_action_id,
+                "secondary_action_id": secondary_action_id,
+                "mask_manifest": dict(mask_manifest),
+                "splice_trace_digest": splice_trace["splice_trace_digest"],
+            },
+            output_digest=output_digest,
+        ),
+        operation_record(
+            index=4,
+            operation="emit_observation",
+            operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+            input_digests=[output_digest],
+            parameters={"event_type": "frame"},
+            output_digest=output_digest,
+        ),
+    ]
+    return operation_chain(operations, output_digest)
+
+
+def critical_corruption_operation_chain(
+    row_id: str,
+    transformation_parameters: Mapping[str, Any],
+    coordinate_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    source = render_row_frame(row_id)
+    transformed, transform_trace = _apply_transformation(
+        source, transformation_parameters
+    )
+    corrupted, corruption_trace = apply_critical_corruption(
+        transformed, coordinate_manifest
+    )
+    source_digest = transform_trace["source_observation_digest"]
+    transformed_digest = transform_trace["transformed_observation_digest"]
+    output_digest = array_digest(corrupted)
+    operations = [
+        operation_record(
+            index=0,
+            operation="render_canonical_row",
+            operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
+            input_digests=[],
+            parameters={
+                "row_id": row_id,
+                "renderer": "zeromodel.arcade_policy.render_state_frame",
+                "config": shooter_config_payload(),
+            },
+            output_digest=source_digest,
+        ),
+        operation_record(
+            index=1,
+            operation="apply_bounded_transformation",
+            operation_version=TRANSFORMATION_FAMILY_VERSION,
+            input_digests=[source_digest],
+            parameters={"transformation_parameters": dict(transformation_parameters)},
+            output_digest=transformed_digest,
+        ),
+        operation_record(
+            index=2,
+            operation="apply_critical_coordinate_corruption",
+            operation_version=CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+            input_digests=[transformed_digest],
+            parameters={
+                "critical_coordinates": dict(coordinate_manifest),
+                "critical_corruption_digest": corruption_trace[
+                    "critical_corruption_digest"
+                ],
+            },
+            output_digest=output_digest,
+        ),
+        operation_record(
+            index=3,
+            operation="emit_observation",
+            operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+            input_digests=[output_digest],
+            parameters={"event_type": "frame"},
+            output_digest=output_digest,
+        ),
+    ]
+    return operation_chain(operations, output_digest)
+
+
+def stale_repeat_operation_chain(
+    destination_before: Mapping[str, Any],
+    replacement_source: Mapping[str, Any],
+    repeat: Mapping[str, Any],
+) -> dict[str, Any]:
+    dest_params = destination_before.get("metadata", {}).get(
+        "transformation_parameters", {}
+    )
+    src_params = replacement_source.get("metadata", {}).get(
+        "transformation_parameters", {}
+    )
+    dest_row = str(destination_before.get("expected_row"))
+    src_row = str(replacement_source.get("expected_row"))
+    dest_chain = valid_frame_operation_chain(dest_row, dest_params)
+    src_chain = valid_frame_operation_chain(src_row, src_params)
+    original_digest = str(destination_before["observation_pixel_digest"])
+    replacement_digest = str(replacement_source["observation_pixel_digest"])
+    operations = list(dest_chain["operations"][:-1])
+    offset = len(operations)
+    for op in src_chain["operations"][:-1]:
+        copied = dict(op)
+        copied["index"] = int(op["index"]) + offset
+        copied["operation_digest"] = canonical_sha256(
+            {key: value for key, value in copied.items() if key != "operation_digest"}
+        )
+        operations.append(copied)
+    operations.append(
+        operation_record(
+            index=len(operations),
+            operation="stale_repeat_replace",
+            operation_version=STALE_REPEATED_FRAME_VERSION,
+            input_digests=[original_digest, replacement_digest],
+            parameters=dict(repeat),
+            output_digest=replacement_digest,
+        )
+    )
+    operations.append(
+        operation_record(
+            index=len(operations),
+            operation="emit_observation",
+            operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+            input_digests=[replacement_digest],
+            parameters={"event_type": "frame"},
+            output_digest=replacement_digest,
+        )
+    )
+    return operation_chain(operations, replacement_digest)
+
+
+def impossible_transition_operation_chain(
+    destination_before: Mapping[str, Any], transition_plan: Mapping[str, Any]
+) -> dict[str, Any]:
+    dest_params = destination_before.get("metadata", {}).get(
+        "transformation_parameters", {}
+    )
+    ordinary_row = str(destination_before.get("expected_row"))
+    ordinary_chain = valid_frame_operation_chain(ordinary_row, dest_params)
+    ordinary_digest = str(destination_before["observation_pixel_digest"])
+    unreachable_row = str(transition_plan["destination_row_id"])
+    unreachable_pixels = render_row_frame(unreachable_row)
+    unreachable_digest = array_digest(unreachable_pixels)
+    operations = list(ordinary_chain["operations"][:-1])
+    operations.append(
+        operation_record(
+            index=len(operations),
+            operation="render_canonical_row",
+            operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
+            input_digests=[],
+            parameters={
+                "row_id": unreachable_row,
+                "renderer": "zeromodel.arcade_policy.render_state_frame",
+                "config": shooter_config_payload(),
+            },
+            output_digest=unreachable_digest,
+        )
+    )
+    operations.append(
+        operation_record(
+            index=len(operations),
+            operation="impossible_transition_replace",
+            operation_version=IMPOSSIBLE_TRANSITION_VERSION,
+            input_digests=[ordinary_digest, unreachable_digest],
+            parameters=dict(transition_plan),
+            output_digest=unreachable_digest,
+        )
+    )
+    operations.append(
+        operation_record(
+            index=len(operations),
+            operation="emit_observation",
+            operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+            input_digests=[unreachable_digest],
+            parameters={"event_type": "frame"},
+            output_digest=unreachable_digest,
+        )
+    )
+    return operation_chain(operations, unreachable_digest)
+
+
+def information_control_operation_chain(current_row_id: str) -> dict[str, Any]:
+    current = render_row_frame(current_row_id)
+    current_digest = array_digest(current)
+    operations = [
+        operation_record(
+            index=0,
+            operation="render_canonical_row",
+            operation_version=ARCADE_RENDERER_CONTRACT_VERSION,
+            input_digests=[],
+            parameters={
+                "row_id": str(current_row_id),
+                "renderer": "zeromodel.arcade_policy.render_state_frame",
+                "config": shooter_config_payload(),
+            },
+            output_digest=current_digest,
+        ),
+        operation_record(
+            index=1,
+            operation="emit_provider_identical_control_observation",
+            operation_version=INFORMATION_CONTROL_VERSION,
+            input_digests=[current_digest],
+            parameters={
+                "current_row_id": str(current_row_id),
+                "provider_observation_boundary_version": PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+            },
+            output_digest=current_digest,
+        ),
+        operation_record(
+            index=2,
+            operation="emit_observation",
+            operation_version=OBSERVATION_OPERATION_CHAIN_VERSION,
+            input_digests=[current_digest],
+            parameters={"event_type": "frame"},
+            output_digest=current_digest,
+        ),
+    ]
+    return operation_chain(operations, current_digest)
+
+
+__all__ = [
+    "conflicting_splice_operation_chain",
+    "critical_corruption_operation_chain",
+    "impossible_transition_operation_chain",
+    "information_control_operation_chain",
+    "stale_repeat_operation_chain",
+]

--- a/zeromodel/domains/video_action_set/family_validation.py
+++ b/zeromodel/domains/video_action_set/family_validation.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from .canonical_json import canonical_sha256
+from .contracts import (
+    FRAME_INVALID_CLOSURE_VERSION,
+    VALID_OBSERVATION_UNIVERSE_VERSION,
+)
+from .observation_universe import (
+    _canonical_observation_digest_index,
+    canonical_observation_universe,
+)
+from .pixel_digest import array_digest
+
+
+def validate_materialized_family_record(record: Mapping[str, Any]) -> str:
+    pixels = record.get("pixels")
+    if pixels is not None and record.get("observation_pixel_digest") != array_digest(
+        np.ascontiguousarray(pixels, dtype=np.uint8)
+    ):
+        return "stale_observation_digest"
+    metadata = record.get("metadata", {})
+    trace = metadata.get("family_intervention_trace")
+    if trace:
+        output_digest = trace.get("output_observation_digest")
+        if output_digest is not None and output_digest != record.get(
+            "observation_pixel_digest"
+        ):
+            return "family_output_digest_mismatch"
+        if trace.get("changed_pixel_count") == 0:
+            return "family_no_op"
+    if (
+        record.get("expected_disposition") == "distinguishable_invalid_input"
+        and pixels is not None
+    ):
+        digest = str(
+            record.get("observation_pixel_digest")
+            or array_digest(np.ascontiguousarray(pixels, dtype=np.uint8))
+        )
+        if _canonical_observation_digest_index().get(digest):
+            return "invalid_family_valid_state_collision"
+    if record.get("event_type") == "gap_unknown" and pixels is not None:
+        return "gap_event_has_pixels"
+    return "ok"
+
+
+def frame_invalid_closure_summary(
+    records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    canonical = canonical_observation_universe()
+    canonical_index = _canonical_observation_digest_index()
+    by_family: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if record.get("expected_disposition") != "distinguishable_invalid_input":
+            continue
+        family = str(record.get("family"))
+        row = by_family.setdefault(
+            family,
+            {
+                "family_id": family,
+                "frame_count": 0,
+                "canonical_collision_count": 0,
+                "valid_decode_count": 0,
+                "no_op_count": 0,
+                "malformed_count": 0,
+                "collision_examples": [],
+            },
+        )
+        row["frame_count"] += 1
+        pixels = record.get("pixels")
+        if pixels is None:
+            row["malformed_count"] += 1
+            continue
+        digest = str(
+            record.get("observation_pixel_digest")
+            or array_digest(np.ascontiguousarray(pixels, dtype=np.uint8))
+        )
+        collisions = canonical_index.get(digest, [])
+        if collisions:
+            row["canonical_collision_count"] += 1
+            row["valid_decode_count"] += 1
+            if len(row["collision_examples"]) < 3:
+                row["collision_examples"].append(
+                    {
+                        "frame_id": record.get("frame_id"),
+                        "observation_pixel_digest": digest,
+                        "canonical_rows": collisions,
+                    }
+                )
+        trace = record.get("metadata", {}).get("family_intervention_trace", {})
+        if trace.get("changed_pixel_count") == 0:
+            row["no_op_count"] += 1
+        status = validate_materialized_family_record(record)
+        if status != "ok":
+            row["malformed_count"] += 1
+    totals = {
+        "frame_count": sum(row["frame_count"] for row in by_family.values()),
+        "canonical_collision_count": sum(
+            row["canonical_collision_count"] for row in by_family.values()
+        ),
+        "valid_decode_count": sum(
+            row["valid_decode_count"] for row in by_family.values()
+        ),
+        "no_op_count": sum(row["no_op_count"] for row in by_family.values()),
+        "malformed_count": sum(row["malformed_count"] for row in by_family.values()),
+    }
+    passed = (
+        totals["frame_count"] > 0
+        and totals["canonical_collision_count"] == 0
+        and totals["valid_decode_count"] == 0
+        and totals["no_op_count"] == 0
+        and totals["malformed_count"] == 0
+    )
+    payload = {
+        "version": FRAME_INVALID_CLOSURE_VERSION,
+        "canonical_universe_version": canonical["version"],
+        "canonical_universe_digest": canonical["universe_digest"],
+        "valid_observation_universe_version": VALID_OBSERVATION_UNIVERSE_VERSION,
+        "families": list(by_family.values()),
+        "totals": totals,
+        "status": "passed" if passed else "failed",
+    }
+    payload["closure_digest"] = canonical_sha256(payload)
+    return payload
+
+
+__all__ = ["frame_invalid_closure_summary", "validate_materialized_family_record"]

--- a/zeromodel/domains/video_action_set/frame_family_kernels.py
+++ b/zeromodel/domains/video_action_set/frame_family_kernels.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from ...arcade_policy import (
+    ACTIONS,
+    CELL_PIXELS,
+    COOLDOWN_BLOCKED_VALUE,
+    COOLDOWN_READY_VALUE,
+    TANK_VALUE,
+    TARGET_VALUE,
+    ShooterConfig,
+    compile_policy_artifact,
+    parse_state_row_id,
+    state_row_id,
+)
+from ...artifact import VPMValidationError
+from ...policy_lookup import VPMPolicyLookup
+from .canonical_json import canonical_sha256
+from .contracts import (
+    CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+    CRITICAL_COORDINATE_SET_VERSION,
+    CRITICAL_REGION_ID,
+    FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION,
+    FRAME_SHAPE,
+    SPLICE_MASK_VERSION,
+    TARGET_REGION_ID,
+)
+from .observation_universe import _canonical_collision_rows
+from .pixel_digest import array_digest
+
+
+def _coordinate_set_digest(coordinates: Sequence[Sequence[int]]) -> str:
+    return canonical_sha256({"coordinates": [[int(y), int(x)] for y, x in coordinates]})
+
+
+def target_signal_coordinates(
+    width: int = FRAME_SHAPE[1],
+) -> tuple[tuple[int, int], ...]:
+    return tuple((y, x) for y in range(2, 5) for x in range(int(width)))
+
+
+def target_signal_mask(pixels: np.ndarray) -> np.ndarray:
+    array = np.ascontiguousarray(pixels, dtype=np.uint8)
+    if tuple(array.shape) != FRAME_SHAPE:
+        raise VPMValidationError(
+            "target evidence mask requires a canonical frame shape"
+        )
+    mask = np.zeros(array.shape, dtype=bool)
+    mask[2:5, :] = array[2:5, :] != 0
+    return mask
+
+
+def splice_evidence_counts(
+    primary_pixels: np.ndarray, secondary_pixels: np.ndarray
+) -> dict[str, int]:
+    primary = np.ascontiguousarray(primary_pixels, dtype=np.uint8)
+    secondary = np.ascontiguousarray(secondary_pixels, dtype=np.uint8)
+    if primary.shape != secondary.shape:
+        raise VPMValidationError("splice sources must have the same shape")
+    primary_target = target_signal_mask(primary)
+    secondary_target = target_signal_mask(secondary)
+    secondary_additive = secondary_target & ~primary_target
+    return {
+        "primary_target_pixel_count": int(np.count_nonzero(primary_target)),
+        "secondary_target_pixel_count": int(np.count_nonzero(secondary_target)),
+        "secondary_additive_target_pixel_count": int(
+            np.count_nonzero(secondary_additive)
+        ),
+        "target_overlap_pixel_count": int(
+            np.count_nonzero(primary_target & secondary_target)
+        ),
+    }
+
+
+def target_slot_signal_coordinates(
+    slot: int, *, width: int = 7
+) -> tuple[tuple[int, int], ...]:
+    centre = int(slot) * CELL_PIXELS + CELL_PIXELS // 2
+    return tuple(
+        [
+            (2, centre - 1),
+            (2, centre),
+            (2, centre + 1),
+            (3, centre - 1),
+            (3, centre),
+            (3, centre + 1),
+            (4, centre),
+        ]
+    )
+
+
+def detect_visible_target_slots(
+    pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()
+) -> list[int]:
+    array = np.ascontiguousarray(pixels, dtype=np.uint8)
+    slots = []
+    for slot in range(config.width):
+        coords = target_slot_signal_coordinates(slot, width=config.width)
+        values = [int(array[y, x]) for y, x in coords]
+        if all(value == TARGET_VALUE for value in values):
+            slots.append(slot)
+    return slots
+
+
+def detect_tank_slot(
+    pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()
+) -> int | None:
+    array = np.ascontiguousarray(pixels, dtype=np.uint8)
+    for slot in range(config.width):
+        centre = int(slot) * CELL_PIXELS + CELL_PIXELS // 2
+        coords = tuple(
+            [
+                (11, centre),
+                (12, centre - 1),
+                (12, centre),
+                (12, centre + 1),
+                (13, centre - 2),
+                (13, centre - 1),
+                (13, centre),
+                (13, centre + 1),
+                (13, centre + 2),
+            ]
+        )
+        if all(int(array[y, x]) == TANK_VALUE for y, x in coords):
+            return slot
+    return None
+
+
+def detect_cooldown_state(pixels: np.ndarray) -> int | None:
+    block = np.ascontiguousarray(pixels, dtype=np.uint8)[7:9, -3:-1]
+    values = {int(item) for item in block.reshape(-1)}
+    if values == {COOLDOWN_READY_VALUE}:
+        return 0
+    if values == {COOLDOWN_BLOCKED_VALUE}:
+        return 1
+    return None
+
+
+def final_visible_target_action_evidence(
+    pixels: np.ndarray,
+    row_actions: Mapping[str, str],
+    *,
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    target_slots = detect_visible_target_slots(pixels, config=config)
+    tank_slot = detect_tank_slot(pixels, config=config)
+    cooldown = detect_cooldown_state(pixels)
+    action_map: dict[str, str] = {}
+    if tank_slot is not None and cooldown is not None:
+        for target in target_slots:
+            row_id = state_row_id(tank_slot, target, cooldown)
+            action_map[str(target)] = str(row_actions[row_id])
+    visible_actions = sorted(set(action_map.values()))
+    payload = {
+        "version": FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION,
+        "final_visible_target_slots": [int(item) for item in target_slots],
+        "final_tank_slot": tank_slot,
+        "final_cooldown": cooldown,
+        "visible_target_action_map": action_map,
+        "visible_action_set": visible_actions,
+        "conflicting_action_evidence_present": len(visible_actions) >= 2,
+    }
+    payload["visible_action_evidence_digest"] = canonical_sha256(payload)
+    return payload
+
+
+def splice_pair_has_final_visible_action_conflict(
+    primary_row_id: str, secondary_row_id: str, row_actions: Mapping[str, str]
+) -> bool:
+    tank, primary_target, cooldown = parse_state_row_id(str(primary_row_id))
+    _secondary_tank, secondary_target, _secondary_cooldown = parse_state_row_id(
+        str(secondary_row_id)
+    )
+    if (
+        primary_target is None
+        or secondary_target is None
+        or primary_target == secondary_target
+    ):
+        return False
+    implied = {
+        row_actions[state_row_id(tank, int(primary_target), cooldown)],
+        row_actions[state_row_id(tank, int(secondary_target), cooldown)],
+    }
+    return len(implied) >= 2
+
+
+def critical_coordinates() -> tuple[tuple[int, int], ...]:
+    return tuple((y, x) for y in range(7, 9) for x in range(25, 27))
+
+
+def critical_coordinate_manifest(
+    coordinates: Sequence[Sequence[int]] | None = None,
+) -> dict[str, Any]:
+    source_coordinates = critical_coordinates() if coordinates is None else coordinates
+    coords = tuple((int(y), int(x)) for y, x in source_coordinates)
+    if not coords:
+        raise VPMValidationError("critical coordinate set cannot be empty")
+    critical = set(critical_coordinates())
+    if any(coord not in critical for coord in coords):
+        raise VPMValidationError(
+            "selected coordinate is not critical under the frozen definition"
+        )
+    if len(set(coords)) != len(coords):
+        raise VPMValidationError("critical coordinate set cannot contain duplicates")
+    return {
+        "version": CRITICAL_COORDINATE_SET_VERSION,
+        "criticality_source": "tiny_arcade_shooter_rendering",
+        "criticality_region_id": CRITICAL_REGION_ID,
+        "coordinates": [[y, x] for y, x in coords],
+        "coordinate_set_digest": _coordinate_set_digest(coords),
+    }
+
+
+def splice_mask_manifest(
+    mask_rows: Sequence[int] = (2, 3, 4), *, width: int = 28
+) -> dict[str, Any]:
+    rows = tuple(int(row) for row in mask_rows)
+    if rows != (2, 3, 4):
+        raise VPMValidationError(
+            "conflicting splice mask is frozen to the rendered target signal rows"
+        )
+    if int(width) != FRAME_SHAPE[1]:
+        raise VPMValidationError(
+            "conflicting splice mask width must match the canonical frame shape"
+        )
+    coordinates = target_signal_coordinates(int(width))
+    return {
+        "version": SPLICE_MASK_VERSION,
+        "mask_kind": "simultaneous_target_evidence",
+        "target_region_id": TARGET_REGION_ID,
+        "composition_rule": "copy primary observation, then add secondary target pixels where the primary has no target signal",
+        "rows": list(rows),
+        "coordinates": [[y, x] for y, x in coordinates],
+        "coordinate_count": len(coordinates),
+        "mask_digest": _coordinate_set_digest(coordinates),
+    }
+
+
+def _validated_splice_sources(
+    *,
+    primary_pixels: np.ndarray,
+    secondary_pixels: np.ndarray,
+    primary_action_id: str,
+    secondary_action_id: str,
+    mask_manifest: Mapping[str, Any],
+) -> tuple[np.ndarray, np.ndarray]:
+    if primary_action_id == secondary_action_id:
+        raise VPMValidationError(
+            "conflicting splice requires different governed actions"
+        )
+    primary = np.ascontiguousarray(primary_pixels, dtype=np.uint8)
+    secondary = np.ascontiguousarray(secondary_pixels, dtype=np.uint8)
+    if primary.shape != secondary.shape:
+        raise VPMValidationError("splice sources must have the same shape")
+    if tuple(primary.shape) != FRAME_SHAPE:
+        raise VPMValidationError(
+            "conflicting splice requires the canonical frame shape"
+        )
+    if mask_manifest.get("version") != SPLICE_MASK_VERSION:
+        raise VPMValidationError("unsupported conflicting splice mask version")
+    if mask_manifest.get("mask_kind") != "simultaneous_target_evidence":
+        raise VPMValidationError(
+            "conflicting splice requires the simultaneous target-evidence mask"
+        )
+    coordinates = tuple((int(y), int(x)) for y, x in mask_manifest["coordinates"])
+    if coordinates != target_signal_coordinates(primary.shape[1]):
+        raise VPMValidationError(
+            "conflicting splice target coordinates do not match the frozen renderer geometry"
+        )
+    for y, x in coordinates:
+        if y < 0 or y >= primary.shape[0] or x < 0 or x >= primary.shape[1]:
+            raise VPMValidationError("splice coordinate out of bounds")
+    return primary, secondary
+
+
+def _splice_composition(primary: np.ndarray, secondary: np.ndarray) -> dict[str, Any]:
+    primary_target = target_signal_mask(primary)
+    secondary_target = target_signal_mask(secondary)
+    secondary_overlay = secondary_target & ~primary_target
+    primary_target_count = int(np.count_nonzero(primary_target))
+    secondary_target_count = int(np.count_nonzero(secondary_target))
+    secondary_effective = int(np.count_nonzero(secondary_overlay))
+    if primary_target_count == 0 or secondary_target_count == 0:
+        raise VPMValidationError(
+            "splice requires visible target evidence from both sources"
+        )
+    if secondary_effective == 0:
+        raise VPMValidationError("splice requires distinct secondary target evidence")
+    output = np.array(primary, copy=True)
+    output[secondary_overlay] = secondary[secondary_overlay]
+    primary_effective = int(np.count_nonzero((primary != 0) & (output == primary)))
+    changed_pixel_count = int(np.count_nonzero(output != primary))
+    if changed_pixel_count == 0 or primary_effective == 0:
+        raise VPMValidationError(
+            "splice requires nonzero effective contribution from both sources"
+        )
+    if np.array_equal(output, primary) or np.array_equal(output, secondary):
+        raise VPMValidationError(
+            "splice output must not equal either source observation"
+        )
+    return {
+        "output": output,
+        "primary_target": primary_target,
+        "secondary_target": secondary_target,
+        "primary_target_count": primary_target_count,
+        "secondary_target_count": secondary_target_count,
+        "secondary_effective": secondary_effective,
+        "primary_effective": primary_effective,
+        "changed_pixel_count": changed_pixel_count,
+    }
+
+
+def _policy_row_actions() -> dict[str, str]:
+    policy = compile_policy_artifact()
+    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
+    return {str(row_id): lookup.choose(str(row_id)) for row_id in policy.source.row_ids}
+
+
+def _validated_final_splice_evidence(output: np.ndarray) -> dict[str, Any]:
+    row_actions = _policy_row_actions()
+    visible_action_evidence = final_visible_target_action_evidence(output, row_actions)
+    if not visible_action_evidence["conflicting_action_evidence_present"]:
+        raise VPMValidationError(
+            "conflicting splice final visible target evidence does not imply conflicting actions"
+        )
+    canonical_collisions = _canonical_collision_rows(output)
+    if canonical_collisions:
+        raise VPMValidationError(
+            "conflicting splice output collides with a canonical valid observation"
+        )
+    return visible_action_evidence
+
+
+def _critical_region_primary_count(primary: np.ndarray, output: np.ndarray) -> int:
+    critical_mask = np.zeros(primary.shape, dtype=bool)
+    for y, x in critical_coordinates():
+        critical_mask[y, x] = True
+    return int(np.count_nonzero(critical_mask & (output == primary)))
+
+
+def _conflicting_splice_trace_manifest(
+    *,
+    primary: np.ndarray,
+    secondary: np.ndarray,
+    primary_row_id: str,
+    secondary_row_id: str,
+    primary_action_id: str,
+    secondary_action_id: str,
+    mask_manifest: Mapping[str, Any],
+    composition: Mapping[str, Any],
+    visible_action_evidence: Mapping[str, Any],
+) -> dict[str, Any]:
+    primary_target = composition["primary_target"]
+    secondary_target = composition["secondary_target"]
+    output = composition["output"]
+    manifest = {
+        "primary_source_row_id": primary_row_id,
+        "primary_source_action_id": primary_action_id,
+        "secondary_source_row_id": secondary_row_id,
+        "secondary_source_action_id": secondary_action_id,
+        "primary_source_digest": array_digest(primary),
+        "secondary_source_digest": array_digest(secondary),
+        "splice_mask_identity": mask_manifest["mask_digest"],
+        "splice_mask_version": mask_manifest["version"],
+        "target_region_id": TARGET_REGION_ID,
+        "composition_rule": mask_manifest["composition_rule"],
+        "primary_contributing_pixel_count": composition["primary_effective"],
+        "secondary_contributing_pixel_count": composition["secondary_effective"],
+        "changed_pixel_count": composition["changed_pixel_count"],
+        "action_relevant_region_contribution_counts": {
+            "primary_target_pixel_count": composition["primary_target_count"],
+            "secondary_target_pixel_count": composition["secondary_target_count"],
+            "secondary_additive_target_pixel_count": composition["secondary_effective"],
+            "target_overlap_pixel_count": int(
+                np.count_nonzero(primary_target & secondary_target)
+            ),
+        },
+        "critical_region_contribution_counts": {
+            "primary_pixel_count": _critical_region_primary_count(primary, output),
+            "secondary_pixel_count": 0,
+        },
+        "canonical_universe_version": CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+        "final_visible_target_slots": visible_action_evidence[
+            "final_visible_target_slots"
+        ],
+        "final_tank_slot": visible_action_evidence["final_tank_slot"],
+        "final_cooldown": visible_action_evidence["final_cooldown"],
+        "visible_target_action_map": visible_action_evidence[
+            "visible_target_action_map"
+        ],
+        "visible_action_set": visible_action_evidence["visible_action_set"],
+        "visible_action_evidence_digest": visible_action_evidence[
+            "visible_action_evidence_digest"
+        ],
+        "canonical_collision_count": 0,
+        "canonical_collision_rows": [],
+        "output_observation_digest": array_digest(output),
+        "expected_invalid_family_label": "conflicting_action_splice",
+    }
+    manifest["splice_trace_digest"] = canonical_sha256(manifest)
+    return manifest
+
+
+def apply_conflicting_splice(
+    *,
+    primary_pixels: np.ndarray,
+    secondary_pixels: np.ndarray,
+    primary_row_id: str,
+    secondary_row_id: str,
+    primary_action_id: str,
+    secondary_action_id: str,
+    mask_manifest: Mapping[str, Any],
+) -> tuple[np.ndarray, dict[str, Any]]:
+    primary, secondary = _validated_splice_sources(
+        primary_pixels=primary_pixels,
+        secondary_pixels=secondary_pixels,
+        primary_action_id=primary_action_id,
+        secondary_action_id=secondary_action_id,
+        mask_manifest=mask_manifest,
+    )
+    composition = _splice_composition(primary, secondary)
+    output = composition["output"]
+    visible_action_evidence = _validated_final_splice_evidence(output)
+    manifest = _conflicting_splice_trace_manifest(
+        primary=primary,
+        secondary=secondary,
+        primary_row_id=primary_row_id,
+        secondary_row_id=secondary_row_id,
+        primary_action_id=primary_action_id,
+        secondary_action_id=secondary_action_id,
+        mask_manifest=mask_manifest,
+        composition=composition,
+        visible_action_evidence=visible_action_evidence,
+    )
+    return output, manifest
+
+
+def apply_critical_corruption(
+    source_pixels: np.ndarray, coordinate_manifest: Mapping[str, Any]
+) -> tuple[np.ndarray, dict[str, Any]]:
+    source = np.ascontiguousarray(source_pixels, dtype=np.uint8)
+    coords = tuple((int(y), int(x)) for y, x in coordinate_manifest["coordinates"])
+    critical_coordinate_manifest(coords)
+    output = np.array(source, copy=True)
+    changes = []
+    for y, x in coords:
+        if y < 0 or y >= output.shape[0] or x < 0 or x >= output.shape[1]:
+            raise VPMValidationError("critical coordinate outside image bounds")
+        original = int(output[y, x])
+        replacement = 255 if original != 255 else 0
+        if replacement == original:
+            raise VPMValidationError(
+                "critical corruption replacement must change the value"
+            )
+        output[y, x] = replacement
+        if int(output[y, x]) == original:
+            raise VPMValidationError("critical corruption no-op after assignment")
+        changes.append(
+            {"y": y, "x": x, "original": original, "replacement": int(output[y, x])}
+        )
+    if not changes:
+        raise VPMValidationError(
+            "critical corruption requires at least one changed pixel"
+        )
+    if np.array_equal(source, output):
+        raise VPMValidationError(
+            "critical corruption must change the observation digest"
+        )
+    manifest = {
+        "criticality_artifact_identity": CRITICAL_COORDINATE_SET_VERSION,
+        "critical_region_id": CRITICAL_REGION_ID,
+        "critical_coordinate_set_identity": coordinate_manifest[
+            "coordinate_set_digest"
+        ],
+        "changes": changes,
+        "changed_pixel_count": len(changes),
+        "source_observation_digest": array_digest(source),
+        "output_observation_digest": array_digest(output),
+    }
+    manifest["critical_corruption_digest"] = canonical_sha256(manifest)
+    return output, manifest
+
+
+__all__ = [
+    "apply_conflicting_splice",
+    "apply_critical_corruption",
+    "critical_coordinate_manifest",
+    "critical_coordinates",
+    "detect_cooldown_state",
+    "detect_tank_slot",
+    "detect_visible_target_slots",
+    "final_visible_target_action_evidence",
+    "splice_evidence_counts",
+    "splice_mask_manifest",
+    "splice_pair_has_final_visible_action_conflict",
+    "target_signal_coordinates",
+    "target_signal_mask",
+    "target_slot_signal_coordinates",
+]

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -8,26 +8,88 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 
-from .arcade_policy import ACTIONS, CELL_PIXELS, COOLDOWN_BLOCKED_VALUE, COOLDOWN_READY_VALUE, TANK_VALUE, TARGET_VALUE, ShooterConfig, arcade_transition_spec, compile_policy_artifact, next_rows, parse_state_row_id, render_state_frame, state_row_id
+from .arcade_policy import (
+    ACTIONS,
+    ShooterConfig,
+    compile_policy_artifact,
+    next_rows,
+    parse_state_row_id,
+    render_state_frame,
+)
 from .artifact import VPMValidationError
 from .domains.video_action_set.canonical_json import canonical_json_bytes, canonical_json_value, canonical_sha256
 from .domains.video_action_set.contracts import (
     ARCADE_RENDERER_CONTRACT_VERSION,
     BENCHMARK_VERSION,
     CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+    CONFLICTING_ACTION_SPLICE_VERSION,
+    CRITICAL_COORDINATE_SET_VERSION,
+    CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+    CRITICAL_REGION_ID,
+    DECLARED_GAP_OR_UNKNOWN_VERSION,
+    EPISODE_FAMILY_REGISTRY_VERSION,
     EPISODE_PLAN_VERSION,
+    FAMILY_CLOSURE_VERSION,
+    FAMILY_INTERVENTION_VERSION,
+    FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION,
     FRAME_SHAPE,
+    FRAME_INVALID_CLOSURE_VERSION,
     GAP_EVENT_VERSION,
     GENERATOR_VERSION,
+    GROUNDED_CONTROL_HISTORY_VERSION,
+    IMPOSSIBLE_TRANSITION_VERSION,
+    INFORMATION_CONTROL_AMBIGUITY_VERSION,
+    INFORMATION_CONTROL_VERSION,
     OBSERVATION_OPERATION_CHAIN_VERSION,
     PROVIDER_OBSERVATION_BOUNDARY_VERSION,
     REACHABILITY_TILE_DIGEST,
     REACHABILITY_TILE_VERSION,
+    REORDERED_FRAMES_VERSION,
     SEED_DERIVATION_VERSION,
+    SPLICE_MASK_VERSION,
+    STALE_REPEATED_FRAME_VERSION,
+    TARGET_REGION_ID,
     TRANSFORMATION_FAMILY_VERSION,
+    VALID_FAMILY_VERSION,
     VALID_OBSERVATION_UNIVERSE_VERSION,
 )
 from .domains.video_action_set.dto import BenchmarkIdentityDTO, EpisodePlanDTO
+from .domains.video_action_set.episode_families import (
+    denominator_class as _denominator_class,
+    episode_disposition as _episode_disposition,
+    episode_family_registry as _episode_family_registry,
+    expected_frame_disposition,
+    family_contract as _family_contract,
+    family_schedule as _family_schedule,
+    frame_disposition_for_episode as _frame_disposition_for_episode,
+)
+from .domains.video_action_set.family_provenance import (
+    conflicting_splice_operation_chain as _conflicting_splice_operation_chain,
+    critical_corruption_operation_chain as _critical_corruption_operation_chain,
+    impossible_transition_operation_chain as _impossible_transition_operation_chain,
+    information_control_operation_chain as _information_control_operation_chain,
+    stale_repeat_operation_chain as _stale_repeat_operation_chain,
+)
+from .domains.video_action_set.family_validation import (
+    frame_invalid_closure_summary as _frame_invalid_closure_summary,
+    validate_materialized_family_record,
+)
+from .domains.video_action_set.frame_family_kernels import (
+    apply_conflicting_splice as _apply_conflicting_splice,
+    apply_critical_corruption as _apply_critical_corruption,
+    critical_coordinate_manifest as _critical_coordinate_manifest,
+    critical_coordinates as _critical_coordinates,
+    detect_cooldown_state as _detect_cooldown_state,
+    detect_tank_slot as _detect_tank_slot,
+    detect_visible_target_slots as _detect_visible_target_slots,
+    final_visible_target_action_evidence as _final_visible_target_action_evidence,
+    splice_evidence_counts as _splice_evidence_counts,
+    splice_mask_manifest as _splice_mask_manifest,
+    splice_pair_has_final_visible_action_conflict as _splice_pair_has_final_visible_action_conflict,
+    target_signal_coordinates as _target_signal_coordinates,
+    target_signal_mask as _target_signal_mask,
+    target_slot_signal_coordinates as _target_slot_signal_coordinates,
+)
 from .domains.video_action_set.observation_legacy_adapters import (
     operation_chain as _operation_chain,
     operation_record as _operation_record,
@@ -91,10 +153,46 @@ from .video_prospective_providers import (
 )
 from .visual_address import IMAGE_OBSERVATION_VERSION, ImageObservation
 
+_STAGE4B_LEGACY_COMPATIBILITY_ALIASES = (
+    ARCADE_RENDERER_CONTRACT_VERSION,
+    CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+    CONFLICTING_ACTION_SPLICE_VERSION,
+    CRITICAL_COORDINATE_SET_VERSION,
+    CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+    CRITICAL_REGION_ID,
+    DECLARED_GAP_OR_UNKNOWN_VERSION,
+    FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION,
+    FRAME_SHAPE,
+    FRAME_INVALID_CLOSURE_VERSION,
+    IMPOSSIBLE_TRANSITION_VERSION,
+    INFORMATION_CONTROL_VERSION,
+    OBSERVATION_OPERATION_CHAIN_VERSION,
+    PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+    REORDERED_FRAMES_VERSION,
+    STALE_REPEATED_FRAME_VERSION,
+    TRANSFORMATION_FAMILY_VERSION,
+    VALID_FAMILY_VERSION,
+    VALID_OBSERVATION_UNIVERSE_VERSION,
+    _detect_cooldown_state,
+    _detect_tank_slot,
+    _detect_visible_target_slots,
+    _frame_disposition_for_episode,
+    _operation_chain,
+    _operation_record,
+    _renderer_identity,
+    _splice_evidence_counts,
+    _target_signal_coordinates,
+    _target_signal_mask,
+    _target_slot_signal_coordinates,
+    _canonical_collision_rows,
+    _valid_transformation_parameter_key,
+    _valid_transformation_parameter_universe,
+    _translation_values_for_seed,
+    valid_observation_universe,
+)
+
 
 EPISODE_SCHEMA_VERSION = "zeromodel-video-policy-episode/v1"
-EPISODE_FAMILY_REGISTRY_VERSION = "zeromodel-video-action-set-episode-family-registry/v4"
-CRITICAL_COORDINATE_SET_VERSION = "zeromodel-video-action-set-critical-coordinate-set/v1"
 REACHABILITY_COMPOSITION_VERSION = "zeromodel-video-action-set-reachability-composition/v1"
 REACHABILITY_TRACE_VERSION = "zeromodel-video-action-set-reachability-trace/v1"
 PHASE_ACCESS_VERSION = "zeromodel-video-prospective-phase-access/v1"
@@ -104,16 +202,7 @@ CLOSURE_REPORT_VERSION = "zeromodel-video-action-set-reference-closure/v1"
 MUTATION_MATRIX_VERSION = "zeromodel-video-action-set-reference-mutation-matrix/v3"
 SOURCE_SCOPE = "zeromodel-video-action-set-reachability-benchmark-v1"
 SEMANTIC_OUTCOME_VERSION = VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION
-FRAME_INVALID_CLOSURE_VERSION = "zeromodel-video-action-set-frame-invalid-closure/v1"
-FAMILY_INTERVENTION_VERSION = "zeromodel-video-action-set-family-intervention/v3"
-CONFLICTING_ACTION_SPLICE_VERSION = "zeromodel-video-action-set-family-conflicting-action-splice/v3"
-SPLICE_MASK_VERSION = "zeromodel-video-action-set-splice-mask/v2"
-INFORMATION_CONTROL_VERSION = "zeromodel-video-action-set-family-information-control/v3"
-INFORMATION_CONTROL_AMBIGUITY_VERSION = "zeromodel-video-action-set-information-control-ambiguity/v2"
-GROUNDED_CONTROL_HISTORY_VERSION = "zeromodel-video-action-set-grounded-control-history/v1"
 AUTHORITATIVE_TRANSITION_FUNCTION_VERSION = "zeromodel-arcade-shooter-next-rows/v1"
-CRITICAL_REGION_ID = "cooldown_indicator"
-TARGET_REGION_ID = "target_band"
 
 
 def _json_ready(value: Any) -> Any:
@@ -182,149 +271,8 @@ def _provider_version(provider_id: str) -> str:
     }[provider_id]
 
 
-def _coordinate_set_digest(coordinates: Sequence[Sequence[int]]) -> str:
-    return _sha256({"coordinates": [[int(y), int(x)] for y, x in coordinates]})
-
-
 def _load_reachability_tile(repo_root: Path) -> dict[str, Any]:
     return _read_json(repo_root / "docs" / "results" / "video-policy-reachability-tile-v1" / "reachability-tile.json")
-
-
-def _episode_family_registry() -> dict[str, Any]:
-    entries = [
-        {
-            "family_id": "valid",
-            "family_version": "zeromodel-video-action-set-family-valid/v1",
-            "classification": "valid",
-            "source_row_required": True,
-            "source_action_required": True,
-            "pixel_intervention": "bounded valid transformation only",
-            "sequence_intervention": "none",
-            "expected_semantic_effect": "row/action should remain admissible under complete evidence",
-            "distinguishability_status": "distinguishable_valid",
-            "denominator_treatment": "valid denominator",
-            "regeneration_requirements": ["source row", "sealed seed lineage", "transformation parameters", "pixel digest"],
-            "implementation_status": "implemented_bounded_scaffold",
-        },
-        {
-            "family_id": "conflicting_action_splice",
-            "family_version": CONFLICTING_ACTION_SPLICE_VERSION,
-            "classification": "invalid",
-            "source_row_required": True,
-            "source_action_required": True,
-            "pixel_intervention": "primary target evidence plus additive secondary target evidence with valid-state collision closure",
-            "sequence_intervention": "none",
-            "expected_semantic_effect": "constructed multi-target visual evidence that cannot decode to a canonical valid state",
-            "distinguishability_status": "distinguishable_invalid_input",
-            "denominator_treatment": "distinguishable-invalid denominator",
-            "regeneration_requirements": ["primary source", "secondary source", "target-evidence composition mask", "source contribution counts", "canonical byte-universe noncollision", "output digest"],
-            "implementation_status": "implemented_bounded_scaffold",
-        },
-        {
-            "family_id": "critical_evidence_corruption",
-            "family_version": "zeromodel-video-action-set-family-critical-evidence-corruption/v1",
-            "classification": "invalid",
-            "source_row_required": True,
-            "source_action_required": True,
-            "pixel_intervention": "frozen critical coordinate replacement",
-            "sequence_intervention": "none",
-            "expected_semantic_effect": "critical evidence is no longer faithful to the source row",
-            "distinguishability_status": "distinguishable_invalid_input",
-            "denominator_treatment": "distinguishable-invalid denominator",
-            "regeneration_requirements": ["critical coordinate set", "original values", "replacement values", "output digest"],
-            "implementation_status": "implemented_bounded_scaffold",
-        },
-        {
-            "family_id": "reordered_frames",
-            "family_version": "zeromodel-video-action-set-family-reordered-frames/v1",
-            "classification": "temporal-negative",
-            "source_row_required": True,
-            "source_action_required": True,
-            "pixel_intervention": "none",
-            "sequence_intervention": "non-identity permutation of frame payload order",
-            "expected_semantic_effect": "sequence order evidence is invalid",
-            "distinguishability_status": "distinguishable_temporal_invalid",
-            "denominator_treatment": "temporal-negative denominator",
-            "regeneration_requirements": ["original order", "mutated order", "sequence digest"],
-            "implementation_status": "implemented_bounded_scaffold",
-        },
-        {
-            "family_id": "stale_repeated_frame",
-            "family_version": "zeromodel-video-action-set-family-stale-repeated-frame/v1",
-            "classification": "temporal-negative",
-            "source_row_required": True,
-            "source_action_required": True,
-            "pixel_intervention": "later frame payload replaced by earlier payload",
-            "sequence_intervention": "explicit stale repeat horizon",
-            "expected_semantic_effect": "current frame evidence is stale",
-            "distinguishability_status": "distinguishable_temporal_invalid",
-            "denominator_treatment": "temporal-negative denominator",
-            "regeneration_requirements": ["source frame index", "destination frame index", "original destination digest", "replacement digest"],
-            "implementation_status": "implemented_bounded_scaffold",
-        },
-        {
-            "family_id": "impossible_transition",
-            "family_version": "zeromodel-video-action-set-family-impossible-transition/v1",
-            "classification": "temporal-negative",
-            "source_row_required": True,
-            "source_action_required": True,
-            "pixel_intervention": "destination frame set to a nonreachable policy row",
-            "sequence_intervention": "violates frozen reachability relation",
-            "expected_semantic_effect": "no admissible source-to-destination transition",
-            "distinguishability_status": "distinguishable_temporal_invalid",
-            "denominator_treatment": "temporal-negative denominator",
-            "regeneration_requirements": ["transition relation identity", "pairwise reachability audit", "endpoint frame digests"],
-            "implementation_status": "implemented_bounded_scaffold",
-        },
-        {
-            "family_id": "declared_gap_or_unknown_action",
-            "family_version": "zeromodel-video-action-set-family-declared-gap-or-unknown/v1",
-            "classification": "temporal-negative",
-            "source_row_required": True,
-            "source_action_required": False,
-            "pixel_intervention": "typed gap event with no ordinary pixels",
-            "sequence_intervention": "explicit gap/unknown event",
-            "expected_semantic_effect": "reader sees a deterministic non-frame event",
-            "distinguishability_status": "typed_temporal_event",
-            "denominator_treatment": "temporal-negative denominator",
-            "regeneration_requirements": ["event identity", "position", "duration", "sequence digest"],
-            "implementation_status": "implemented_bounded_scaffold",
-        },
-        {
-            "family_id": "information_control",
-            "family_version": INFORMATION_CONTROL_VERSION,
-            "classification": "information-theoretic-control",
-            "source_row_required": True,
-            "source_action_required": False,
-            "pixel_intervention": "byte-identical control observations with multiple hidden source-history labels",
-            "sequence_intervention": "control-only grouping",
-            "expected_semantic_effect": "hidden distinction unavailable to providers",
-            "distinguishability_status": "information_theoretic_control",
-            "denominator_treatment": "excluded from distinguishable-invalid denominators",
-            "regeneration_requirements": [
-                "control group",
-                "byte identity digest",
-                "hidden history labels",
-                "hidden-label cardinality",
-                "provider-visible field closure",
-            ],
-            "implementation_status": "implemented_bounded_scaffold",
-        },
-    ]
-    return {
-        "version": EPISODE_FAMILY_REGISTRY_VERSION,
-        "transformation_contract_version": TRANSFORMATION_FAMILY_VERSION,
-        "families": entries,
-        "registry_digest": _sha256({"version": EPISODE_FAMILY_REGISTRY_VERSION, "families": entries}),
-    }
-
-
-def _family_contract(family_label: str, mutation_kind: str | None) -> dict[str, Any]:
-    family_id = "valid" if family_label == "valid" else str(mutation_kind or family_label)
-    for entry in _episode_family_registry()["families"]:
-        if entry["family_id"] == family_id:
-            return dict(entry)
-    raise VPMValidationError("unknown episode family")
 
 
 BenchmarkIdentity = BenchmarkIdentityDTO
@@ -361,196 +309,6 @@ def _derived_seed(
     }
     digest = _sha256(payload)
     return payload | {"seed_digest": digest, "seed_int64": _seed_int_from_digest(digest)}
-
-
-def _target_signal_coordinates(width: int = FRAME_SHAPE[1]) -> tuple[tuple[int, int], ...]:
-    return tuple((y, x) for y in range(2, 5) for x in range(int(width)))
-
-
-def _target_signal_mask(pixels: np.ndarray) -> np.ndarray:
-    array = np.ascontiguousarray(pixels, dtype=np.uint8)
-    if tuple(array.shape) != FRAME_SHAPE:
-        raise VPMValidationError("target evidence mask requires a canonical frame shape")
-    mask = np.zeros(array.shape, dtype=bool)
-    mask[2:5, :] = array[2:5, :] != 0
-    return mask
-
-
-def _splice_evidence_counts(primary_pixels: np.ndarray, secondary_pixels: np.ndarray) -> dict[str, int]:
-    primary = np.ascontiguousarray(primary_pixels, dtype=np.uint8)
-    secondary = np.ascontiguousarray(secondary_pixels, dtype=np.uint8)
-    if primary.shape != secondary.shape:
-        raise VPMValidationError("splice sources must have the same shape")
-    primary_target = _target_signal_mask(primary)
-    secondary_target = _target_signal_mask(secondary)
-    secondary_additive = secondary_target & ~primary_target
-    return {
-        "primary_target_pixel_count": int(np.count_nonzero(primary_target)),
-        "secondary_target_pixel_count": int(np.count_nonzero(secondary_target)),
-        "secondary_additive_target_pixel_count": int(np.count_nonzero(secondary_additive)),
-        "target_overlap_pixel_count": int(np.count_nonzero(primary_target & secondary_target)),
-    }
-
-
-def _target_slot_signal_coordinates(slot: int, *, width: int = 7) -> tuple[tuple[int, int], ...]:
-    centre = int(slot) * CELL_PIXELS + CELL_PIXELS // 2
-    return tuple([(2, centre - 1), (2, centre), (2, centre + 1), (3, centre - 1), (3, centre), (3, centre + 1), (4, centre)])
-
-
-
-def _detect_visible_target_slots(pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()) -> list[int]:
-    array = np.ascontiguousarray(pixels, dtype=np.uint8)
-    slots = []
-    for slot in range(config.width):
-        coords = _target_slot_signal_coordinates(slot, width=config.width)
-        values = [int(array[y, x]) for y, x in coords]
-        if all(value == TARGET_VALUE for value in values):
-            slots.append(slot)
-    return slots
-
-
-
-def _detect_tank_slot(pixels: np.ndarray, *, config: ShooterConfig = ShooterConfig()) -> int | None:
-    array = np.ascontiguousarray(pixels, dtype=np.uint8)
-    for slot in range(config.width):
-        centre = int(slot) * CELL_PIXELS + CELL_PIXELS // 2
-        coords = tuple([(11, centre), (12, centre - 1), (12, centre), (12, centre + 1), (13, centre - 2), (13, centre - 1), (13, centre), (13, centre + 1), (13, centre + 2)])
-        if all(int(array[y, x]) == TANK_VALUE for y, x in coords):
-            return slot
-    return None
-
-
-
-def _detect_cooldown_state(pixels: np.ndarray) -> int | None:
-    block = np.ascontiguousarray(pixels, dtype=np.uint8)[7:9, -3:-1]
-    values = {int(item) for item in block.reshape(-1)}
-    if values == {COOLDOWN_READY_VALUE}:
-        return 0
-    if values == {COOLDOWN_BLOCKED_VALUE}:
-        return 1
-    return None
-
-
-
-def _final_visible_target_action_evidence(pixels: np.ndarray, row_actions: Mapping[str, str], *, config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
-    target_slots = _detect_visible_target_slots(pixels, config=config)
-    tank_slot = _detect_tank_slot(pixels, config=config)
-    cooldown = _detect_cooldown_state(pixels)
-    action_map: dict[str, str] = {}
-    if tank_slot is not None and cooldown is not None:
-        for target in target_slots:
-            row_id = state_row_id(tank_slot, target, cooldown)
-            action_map[str(target)] = str(row_actions[row_id])
-    visible_actions = sorted(set(action_map.values()))
-    payload = {
-        "version": "zeromodel-video-action-set-final-visible-target-action-evidence/v1",
-        "final_visible_target_slots": [int(item) for item in target_slots],
-        "final_tank_slot": tank_slot,
-        "final_cooldown": cooldown,
-        "visible_target_action_map": action_map,
-        "visible_action_set": visible_actions,
-        "conflicting_action_evidence_present": len(visible_actions) >= 2,
-    }
-    payload["visible_action_evidence_digest"] = _sha256(payload)
-    return payload
-
-
-
-def _splice_pair_has_final_visible_action_conflict(primary_row_id: str, secondary_row_id: str, row_actions: Mapping[str, str]) -> bool:
-    tank, primary_target, cooldown = parse_state_row_id(str(primary_row_id))
-    _secondary_tank, secondary_target, _secondary_cooldown = parse_state_row_id(str(secondary_row_id))
-    if primary_target is None or secondary_target is None or primary_target == secondary_target:
-        return False
-    implied = {
-        row_actions[state_row_id(tank, int(primary_target), cooldown)],
-        row_actions[state_row_id(tank, int(secondary_target), cooldown)],
-    }
-    return len(implied) >= 2
-
-
-
-def _family_schedule() -> tuple[str, ...]:
-    return (
-        "exact",
-        "bounded_photometric",
-        "bounded_translation",
-        "bounded_translation_photometric",
-        "bounded_translation_occlusion",
-        "compound_bounded",
-    )
-
-
-
-def _episode_disposition(family_label: str, mutation_kind: str | None = None) -> str:
-    if family_label == "valid":
-        return "valid"
-    if family_label == "frame_invalid":
-        return "distinguishable_invalid_input"
-    if family_label == "temporal_negative":
-        return "distinguishable_temporal_invalid"
-    if family_label == "information_control":
-        return "information_theoretic_control"
-    return str(mutation_kind or family_label)
-
-
-
-def _denominator_class(family_label: str, mutation_kind: str | None = None) -> str:
-    if family_label == "valid":
-        return "valid_denominator"
-    if family_label == "frame_invalid":
-        return "distinguishable_invalid_denominator"
-    if family_label == "temporal_negative":
-        return "temporal_negative_denominator"
-    if family_label == "information_control":
-        return "excluded_information_control"
-    return str(mutation_kind or family_label)
-
-
-
-def _frame_disposition_for_episode(family_label: str, mutation_kind: str | None = None) -> str:
-    if family_label == "valid":
-        return "valid"
-    if family_label == "frame_invalid":
-        return "distinguishable_invalid_input"
-    if family_label == "information_control":
-        return "information_theoretic_control"
-    if family_label == "temporal_negative":
-        return "valid_frame_payload"
-    return str(mutation_kind or family_label)
-
-
-
-def expected_frame_disposition(
-    episode_family: str,
-    mutation_kind: str | None,
-    frame_index: int,
-    intervention_plan: Mapping[str, Any] | None = None,
-) -> str:
-    family = str(episode_family)
-    kind = None if mutation_kind is None else str(mutation_kind)
-    index = int(frame_index)
-    intervention = dict(intervention_plan or {})
-    if family == "valid":
-        return "valid"
-    if family == "frame_invalid":
-        return "distinguishable_invalid_input"
-    if family == "information_control":
-        return "information_theoretic_control"
-    if family != "temporal_negative":
-        return str(kind or family)
-    if kind == "reordered_frames":
-        return "temporally_reordered_frame_payload"
-    if kind == "stale_repeated_frame":
-        repeat = intervention.get("stale_repeat", {})
-        return "stale_repeated_frame_payload" if index == int(repeat.get("destination_frame_index", -1)) else "valid_frame_payload"
-    if kind == "impossible_transition":
-        transition = intervention.get("impossible_transition", {})
-        return "unreachable_destination_frame_payload" if index == int(transition.get("destination_frame_index", -1)) else "valid_frame_payload"
-    if kind == "declared_gap_or_unknown_action":
-        gap = intervention.get("gap_event", {})
-        return "declared_gap_or_unknown_action" if index == int(gap.get("position", -1)) else "valid_frame_payload"
-    return "valid_frame_payload"
-
 
 
 def _transition_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
@@ -897,48 +655,6 @@ def _frame_count_for_plan(split: str, family_label: str) -> int:
     if split == "development":
         return 1
     return 4
-
-
-def _critical_coordinates() -> tuple[tuple[int, int], ...]:
-    return tuple((y, x) for y in range(7, 9) for x in range(25, 27))
-
-
-def _critical_coordinate_manifest(coordinates: Sequence[Sequence[int]] | None = None) -> dict[str, Any]:
-    source_coordinates = _critical_coordinates() if coordinates is None else coordinates
-    coords = tuple((int(y), int(x)) for y, x in source_coordinates)
-    if not coords:
-        raise VPMValidationError("critical coordinate set cannot be empty")
-    critical = set(_critical_coordinates())
-    if any(coord not in critical for coord in coords):
-        raise VPMValidationError("selected coordinate is not critical under the frozen definition")
-    if len(set(coords)) != len(coords):
-        raise VPMValidationError("critical coordinate set cannot contain duplicates")
-    return {
-        "version": CRITICAL_COORDINATE_SET_VERSION,
-        "criticality_source": "tiny_arcade_shooter_rendering",
-        "criticality_region_id": CRITICAL_REGION_ID,
-        "coordinates": [[y, x] for y, x in coords],
-        "coordinate_set_digest": _coordinate_set_digest(coords),
-    }
-
-
-def _splice_mask_manifest(mask_rows: Sequence[int] = (2, 3, 4), *, width: int = 28) -> dict[str, Any]:
-    rows = tuple(int(row) for row in mask_rows)
-    if rows != (2, 3, 4):
-        raise VPMValidationError("conflicting splice mask is frozen to the rendered target signal rows")
-    if int(width) != FRAME_SHAPE[1]:
-        raise VPMValidationError("conflicting splice mask width must match the canonical frame shape")
-    coordinates = _target_signal_coordinates(int(width))
-    return {
-        "version": SPLICE_MASK_VERSION,
-        "mask_kind": "simultaneous_target_evidence",
-        "target_region_id": TARGET_REGION_ID,
-        "composition_rule": "copy primary observation, then add secondary target pixels where the primary has no target signal",
-        "rows": list(rows),
-        "coordinates": [[y, x] for y, x in coordinates],
-        "coordinate_count": len(coordinates),
-        "mask_digest": _coordinate_set_digest(coordinates),
-    }
 
 
 def _state_row_values(row_id: str) -> tuple[int, int | None, int]:
@@ -1496,273 +1212,6 @@ def _apply_frame_plan(frame: np.ndarray, frame_plan: Mapping[str, Any]) -> tuple
     if str(params["parameter_digest"]) != str(frame_plan["transformation_parameter_digest"]):
         raise VPMValidationError("frame transformation parameter digest mismatch")
     return _apply_transformation(frame, params)
-
-
-def _apply_conflicting_splice(
-    *,
-    primary_pixels: np.ndarray,
-    secondary_pixels: np.ndarray,
-    primary_row_id: str,
-    secondary_row_id: str,
-    primary_action_id: str,
-    secondary_action_id: str,
-    mask_manifest: Mapping[str, Any],
-) -> tuple[np.ndarray, dict[str, Any]]:
-    if primary_action_id == secondary_action_id:
-        raise VPMValidationError("conflicting splice requires different governed actions")
-    primary = np.ascontiguousarray(primary_pixels, dtype=np.uint8)
-    secondary = np.ascontiguousarray(secondary_pixels, dtype=np.uint8)
-    if primary.shape != secondary.shape:
-        raise VPMValidationError("splice sources must have the same shape")
-    if tuple(primary.shape) != FRAME_SHAPE:
-        raise VPMValidationError("conflicting splice requires the canonical frame shape")
-    if mask_manifest.get("version") != SPLICE_MASK_VERSION:
-        raise VPMValidationError("unsupported conflicting splice mask version")
-    if mask_manifest.get("mask_kind") != "simultaneous_target_evidence":
-        raise VPMValidationError("conflicting splice requires the simultaneous target-evidence mask")
-    coordinates = tuple((int(y), int(x)) for y, x in mask_manifest["coordinates"])
-    if coordinates != _target_signal_coordinates(primary.shape[1]):
-        raise VPMValidationError("conflicting splice target coordinates do not match the frozen renderer geometry")
-    for y, x in coordinates:
-        if y < 0 or y >= primary.shape[0] or x < 0 or x >= primary.shape[1]:
-            raise VPMValidationError("splice coordinate out of bounds")
-    primary_target = _target_signal_mask(primary)
-    secondary_target = _target_signal_mask(secondary)
-    secondary_overlay = secondary_target & ~primary_target
-    primary_target_count = int(np.count_nonzero(primary_target))
-    secondary_target_count = int(np.count_nonzero(secondary_target))
-    secondary_effective = int(np.count_nonzero(secondary_overlay))
-    if primary_target_count == 0 or secondary_target_count == 0:
-        raise VPMValidationError("splice requires visible target evidence from both sources")
-    if secondary_effective == 0:
-        raise VPMValidationError("splice requires distinct secondary target evidence")
-    output = np.array(primary, copy=True)
-    output[secondary_overlay] = secondary[secondary_overlay]
-    primary_effective = int(np.count_nonzero((primary != 0) & (output == primary)))
-    changed_pixel_count = int(np.count_nonzero(output != primary))
-    if changed_pixel_count == 0 or primary_effective == 0:
-        raise VPMValidationError("splice requires nonzero effective contribution from both sources")
-    if np.array_equal(output, primary) or np.array_equal(output, secondary):
-        raise VPMValidationError("splice output must not equal either source observation")
-    policy = compile_policy_artifact()
-    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
-    row_actions = {str(row_id): lookup.choose(str(row_id)) for row_id in policy.source.row_ids}
-    visible_action_evidence = _final_visible_target_action_evidence(output, row_actions)
-    if not visible_action_evidence["conflicting_action_evidence_present"]:
-        raise VPMValidationError("conflicting splice final visible target evidence does not imply conflicting actions")
-    canonical_collisions = _canonical_collision_rows(output)
-    if canonical_collisions:
-        raise VPMValidationError("conflicting splice output collides with a canonical valid observation")
-    critical_mask = np.zeros(primary.shape, dtype=bool)
-    for y, x in _critical_coordinates():
-        critical_mask[y, x] = True
-    manifest = {
-        "primary_source_row_id": primary_row_id,
-        "primary_source_action_id": primary_action_id,
-        "secondary_source_row_id": secondary_row_id,
-        "secondary_source_action_id": secondary_action_id,
-        "primary_source_digest": _array_digest(primary),
-        "secondary_source_digest": _array_digest(secondary),
-        "splice_mask_identity": mask_manifest["mask_digest"],
-        "splice_mask_version": mask_manifest["version"],
-        "target_region_id": TARGET_REGION_ID,
-        "composition_rule": mask_manifest["composition_rule"],
-        "primary_contributing_pixel_count": primary_effective,
-        "secondary_contributing_pixel_count": secondary_effective,
-        "changed_pixel_count": changed_pixel_count,
-        "action_relevant_region_contribution_counts": {
-            "primary_target_pixel_count": primary_target_count,
-            "secondary_target_pixel_count": secondary_target_count,
-            "secondary_additive_target_pixel_count": secondary_effective,
-            "target_overlap_pixel_count": int(np.count_nonzero(primary_target & secondary_target)),
-        },
-        "critical_region_contribution_counts": {
-            "primary_pixel_count": int(np.count_nonzero(critical_mask & (output == primary))),
-            "secondary_pixel_count": 0,
-        },
-        "canonical_universe_version": CANONICAL_OBSERVATION_UNIVERSE_VERSION,
-        "final_visible_target_slots": visible_action_evidence["final_visible_target_slots"],
-        "final_tank_slot": visible_action_evidence["final_tank_slot"],
-        "final_cooldown": visible_action_evidence["final_cooldown"],
-        "visible_target_action_map": visible_action_evidence["visible_target_action_map"],
-        "visible_action_set": visible_action_evidence["visible_action_set"],
-        "visible_action_evidence_digest": visible_action_evidence["visible_action_evidence_digest"],
-        "canonical_collision_count": 0,
-        "canonical_collision_rows": [],
-        "output_observation_digest": _array_digest(output),
-        "expected_invalid_family_label": "conflicting_action_splice",
-    }
-    manifest["splice_trace_digest"] = _sha256(manifest)
-    return output, manifest
-
-
-def _apply_critical_corruption(source_pixels: np.ndarray, coordinate_manifest: Mapping[str, Any]) -> tuple[np.ndarray, dict[str, Any]]:
-    source = np.ascontiguousarray(source_pixels, dtype=np.uint8)
-    coords = tuple((int(y), int(x)) for y, x in coordinate_manifest["coordinates"])
-    _critical_coordinate_manifest(coords)
-    output = np.array(source, copy=True)
-    changes = []
-    for y, x in coords:
-        if y < 0 or y >= output.shape[0] or x < 0 or x >= output.shape[1]:
-            raise VPMValidationError("critical coordinate outside image bounds")
-        original = int(output[y, x])
-        replacement = 255 if original != 255 else 0
-        if replacement == original:
-            raise VPMValidationError("critical corruption replacement must change the value")
-        output[y, x] = replacement
-        if int(output[y, x]) == original:
-            raise VPMValidationError("critical corruption no-op after assignment")
-        changes.append({"y": y, "x": x, "original": original, "replacement": int(output[y, x])})
-    if not changes:
-        raise VPMValidationError("critical corruption requires at least one changed pixel")
-    if np.array_equal(source, output):
-        raise VPMValidationError("critical corruption must change the observation digest")
-    manifest = {
-        "criticality_artifact_identity": CRITICAL_COORDINATE_SET_VERSION,
-        "critical_region_id": CRITICAL_REGION_ID,
-        "critical_coordinate_set_identity": coordinate_manifest["coordinate_set_digest"],
-        "changes": changes,
-        "changed_pixel_count": len(changes),
-        "source_observation_digest": _array_digest(source),
-        "output_observation_digest": _array_digest(output),
-    }
-    manifest["critical_corruption_digest"] = _sha256(manifest)
-    return output, manifest
-
-
-def _conflicting_splice_operation_chain(
-    *,
-    primary_row_id: str,
-    secondary_row_id: str,
-    primary_action_id: str,
-    secondary_action_id: str,
-    primary_transformation_parameters: Mapping[str, Any],
-    mask_manifest: Mapping[str, Any],
-) -> dict[str, Any]:
-    primary_base = _render_row_frame(primary_row_id)
-    primary_transformed, primary_trace = _apply_transformation(primary_base, primary_transformation_parameters)
-    secondary = _render_row_frame(secondary_row_id)
-    output, splice_trace = _apply_conflicting_splice(
-        primary_pixels=primary_transformed,
-        secondary_pixels=secondary,
-        primary_row_id=primary_row_id,
-        secondary_row_id=secondary_row_id,
-        primary_action_id=primary_action_id,
-        secondary_action_id=secondary_action_id,
-        mask_manifest=mask_manifest,
-    )
-    primary_base_digest = primary_trace["source_observation_digest"]
-    primary_transformed_digest = primary_trace["transformed_observation_digest"]
-    secondary_digest = _array_digest(secondary)
-    output_digest = _array_digest(output)
-    operations = [
-        _operation_record(index=0, operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": primary_row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=primary_base_digest),
-        _operation_record(index=1, operation="apply_bounded_transformation", operation_version=TRANSFORMATION_FAMILY_VERSION, input_digests=[primary_base_digest], parameters={"transformation_parameters": dict(primary_transformation_parameters)}, output_digest=primary_transformed_digest),
-        _operation_record(index=2, operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": secondary_row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=secondary_digest),
-        _operation_record(
-            index=3,
-            operation="compose_simultaneous_target_evidence",
-            operation_version=CONFLICTING_ACTION_SPLICE_VERSION,
-            input_digests=[primary_transformed_digest, secondary_digest],
-            parameters={
-                "primary_row_id": primary_row_id,
-                "secondary_row_id": secondary_row_id,
-                "primary_action_id": primary_action_id,
-                "secondary_action_id": secondary_action_id,
-                "mask_manifest": dict(mask_manifest),
-                "splice_trace_digest": splice_trace["splice_trace_digest"],
-            },
-            output_digest=output_digest,
-        ),
-        _operation_record(index=4, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[output_digest], parameters={"event_type": "frame"}, output_digest=output_digest),
-    ]
-    return _operation_chain(operations, output_digest)
-
-
-
-def _critical_corruption_operation_chain(row_id: str, transformation_parameters: Mapping[str, Any], coordinate_manifest: Mapping[str, Any]) -> dict[str, Any]:
-    source = _render_row_frame(row_id)
-    transformed, transform_trace = _apply_transformation(source, transformation_parameters)
-    corrupted, corruption_trace = _apply_critical_corruption(transformed, coordinate_manifest)
-    source_digest = transform_trace["source_observation_digest"]
-    transformed_digest = transform_trace["transformed_observation_digest"]
-    output_digest = _array_digest(corrupted)
-    operations = [
-        _operation_record(index=0, operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": row_id, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=source_digest),
-        _operation_record(index=1, operation="apply_bounded_transformation", operation_version=TRANSFORMATION_FAMILY_VERSION, input_digests=[source_digest], parameters={"transformation_parameters": dict(transformation_parameters)}, output_digest=transformed_digest),
-        _operation_record(index=2, operation="apply_critical_coordinate_corruption", operation_version="zeromodel-video-action-set-family-critical-evidence-corruption/v1", input_digests=[transformed_digest], parameters={"critical_coordinates": dict(coordinate_manifest), "critical_corruption_digest": corruption_trace["critical_corruption_digest"]}, output_digest=output_digest),
-        _operation_record(index=3, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[output_digest], parameters={"event_type": "frame"}, output_digest=output_digest),
-    ]
-    return _operation_chain(operations, output_digest)
-
-
-
-def _stale_repeat_operation_chain(destination_before: Mapping[str, Any], replacement_source: Mapping[str, Any], repeat: Mapping[str, Any]) -> dict[str, Any]:
-    dest_params = destination_before.get("metadata", {}).get("transformation_parameters", {})
-    src_params = replacement_source.get("metadata", {}).get("transformation_parameters", {})
-    dest_row = str(destination_before.get("expected_row"))
-    src_row = str(replacement_source.get("expected_row"))
-    dest_chain = _valid_frame_operation_chain(dest_row, dest_params)
-    src_chain = _valid_frame_operation_chain(src_row, src_params)
-    original_digest = str(destination_before["observation_pixel_digest"])
-    replacement_digest = str(replacement_source["observation_pixel_digest"])
-    operations = list(dest_chain["operations"][:-1])
-    offset = len(operations)
-    for op in src_chain["operations"][:-1]:
-        copied = dict(op)
-        copied["index"] = int(op["index"]) + offset
-        copied["operation_digest"] = _sha256({key: value for key, value in copied.items() if key != "operation_digest"})
-        operations.append(copied)
-    operations.append(
-        _operation_record(
-            index=len(operations),
-            operation="stale_repeat_replace",
-            operation_version="zeromodel-video-action-set-family-stale-repeated-frame/v1",
-            input_digests=[original_digest, replacement_digest],
-            parameters=dict(repeat),
-            output_digest=replacement_digest,
-        )
-    )
-    operations.append(_operation_record(index=len(operations), operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[replacement_digest], parameters={"event_type": "frame"}, output_digest=replacement_digest))
-    return _operation_chain(operations, replacement_digest)
-
-
-
-def _impossible_transition_operation_chain(destination_before: Mapping[str, Any], transition_plan: Mapping[str, Any]) -> dict[str, Any]:
-    dest_params = destination_before.get("metadata", {}).get("transformation_parameters", {})
-    ordinary_row = str(destination_before.get("expected_row"))
-    ordinary_chain = _valid_frame_operation_chain(ordinary_row, dest_params)
-    ordinary_digest = str(destination_before["observation_pixel_digest"])
-    unreachable_row = str(transition_plan["destination_row_id"])
-    unreachable_pixels = _render_row_frame(unreachable_row)
-    unreachable_digest = _array_digest(unreachable_pixels)
-    operations = list(ordinary_chain["operations"][:-1])
-    operations.append(_operation_record(index=len(operations), operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": unreachable_row, "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=unreachable_digest))
-    operations.append(
-        _operation_record(
-            index=len(operations),
-            operation="impossible_transition_replace",
-            operation_version="zeromodel-video-action-set-family-impossible-transition/v1",
-            input_digests=[ordinary_digest, unreachable_digest],
-            parameters=dict(transition_plan),
-            output_digest=unreachable_digest,
-        )
-    )
-    operations.append(_operation_record(index=len(operations), operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[unreachable_digest], parameters={"event_type": "frame"}, output_digest=unreachable_digest))
-    return _operation_chain(operations, unreachable_digest)
-
-
-
-def _information_control_operation_chain(current_row_id: str) -> dict[str, Any]:
-    current = _render_row_frame(current_row_id)
-    current_digest = _array_digest(current)
-    operations = [
-        _operation_record(index=0, operation="render_canonical_row", operation_version=ARCADE_RENDERER_CONTRACT_VERSION, input_digests=[], parameters={"row_id": str(current_row_id), "renderer": "zeromodel.arcade_policy.render_state_frame", "config": _transition_config_payload()}, output_digest=current_digest),
-        _operation_record(index=1, operation="emit_provider_identical_control_observation", operation_version=INFORMATION_CONTROL_VERSION, input_digests=[current_digest], parameters={"current_row_id": str(current_row_id), "provider_observation_boundary_version": PROVIDER_OBSERVATION_BOUNDARY_VERSION}, output_digest=current_digest),
-        _operation_record(index=2, operation="emit_observation", operation_version=OBSERVATION_OPERATION_CHAIN_VERSION, input_digests=[current_digest], parameters={"event_type": "frame"}, output_digest=current_digest),
-    ]
-    return _operation_chain(operations, current_digest)
-
 
 
 def _refresh_provider_observation_metadata(record: dict[str, Any]) -> None:
@@ -2414,71 +1863,6 @@ def _record_regeneration_view(record: Mapping[str, Any]) -> dict[str, Any]:
 
 
 
-def _frame_invalid_closure_summary(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
-    canonical = canonical_observation_universe()
-    canonical_index = _canonical_observation_digest_index()
-    by_family: dict[str, dict[str, Any]] = {}
-    for record in records:
-        if record.get("expected_disposition") != "distinguishable_invalid_input":
-            continue
-        family = str(record.get("family"))
-        row = by_family.setdefault(
-            family,
-            {
-                "family_id": family,
-                "frame_count": 0,
-                "canonical_collision_count": 0,
-                "valid_decode_count": 0,
-                "no_op_count": 0,
-                "malformed_count": 0,
-                "collision_examples": [],
-            },
-        )
-        row["frame_count"] += 1
-        pixels = record.get("pixels")
-        if pixels is None:
-            row["malformed_count"] += 1
-            continue
-        digest = str(record.get("observation_pixel_digest") or _array_digest(np.ascontiguousarray(pixels, dtype=np.uint8)))
-        collisions = canonical_index.get(digest, [])
-        if collisions:
-            row["canonical_collision_count"] += 1
-            row["valid_decode_count"] += 1
-            if len(row["collision_examples"]) < 3:
-                row["collision_examples"].append(
-                    {
-                        "frame_id": record.get("frame_id"),
-                        "observation_pixel_digest": digest,
-                        "canonical_rows": collisions,
-                    }
-                )
-        trace = record.get("metadata", {}).get("family_intervention_trace", {})
-        if trace.get("changed_pixel_count") == 0:
-            row["no_op_count"] += 1
-        status = validate_materialized_family_record(record)
-        if status != "ok":
-            row["malformed_count"] += 1
-    totals = {
-        "frame_count": sum(row["frame_count"] for row in by_family.values()),
-        "canonical_collision_count": sum(row["canonical_collision_count"] for row in by_family.values()),
-        "valid_decode_count": sum(row["valid_decode_count"] for row in by_family.values()),
-        "no_op_count": sum(row["no_op_count"] for row in by_family.values()),
-        "malformed_count": sum(row["malformed_count"] for row in by_family.values()),
-    }
-    passed = totals["frame_count"] > 0 and totals["canonical_collision_count"] == 0 and totals["valid_decode_count"] == 0 and totals["no_op_count"] == 0 and totals["malformed_count"] == 0
-    payload = {
-        "version": FRAME_INVALID_CLOSURE_VERSION,
-        "canonical_universe_version": canonical["version"],
-        "canonical_universe_digest": canonical["universe_digest"],
-        "valid_observation_universe_version": VALID_OBSERVATION_UNIVERSE_VERSION,
-        "families": list(by_family.values()),
-        "totals": totals,
-        "status": "passed" if passed else "failed",
-    }
-    payload["closure_digest"] = _sha256(payload)
-    return payload
-
-
 def _family_closure_report(
     *,
     split: str,
@@ -2561,7 +1945,7 @@ def _family_closure_report(
             else "unresolved"
         )
     return {
-        "version": "zeromodel-video-action-set-family-closure/v1",
+        "version": FAMILY_CLOSURE_VERSION,
         "split": split,
         "registry_version": EPISODE_FAMILY_REGISTRY_VERSION,
         "families": list(rows.values()),
@@ -2573,27 +1957,6 @@ def _family_closure_report(
         "repository_status": "reference_instrument_correctness_unresolved",
         "materialization_status": "prospective_materialization_prohibited",
     }
-
-
-def validate_materialized_family_record(record: Mapping[str, Any]) -> str:
-    pixels = record.get("pixels")
-    if pixels is not None and record.get("observation_pixel_digest") != _array_digest(np.ascontiguousarray(pixels, dtype=np.uint8)):
-        return "stale_observation_digest"
-    metadata = record.get("metadata", {})
-    trace = metadata.get("family_intervention_trace")
-    if trace:
-        output_digest = trace.get("output_observation_digest")
-        if output_digest is not None and output_digest != record.get("observation_pixel_digest"):
-            return "family_output_digest_mismatch"
-        if trace.get("changed_pixel_count") == 0:
-            return "family_no_op"
-    if record.get("expected_disposition") == "distinguishable_invalid_input" and pixels is not None:
-        digest = str(record.get("observation_pixel_digest") or _array_digest(np.ascontiguousarray(pixels, dtype=np.uint8)))
-        if _canonical_observation_digest_index().get(digest):
-            return "invalid_family_valid_state_collision"
-    if record.get("event_type") == "gap_unknown" and pixels is not None:
-        return "gap_event_has_pixels"
-    return "ok"
 
 
 def validate_control_episode_records(records: Sequence[Mapping[str, Any]]) -> str:


### PR DESCRIPTION
## Summary

- Extract episode-family contracts/dispositions into `episode_families`, frame-level family intervention kernels into `frame_family_kernels`, family operation-chain construction into `family_provenance`, and frame-invalid validation/closure into `family_validation`.
- Move Stage 4B family identity/version constants into `contracts.py` while preserving legacy benchmark names as direct aliases.
- Add architecture checks preventing family science modules from importing the legacy benchmark, persistence/runtime layers, replay/validation cycles, or lower-kernel back edges.
- Add focused frozen-golden tests for registry identity, visual intervention digests, provenance chain digests, validation statuses, closure digest, and legacy alias preservation.
- Address review blockers by restoring historical non-mapping metadata failure behavior and adding high-risk tests for splice validation precedence, forged critical manifests, real replay executors, and family-validation status precedence.

## Validation

- `python -m pytest -q tests/test_video_episode_family_kernel.py tests/test_video_family_provenance_kernel.py tests/test_video_observation_provenance_kernel.py tests/test_video_observation_universe_kernel.py` (51 passed)
- `python scripts/check_architecture.py`
- `python scripts/check_quality.py`
- `python scripts/run_fast_tests.py` (400 passed, 1 skipped, 138 deselected; 26.17s)
- `python -m build`

Audit-Exempt: behavior-preserving extraction of episode-family contracts, frame-level invalid-family kernels, family-specific provenance construction, and frame-invalid validation/closure. No family identities, visual outputs, intervention traces, operation-chain identities, episode plans, materialized records, scientific evidence, claims, or conclusions changed.