### PR TITLE
refactor: extract video episode-planning compiler

### DIFF
--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -9,7 +9,7 @@ maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
 reason = "Stage 3 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 4819
+maximum_lines = 3985
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -32,11 +32,21 @@ EPISODE_FAMILIES_MODULE = "zeromodel.domains.video_action_set.episode_families"
 FRAME_FAMILY_KERNELS_MODULE = "zeromodel.domains.video_action_set.frame_family_kernels"
 FAMILY_PROVENANCE_MODULE = "zeromodel.domains.video_action_set.family_provenance"
 FAMILY_VALIDATION_MODULE = "zeromodel.domains.video_action_set.family_validation"
+CONTROL_HISTORIES_MODULE = "zeromodel.domains.video_action_set.control_histories"
+FAMILY_INTERVENTION_PLANNING_MODULE = (
+    "zeromodel.domains.video_action_set.family_intervention_planning"
+)
+EPISODE_PLANNING_MODULE = "zeromodel.domains.video_action_set.episode_planning"
 FAMILY_SCIENCE_MODULES = {
     EPISODE_FAMILIES_MODULE,
     FRAME_FAMILY_KERNELS_MODULE,
     FAMILY_PROVENANCE_MODULE,
     FAMILY_VALIDATION_MODULE,
+}
+EPISODE_PLANNING_MODULES = {
+    CONTROL_HISTORIES_MODULE,
+    FAMILY_INTERVENTION_PLANNING_MODULE,
+    EPISODE_PLANNING_MODULE,
 }
 VIDEO_OBSERVATION_KERNEL_MODULES = {
     ARCADE_OBSERVATION_MODULE,
@@ -67,8 +77,11 @@ VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
 VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
     ARCADE_OBSERVATION_MODULE,
     CANONICAL_JSON_MODULE,
+    CONTROL_HISTORIES_MODULE,
     CONTRACTS_MODULE,
     EPISODE_FAMILIES_MODULE,
+    EPISODE_PLANNING_MODULE,
+    FAMILY_INTERVENTION_PLANNING_MODULE,
     FAMILY_PROVENANCE_MODULE,
     FAMILY_VALIDATION_MODULE,
     FRAME_FAMILY_KERNELS_MODULE,
@@ -555,6 +568,13 @@ def family_science_forbidden_edge_violations(edge: ImportEdge) -> list[Violation
                 edge,
             )
         )
+    if (
+        edge.importer in FAMILY_SCIENCE_MODULES
+        and edge.imported in EPISODE_PLANNING_MODULES
+    ):
+        violations.append(
+            edge_violation("family science must not import planning", edge)
+        )
     if edge.importer == EPISODE_FAMILIES_MODULE and edge.imported in {
         ARCADE_OBSERVATION_MODULE,
         FAMILY_PROVENANCE_MODULE,
@@ -628,38 +648,74 @@ def family_science_forbidden_edge_violations(edge: ImportEdge) -> list[Violation
     return violations
 
 
+def episode_planning_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
+    violations: list[Violation] = []
+    importer = edge.importer
+    imported = edge.imported
+
+    def reject(rule: str) -> None:
+        violations.append(edge_violation(rule, edge))
+
+    if (
+        importer in VIDEO_OBSERVATION_KERNEL_MODULES
+        and imported in EPISODE_PLANNING_MODULES
+    ):
+        reject("video observation kernels must not import episode planning modules")
+    if importer in EPISODE_PLANNING_MODULES and (
+        imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+        or is_module_under(imported, DB_ORM_PREFIX)
+        or is_module_under(imported, DB_STORES_PREFIX)
+        or is_module_under(imported, "zeromodel.db.session")
+        or is_module_under(imported, "zeromodel.stores")
+        or imported == "zeromodel.runtime"
+        or is_sqlalchemy_import(imported)
+    ):
+        reject("planning must not import benchmark/persistence/runtime")
+    if importer in EPISODE_PLANNING_MODULES and imported in {
+        ARCADE_OBSERVATION_MODULE,
+        FAMILY_PROVENANCE_MODULE,
+        FAMILY_VALIDATION_MODULE,
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+        PIXEL_DIGEST_MODULE,
+    }:
+        reject("planning must not import rendering/replay/provenance/pixels")
+    if importer == CONTROL_HISTORIES_MODULE and imported in {
+        FAMILY_INTERVENTION_PLANNING_MODULE,
+        EPISODE_PLANNING_MODULE,
+    }:
+        reject("control_histories must not import higher episode planning modules")
+    if (
+        importer == FAMILY_INTERVENTION_PLANNING_MODULE
+        and imported == EPISODE_PLANNING_MODULE
+    ):
+        reject("family_intervention_planning must not import episode_planning")
+    return violations
+
+
 def rmdto_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
     violations: list[Violation] = []
+
+    def reject(rule: str) -> None:
+        violations.append(edge_violation(rule, edge))
+
     if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
         is_module_under(edge.imported, DB_ORM_PREFIX)
         or is_module_under(edge.imported, DB_STORES_PREFIX)
         or is_module_under(edge.imported, "zeromodel.db.session")
         or is_sqlalchemy_import(edge.imported)
     ):
-        violations.append(
-            edge_violation(
-                "video_action_set domain modules must not import persistence layers",
-                edge,
-            )
-        )
+        reject("video_action_set domain modules must not import persistence layers")
     if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
         edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
     ):
-        violations.append(
-            edge_violation(
-                "video_action_set domain modules must not import legacy benchmark",
-                edge,
-            )
-        )
+        reject("video_action_set domain modules must not import legacy benchmark")
     if edge.importer in VIDEO_ACTION_SET_PURE_DOMAIN_MODULES and (
         is_module_under(edge.imported, "zeromodel.stores")
         or edge.imported == "zeromodel.runtime"
     ):
-        violations.append(
-            edge_violation(
-                "video_action_set DTO, contracts, and Services must not import runtime layers",
-                edge,
-            )
+        reject(
+            "video_action_set DTO, contracts, and Services must not import runtime layers"
         )
     if edge.importer == "zeromodel.runtime" and (
         is_module_under(edge.imported, "zeromodel.db")
@@ -713,6 +769,7 @@ def forbidden_edge_violations(edges: list[ImportEdge]) -> list[Violation]:
         violations.extend(transformation_kernel_forbidden_edge_violations(edge))
         violations.extend(observation_provenance_replay_forbidden_edge_violations(edge))
         violations.extend(family_science_forbidden_edge_violations(edge))
+        violations.extend(episode_planning_forbidden_edge_violations(edge))
         violations.extend(rmdto_forbidden_edge_violations(edge))
     return violations
 

--- a/tests/test_video_control_history_planning.py
+++ b/tests/test_video_control_history_planning.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set import control_histories
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CONTROL_SOURCE_ROWS = [
+    "tank=0|target=none|cooldown=0",
+    "tank=0|target=0|cooldown=0",
+    "tank=0|target=1|cooldown=0",
+]
+FIRST_CANDIDATE = {
+    "actual_executed_action": "LEFT",
+    "normalized_causal_tuple_digest": "sha256:c03a8f6e753cdecb1e9f94c8c50db5131726d08a0f6d54616f90e42fc2a1734e",
+    "predecessor_row_id": "tank=0|target=none|cooldown=0",
+    "resulting_row_id": "tank=0|target=none|cooldown=0",
+    "transition_choice_index": 0,
+}
+SELECTED_HISTORY_IDS = [
+    "sha256:c03a8f6e753cdecb1e9f94c8c50db5131726d08a0f6d54616f90e42fc2a1734e",
+    "sha256:e35c5faeab0bfff99af9b629ff473149507b7f73c6137b41bc479379cac877a3",
+    "sha256:0bbfa71389d9c6b97646c62edb0effce87f2229ce5cbde902cdaa6b685cd4bb0",
+    "sha256:405d893d7e9456f025c932ffb468148babbc95b34d6d16b1680bb88514a6f28b",
+]
+
+
+def _row_ids_actions() -> tuple[list[str], dict[str, str]]:
+    policy = benchmark.compile_policy_artifact()
+    lookup = benchmark.VPMPolicyLookup(policy, action_metric_ids=benchmark.ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    return row_ids, {row_id: lookup.choose(row_id) for row_id in row_ids}
+
+
+def test_transition_identity_and_causal_tuple_goldens() -> None:
+    row_ids, row_actions = _row_ids_actions()
+    source_row_id = row_ids[0]
+    action = row_actions[source_row_id]
+    causal_tuple = control_histories.normalized_control_causal_tuple(
+        predecessor_row_id=source_row_id,
+        actual_executed_action=FIRST_CANDIDATE["actual_executed_action"],
+        transition_choice_index=0,
+        resulting_row_id=source_row_id,
+    )
+
+    assert control_histories.transition_identity()["transition_identity_digest"] == (
+        "sha256:6e96c50329265b21ecb96db7fc6e5b020afaa8487cb4d93c4ab556be40063403"
+    )
+    assert control_histories.transition_input_digest(source_row_id, action) == (
+        "sha256:4dc004f18d5b5675b04dd4714693b28fbbbefc35eee02bf842d28b41a4cfd668"
+    )
+    assert control_histories.transition_result_digest(source_row_id, action, 0, source_row_id) == (
+        "sha256:0f1816adedc21735c89854d8e91f922de335892b7fe97def1941f59c2c2a3bca"
+    )
+    assert canonical_sha256(causal_tuple) == FIRST_CANDIDATE["normalized_causal_tuple_digest"]
+
+
+def test_control_history_enumeration_selection_and_reconstruction_are_frozen() -> None:
+    row_ids, _row_actions = _row_ids_actions()
+
+    assert control_histories.control_source_rows(row_ids, count=3, frame_count=4) == CONTROL_SOURCE_ROWS
+    candidates = control_histories.grounded_control_histories_for_current_row(CONTROL_SOURCE_ROWS[0], row_ids)
+    assert len(candidates) == 6
+    assert candidates[0] == FIRST_CANDIDATE
+    assert canonical_sha256(candidates) == "sha256:fe5bd93b70a20d87c12f0e543acdc56f0b2372e3ebdf68ae2d06df6cbe30e8fe"
+
+    selected = control_histories.select_grounded_control_histories(
+        CONTROL_SOURCE_ROWS[0],
+        row_ids,
+        control_group_id="stage5-control-group",
+        frame_count=4,
+    )
+    assert [history["history_id"] for history in selected] == SELECTED_HISTORY_IDS
+    assert canonical_sha256(selected) == "sha256:77e821ed82496125338322aa62a1c61321c54c68acb8d5b04a14ac18903183e8"
+    assert control_histories.reconstructed_control_causal_tuple_digest(selected[0]) == SELECTED_HISTORY_IDS[0]
+
+    tampered = deepcopy(selected[0])
+    tampered["transition_result_digest"] = "sha256:" + "0" * 64
+    with pytest.raises(VPMValidationError, match="result digest mismatch"):
+        control_histories.reconstructed_control_causal_tuple_digest(tampered)
+
+
+def test_benchmark_control_history_aliases_are_direct() -> None:
+    assert benchmark._transition_identity is control_histories.transition_identity
+    assert benchmark._transition_input_digest is control_histories.transition_input_digest
+    assert benchmark._transition_result_digest is control_histories.transition_result_digest
+    assert benchmark._normalized_control_causal_tuple is control_histories.normalized_control_causal_tuple
+    assert benchmark._grounded_control_history is control_histories.grounded_control_history
+    assert benchmark._reconstructed_control_causal_tuple_digest is (
+        control_histories.reconstructed_control_causal_tuple_digest
+    )
+    assert benchmark._grounded_control_histories_for_current_row is (
+        control_histories.grounded_control_histories_for_current_row
+    )
+    assert benchmark._select_grounded_control_histories is control_histories.select_grounded_control_histories
+    assert benchmark._control_source_rows is control_histories.control_source_rows

--- a/tests/test_video_episode_planning_kernel.py
+++ b/tests/test_video_episode_planning_kernel.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set import (
+    control_histories,
+    episode_planning,
+    family_intervention_planning,
+)
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_SPLIT_SUMMARIES = {
+    "development": {
+        "count": 112,
+        "first_episode_id": "development:valid:8d2e4b45539bc773",
+        "last_episode_id": "development:valid:da2f93a150a2e789",
+        "frame_count_total": 112,
+        "plan_digest_rollup": "sha256:000106d8842e90698d44d07534b878cf8c580e4b80b92f2b692d57e7cb78c291",
+        "episode_id_rollup": "sha256:55e1eb64193f199a6d2ea7fc01fac9dfc2b9f50781528f61e589a10c020ef61c",
+        "family_counts": {"valid": 112},
+        "mutation_counts": {},
+    },
+    "calibration": {
+        "count": 112,
+        "first_episode_id": "calibration:valid:171e7c1e602df153",
+        "last_episode_id": "calibration:valid:0eaf29b67f6c98d3",
+        "frame_count_total": 448,
+        "plan_digest_rollup": "sha256:3844bff2c0eac4cfc476444177e36ad6b2b8c4800bf2f0e1716fe2484ce72716",
+        "episode_id_rollup": "sha256:8b36e4badfa6d4a37d77df3b18b85fb982b433d4e82ff495b1dc7d6e6c5127b6",
+        "family_counts": {"valid": 112},
+        "mutation_counts": {},
+    },
+    "selection": {
+        "count": 252,
+        "first_episode_id": "selection:valid:3b017d7e360a1086",
+        "last_episode_id": "selection:information_control:c63e511d702c29a4",
+        "frame_count_total": 1008,
+        "plan_digest_rollup": "sha256:3294f053295a6d5c634f78065fa410211296b9c0d14fdf204e6bf90b462f6612",
+        "episode_id_rollup": "sha256:33d0a1122332ad29679019914e3e6be03b52f2757021eac6f26a169eec3819dc",
+        "family_counts": {"frame_invalid": 56, "information_control": 28, "temporal_negative": 56, "valid": 112},
+        "mutation_counts": {
+            "conflicting_action_splice": 28,
+            "critical_evidence_corruption": 28,
+            "declared_gap_or_unknown_action": 14,
+            "impossible_transition": 14,
+            "reordered_frames": 14,
+            "stale_repeated_frame": 14,
+        },
+    },
+    "final": {
+        "count": 252,
+        "first_episode_id": "final:valid:1058e7c00930ff46",
+        "last_episode_id": "final:information_control:d26f251078213b36",
+        "frame_count_total": 1008,
+        "plan_digest_rollup": "sha256:7ada2002b9fb8be46f910ae79337b5fdda603e3413eaa3087b436354ca9ebde0",
+        "episode_id_rollup": "sha256:7f95640e9ea81edcff80c8252b7fd52960b849d9e9825b197fdbc38d31b7aa22",
+        "family_counts": {"frame_invalid": 56, "information_control": 28, "temporal_negative": 56, "valid": 112},
+        "mutation_counts": {
+            "conflicting_action_splice": 28,
+            "critical_evidence_corruption": 28,
+            "declared_gap_or_unknown_action": 14,
+            "impossible_transition": 14,
+            "reordered_frames": 14,
+            "stale_repeated_frame": 14,
+        },
+    },
+}
+
+
+def _identity_rows_actions() -> tuple[benchmark.BenchmarkIdentity, list[str], dict[str, str]]:
+    identity = benchmark.load_identity(REPO_ROOT)
+    policy = benchmark.compile_policy_artifact()
+    lookup = benchmark.VPMPolicyLookup(policy, action_metric_ids=benchmark.ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    return identity, row_ids, {row_id: lookup.choose(row_id) for row_id in row_ids}
+
+
+def _summary(plans: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "count": len(plans),
+        "first_episode_id": plans[0]["episode_id"],
+        "last_episode_id": plans[-1]["episode_id"],
+        "family_counts": dict(sorted(Counter(str(plan["family_label"]) for plan in plans).items())),
+        "mutation_counts": dict(sorted(Counter(str(plan["mutation_kind"]) for plan in plans if plan.get("mutation_kind") is not None).items())),
+        "frame_count_total": sum(int(plan["frame_count"]) for plan in plans),
+        "plan_digest_rollup": canonical_sha256([plan["plan_digest"] for plan in plans]),
+        "episode_id_rollup": canonical_sha256([plan["episode_id"] for plan in plans]),
+    }
+
+
+def _contains_materialized_payload(value: object) -> bool:
+    if isinstance(value, dict):
+        if any(key in {"pixels", "ImageObservation", "score_vector", "candidate_set"} for key in value):
+            return True
+        return any(_contains_materialized_payload(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_materialized_payload(item) for item in value)
+    return False
+
+
+def test_derived_seed_and_representative_episode_plan_are_frozen() -> None:
+    identity, row_ids, row_actions = _identity_rows_actions()
+    seed = episode_planning.derived_seed(
+        identity,
+        split="selection",
+        ordinal=7,
+        namespace="stage5_probe",
+        parent_identities=(("alpha", "one"), ("beta", "two")),
+    )
+    plan = episode_planning.make_episode_plan(
+        identity,
+        split="selection",
+        ordinal=0,
+        family_label="valid",
+        family_ordinal=0,
+        source_row_id=row_ids[0],
+        row_actions=row_actions,
+    )
+
+    assert seed["seed_digest"] == "sha256:4d09890ab6c6cec5916e4d3a8872fd08016dcf7eebce4586f7965db8ce419a40"
+    assert seed["seed_int64"] == 5551118694820007621
+    assert plan["episode_id"] == "selection:valid:3b017d7e360a1086"
+    assert plan["plan_digest"] == "sha256:711d180c93547b5f6f1489cccaf5648ffb8ab7af3e0d55c8cc9cd8416d11ff0e"
+    assert [frame["transformation_family"] for frame in plan["frame_plans"]] == [
+        "bounded_translation_photometric",
+        "bounded_translation",
+        "bounded_photometric",
+        "bounded_photometric",
+    ]
+    assert [frame["transformation_parameter_digest"] for frame in plan["frame_plans"]] == [
+        "sha256:fd10a0e5b42d0abfed681a2b8a97dbd11a20c64e26c01291ebc96110f25a5a1f",
+        "sha256:0fe587bbfb1d6b93055576c4a5f896c804d7d6a51e43166fcdb9f500b628ea3c",
+        "sha256:8725d2ee9a282d2c5c5a0da96f62e2c1ece3295f51e4a2968e0e7eaa865b9b28",
+        "sha256:870e36708b0c8cb4cc3538f552de3bab2765e82d42e0c7ff017ee42031d5587c",
+    ]
+
+
+def test_split_episode_plan_collections_match_pre_extraction_goldens(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("episode planning must not materialize pixels or provider scores")
+
+    monkeypatch.setattr(benchmark, "_render_row_frame", fail)
+    monkeypatch.setattr(benchmark, "render_state_frame", fail)
+    monkeypatch.setattr(benchmark, "score_normalized_pixel", fail)
+    monkeypatch.setattr(benchmark, "score_registered_local_correlation", fail)
+    monkeypatch.setattr(benchmark, "score_b3_joint_fit", fail)
+
+    identity, row_ids, row_actions = _identity_rows_actions()
+    plans_by_split = {
+        split: episode_planning.episode_plans_for_split(identity, split, row_ids, row_actions)
+        for split in ("development", "calibration", "selection", "final")
+    }
+
+    assert {split: _summary(plans) for split, plans in plans_by_split.items()} == EXPECTED_SPLIT_SUMMARIES
+    assert canonical_sha256({split: [plan["plan_digest"] for plan in plans] for split, plans in plans_by_split.items()}) == (
+        "sha256:a56aef694069a5bc46639834e6d323866a35b701e1085c743b4b080918a0bced"
+    )
+    assert all(not _contains_materialized_payload(plan) for plans in plans_by_split.values() for plan in plans)
+    assert all(plan["final_observation_provenance"]["observation_payload_included"] is False for plan in plans_by_split["final"])
+
+
+def test_episode_plan_validation_rejects_lineage_and_identity_tampering() -> None:
+    identity, row_ids, row_actions = _identity_rows_actions()
+    plan = episode_planning.episode_plans_for_split(identity, "selection", row_ids, row_actions)[0]
+    tampered = deepcopy(plan)
+    tampered["seed_lineage"]["concrete_episode_seed"]["seed_digest"] = "sha256:" + "0" * 64
+
+    with pytest.raises(VPMValidationError, match="seed lineage or identity"):
+        episode_planning.validate_episode_plan(identity, tampered, row_actions)
+    with pytest.raises(VPMValidationError, match="duplicate concrete episode identity"):
+        episode_planning.validate_episode_plan_collection(identity, {"selection": [plan, plan]}, row_actions)
+
+
+def test_benchmark_episode_planning_aliases_are_direct() -> None:
+    assert benchmark._derived_seed is episode_planning.derived_seed
+    assert benchmark._final_observation_provenance is episode_planning.final_observation_provenance
+    assert benchmark._frame_count_for_plan is episode_planning.frame_count_for_plan
+    assert benchmark._frame_plans is episode_planning.frame_plans
+    assert benchmark._make_episode_plan is episode_planning.make_episode_plan
+    assert benchmark._episode_plans_for_split is episode_planning.episode_plans_for_split
+    assert benchmark._episode_ids_by_family is episode_planning.episode_ids_by_family
+    assert benchmark._validate_episode_plan is episode_planning.validate_episode_plan
+    assert benchmark._validate_episode_plan_collection is episode_planning.validate_episode_plan_collection
+    assert episode_planning.derived_seed is family_intervention_planning.derived_seed
+    assert benchmark._family_intervention_plan is family_intervention_planning.family_intervention_plan
+    assert benchmark._grounded_control_history is control_histories.grounded_control_history

--- a/tests/test_video_family_intervention_planning.py
+++ b/tests/test_video_family_intervention_planning.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.domains.video_action_set import family_intervention_planning
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _identity_rows_actions() -> tuple[
+    benchmark.BenchmarkIdentity, list[str], dict[str, str]
+]:
+    identity = benchmark.load_identity(REPO_ROOT)
+    policy = benchmark.compile_policy_artifact()
+    lookup = benchmark.VPMPolicyLookup(policy, action_metric_ids=benchmark.ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    return identity, row_ids, {row_id: lookup.choose(row_id) for row_id in row_ids}
+
+
+def _contains_materialized_payload(value: object) -> bool:
+    if isinstance(value, dict):
+        if any(
+            key in {"pixels", "ImageObservation", "score_vector", "candidate_set"}
+            for key in value
+        ):
+            return True
+        return any(_contains_materialized_payload(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_materialized_payload(item) for item in value)
+    return False
+
+
+def _plan_kwargs(
+    case: dict[str, Any],
+    identity: benchmark.BenchmarkIdentity,
+    row_ids: list[str],
+    row_actions: dict[str, str],
+) -> dict[str, Any]:
+    return {
+        "identity": identity,
+        "split": "selection",
+        "ordinal": int(case["ordinal"]),
+        "family_label": str(case["family_label"]),
+        "mutation_kind": case["mutation_kind"],
+        "source_row_id": str(case["source_row_id"]),
+        "secondary_row_id": case["secondary_row_id"],
+        "row_ids": row_ids,
+        "row_actions": row_actions,
+    }
+
+
+FAMILY_INTERVENTION_CASES = [
+    {
+        "name": "valid",
+        "ordinal": 0,
+        "family_label": "valid",
+        "mutation_kind": None,
+        "source_row_id": "tank=0|target=none|cooldown=0",
+        "secondary_row_id": None,
+        "intervention_digest": "sha256:c5af54ecfb6d942c82cb83c89b8db94b600850d060ae8878ef8256cc2b3cfc41",
+        "sequence_digest": "sha256:938d8433571fe92ccb667207fe13eb990bb3eba922c9543d2ef0bb1b35e9256f",
+        "materialized_order": [0, 1, 2, 3],
+        "event_type": "frame_sequence",
+    },
+    {
+        "name": "conflicting_action_splice",
+        "ordinal": 112,
+        "family_label": "frame_invalid",
+        "mutation_kind": "conflicting_action_splice",
+        "source_row_id": "tank=0|target=0|cooldown=0",
+        "secondary_row_id": "tank=0|target=1|cooldown=0",
+        "intervention_digest": "sha256:8a23f959070e66db5e40f12da0fede5a513b0ab60f1237b4e81e529a40b532f0",
+        "sequence_digest": "sha256:bdb97c58424512d5cb44d47ccf87dc455728770a3a19ddb949a18bc64839a32b",
+        "materialized_order": [0, 1, 2, 3],
+        "event_type": "frame_sequence",
+    },
+    {
+        "name": "critical_evidence_corruption",
+        "ordinal": 140,
+        "family_label": "frame_invalid",
+        "mutation_kind": "critical_evidence_corruption",
+        "source_row_id": "tank=1|target=5|cooldown=0",
+        "secondary_row_id": None,
+        "intervention_digest": "sha256:d41753a5d1fa3de145e286f10d53fcb81d29e8f90db82fed731fca7127912310",
+        "sequence_digest": "sha256:ee4cc62bcaa4cdde07213db011fabff0e857f400b2b3097e5aa2715c55b4d101",
+        "materialized_order": [0, 1, 2, 3],
+        "event_type": "frame_sequence",
+    },
+    {
+        "name": "reordered_frames",
+        "ordinal": 168,
+        "family_label": "temporal_negative",
+        "mutation_kind": "reordered_frames",
+        "source_row_id": "tank=0|target=none|cooldown=0",
+        "secondary_row_id": None,
+        "intervention_digest": "sha256:a7c5072a4a62197f2b3352a187dd454197b4f5ad34f237016259ecc5d4ca0239",
+        "sequence_digest": "sha256:774355a41324457e1975a623871c6a43f6998e04653e586dfe0f9e6defa4f0ef",
+        "materialized_order": [1, 0, 2, 3],
+        "event_type": "frame_sequence",
+    },
+    {
+        "name": "stale_repeated_frame",
+        "ordinal": 182,
+        "family_label": "temporal_negative",
+        "mutation_kind": "stale_repeated_frame",
+        "source_row_id": "tank=0|target=6|cooldown=0",
+        "secondary_row_id": None,
+        "intervention_digest": "sha256:731ed9485303856dccbb13d00044c3eb613940f5172eb2f7eaf1610bd27f7dea",
+        "sequence_digest": "sha256:de8f59042fbd337f202d527ff5923ebb11f1c383191ddc31fbe67d64f3886d99",
+        "materialized_order": [0, 1, 2, 3],
+        "event_type": "frame_sequence",
+    },
+    {
+        "name": "impossible_transition",
+        "ordinal": 196,
+        "family_label": "temporal_negative",
+        "mutation_kind": "impossible_transition",
+        "source_row_id": "tank=1|target=5|cooldown=0",
+        "secondary_row_id": None,
+        "intervention_digest": "sha256:f8705eb29cd67fa700710146c7541bd336ca046217b8cc25277f366ee0c08bfd",
+        "sequence_digest": "sha256:a743029be192be7fbf6a6c3cea11baeac406fe3f8c5a9da27ae498b2826810bd",
+        "materialized_order": [0, 1, 2, 3],
+        "event_type": "frame_sequence",
+    },
+    {
+        "name": "declared_gap_or_unknown_action",
+        "ordinal": 210,
+        "family_label": "temporal_negative",
+        "mutation_kind": "declared_gap_or_unknown_action",
+        "source_row_id": "tank=2|target=4|cooldown=0",
+        "secondary_row_id": None,
+        "intervention_digest": "sha256:e8658e3bc5330011237e6919339c8fe5a628d611ead510a5020cd91cd68582a6",
+        "sequence_digest": "sha256:8aae9a1bd2378fb8a7dc8746ebf55cb905e34fd387ae023e7c44a4a993bffc9b",
+        "materialized_order": [0, 1, 2, 3],
+        "event_type": "typed_gap_sequence",
+    },
+    {
+        "name": "information_control",
+        "ordinal": 224,
+        "family_label": "information_control",
+        "mutation_kind": None,
+        "source_row_id": "tank=0|target=none|cooldown=0",
+        "secondary_row_id": None,
+        "intervention_digest": "sha256:a41720bc236bd63fc29898878fb0a9d6d0779e7dffc0bcb9f1e6f01995f3e975",
+        "sequence_digest": "sha256:5c9d7285bb886a55f94161de7cbc46ba98f8242948904a5331fa9e2266ff100b",
+        "materialized_order": [0, 1, 2, 3],
+        "event_type": "frame_sequence",
+    },
+]
+
+
+def test_source_row_selection_helpers_are_frozen() -> None:
+    _identity, row_ids, row_actions = _identity_rows_actions()
+
+    assert family_intervention_planning.state_row_values(
+        "tank=0|target=none|cooldown=0"
+    ) == (0, None, 0)
+    assert family_intervention_planning.conflicting_splice_source_rows(
+        row_ids, row_actions, 5
+    ) == [
+        "tank=0|target=0|cooldown=0",
+        "tank=0|target=0|cooldown=1",
+        "tank=0|target=1|cooldown=0",
+        "tank=0|target=1|cooldown=1",
+        "tank=0|target=2|cooldown=0",
+    ]
+    assert (
+        family_intervention_planning.secondary_row_for_splice(
+            row_ids,
+            row_actions,
+            "tank=0|target=0|cooldown=0",
+        )
+        == "tank=0|target=1|cooldown=0"
+    )
+    assert (
+        family_intervention_planning.impossible_destination_row(
+            row_ids,
+            row_actions,
+            "tank=0|target=none|cooldown=0",
+        )
+        == "tank=6|target=6|cooldown=1"
+    )
+
+
+def test_family_intervention_plans_match_pre_extraction_goldens() -> None:
+    identity, row_ids, row_actions = _identity_rows_actions()
+    for case in FAMILY_INTERVENTION_CASES:
+        plan = family_intervention_planning.family_intervention_plan(
+            **_plan_kwargs(case, identity, row_ids, row_actions)
+        )
+        assert plan["intervention_digest"] == case["intervention_digest"]
+        assert plan["sequence_digest"] == case["sequence_digest"]
+        assert plan["materialized_order"] == case["materialized_order"]
+        assert plan["event_type"] == case["event_type"]
+        assert not _contains_materialized_payload(plan)
+        if case["name"] == "information_control":
+            control_group = plan["control_group"]
+            assert control_group["control_group_id"] == (
+                "sha256:5a343fdfa3da7f0fbd0e5a1b24492411181e883633e230e0afd79d3d05e88874"
+            )
+            assert control_group["hidden_source_label_digest"] == (
+                "sha256:33c4730b9378b58b562e9c2ce58ac5dcd6843072729d8f89917a5b859f13d260"
+            )
+            assert [
+                history["history_id"]
+                for history in control_group["hidden_source_histories"]
+            ] == [
+                "sha256:c03a8f6e753cdecb1e9f94c8c50db5131726d08a0f6d54616f90e42fc2a1734e",
+                "sha256:e35c5faeab0bfff99af9b629ff473149507b7f73c6137b41bc479379cac877a3",
+                "sha256:0bbfa71389d9c6b97646c62edb0effce87f2229ce5cbde902cdaa6b685cd4bb0",
+                "sha256:405d893d7e9456f025c932ffb468148babbc95b34d6d16b1680bb88514a6f28b",
+            ]
+
+
+def test_benchmark_family_intervention_aliases_are_direct() -> None:
+    assert (
+        benchmark._seed_int_from_digest
+        is family_intervention_planning.seed_int_from_digest
+    )
+    assert benchmark._state_row_values is family_intervention_planning.state_row_values
+    assert (
+        benchmark._secondary_row_for_splice
+        is family_intervention_planning.secondary_row_for_splice
+    )
+    assert (
+        benchmark._conflicting_splice_source_rows
+        is family_intervention_planning.conflicting_splice_source_rows
+    )
+    assert (
+        benchmark._impossible_destination_row
+        is family_intervention_planning.impossible_destination_row
+    )
+    assert (
+        benchmark._family_intervention_plan
+        is family_intervention_planning.family_intervention_plan
+    )

--- a/zeromodel/domains/video_action_set/contracts.py
+++ b/zeromodel/domains/video_action_set/contracts.py
@@ -2,6 +2,7 @@
 
 ARCADE_RENDERER_CONTRACT_VERSION = "zeromodel-arcade-shooter-render-state-frame/v1"
 ARCADE_RENDERER_IDENTITY_VERSION = "zeromodel-arcade-shooter-renderer-identity/v1"
+AUTHORITATIVE_TRANSITION_FUNCTION_VERSION = "zeromodel-arcade-shooter-next-rows/v1"
 BENCHMARK_VERSION = "zeromodel-video-action-set-reachability-benchmark/v1"
 CANONICAL_OBSERVATION_UNIVERSE_VERSION = (
     "zeromodel-video-action-set-canonical-observation-universe/v1"
@@ -69,6 +70,7 @@ VALID_TRANSFORMATION_PARAMETER_UNIVERSE_VERSION = (
 __all__ = [
     "ARCADE_RENDERER_CONTRACT_VERSION",
     "ARCADE_RENDERER_IDENTITY_VERSION",
+    "AUTHORITATIVE_TRANSITION_FUNCTION_VERSION",
     "BENCHMARK_VERSION",
     "CANONICAL_OBSERVATION_UNIVERSE_VERSION",
     "CONFLICTING_ACTION_SPLICE_VERSION",

--- a/zeromodel/domains/video_action_set/control_histories.py
+++ b/zeromodel/domains/video_action_set/control_histories.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ...arcade_policy import ACTIONS, ShooterConfig, next_rows, parse_state_row_id
+from ...artifact import VPMValidationError
+from .canonical_json import canonical_sha256
+from .contracts import (
+    AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
+    GROUNDED_CONTROL_HISTORY_VERSION,
+)
+
+
+def _transition_config_payload(
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    return {
+        "width": int(config.width),
+        "wave": [int(item) for item in config.wave],
+        "max_steps": int(config.max_steps),
+    }
+
+
+def transition_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
+    payload = {
+        "version": AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
+        "function": "zeromodel.arcade_policy.transitions.next_rows",
+        "action_universe": list(ACTIONS),
+        "config": _transition_config_payload(config),
+    }
+    return payload | {"transition_identity_digest": canonical_sha256(payload)}
+
+
+def transition_input_digest(
+    predecessor_row_id: str,
+    action: str,
+    *,
+    config: ShooterConfig = ShooterConfig(),
+) -> str:
+    tank, target, cooldown = parse_state_row_id(str(predecessor_row_id))
+    return canonical_sha256(
+        {
+            "version": AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
+            "predecessor_row_id": str(predecessor_row_id),
+            "parsed_state": {"tank_x": tank, "target_x": target, "cooldown": cooldown},
+            "actual_executed_action": str(action),
+            "config_digest": canonical_sha256(_transition_config_payload(config)),
+        }
+    )
+
+
+def transition_result_digest(
+    predecessor_row_id: str,
+    action: str,
+    transition_choice_index: int,
+    resulting_row_id: str,
+    *,
+    config: ShooterConfig = ShooterConfig(),
+) -> str:
+    tank, target, cooldown = parse_state_row_id(str(predecessor_row_id))
+    destinations = list(
+        next_rows(tank, target, cooldown, str(action), width=config.width)
+    )
+    return canonical_sha256(
+        {
+            "version": AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
+            "predecessor_row_id": str(predecessor_row_id),
+            "actual_executed_action": str(action),
+            "reachable_row_ids": destinations,
+            "transition_choice_index": int(transition_choice_index),
+            "resulting_row_id": str(resulting_row_id),
+            "config_digest": canonical_sha256(_transition_config_payload(config)),
+        }
+    )
+
+
+def normalized_control_causal_tuple(
+    *,
+    predecessor_row_id: str,
+    actual_executed_action: str,
+    transition_choice_index: int,
+    resulting_row_id: str,
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    identity = transition_identity(config)
+    return {
+        "version": GROUNDED_CONTROL_HISTORY_VERSION,
+        "predecessor_row_id": str(predecessor_row_id),
+        "actual_executed_action": str(actual_executed_action),
+        "transition_choice_index": int(transition_choice_index),
+        "resulting_row_id": str(resulting_row_id),
+        "transition_identity": identity,
+        "transition_input_digest": transition_input_digest(
+            str(predecessor_row_id),
+            str(actual_executed_action),
+            config=config,
+        ),
+        "transition_result_digest": transition_result_digest(
+            str(predecessor_row_id),
+            str(actual_executed_action),
+            int(transition_choice_index),
+            str(resulting_row_id),
+            config=config,
+        ),
+    }
+
+
+def grounded_control_history(
+    *,
+    control_group_id: str,
+    hidden_history_index: int,
+    predecessor_row_id: str,
+    actual_executed_action: str,
+    transition_choice_index: int,
+    resulting_row_id: str,
+    config: ShooterConfig = ShooterConfig(),
+) -> dict[str, Any]:
+    causal_tuple = normalized_control_causal_tuple(
+        predecessor_row_id=predecessor_row_id,
+        actual_executed_action=actual_executed_action,
+        transition_choice_index=transition_choice_index,
+        resulting_row_id=resulting_row_id,
+        config=config,
+    )
+    tuple_digest = canonical_sha256(causal_tuple)
+    payload = {
+        "version": GROUNDED_CONTROL_HISTORY_VERSION,
+        "control_group_id": str(control_group_id),
+        "hidden_history_index": int(hidden_history_index),
+        "history_id": tuple_digest,
+        "hidden_history_id": tuple_digest,
+        "predecessor_row_id": str(predecessor_row_id),
+        "actual_executed_action": str(actual_executed_action),
+        "transition_choice_index": int(transition_choice_index),
+        "resulting_row_id": str(resulting_row_id),
+        "transition_identity": causal_tuple["transition_identity"],
+        "transition_input_digest": causal_tuple["transition_input_digest"],
+        "transition_result_digest": causal_tuple["transition_result_digest"],
+        "normalized_causal_tuple_digest": tuple_digest,
+    }
+    payload["history_digest"] = canonical_sha256(payload)
+    payload["hidden_source_label_digest"] = payload["history_digest"]
+    return payload
+
+
+def reconstructed_control_causal_tuple_digest(
+    history: Mapping[str, Any],
+    *,
+    config: ShooterConfig = ShooterConfig(),
+) -> str:
+    if history.get("version") != GROUNDED_CONTROL_HISTORY_VERSION:
+        raise VPMValidationError("unsupported grounded control history version")
+    action = str(history.get("actual_executed_action"))
+    if action not in ACTIONS:
+        raise VPMValidationError("control history action is not declared")
+    predecessor = str(history.get("predecessor_row_id"))
+    resulting = str(history.get("resulting_row_id"))
+    choice_index = int(history.get("transition_choice_index", -1))
+    tank, target, cooldown = parse_state_row_id(predecessor)
+    destinations = list(next_rows(tank, target, cooldown, action, width=config.width))
+    if choice_index < 0 or choice_index >= len(destinations):
+        raise VPMValidationError("control history transition choice is invalid")
+    if str(destinations[choice_index]) != resulting:
+        raise VPMValidationError(
+            "control history result does not match the declared choice"
+        )
+    causal_tuple = normalized_control_causal_tuple(
+        predecessor_row_id=predecessor,
+        actual_executed_action=action,
+        transition_choice_index=choice_index,
+        resulting_row_id=resulting,
+        config=config,
+    )
+    tuple_digest = canonical_sha256(causal_tuple)
+    if history.get("transition_identity") != causal_tuple["transition_identity"]:
+        raise VPMValidationError("control history transition identity mismatch")
+    if (
+        history.get("transition_input_digest")
+        != causal_tuple["transition_input_digest"]
+    ):
+        raise VPMValidationError("control history input digest mismatch")
+    if (
+        history.get("transition_result_digest")
+        != causal_tuple["transition_result_digest"]
+    ):
+        raise VPMValidationError("control history result digest mismatch")
+    if history.get("normalized_causal_tuple_digest") != tuple_digest:
+        raise VPMValidationError("control history causal tuple digest mismatch")
+    return tuple_digest
+
+
+def grounded_control_histories_for_current_row(
+    current_row_id: str,
+    row_ids: Sequence[str],
+    *,
+    config: ShooterConfig = ShooterConfig(),
+) -> list[dict[str, Any]]:
+    histories: list[dict[str, Any]] = []
+    for predecessor in row_ids:
+        tank, target, cooldown = parse_state_row_id(str(predecessor))
+        for action in ACTIONS:
+            destinations = list(
+                next_rows(tank, target, cooldown, action, width=config.width)
+            )
+            for index, destination in enumerate(destinations):
+                if str(destination) != str(current_row_id):
+                    continue
+                histories.append(
+                    {
+                        "predecessor_row_id": str(predecessor),
+                        "actual_executed_action": str(action),
+                        "transition_choice_index": int(index),
+                        "resulting_row_id": str(current_row_id),
+                        "normalized_causal_tuple_digest": canonical_sha256(
+                            normalized_control_causal_tuple(
+                                predecessor_row_id=str(predecessor),
+                                actual_executed_action=str(action),
+                                transition_choice_index=int(index),
+                                resulting_row_id=str(current_row_id),
+                                config=config,
+                            )
+                        ),
+                    }
+                )
+    return sorted(
+        histories,
+        key=lambda item: (
+            str(item["actual_executed_action"]),
+            str(item["predecessor_row_id"]),
+            int(item["transition_choice_index"]),
+        ),
+    )
+
+
+def select_grounded_control_histories(
+    current_row_id: str,
+    row_ids: Sequence[str],
+    *,
+    control_group_id: str,
+    frame_count: int,
+    config: ShooterConfig = ShooterConfig(),
+) -> list[dict[str, Any]]:
+    candidates = grounded_control_histories_for_current_row(
+        current_row_id,
+        row_ids,
+        config=config,
+    )
+    if len({item["normalized_causal_tuple_digest"] for item in candidates}) < 2:
+        raise VPMValidationError(
+            "information control current row lacks grounded causal ambiguity"
+        )
+    preferred: list[dict[str, Any]] = []
+    used_predecessors: set[str] = set()
+    used_actions: set[str] = set()
+    for candidate in candidates:
+        predecessor = str(candidate["predecessor_row_id"])
+        action = str(candidate["actual_executed_action"])
+        if predecessor in used_predecessors or action in used_actions:
+            continue
+        preferred.append(candidate)
+        used_predecessors.add(predecessor)
+        used_actions.add(action)
+        if len(preferred) == int(frame_count):
+            break
+    for candidate in candidates:
+        if len(preferred) == int(frame_count):
+            break
+        if candidate in preferred:
+            continue
+        predecessor = str(candidate["predecessor_row_id"])
+        if predecessor in used_predecessors:
+            continue
+        preferred.append(candidate)
+        used_predecessors.add(predecessor)
+    for candidate in candidates:
+        if len(preferred) == int(frame_count):
+            break
+        if candidate not in preferred:
+            preferred.append(candidate)
+    if len(preferred) < min(2, int(frame_count)):
+        raise VPMValidationError(
+            "information control needs at least two grounded causal histories"
+        )
+    return [
+        grounded_control_history(
+            control_group_id=control_group_id,
+            hidden_history_index=index,
+            predecessor_row_id=str(item["predecessor_row_id"]),
+            actual_executed_action=str(item["actual_executed_action"]),
+            transition_choice_index=int(item["transition_choice_index"]),
+            resulting_row_id=str(current_row_id),
+            config=config,
+        )
+        for index, item in enumerate(preferred)
+    ]
+
+
+def control_source_rows(
+    row_ids: Sequence[str],
+    *,
+    count: int,
+    frame_count: int,
+    config: ShooterConfig = ShooterConfig(),
+) -> list[str]:
+    selected = []
+    for row_id in row_ids:
+        histories = grounded_control_histories_for_current_row(
+            str(row_id),
+            row_ids,
+            config=config,
+        )
+        if len({item["normalized_causal_tuple_digest"] for item in histories}) >= int(
+            frame_count
+        ):
+            selected.append(str(row_id))
+        if len(selected) == int(count):
+            return selected
+    raise VPMValidationError(
+        "unable to select enough grounded information-control rows"
+    )
+
+
+__all__ = [
+    "control_source_rows",
+    "grounded_control_histories_for_current_row",
+    "grounded_control_history",
+    "normalized_control_causal_tuple",
+    "reconstructed_control_causal_tuple_digest",
+    "select_grounded_control_histories",
+    "transition_identity",
+    "transition_input_digest",
+    "transition_result_digest",
+]

--- a/zeromodel/domains/video_action_set/episode_planning.py
+++ b/zeromodel/domains/video_action_set/episode_planning.py
@@ -1,0 +1,678 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ...artifact import VPMValidationError
+from .canonical_json import canonical_sha256
+from .contracts import (
+    BENCHMARK_VERSION,
+    EPISODE_PLAN_VERSION,
+    GENERATOR_VERSION,
+    SEED_DERIVATION_VERSION,
+)
+from .control_histories import control_source_rows
+from .dto import BenchmarkIdentityDTO, EpisodePlanDTO
+from .episode_families import (
+    denominator_class,
+    episode_disposition,
+    family_contract,
+    family_schedule,
+)
+from .family_intervention_planning import (
+    conflicting_splice_source_rows,
+    derived_seed,
+    family_intervention_plan,
+    frame_count_for_plan,
+    secondary_row_for_splice,
+)
+from .transformations import _transformation_parameters
+
+
+def final_observation_provenance(split: str) -> dict[str, Any]:
+    if split == "final":
+        return {
+            "materialization_status": "prospective_materialization_prohibited",
+            "observation_payload_included": False,
+            "provenance": "sealed_plan_only",
+        }
+    return {
+        "materialization_status": "materialized",
+        "observation_payload_included": True,
+        "provenance": "in_memory_generation",
+    }
+
+
+def frame_plans(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    family_label: str,
+    mutation_kind: str | None,
+    frame_count: int,
+    concrete_episode_seed_digest: str,
+) -> list[dict[str, Any]]:
+    schedule = family_schedule()
+    schedule_digest = canonical_sha256({"family_schedule": list(schedule)})
+    frames = []
+    for frame_index in range(frame_count):
+        frame_seed = derived_seed(
+            identity,
+            split=split,
+            ordinal=ordinal,
+            namespace="frame_identity",
+            parent_identities=(
+                ("concrete_episode_seed", concrete_episode_seed_digest),
+                ("frame_index", str(frame_index)),
+            ),
+        )
+        transform_family_seed = derived_seed(
+            identity,
+            split=split,
+            ordinal=ordinal,
+            namespace="transformation_family",
+            parent_identities=(
+                ("frame_identity", frame_seed["seed_digest"]),
+                ("family_schedule_digest", schedule_digest),
+                ("episode_family", family_label),
+            ),
+        )
+        if family_label == "frame_invalid":
+            transformation_family = "exact"
+        else:
+            transformation_family = schedule[
+                transform_family_seed["seed_int64"] % len(schedule)
+            ]
+        transform_parameter_seed = derived_seed(
+            identity,
+            split=split,
+            ordinal=ordinal,
+            namespace="transformation_parameters",
+            parent_identities=(
+                ("transformation_family_seed", transform_family_seed["seed_digest"]),
+                ("transformation_family", transformation_family),
+                ("frame_index", str(frame_index)),
+            ),
+        )
+        transition_choice_seed = derived_seed(
+            identity,
+            split=split,
+            ordinal=ordinal,
+            namespace="transition_choice",
+            parent_identities=(
+                ("frame_identity", frame_seed["seed_digest"]),
+                ("frame_index", str(frame_index)),
+            ),
+        )
+        temporal_mutation_seed = derived_seed(
+            identity,
+            split=split,
+            ordinal=ordinal,
+            namespace="temporal_mutation_choice",
+            parent_identities=(
+                ("frame_identity", frame_seed["seed_digest"]),
+                ("temporal_mutation", mutation_kind or "none"),
+            ),
+        )
+        parameters = _transformation_parameters(
+            transformation_family, transform_parameter_seed["seed_int64"]
+        )
+        frames.append(
+            {
+                "frame_index": frame_index,
+                "frame_seed_identity": frame_seed["seed_digest"],
+                "transformation_family_seed_identity": transform_family_seed[
+                    "seed_digest"
+                ],
+                "transformation_family": transformation_family,
+                "transformation_seed_identity": transform_parameter_seed["seed_digest"],
+                "transformation_seed": transform_parameter_seed["seed_int64"],
+                "transformation_parameter_digest": parameters["parameter_digest"],
+                "transformation_parameters": parameters,
+                "transition_choice_seed_identity": transition_choice_seed[
+                    "seed_digest"
+                ],
+                "transition_choice_seed": transition_choice_seed["seed_int64"],
+                "temporal_mutation_seed_identity": temporal_mutation_seed[
+                    "seed_digest"
+                ],
+                "temporal_mutation_kind": mutation_kind
+                if family_label == "temporal_negative"
+                else None,
+            }
+        )
+    return frames
+
+
+def _validate_episode_plan_inputs(
+    *,
+    source_row_id: str,
+    row_actions: Mapping[str, str],
+    mutation_kind: str | None,
+    secondary_row_id: str | None,
+) -> None:
+    if source_row_id not in row_actions:
+        raise VPMValidationError(
+            "episode source row is absent from the policy universe"
+        )
+    if secondary_row_id is not None and secondary_row_id not in row_actions:
+        raise VPMValidationError(
+            "episode secondary row is absent from the policy universe"
+        )
+    if mutation_kind != "conflicting_action_splice" and secondary_row_id is not None:
+        raise VPMValidationError(
+            "secondary row is only admissible for conflicting-action splices"
+        )
+    if mutation_kind == "conflicting_action_splice":
+        if secondary_row_id is None:
+            raise VPMValidationError(
+                "conflicting-action splice requires a secondary row"
+            )
+        if row_actions[secondary_row_id] == row_actions[source_row_id]:
+            raise VPMValidationError(
+                "conflicting-action splice secondary row must govern a different action"
+            )
+
+
+def _seed_node(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    namespace: str,
+    parents: tuple[tuple[str, str], ...],
+) -> dict[str, Any]:
+    return derived_seed(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace=namespace,
+        parent_identities=parents,
+    )
+
+
+def _source_seed_lineage(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    family_label: str,
+    family_ordinal: int,
+    source_row_id: str,
+    mutation_kind: str | None = None,
+    secondary_row_id: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    split_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="split_identity",
+        parents=(
+            ("benchmark_version", BENCHMARK_VERSION),
+            ("generator_version", GENERATOR_VERSION),
+        ),
+    )
+    ordinal_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="episode_ordinal",
+        parents=(
+            ("split_identity", split_seed["seed_digest"]),
+            ("family_ordinal", str(family_ordinal)),
+        ),
+    )
+    family_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="episode_family",
+        parents=(
+            ("episode_ordinal", ordinal_seed["seed_digest"]),
+            ("family_label", family_label),
+            ("mutation_kind", mutation_kind or "none"),
+        ),
+    )
+    source_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="source_row_choice",
+        parents=(
+            ("episode_family", family_seed["seed_digest"]),
+            ("source_row_id", source_row_id),
+        ),
+    )
+    secondary_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="secondary_splice_row_choice",
+        parents=(
+            ("source_row_choice", source_seed["seed_digest"]),
+            ("secondary_row_id", secondary_row_id or "none"),
+        ),
+    )
+    return {
+        "split_identity": split_seed,
+        "episode_ordinal": ordinal_seed,
+        "episode_family": family_seed,
+        "source_row_choice": source_seed,
+        "secondary_splice_row_choice": secondary_seed,
+    }
+
+
+def _transformation_seed_lineage(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    family_label: str,
+    mutation_kind: str | None,
+    source_lineage: Mapping[str, Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    split_seed = source_lineage["split_identity"]
+    ordinal_seed = source_lineage["episode_ordinal"]
+    family_seed = source_lineage["episode_family"]
+    source_seed = source_lineage["source_row_choice"]
+    secondary_seed = source_lineage["secondary_splice_row_choice"]
+    transformation_family_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="transformation_family",
+        parents=(
+            ("secondary_splice_row_choice", secondary_seed["seed_digest"]),
+            (
+                "family_schedule_digest",
+                canonical_sha256({"family_schedule": list(family_schedule())}),
+            ),
+        ),
+    )
+    transformation_parameter_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="transformation_parameters",
+        parents=(
+            ("transformation_family", transformation_family_seed["seed_digest"]),
+            ("frame_count", str(frame_count_for_plan(split, family_label))),
+        ),
+    )
+    temporal_mutation_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="temporal_mutation_choice",
+        parents=(
+            ("transformation_parameters", transformation_parameter_seed["seed_digest"]),
+            ("temporal_mutation", mutation_kind or "none"),
+        ),
+    )
+    episode_seed = _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="concrete_episode_seed",
+        parents=(
+            ("split_identity", split_seed["seed_digest"]),
+            ("episode_ordinal", ordinal_seed["seed_digest"]),
+            ("episode_family", family_seed["seed_digest"]),
+            ("source_row_choice", source_seed["seed_digest"]),
+            ("secondary_splice_row_choice", secondary_seed["seed_digest"]),
+            ("transformation_family", transformation_family_seed["seed_digest"]),
+            ("transformation_parameters", transformation_parameter_seed["seed_digest"]),
+            ("temporal_mutation_choice", temporal_mutation_seed["seed_digest"]),
+        ),
+    )
+    return {
+        "transformation_family": transformation_family_seed,
+        "transformation_parameters": transformation_parameter_seed,
+        "temporal_mutation_choice": temporal_mutation_seed,
+        "concrete_episode_seed": episode_seed,
+    }
+
+
+def _episode_seed_lineage(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    family_label: str,
+    family_ordinal: int,
+    source_row_id: str,
+    mutation_kind: str | None = None,
+    secondary_row_id: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    source_lineage = _source_seed_lineage(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        family_label=family_label,
+        family_ordinal=family_ordinal,
+        source_row_id=source_row_id,
+        mutation_kind=mutation_kind,
+        secondary_row_id=secondary_row_id,
+    )
+    transformation_lineage = _transformation_seed_lineage(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        family_label=family_label,
+        mutation_kind=mutation_kind,
+        source_lineage=source_lineage,
+    )
+    return source_lineage | transformation_lineage
+
+
+def _episode_id_seed(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    episode_seed: Mapping[str, Any],
+    contract: Mapping[str, Any],
+    intervention: Mapping[str, Any],
+    disposition: str,
+    denominator: str,
+    source_row_id: str,
+    secondary_row_id: str | None,
+) -> dict[str, Any]:
+    return _seed_node(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="concrete_episode_id",
+        parents=(
+            ("concrete_episode_seed", episode_seed["seed_digest"]),
+            ("family_contract", contract["family_version"]),
+            ("family_intervention", intervention["intervention_digest"]),
+            ("episode_disposition", disposition),
+            ("denominator_class", denominator),
+            ("source_row_id", source_row_id),
+            ("secondary_row_id", secondary_row_id or "none"),
+        ),
+    )
+
+
+def _episode_plan_payload(fields: Mapping[str, Any]) -> dict[str, Any]:
+    split = str(fields["split"])
+    family_label = str(fields["family_label"])
+    episode_id_seed = fields["episode_id_seed"]
+    episode_id = f"{split}:{family_label}:{episode_id_seed['seed_digest'].removeprefix('sha256:')[:16]}"
+    return {
+        "version": EPISODE_PLAN_VERSION,
+        "seed_derivation_version": SEED_DERIVATION_VERSION,
+        "episode_id": episode_id,
+        "split": split,
+        "ordinal": int(fields["ordinal"]),
+        "family_label": family_label,
+        "family_ordinal": int(fields["family_ordinal"]),
+        "episode_family": family_label,
+        "episode_disposition": fields["disposition"],
+        "denominator_class": fields["denominator"],
+        "final_observation_provenance": fields["provenance"],
+        "mutation_kind": fields["mutation_kind"],
+        "source_row_id": fields["source_row_id"],
+        "secondary_row_id": fields["secondary_row_id"],
+        "family_contract": fields["contract"],
+        "family_intervention": fields["intervention"],
+        "derived_seed_identity": fields["episode_seed"]["seed_digest"],
+        "episode_seed": fields["episode_seed"]["seed_int64"],
+        "frame_count": fields["frame_count"],
+        "seed_lineage": fields["lineage"] | {"concrete_episode_id": episode_id_seed},
+        "frame_plans": fields["frames"],
+    }
+
+
+def make_episode_plan(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    family_label: str,
+    family_ordinal: int,
+    source_row_id: str,
+    row_actions: Mapping[str, str],
+    mutation_kind: str | None = None,
+    secondary_row_id: str | None = None,
+) -> dict[str, Any]:
+    _validate_episode_plan_inputs(
+        source_row_id=source_row_id,
+        row_actions=row_actions,
+        mutation_kind=mutation_kind,
+        secondary_row_id=secondary_row_id,
+    )
+    lineage = _episode_seed_lineage(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        family_label=family_label,
+        family_ordinal=family_ordinal,
+        source_row_id=source_row_id,
+        mutation_kind=mutation_kind,
+        secondary_row_id=secondary_row_id,
+    )
+    episode_seed = lineage["concrete_episode_seed"]
+    frame_count = frame_count_for_plan(split, family_label)
+    frames = frame_plans(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        family_label=family_label,
+        mutation_kind=mutation_kind,
+        frame_count=frame_count,
+        concrete_episode_seed_digest=episode_seed["seed_digest"],
+    )
+    contract = family_contract(family_label, mutation_kind)
+    intervention = family_intervention_plan(
+        identity=identity,
+        split=split,
+        ordinal=ordinal,
+        family_label=family_label,
+        mutation_kind=mutation_kind,
+        source_row_id=source_row_id,
+        secondary_row_id=secondary_row_id,
+        row_ids=tuple(row_actions.keys()),
+        row_actions=row_actions,
+    )
+    disposition = episode_disposition(family_label, mutation_kind)
+    denominator = denominator_class(family_label, mutation_kind)
+    episode_id_seed = _episode_id_seed(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        episode_seed=episode_seed,
+        contract=contract,
+        intervention=intervention,
+        disposition=disposition,
+        denominator=denominator,
+        source_row_id=source_row_id,
+        secondary_row_id=secondary_row_id,
+    )
+    plan = _episode_plan_payload(
+        {
+            "split": split,
+            "ordinal": ordinal,
+            "family_label": family_label,
+            "family_ordinal": family_ordinal,
+            "disposition": disposition,
+            "denominator": denominator,
+            "provenance": final_observation_provenance(split),
+            "mutation_kind": mutation_kind,
+            "source_row_id": source_row_id,
+            "secondary_row_id": secondary_row_id,
+            "contract": contract,
+            "intervention": intervention,
+            "episode_seed": episode_seed,
+            "episode_id_seed": episode_id_seed,
+            "frame_count": frame_count,
+            "frames": frames,
+            "lineage": lineage,
+        }
+    )
+    dto = EpisodePlanDTO.from_dict(plan | {"plan_digest": canonical_sha256(plan)})
+    return dto.to_dict()
+
+
+def episode_plans_for_split(
+    identity: BenchmarkIdentityDTO,
+    split: str,
+    row_ids: list[str],
+    row_actions: Mapping[str, str],
+) -> list[dict[str, Any]]:
+    plans: list[dict[str, Any]] = []
+
+    def add(
+        family_label: str,
+        family_ordinal: int,
+        row_id: str,
+        *,
+        mutation_kind: str | None = None,
+    ) -> None:
+        secondary = None
+        if mutation_kind == "conflicting_action_splice":
+            secondary = secondary_row_for_splice(row_ids, row_actions, row_id)
+        plans.append(
+            make_episode_plan(
+                identity,
+                split=split,
+                ordinal=len(plans),
+                family_label=family_label,
+                family_ordinal=family_ordinal,
+                source_row_id=row_id,
+                row_actions=row_actions,
+                mutation_kind=mutation_kind,
+                secondary_row_id=secondary,
+            )
+        )
+
+    if split == "development":
+        for index, row_id in enumerate(row_ids):
+            add("valid", index, row_id)
+        return plans
+    if split == "calibration":
+        for index, row_id in enumerate(row_ids):
+            add("valid", index, row_id)
+        return plans
+    if split in {"selection", "final"}:
+        for index, row_id in enumerate(row_ids):
+            add("valid", index, row_id)
+        splice_rows = conflicting_splice_source_rows(row_ids, row_actions, 28)
+        for index, row_id in enumerate(splice_rows):
+            add(
+                "frame_invalid",
+                index,
+                row_id,
+                mutation_kind="conflicting_action_splice",
+            )
+        for index, row_id in enumerate(row_ids[28:56]):
+            add(
+                "frame_invalid",
+                28 + index,
+                row_id,
+                mutation_kind="critical_evidence_corruption",
+            )
+        temporal_rows = row_ids[:56]
+        kinds = (
+            "reordered_frames",
+            "stale_repeated_frame",
+            "impossible_transition",
+            "declared_gap_or_unknown_action",
+        )
+        for group_index, kind in enumerate(kinds):
+            for index, row_id in enumerate(
+                temporal_rows[group_index * 14 : (group_index + 1) * 14]
+            ):
+                add(
+                    "temporal_negative",
+                    group_index * 14 + index,
+                    row_id,
+                    mutation_kind=kind,
+                )
+        control_rows = control_source_rows(
+            row_ids,
+            count=28,
+            frame_count=frame_count_for_plan(split, "information_control"),
+        )
+        for index, row_id in enumerate(control_rows):
+            add("information_control", index, row_id)
+        return plans
+    raise VPMValidationError("unsupported split")
+
+
+def episode_ids_by_family(plans: list[dict[str, Any]]) -> dict[str, list[str]]:
+    grouped: dict[str, list[str]] = {
+        "valid": [],
+        "frame_invalid": [],
+        "temporal_negative": [],
+        "information_control": [],
+    }
+    for plan in plans:
+        grouped[str(plan["family_label"])].append(str(plan["episode_id"]))
+    return grouped
+
+
+def validate_episode_plan(
+    identity: BenchmarkIdentityDTO,
+    plan: Mapping[str, Any],
+    row_actions: Mapping[str, str],
+) -> None:
+    try:
+        EpisodePlanDTO.from_dict(plan)
+    except VPMValidationError as exc:
+        raise VPMValidationError(
+            "episode plan is inconsistent with declared seed lineage or identity"
+        ) from exc
+    expected = make_episode_plan(
+        identity,
+        split=str(plan["split"]),
+        ordinal=int(plan["ordinal"]),
+        family_label=str(plan["family_label"]),
+        family_ordinal=int(plan["family_ordinal"]),
+        source_row_id=str(plan["source_row_id"]),
+        row_actions=row_actions,
+        mutation_kind=plan.get("mutation_kind"),
+        secondary_row_id=plan.get("secondary_row_id"),
+    )
+    if dict(plan) != expected:
+        raise VPMValidationError(
+            "episode plan is inconsistent with declared seed lineage or identity"
+        )
+
+
+def validate_episode_plan_collection(
+    identity: BenchmarkIdentityDTO,
+    plans_by_split: Mapping[str, list[dict[str, Any]]],
+    row_actions: Mapping[str, str],
+) -> None:
+    seen: dict[str, str] = {}
+    for split, plans in plans_by_split.items():
+        for plan in plans:
+            episode_id = str(plan["episode_id"])
+            if plan["split"] != split:
+                raise VPMValidationError(
+                    "episode plan split does not match containing split"
+                )
+            if episode_id in seen:
+                if seen[episode_id] != split:
+                    raise VPMValidationError(
+                        "episode identity reassigned to another split"
+                    )
+                raise VPMValidationError("duplicate concrete episode identity")
+            seen[episode_id] = split
+            validate_episode_plan(identity, plan, row_actions)
+
+
+__all__ = [
+    "derived_seed",
+    "episode_ids_by_family",
+    "episode_plans_for_split",
+    "final_observation_provenance",
+    "frame_count_for_plan",
+    "frame_plans",
+    "make_episode_plan",
+    "validate_episode_plan",
+    "validate_episode_plan_collection",
+]

--- a/zeromodel/domains/video_action_set/family_intervention_planning.py
+++ b/zeromodel/domains/video_action_set/family_intervention_planning.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ...arcade_policy import ShooterConfig, next_rows, parse_state_row_id
+from ...artifact import VPMValidationError
+from .canonical_json import canonical_sha256
+from .contracts import (
+    FAMILY_INTERVENTION_VERSION,
+    GAP_EVENT_VERSION,
+    INFORMATION_CONTROL_AMBIGUITY_VERSION,
+    PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+    REACHABILITY_TILE_DIGEST,
+    SEED_DERIVATION_VERSION,
+)
+from .control_histories import select_grounded_control_histories
+from .dto import BenchmarkIdentityDTO
+from .frame_family_kernels import (
+    critical_coordinate_manifest,
+    splice_mask_manifest,
+    splice_pair_has_final_visible_action_conflict,
+)
+
+
+def seed_int_from_digest(digest: str) -> int:
+    if not digest.startswith("sha256:"):
+        raise VPMValidationError("seed identity must be a sha256 digest")
+    return int(digest.removeprefix("sha256:")[:16], 16)
+
+
+def derived_seed(
+    identity: BenchmarkIdentityDTO,
+    *,
+    split: str,
+    ordinal: int,
+    namespace: str,
+    parent_identities: tuple[tuple[str, str], ...],
+) -> dict[str, Any]:
+    parents = tuple((str(name), str(value)) for name, value in parent_identities)
+    if len({name for name, _value in parents}) != len(parents):
+        raise VPMValidationError("derived seed parent names must be unique")
+    payload = {
+        "version": SEED_DERIVATION_VERSION,
+        "root_seed_digest": identity.seed_digest,
+        "split": split,
+        "episode_ordinal": int(ordinal),
+        "namespace": namespace,
+        "parent_identities": [
+            {"name": name, "identity": value} for name, value in parents
+        ],
+    }
+    digest = canonical_sha256(payload)
+    return payload | {"seed_digest": digest, "seed_int64": seed_int_from_digest(digest)}
+
+
+def frame_count_for_plan(split: str, family_label: str) -> int:
+    if split == "development":
+        return 1
+    return 4
+
+
+def state_row_values(row_id: str) -> tuple[int, int | None, int]:
+    return parse_state_row_id(str(row_id))
+
+
+def secondary_row_for_splice(
+    row_ids: list[str],
+    row_actions: Mapping[str, str],
+    source_row_id: str,
+) -> str:
+    source_action = row_actions[source_row_id]
+    _source_tank, source_target, _source_cooldown = state_row_values(source_row_id)
+    if source_target is None:
+        raise VPMValidationError(
+            "conflicting splice source row must contain visible target evidence"
+        )
+    for row_id in row_ids:
+        if row_id == source_row_id:
+            continue
+        if row_actions[row_id] == source_action:
+            continue
+        _tank, target, _cooldown = state_row_values(row_id)
+        if target is None or target == source_target:
+            continue
+        if not splice_pair_has_final_visible_action_conflict(
+            source_row_id, row_id, row_actions
+        ):
+            continue
+        return row_id
+    raise VPMValidationError(
+        "frame splice requires a secondary row with conflicting action and distinct visible target evidence"
+    )
+
+
+def conflicting_splice_source_rows(
+    row_ids: list[str],
+    row_actions: Mapping[str, str],
+    count: int,
+) -> list[str]:
+    selected: list[str] = []
+    for row_id in row_ids:
+        _tank, target, _cooldown = state_row_values(row_id)
+        if target is None:
+            continue
+        try:
+            secondary_row_for_splice(row_ids, row_actions, row_id)
+        except VPMValidationError:
+            continue
+        selected.append(row_id)
+        if len(selected) == int(count):
+            return selected
+    raise VPMValidationError(
+        "unable to select enough conflicting splice source rows with visible target evidence"
+    )
+
+
+def impossible_destination_row(
+    row_ids: list[str],
+    row_actions: Mapping[str, str],
+    source_row_id: str,
+) -> str:
+    action = row_actions[source_row_id]
+    tank, target, cooldown = state_row_values(source_row_id)
+    reachable = set(
+        next_rows(tank, target, cooldown, action, width=ShooterConfig().width)
+    )
+    for row_id in reversed(row_ids):
+        if row_id not in reachable and row_id != source_row_id:
+            return row_id
+    raise VPMValidationError("unable to select impossible transition destination")
+
+
+def _family_id(family_label: str, mutation_kind: str | None) -> str:
+    return "valid" if family_label == "valid" else str(mutation_kind or family_label)
+
+
+def _family_intervention_seed(
+    *,
+    identity: BenchmarkIdentityDTO,
+    split: str,
+    ordinal: int,
+    family_id: str,
+    source_row_id: str,
+    secondary_row_id: str | None,
+) -> dict[str, Any]:
+    return derived_seed(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="family_intervention",
+        parent_identities=(
+            ("family_id", family_id),
+            ("source_row_id", source_row_id),
+            ("secondary_row_id", secondary_row_id or "none"),
+        ),
+    )
+
+
+def _base_payload(
+    family_id: str,
+    seed: Mapping[str, Any],
+    original_order: list[int],
+) -> dict[str, Any]:
+    return {
+        "version": FAMILY_INTERVENTION_VERSION,
+        "family_id": family_id,
+        "intervention_seed_identity": seed["seed_digest"],
+        "original_order": original_order,
+        "materialized_order": list(original_order),
+        "event_type": "frame_sequence",
+    }
+
+
+def _impossible_transition_payload(
+    row_ids: Sequence[str],
+    row_actions: Mapping[str, str],
+    source_row_id: str,
+) -> dict[str, Any]:
+    destination = impossible_destination_row(list(row_ids), row_actions, source_row_id)
+    return {
+        "transition_relation_identity": REACHABILITY_TILE_DIGEST,
+        "impossible_transition": {
+            "source_frame_index": 0,
+            "destination_frame_index": 1,
+            "source_row_id": source_row_id,
+            "source_action_id": row_actions[source_row_id],
+            "destination_row_id": destination,
+            "destination_action_id": row_actions[destination],
+        },
+    }
+
+
+def _gap_event_payload(
+    *,
+    identity: BenchmarkIdentityDTO,
+    split: str,
+    ordinal: int,
+    seed: Mapping[str, Any],
+) -> dict[str, Any]:
+    gap_seed = derived_seed(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="gap_event_identity",
+        parent_identities=(
+            ("family_intervention", seed["seed_digest"]),
+            ("gap_position", "2"),
+        ),
+    )
+    return {
+        "event_type": "typed_gap_sequence",
+        "gap_event": {
+            "version": GAP_EVENT_VERSION,
+            "position": 2,
+            "duration_frames": 1,
+            "reason": "declared_gap_or_unknown_action",
+            "event_id": gap_seed["seed_digest"],
+        },
+    }
+
+
+def _control_group_payload(
+    *,
+    identity: BenchmarkIdentityDTO,
+    split: str,
+    ordinal: int,
+    seed: Mapping[str, Any],
+    source_row_id: str,
+    row_ids: Sequence[str],
+    frame_count: int,
+) -> dict[str, Any]:
+    control_seed = derived_seed(
+        identity,
+        split=split,
+        ordinal=ordinal,
+        namespace="information_control_identity",
+        parent_identities=(
+            ("family_intervention", seed["seed_digest"]),
+            ("current_row_id", source_row_id),
+        ),
+    )
+    hidden_histories = select_grounded_control_histories(
+        source_row_id,
+        row_ids,
+        control_group_id=control_seed["seed_digest"],
+        frame_count=frame_count,
+    )
+    hidden_label_digests = [
+        history["hidden_source_label_digest"] for history in hidden_histories
+    ]
+    return {
+        "control_group": {
+            "version": INFORMATION_CONTROL_AMBIGUITY_VERSION,
+            "control_group_id": control_seed["seed_digest"],
+            "current_row_id": source_row_id,
+            "byte_identity_required": True,
+            "minimum_grounded_causal_history_cardinality": 2,
+            "grounded_causal_history_count": len(
+                {
+                    history["normalized_causal_tuple_digest"]
+                    for history in hidden_histories
+                }
+            ),
+            "hidden_source_history_count": len(hidden_histories),
+            "hidden_source_histories": hidden_histories,
+            "hidden_source_label_digests": hidden_label_digests,
+            "hidden_source_label_digest": canonical_sha256(
+                {
+                    "control_group_id": control_seed["seed_digest"],
+                    "hidden_source_label_digests": hidden_label_digests,
+                }
+            ),
+            "provider_observation_boundary_version": PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+            "provider_visible_fields": [
+                "pixels",
+                "shape",
+                "raw_digest",
+                "timestamp",
+                "source_id",
+                "metadata",
+                "version",
+            ],
+            "provider_hidden_fields": [
+                "frame_id",
+                "source_row_id",
+                "source_action_id",
+                "grounded_causal_history",
+                "hidden_source_history_id",
+                "hidden_source_label_digest",
+            ],
+        }
+    }
+
+
+def _with_intervention_digest(
+    payload: dict[str, Any], family_id: str
+) -> dict[str, Any]:
+    payload["sequence_digest"] = canonical_sha256(
+        {
+            "order": payload["materialized_order"],
+            "event_type": payload["event_type"],
+            "family_id": family_id,
+        }
+    )
+    payload["intervention_digest"] = canonical_sha256(payload)
+    return payload
+
+
+def family_intervention_plan(
+    *,
+    identity: BenchmarkIdentityDTO,
+    split: str,
+    ordinal: int,
+    family_label: str,
+    mutation_kind: str | None,
+    source_row_id: str,
+    secondary_row_id: str | None,
+    row_ids: Sequence[str],
+    row_actions: Mapping[str, str],
+) -> dict[str, Any]:
+    family_id = _family_id(family_label, mutation_kind)
+    seed = _family_intervention_seed(
+        identity=identity,
+        split=split,
+        ordinal=ordinal,
+        family_id=family_id,
+        source_row_id=source_row_id,
+        secondary_row_id=secondary_row_id,
+    )
+    original_order = list(range(frame_count_for_plan(split, family_label)))
+    payload = _base_payload(family_id, seed, original_order)
+    if family_id == "conflicting_action_splice":
+        payload |= {
+            "primary_source_row_id": source_row_id,
+            "primary_source_action_id": row_actions[source_row_id],
+            "secondary_source_row_id": secondary_row_id,
+            "secondary_source_action_id": None
+            if secondary_row_id is None
+            else row_actions[secondary_row_id],
+            "splice_mask": splice_mask_manifest(),
+        }
+    elif family_id == "critical_evidence_corruption":
+        payload |= {"critical_coordinates": critical_coordinate_manifest()}
+    elif family_id == "reordered_frames":
+        mutated = [1, 0, 2, 3]
+        if mutated == original_order:
+            raise VPMValidationError("reordered family requires non-identity order")
+        payload |= {
+            "materialized_order": mutated,
+            "sequence_rule": "non_identity_permutation",
+        }
+    elif family_id == "stale_repeated_frame":
+        payload |= {
+            "stale_repeat": {
+                "source_frame_index": 0,
+                "destination_frame_index": 1,
+                "maximum_stale_horizon": 1,
+            }
+        }
+    elif family_id == "impossible_transition":
+        payload |= _impossible_transition_payload(row_ids, row_actions, source_row_id)
+    elif family_id == "declared_gap_or_unknown_action":
+        payload |= _gap_event_payload(
+            identity=identity,
+            split=split,
+            ordinal=ordinal,
+            seed=seed,
+        )
+    elif family_id == "information_control":
+        payload |= _control_group_payload(
+            identity=identity,
+            split=split,
+            ordinal=ordinal,
+            seed=seed,
+            source_row_id=source_row_id,
+            row_ids=row_ids,
+            frame_count=len(original_order),
+        )
+    return _with_intervention_digest(payload, family_id)
+
+
+__all__ = [
+    "conflicting_splice_source_rows",
+    "derived_seed",
+    "family_intervention_plan",
+    "frame_count_for_plan",
+    "impossible_destination_row",
+    "secondary_row_for_splice",
+    "seed_int_from_digest",
+    "state_row_values",
+]

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -20,6 +20,7 @@ from .artifact import VPMValidationError
 from .domains.video_action_set.canonical_json import canonical_json_bytes, canonical_json_value, canonical_sha256
 from .domains.video_action_set.contracts import (
     ARCADE_RENDERER_CONTRACT_VERSION,
+    AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
     BENCHMARK_VERSION,
     CANONICAL_OBSERVATION_UNIVERSE_VERSION,
     CONFLICTING_ACTION_SPLICE_VERSION,
@@ -53,7 +54,29 @@ from .domains.video_action_set.contracts import (
     VALID_FAMILY_VERSION,
     VALID_OBSERVATION_UNIVERSE_VERSION,
 )
+from .domains.video_action_set.control_histories import (
+    control_source_rows as _control_source_rows,
+    grounded_control_histories_for_current_row as _grounded_control_histories_for_current_row,
+    grounded_control_history as _grounded_control_history,
+    normalized_control_causal_tuple as _normalized_control_causal_tuple,
+    reconstructed_control_causal_tuple_digest as _reconstructed_control_causal_tuple_digest,
+    select_grounded_control_histories as _select_grounded_control_histories,
+    transition_identity as _transition_identity,
+    transition_input_digest as _transition_input_digest,
+    transition_result_digest as _transition_result_digest,
+)
 from .domains.video_action_set.dto import BenchmarkIdentityDTO, EpisodePlanDTO
+from .domains.video_action_set.episode_planning import (
+    derived_seed as _derived_seed,
+    episode_ids_by_family as _episode_ids_by_family,
+    episode_plans_for_split as _episode_plans_for_split,
+    final_observation_provenance as _final_observation_provenance,
+    frame_count_for_plan as _frame_count_for_plan,
+    frame_plans as _frame_plans,
+    make_episode_plan as _make_episode_plan,
+    validate_episode_plan as _validate_episode_plan,
+    validate_episode_plan_collection as _validate_episode_plan_collection,
+)
 from .domains.video_action_set.episode_families import (
     denominator_class as _denominator_class,
     episode_disposition as _episode_disposition,
@@ -62,6 +85,14 @@ from .domains.video_action_set.episode_families import (
     family_contract as _family_contract,
     family_schedule as _family_schedule,
     frame_disposition_for_episode as _frame_disposition_for_episode,
+)
+from .domains.video_action_set.family_intervention_planning import (
+    conflicting_splice_source_rows as _conflicting_splice_source_rows,
+    family_intervention_plan as _family_intervention_plan,
+    impossible_destination_row as _impossible_destination_row,
+    secondary_row_for_splice as _secondary_row_for_splice,
+    seed_int_from_digest as _seed_int_from_digest,
+    state_row_values as _state_row_values,
 )
 from .domains.video_action_set.family_provenance import (
     conflicting_splice_operation_chain as _conflicting_splice_operation_chain,
@@ -202,7 +233,6 @@ CLOSURE_REPORT_VERSION = "zeromodel-video-action-set-reference-closure/v1"
 MUTATION_MATRIX_VERSION = "zeromodel-video-action-set-reference-mutation-matrix/v3"
 SOURCE_SCOPE = "zeromodel-video-action-set-reachability-benchmark-v1"
 SEMANTIC_OUTCOME_VERSION = VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION
-AUTHORITATIVE_TRANSITION_FUNCTION_VERSION = "zeromodel-arcade-shooter-next-rows/v1"
 
 
 def _json_ready(value: Any) -> Any:
@@ -282,299 +312,8 @@ def load_identity(repo_root: Path) -> BenchmarkIdentity:
     return build_runtime().video_action_set.load_identity(repo_root)
 
 
-def _seed_int_from_digest(digest: str) -> int:
-    if not digest.startswith("sha256:"):
-        raise VPMValidationError("seed identity must be a sha256 digest")
-    return int(digest.removeprefix("sha256:")[:16], 16)
-
-
-def _derived_seed(
-    identity: BenchmarkIdentity,
-    *,
-    split: str,
-    ordinal: int,
-    namespace: str,
-    parent_identities: tuple[tuple[str, str], ...],
-) -> dict[str, Any]:
-    parents = tuple((str(name), str(value)) for name, value in parent_identities)
-    if len({name for name, _value in parents}) != len(parents):
-        raise VPMValidationError("derived seed parent names must be unique")
-    payload = {
-        "version": SEED_DERIVATION_VERSION,
-        "root_seed_digest": identity.seed_digest,
-        "split": split,
-        "episode_ordinal": int(ordinal),
-        "namespace": namespace,
-        "parent_identities": [{"name": name, "identity": value} for name, value in parents],
-    }
-    digest = _sha256(payload)
-    return payload | {"seed_digest": digest, "seed_int64": _seed_int_from_digest(digest)}
-
-
-def _transition_identity(config: ShooterConfig = ShooterConfig()) -> dict[str, Any]:
-    payload = {
-        "version": AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
-        "function": "zeromodel.arcade_policy.transitions.next_rows",
-        "action_universe": list(ACTIONS),
-        "config": _transition_config_payload(config),
-    }
-    return payload | {"transition_identity_digest": _sha256(payload)}
-
-
-
-def _transition_input_digest(predecessor_row_id: str, action: str, *, config: ShooterConfig = ShooterConfig()) -> str:
-    tank, target, cooldown = parse_state_row_id(str(predecessor_row_id))
-    return _sha256(
-        {
-            "version": AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
-            "predecessor_row_id": str(predecessor_row_id),
-            "parsed_state": {"tank_x": tank, "target_x": target, "cooldown": cooldown},
-            "actual_executed_action": str(action),
-            "config_digest": _sha256(_transition_config_payload(config)),
-        }
-    )
-
-
-
-def _transition_result_digest(
-    predecessor_row_id: str,
-    action: str,
-    transition_choice_index: int,
-    resulting_row_id: str,
-    *,
-    config: ShooterConfig = ShooterConfig(),
-) -> str:
-    tank, target, cooldown = parse_state_row_id(str(predecessor_row_id))
-    destinations = list(next_rows(tank, target, cooldown, str(action), width=config.width))
-    return _sha256(
-        {
-            "version": AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
-            "predecessor_row_id": str(predecessor_row_id),
-            "actual_executed_action": str(action),
-            "reachable_row_ids": destinations,
-            "transition_choice_index": int(transition_choice_index),
-            "resulting_row_id": str(resulting_row_id),
-            "config_digest": _sha256(_transition_config_payload(config)),
-        }
-    )
-
-
-
-def _normalized_control_causal_tuple(
-    *,
-    predecessor_row_id: str,
-    actual_executed_action: str,
-    transition_choice_index: int,
-    resulting_row_id: str,
-    config: ShooterConfig = ShooterConfig(),
-) -> dict[str, Any]:
-    transition_identity = _transition_identity(config)
-    return {
-        "version": GROUNDED_CONTROL_HISTORY_VERSION,
-        "predecessor_row_id": str(predecessor_row_id),
-        "actual_executed_action": str(actual_executed_action),
-        "transition_choice_index": int(transition_choice_index),
-        "resulting_row_id": str(resulting_row_id),
-        "transition_identity": transition_identity,
-        "transition_input_digest": _transition_input_digest(str(predecessor_row_id), str(actual_executed_action), config=config),
-        "transition_result_digest": _transition_result_digest(
-            str(predecessor_row_id),
-            str(actual_executed_action),
-            int(transition_choice_index),
-            str(resulting_row_id),
-            config=config,
-        ),
-    }
-
-
-
-def _grounded_control_history(
-    *,
-    control_group_id: str,
-    hidden_history_index: int,
-    predecessor_row_id: str,
-    actual_executed_action: str,
-    transition_choice_index: int,
-    resulting_row_id: str,
-    config: ShooterConfig = ShooterConfig(),
-) -> dict[str, Any]:
-    causal_tuple = _normalized_control_causal_tuple(
-        predecessor_row_id=predecessor_row_id,
-        actual_executed_action=actual_executed_action,
-        transition_choice_index=transition_choice_index,
-        resulting_row_id=resulting_row_id,
-        config=config,
-    )
-    tuple_digest = _sha256(causal_tuple)
-    payload = {
-        "version": GROUNDED_CONTROL_HISTORY_VERSION,
-        "control_group_id": str(control_group_id),
-        "hidden_history_index": int(hidden_history_index),
-        "history_id": tuple_digest,
-        "hidden_history_id": tuple_digest,
-        "predecessor_row_id": str(predecessor_row_id),
-        "actual_executed_action": str(actual_executed_action),
-        "transition_choice_index": int(transition_choice_index),
-        "resulting_row_id": str(resulting_row_id),
-        "transition_identity": causal_tuple["transition_identity"],
-        "transition_input_digest": causal_tuple["transition_input_digest"],
-        "transition_result_digest": causal_tuple["transition_result_digest"],
-        "normalized_causal_tuple_digest": tuple_digest,
-    }
-    payload["history_digest"] = _sha256(payload)
-    payload["hidden_source_label_digest"] = payload["history_digest"]
-    return payload
-
-
-
-def _reconstructed_control_causal_tuple_digest(history: Mapping[str, Any], *, config: ShooterConfig = ShooterConfig()) -> str:
-    if history.get("version") != GROUNDED_CONTROL_HISTORY_VERSION:
-        raise VPMValidationError("unsupported grounded control history version")
-    action = str(history.get("actual_executed_action"))
-    if action not in ACTIONS:
-        raise VPMValidationError("control history action is not declared")
-    predecessor = str(history.get("predecessor_row_id"))
-    resulting = str(history.get("resulting_row_id"))
-    choice_index = int(history.get("transition_choice_index", -1))
-    tank, target, cooldown = parse_state_row_id(predecessor)
-    destinations = list(next_rows(tank, target, cooldown, action, width=config.width))
-    if choice_index < 0 or choice_index >= len(destinations):
-        raise VPMValidationError("control history transition choice is invalid")
-    if str(destinations[choice_index]) != resulting:
-        raise VPMValidationError("control history result does not match the declared choice")
-    causal_tuple = _normalized_control_causal_tuple(
-        predecessor_row_id=predecessor,
-        actual_executed_action=action,
-        transition_choice_index=choice_index,
-        resulting_row_id=resulting,
-        config=config,
-    )
-    tuple_digest = _sha256(causal_tuple)
-    if history.get("transition_identity") != causal_tuple["transition_identity"]:
-        raise VPMValidationError("control history transition identity mismatch")
-    if history.get("transition_input_digest") != causal_tuple["transition_input_digest"]:
-        raise VPMValidationError("control history input digest mismatch")
-    if history.get("transition_result_digest") != causal_tuple["transition_result_digest"]:
-        raise VPMValidationError("control history result digest mismatch")
-    if history.get("normalized_causal_tuple_digest") != tuple_digest:
-        raise VPMValidationError("control history causal tuple digest mismatch")
-    return tuple_digest
-
-
-
-def _grounded_control_histories_for_current_row(
-    current_row_id: str,
-    row_ids: Sequence[str],
-    *,
-    config: ShooterConfig = ShooterConfig(),
-) -> list[dict[str, Any]]:
-    histories: list[dict[str, Any]] = []
-    for predecessor in row_ids:
-        tank, target, cooldown = parse_state_row_id(str(predecessor))
-        for action in ACTIONS:
-            destinations = list(next_rows(tank, target, cooldown, action, width=config.width))
-            for index, destination in enumerate(destinations):
-                if str(destination) != str(current_row_id):
-                    continue
-                histories.append(
-                    {
-                        "predecessor_row_id": str(predecessor),
-                        "actual_executed_action": str(action),
-                        "transition_choice_index": int(index),
-                        "resulting_row_id": str(current_row_id),
-                        "normalized_causal_tuple_digest": _sha256(
-                            _normalized_control_causal_tuple(
-                                predecessor_row_id=str(predecessor),
-                                actual_executed_action=str(action),
-                                transition_choice_index=int(index),
-                                resulting_row_id=str(current_row_id),
-                                config=config,
-                            )
-                        ),
-                    }
-                )
-    return sorted(
-        histories,
-        key=lambda item: (
-            str(item["actual_executed_action"]),
-            str(item["predecessor_row_id"]),
-            int(item["transition_choice_index"]),
-        ),
-    )
-
-
-
-def _select_grounded_control_histories(
-    current_row_id: str,
-    row_ids: Sequence[str],
-    *,
-    control_group_id: str,
-    frame_count: int,
-    config: ShooterConfig = ShooterConfig(),
-) -> list[dict[str, Any]]:
-    candidates = _grounded_control_histories_for_current_row(current_row_id, row_ids, config=config)
-    if len({item["normalized_causal_tuple_digest"] for item in candidates}) < 2:
-        raise VPMValidationError("information control current row lacks grounded causal ambiguity")
-    preferred: list[dict[str, Any]] = []
-    used_predecessors: set[str] = set()
-    used_actions: set[str] = set()
-    for candidate in candidates:
-        predecessor = str(candidate["predecessor_row_id"])
-        action = str(candidate["actual_executed_action"])
-        if predecessor in used_predecessors or action in used_actions:
-            continue
-        preferred.append(candidate)
-        used_predecessors.add(predecessor)
-        used_actions.add(action)
-        if len(preferred) == int(frame_count):
-            break
-    for candidate in candidates:
-        if len(preferred) == int(frame_count):
-            break
-        if candidate in preferred:
-            continue
-        predecessor = str(candidate["predecessor_row_id"])
-        if predecessor in used_predecessors:
-            continue
-        preferred.append(candidate)
-        used_predecessors.add(predecessor)
-    for candidate in candidates:
-        if len(preferred) == int(frame_count):
-            break
-        if candidate not in preferred:
-            preferred.append(candidate)
-    if len(preferred) < min(2, int(frame_count)):
-        raise VPMValidationError("information control needs at least two grounded causal histories")
-    return [
-        _grounded_control_history(
-            control_group_id=control_group_id,
-            hidden_history_index=index,
-            predecessor_row_id=str(item["predecessor_row_id"]),
-            actual_executed_action=str(item["actual_executed_action"]),
-            transition_choice_index=int(item["transition_choice_index"]),
-            resulting_row_id=str(current_row_id),
-            config=config,
-        )
-        for index, item in enumerate(preferred)
-    ]
-
-
-
-def _control_source_rows(row_ids: Sequence[str], *, count: int, frame_count: int, config: ShooterConfig = ShooterConfig()) -> list[str]:
-    selected = []
-    for row_id in row_ids:
-        histories = _grounded_control_histories_for_current_row(str(row_id), row_ids, config=config)
-        if len({item["normalized_causal_tuple_digest"] for item in histories}) >= int(frame_count):
-            selected.append(str(row_id))
-        if len(selected) == int(count):
-            return selected
-    raise VPMValidationError("unable to select enough grounded information-control rows")
-
-
-
 def _provider_observation_digest(descriptor: Mapping[str, Any]) -> str:
     return _sha256({"version": PROVIDER_OBSERVATION_BOUNDARY_VERSION, "descriptor": descriptor})
-
 
 
 def _control_provider_source_id(record: Mapping[str, Any]) -> str:
@@ -583,7 +322,6 @@ def _control_provider_source_id(record: Mapping[str, Any]) -> str:
     if not group_id:
         raise VPMValidationError("information control record lacks a control group id")
     return str(metadata.get("provider_observation_source_id") or f"control:{group_id}")
-
 
 
 def provider_observation_for_record(record: Mapping[str, Any]) -> ImageObservation:
@@ -600,7 +338,6 @@ def provider_observation_for_record(record: Mapping[str, Any]) -> ImageObservati
         timestamp = metadata.get("provider_observation_timestamp") if "provider_observation_timestamp" in metadata else None
         visible_metadata = metadata.get("provider_observation_metadata", {}) if "provider_observation_metadata" in metadata else {}
     return ImageObservation(pixels, timestamp=None if timestamp is None else str(timestamp), source_id=source_id, metadata=visible_metadata)
-
 
 
 def provider_observation_descriptor_for_record(record: Mapping[str, Any]) -> dict[str, Any]:
@@ -636,572 +373,6 @@ def provider_observation_descriptor_for_record(record: Mapping[str, Any]) -> dic
     }
 
 
-
-def _final_observation_provenance(split: str) -> dict[str, Any]:
-    if split == "final":
-        return {
-            "materialization_status": "prospective_materialization_prohibited",
-            "observation_payload_included": False,
-            "provenance": "sealed_plan_only",
-        }
-    return {
-        "materialization_status": "materialized",
-        "observation_payload_included": True,
-        "provenance": "in_memory_generation",
-    }
-
-
-def _frame_count_for_plan(split: str, family_label: str) -> int:
-    if split == "development":
-        return 1
-    return 4
-
-
-def _state_row_values(row_id: str) -> tuple[int, int | None, int]:
-    return parse_state_row_id(str(row_id))
-
-
-def _secondary_row_for_splice(row_ids: list[str], row_actions: Mapping[str, str], source_row_id: str) -> str:
-    source_action = row_actions[source_row_id]
-    _source_tank, source_target, _source_cooldown = _state_row_values(source_row_id)
-    if source_target is None:
-        raise VPMValidationError("conflicting splice source row must contain visible target evidence")
-    for row_id in row_ids:
-        if row_id == source_row_id:
-            continue
-        if row_actions[row_id] == source_action:
-            continue
-        _tank, target, _cooldown = _state_row_values(row_id)
-        if target is None or target == source_target:
-            continue
-        if not _splice_pair_has_final_visible_action_conflict(source_row_id, row_id, row_actions):
-            continue
-        return row_id
-    raise VPMValidationError("frame splice requires a secondary row with conflicting action and distinct visible target evidence")
-
-
-def _conflicting_splice_source_rows(row_ids: list[str], row_actions: Mapping[str, str], count: int) -> list[str]:
-    selected: list[str] = []
-    for row_id in row_ids:
-        _tank, target, _cooldown = _state_row_values(row_id)
-        if target is None:
-            continue
-        try:
-            _secondary_row_for_splice(row_ids, row_actions, row_id)
-        except VPMValidationError:
-            continue
-        selected.append(row_id)
-        if len(selected) == int(count):
-            return selected
-    raise VPMValidationError("unable to select enough conflicting splice source rows with visible target evidence")
-
-
-def _impossible_destination_row(row_ids: list[str], row_actions: Mapping[str, str], source_row_id: str) -> str:
-    action = row_actions[source_row_id]
-    tank, target, cooldown = _state_row_values(source_row_id)
-    reachable = set(next_rows(tank, target, cooldown, action, width=ShooterConfig().width))
-    for row_id in reversed(row_ids):
-        if row_id not in reachable and row_id != source_row_id:
-            return row_id
-    raise VPMValidationError("unable to select impossible transition destination")
-
-
-def _family_intervention_plan(
-    *,
-    identity: BenchmarkIdentity,
-    split: str,
-    ordinal: int,
-    family_label: str,
-    mutation_kind: str | None,
-    source_row_id: str,
-    secondary_row_id: str | None,
-    row_ids: Sequence[str],
-    row_actions: Mapping[str, str],
-) -> dict[str, Any]:
-    family_id = "valid" if family_label == "valid" else str(mutation_kind or family_label)
-    seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="family_intervention",
-        parent_identities=(
-            ("family_id", family_id),
-            ("source_row_id", source_row_id),
-            ("secondary_row_id", secondary_row_id or "none"),
-        ),
-    )
-    original_order = list(range(_frame_count_for_plan(split, family_label)))
-    payload: dict[str, Any] = {
-        "version": FAMILY_INTERVENTION_VERSION,
-        "family_id": family_id,
-        "intervention_seed_identity": seed["seed_digest"],
-        "original_order": original_order,
-        "materialized_order": list(original_order),
-        "event_type": "frame_sequence",
-    }
-    if family_id == "conflicting_action_splice":
-        payload |= {
-            "primary_source_row_id": source_row_id,
-            "primary_source_action_id": row_actions[source_row_id],
-            "secondary_source_row_id": secondary_row_id,
-            "secondary_source_action_id": None if secondary_row_id is None else row_actions[secondary_row_id],
-            "splice_mask": _splice_mask_manifest(),
-        }
-    elif family_id == "critical_evidence_corruption":
-        payload |= {"critical_coordinates": _critical_coordinate_manifest()}
-    elif family_id == "reordered_frames":
-        mutated = [1, 0, 2, 3]
-        if mutated == original_order:
-            raise VPMValidationError("reordered family requires non-identity order")
-        payload |= {"materialized_order": mutated, "sequence_rule": "non_identity_permutation"}
-    elif family_id == "stale_repeated_frame":
-        payload |= {"stale_repeat": {"source_frame_index": 0, "destination_frame_index": 1, "maximum_stale_horizon": 1}}
-    elif family_id == "impossible_transition":
-        destination = _impossible_destination_row(list(row_ids), row_actions, source_row_id)
-        payload |= {
-            "transition_relation_identity": REACHABILITY_TILE_DIGEST,
-            "impossible_transition": {
-                "source_frame_index": 0,
-                "destination_frame_index": 1,
-                "source_row_id": source_row_id,
-                "source_action_id": row_actions[source_row_id],
-                "destination_row_id": destination,
-                "destination_action_id": row_actions[destination],
-            },
-        }
-    elif family_id == "declared_gap_or_unknown_action":
-        gap_seed = _derived_seed(
-            identity,
-            split=split,
-            ordinal=ordinal,
-            namespace="gap_event_identity",
-            parent_identities=(("family_intervention", seed["seed_digest"]), ("gap_position", "2")),
-        )
-        payload |= {
-            "event_type": "typed_gap_sequence",
-            "gap_event": {
-                "version": GAP_EVENT_VERSION,
-                "position": 2,
-                "duration_frames": 1,
-                "reason": "declared_gap_or_unknown_action",
-                "event_id": gap_seed["seed_digest"],
-            },
-        }
-    elif family_id == "information_control":
-        control_seed = _derived_seed(
-            identity,
-            split=split,
-            ordinal=ordinal,
-            namespace="information_control_identity",
-            parent_identities=(("family_intervention", seed["seed_digest"]), ("current_row_id", source_row_id)),
-        )
-        hidden_histories = _select_grounded_control_histories(
-            source_row_id,
-            row_ids,
-            control_group_id=control_seed["seed_digest"],
-            frame_count=len(original_order),
-        )
-        hidden_label_digests = [history["hidden_source_label_digest"] for history in hidden_histories]
-        payload |= {
-            "control_group": {
-                "version": INFORMATION_CONTROL_AMBIGUITY_VERSION,
-                "control_group_id": control_seed["seed_digest"],
-                "current_row_id": source_row_id,
-                "byte_identity_required": True,
-                "minimum_grounded_causal_history_cardinality": 2,
-                "grounded_causal_history_count": len({history["normalized_causal_tuple_digest"] for history in hidden_histories}),
-                "hidden_source_history_count": len(hidden_histories),
-                "hidden_source_histories": hidden_histories,
-                "hidden_source_label_digests": hidden_label_digests,
-                "hidden_source_label_digest": _sha256(
-                    {
-                        "control_group_id": control_seed["seed_digest"],
-                        "hidden_source_label_digests": hidden_label_digests,
-                    }
-                ),
-                "provider_observation_boundary_version": PROVIDER_OBSERVATION_BOUNDARY_VERSION,
-                "provider_visible_fields": ["pixels", "shape", "raw_digest", "timestamp", "source_id", "metadata", "version"],
-                "provider_hidden_fields": [
-                    "frame_id",
-                    "source_row_id",
-                    "source_action_id",
-                    "grounded_causal_history",
-                    "hidden_source_history_id",
-                    "hidden_source_label_digest",
-                ],
-            }
-        }
-    payload["sequence_digest"] = _sha256({"order": payload["materialized_order"], "event_type": payload["event_type"], "family_id": family_id})
-    payload["intervention_digest"] = _sha256(payload)
-    return payload
-
-
-def _frame_plans(
-    identity: BenchmarkIdentity,
-    *,
-    split: str,
-    ordinal: int,
-    family_label: str,
-    mutation_kind: str | None,
-    frame_count: int,
-    concrete_episode_seed_digest: str,
-) -> list[dict[str, Any]]:
-    schedule = _family_schedule()
-    schedule_digest = _sha256({"family_schedule": list(schedule)})
-    frames = []
-    for frame_index in range(frame_count):
-        frame_seed = _derived_seed(
-            identity,
-            split=split,
-            ordinal=ordinal,
-            namespace="frame_identity",
-            parent_identities=(
-                ("concrete_episode_seed", concrete_episode_seed_digest),
-                ("frame_index", str(frame_index)),
-            ),
-        )
-        transform_family_seed = _derived_seed(
-            identity,
-            split=split,
-            ordinal=ordinal,
-            namespace="transformation_family",
-            parent_identities=(
-                ("frame_identity", frame_seed["seed_digest"]),
-                ("family_schedule_digest", schedule_digest),
-                ("episode_family", family_label),
-            ),
-        )
-        if family_label == "frame_invalid":
-            transformation_family = "exact"
-        else:
-            transformation_family = schedule[transform_family_seed["seed_int64"] % len(schedule)]
-        transform_parameter_seed = _derived_seed(
-            identity,
-            split=split,
-            ordinal=ordinal,
-            namespace="transformation_parameters",
-            parent_identities=(
-                ("transformation_family_seed", transform_family_seed["seed_digest"]),
-                ("transformation_family", transformation_family),
-                ("frame_index", str(frame_index)),
-            ),
-        )
-        transition_choice_seed = _derived_seed(
-            identity,
-            split=split,
-            ordinal=ordinal,
-            namespace="transition_choice",
-            parent_identities=(
-                ("frame_identity", frame_seed["seed_digest"]),
-                ("frame_index", str(frame_index)),
-            ),
-        )
-        temporal_mutation_seed = _derived_seed(
-            identity,
-            split=split,
-            ordinal=ordinal,
-            namespace="temporal_mutation_choice",
-            parent_identities=(
-                ("frame_identity", frame_seed["seed_digest"]),
-                ("temporal_mutation", mutation_kind or "none"),
-            ),
-        )
-        parameters = _transformation_parameters(transformation_family, transform_parameter_seed["seed_int64"])
-        frames.append(
-            {
-                "frame_index": frame_index,
-                "frame_seed_identity": frame_seed["seed_digest"],
-                "transformation_family_seed_identity": transform_family_seed["seed_digest"],
-                "transformation_family": transformation_family,
-                "transformation_seed_identity": transform_parameter_seed["seed_digest"],
-                "transformation_seed": transform_parameter_seed["seed_int64"],
-                "transformation_parameter_digest": parameters["parameter_digest"],
-                "transformation_parameters": parameters,
-                "transition_choice_seed_identity": transition_choice_seed["seed_digest"],
-                "transition_choice_seed": transition_choice_seed["seed_int64"],
-                "temporal_mutation_seed_identity": temporal_mutation_seed["seed_digest"],
-                "temporal_mutation_kind": mutation_kind if family_label == "temporal_negative" else None,
-            }
-        )
-    return frames
-
-
-def _make_episode_plan(
-    identity: BenchmarkIdentity,
-    *,
-    split: str,
-    ordinal: int,
-    family_label: str,
-    family_ordinal: int,
-    source_row_id: str,
-    row_actions: Mapping[str, str],
-    mutation_kind: str | None = None,
-    secondary_row_id: str | None = None,
-) -> dict[str, Any]:
-    if source_row_id not in row_actions:
-        raise VPMValidationError("episode source row is absent from the policy universe")
-    if secondary_row_id is not None and secondary_row_id not in row_actions:
-        raise VPMValidationError("episode secondary row is absent from the policy universe")
-    if mutation_kind != "conflicting_action_splice" and secondary_row_id is not None:
-        raise VPMValidationError("secondary row is only admissible for conflicting-action splices")
-    if mutation_kind == "conflicting_action_splice":
-        if secondary_row_id is None:
-            raise VPMValidationError("conflicting-action splice requires a secondary row")
-        if row_actions[secondary_row_id] == row_actions[source_row_id]:
-            raise VPMValidationError("conflicting-action splice secondary row must govern a different action")
-
-    split_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="split_identity",
-        parent_identities=(("benchmark_version", BENCHMARK_VERSION), ("generator_version", GENERATOR_VERSION)),
-    )
-    ordinal_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="episode_ordinal",
-        parent_identities=(("split_identity", split_seed["seed_digest"]), ("family_ordinal", str(family_ordinal))),
-    )
-    family_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="episode_family",
-        parent_identities=(
-            ("episode_ordinal", ordinal_seed["seed_digest"]),
-            ("family_label", family_label),
-            ("mutation_kind", mutation_kind or "none"),
-        ),
-    )
-    source_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="source_row_choice",
-        parent_identities=(("episode_family", family_seed["seed_digest"]), ("source_row_id", source_row_id)),
-    )
-    secondary_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="secondary_splice_row_choice",
-        parent_identities=(
-            ("source_row_choice", source_seed["seed_digest"]),
-            ("secondary_row_id", secondary_row_id or "none"),
-        ),
-    )
-    transformation_family_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="transformation_family",
-        parent_identities=(
-            ("secondary_splice_row_choice", secondary_seed["seed_digest"]),
-            ("family_schedule_digest", _sha256({"family_schedule": list(_family_schedule())})),
-        ),
-    )
-    transformation_parameter_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="transformation_parameters",
-        parent_identities=(("transformation_family", transformation_family_seed["seed_digest"]), ("frame_count", str(_frame_count_for_plan(split, family_label)))),
-    )
-    temporal_mutation_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="temporal_mutation_choice",
-        parent_identities=(("transformation_parameters", transformation_parameter_seed["seed_digest"]), ("temporal_mutation", mutation_kind or "none")),
-    )
-    episode_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="concrete_episode_seed",
-        parent_identities=(
-            ("split_identity", split_seed["seed_digest"]),
-            ("episode_ordinal", ordinal_seed["seed_digest"]),
-            ("episode_family", family_seed["seed_digest"]),
-            ("source_row_choice", source_seed["seed_digest"]),
-            ("secondary_splice_row_choice", secondary_seed["seed_digest"]),
-            ("transformation_family", transformation_family_seed["seed_digest"]),
-            ("transformation_parameters", transformation_parameter_seed["seed_digest"]),
-            ("temporal_mutation_choice", temporal_mutation_seed["seed_digest"]),
-        ),
-    )
-    frame_count = _frame_count_for_plan(split, family_label)
-    frame_plans = _frame_plans(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        family_label=family_label,
-        mutation_kind=mutation_kind,
-        frame_count=frame_count,
-        concrete_episode_seed_digest=episode_seed["seed_digest"],
-    )
-    family_contract = _family_contract(family_label, mutation_kind)
-    family_intervention = _family_intervention_plan(
-        identity=identity,
-        split=split,
-        ordinal=ordinal,
-        family_label=family_label,
-        mutation_kind=mutation_kind,
-        source_row_id=source_row_id,
-        secondary_row_id=secondary_row_id,
-        row_ids=tuple(row_actions.keys()),
-        row_actions=row_actions,
-    )
-    episode_disposition = _episode_disposition(family_label, mutation_kind)
-    denominator_class = _denominator_class(family_label, mutation_kind)
-    final_observation_provenance = _final_observation_provenance(split)
-    episode_id_seed = _derived_seed(
-        identity,
-        split=split,
-        ordinal=ordinal,
-        namespace="concrete_episode_id",
-        parent_identities=(
-            ("concrete_episode_seed", episode_seed["seed_digest"]),
-            ("family_contract", family_contract["family_version"]),
-            ("family_intervention", family_intervention["intervention_digest"]),
-            ("episode_disposition", episode_disposition),
-            ("denominator_class", denominator_class),
-            ("source_row_id", source_row_id),
-            ("secondary_row_id", secondary_row_id or "none"),
-        ),
-    )
-    episode_id = f"{split}:{family_label}:{episode_id_seed['seed_digest'].removeprefix('sha256:')[:16]}"
-    plan = {
-        "version": EPISODE_PLAN_VERSION,
-        "seed_derivation_version": SEED_DERIVATION_VERSION,
-        "episode_id": episode_id,
-        "split": split,
-        "ordinal": int(ordinal),
-        "family_label": family_label,
-        "family_ordinal": int(family_ordinal),
-        "episode_family": family_label,
-        "episode_disposition": episode_disposition,
-        "denominator_class": denominator_class,
-        "final_observation_provenance": final_observation_provenance,
-        "mutation_kind": mutation_kind,
-        "source_row_id": source_row_id,
-        "secondary_row_id": secondary_row_id,
-        "family_contract": family_contract,
-        "family_intervention": family_intervention,
-        "derived_seed_identity": episode_seed["seed_digest"],
-        "episode_seed": episode_seed["seed_int64"],
-        "frame_count": frame_count,
-        "seed_lineage": {
-            "split_identity": split_seed,
-            "episode_ordinal": ordinal_seed,
-            "episode_family": family_seed,
-            "source_row_choice": source_seed,
-            "secondary_splice_row_choice": secondary_seed,
-            "transformation_family": transformation_family_seed,
-            "transformation_parameters": transformation_parameter_seed,
-            "temporal_mutation_choice": temporal_mutation_seed,
-            "concrete_episode_seed": episode_seed,
-            "concrete_episode_id": episode_id_seed,
-        },
-        "frame_plans": frame_plans,
-    }
-    dto = EpisodePlanDTO.from_dict(plan | {"plan_digest": _sha256(plan)})
-    return dto.to_dict()
-
-
-def _episode_plans_for_split(identity: BenchmarkIdentity, split: str, row_ids: list[str], row_actions: Mapping[str, str]) -> list[dict[str, Any]]:
-    plans: list[dict[str, Any]] = []
-
-    def add(family_label: str, family_ordinal: int, row_id: str, *, mutation_kind: str | None = None) -> None:
-        secondary = None
-        if mutation_kind == "conflicting_action_splice":
-            secondary = _secondary_row_for_splice(row_ids, row_actions, row_id)
-        plans.append(
-            _make_episode_plan(
-                identity,
-                split=split,
-                ordinal=len(plans),
-                family_label=family_label,
-                family_ordinal=family_ordinal,
-                source_row_id=row_id,
-                row_actions=row_actions,
-                mutation_kind=mutation_kind,
-                secondary_row_id=secondary,
-            )
-        )
-
-    if split == "development":
-        for index, row_id in enumerate(row_ids):
-            add("valid", index, row_id)
-        return plans
-    if split == "calibration":
-        for index, row_id in enumerate(row_ids):
-            add("valid", index, row_id)
-        return plans
-    if split in {"selection", "final"}:
-        for index, row_id in enumerate(row_ids):
-            add("valid", index, row_id)
-        splice_rows = _conflicting_splice_source_rows(row_ids, row_actions, 28)
-        for index, row_id in enumerate(splice_rows):
-            add("frame_invalid", index, row_id, mutation_kind="conflicting_action_splice")
-        for index, row_id in enumerate(row_ids[28:56]):
-            add("frame_invalid", 28 + index, row_id, mutation_kind="critical_evidence_corruption")
-        temporal_rows = row_ids[:56]
-        kinds = ("reordered_frames", "stale_repeated_frame", "impossible_transition", "declared_gap_or_unknown_action")
-        for group_index, kind in enumerate(kinds):
-            for index, row_id in enumerate(temporal_rows[group_index * 14 : (group_index + 1) * 14]):
-                add("temporal_negative", group_index * 14 + index, row_id, mutation_kind=kind)
-        control_rows = _control_source_rows(row_ids, count=28, frame_count=_frame_count_for_plan(split, "information_control"))
-        for index, row_id in enumerate(control_rows):
-            add("information_control", index, row_id)
-        return plans
-    raise VPMValidationError("unsupported split")
-
-
-def _episode_ids_by_family(plans: list[dict[str, Any]]) -> dict[str, list[str]]:
-    grouped = {"valid": [], "frame_invalid": [], "temporal_negative": [], "information_control": []}
-    for plan in plans:
-        grouped[str(plan["family_label"])].append(str(plan["episode_id"]))
-    return grouped
-
-
-def _validate_episode_plan(identity: BenchmarkIdentity, plan: Mapping[str, Any], row_actions: Mapping[str, str]) -> None:
-    try:
-        EpisodePlanDTO.from_dict(plan)
-    except VPMValidationError as exc:
-        raise VPMValidationError("episode plan is inconsistent with declared seed lineage or identity") from exc
-    expected = _make_episode_plan(
-        identity,
-        split=str(plan["split"]),
-        ordinal=int(plan["ordinal"]),
-        family_label=str(plan["family_label"]),
-        family_ordinal=int(plan["family_ordinal"]),
-        source_row_id=str(plan["source_row_id"]),
-        row_actions=row_actions,
-        mutation_kind=plan.get("mutation_kind"),
-        secondary_row_id=plan.get("secondary_row_id"),
-    )
-    if dict(plan) != expected:
-        raise VPMValidationError("episode plan is inconsistent with declared seed lineage or identity")
-
-
-def _validate_episode_plan_collection(identity: BenchmarkIdentity, plans_by_split: Mapping[str, list[dict[str, Any]]], row_actions: Mapping[str, str]) -> None:
-    seen: dict[str, str] = {}
-    for split, plans in plans_by_split.items():
-        for plan in plans:
-            episode_id = str(plan["episode_id"])
-            if plan["split"] != split:
-                raise VPMValidationError("episode plan split does not match containing split")
-            if episode_id in seen:
-                if seen[episode_id] != split:
-                    raise VPMValidationError("episode identity reassigned to another split")
-                raise VPMValidationError("duplicate concrete episode identity")
-            seen[episode_id] = split
-            _validate_episode_plan(identity, plan, row_actions)
-
-
 def _apply_family(frame: np.ndarray, family: str, *, seed: int) -> np.ndarray:
     result, _metadata = _apply_transformation(frame, _transformation_parameters(family, seed))
     return result
@@ -1226,7 +397,6 @@ def _refresh_provider_observation_metadata(record: dict[str, Any]) -> None:
     metadata["provider_observation_digest"] = _provider_observation_digest(descriptor)
 
 
-
 def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, Any]:
     return _replay_observation_operation_chain_core(
         chain,
@@ -1235,14 +405,12 @@ def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, An
     )
 
 
-
 def validate_observation_operation_chain(record: Mapping[str, Any]) -> str:
     return _validate_observation_operation_chain_core(
         record,
         conflicting_splice_executor=_apply_conflicting_splice,
         critical_corruption_executor=_apply_critical_corruption,
     )
-
 
 
 def _frame_descriptor(
@@ -1859,8 +1027,6 @@ def _record_regeneration_view(record: Mapping[str, Any]) -> dict[str, Any]:
         "sequence_digest": record.get("metadata", {}).get("sequence_digest"),
         "episode_plan_digest": record.get("metadata", {}).get("episode_plan_digest"),
     }
-
-
 
 
 def _family_closure_report(


### PR DESCRIPTION
## Summary

- Extract deterministic video action-set control history, family intervention, and episode planning into pure domain modules.
- Keep legacy benchmark private planning symbols as direct compatibility aliases.
- Add frozen pre-extraction golden tests for planning identities, split rollups, branch plans, validation, and no-materialization boundaries.
- Extend architecture guards for the new planning layer and lower the benchmark quality ceiling to the new measured line count.

## Validation

- `pytest tests/test_video_control_history_planning.py tests/test_video_family_intervention_planning.py tests/test_video_episode_planning_kernel.py tests/test_video_episode_family_kernel.py tests/test_video_family_provenance_kernel.py -q`
- `python scripts/check_architecture.py`
- `python scripts/check_quality.py`
- `python scripts/run_fast_tests.py`
- `python -m build`

Audit-Exempt: behavior-preserving deterministic episode-planning extraction; no claim status, benchmark evidence, scientific semantics, observation identities, provider identities, digest semantics, materialization policy, or conclusions changed.