### PR TITLE
refactor: extract video provider measurement

### DIFF
--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -8,8 +8,8 @@ maximum_function_parameters = 10
 maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
-reason = "Stage 6 scientific instrument pending behavior-preserving decomposition"
-maximum_lines = 3274
+reason = "Stage 7A benchmark orchestration with verification and audit paths pending behavior-preserving decomposition"
+maximum_lines = 2987
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/architecture_rules/__init__.py
+++ b/scripts/architecture_rules/__init__.py
@@ -5,6 +5,9 @@ from collections.abc import Sequence
 from typing import Any
 
 
+TRACKED_EXTERNAL_MODULES = frozenset({"json", "pathlib", "sqlite3", "sqlalchemy"})
+
+
 def print_violations(violations: Sequence[Any]) -> None:
     for violation in sorted(
         violations, key=lambda item: (item.rule, item.importer, item.imported)

--- a/scripts/architecture_rules/video_action_set_modules.py
+++ b/scripts/architecture_rules/video_action_set_modules.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+
+class ImportEdgeLike(Protocol):
+    importer: str
+    imported: str
+    line: int
+
+
+ViolationFactory = Callable[[str, ImportEdgeLike], Any]
+
+DOMAIN_PREFIX = "zeromodel.domains.video_action_set"
+BENCHMARK_MODULE = "zeromodel.video_action_set_benchmark"
+DB_ORM_PREFIX = "zeromodel.db.orm"
+DB_STORES_PREFIX = "zeromodel.db.stores"
+
+PROVIDER_OBSERVATION_BOUNDARY_MODULE = f"{DOMAIN_PREFIX}.provider_observation_boundary"
+MATERIALIZATION_REACHABILITY_MODULE = f"{DOMAIN_PREFIX}.materialization_reachability"
+REACHABILITY_COMPOSITION_MODULE = f"{DOMAIN_PREFIX}.reachability_composition"
+PROVIDER_MEASUREMENT_MODULE = f"{DOMAIN_PREFIX}.provider_measurement"
+RUNTIME_PROFILING_MODULE = f"{DOMAIN_PREFIX}.runtime_profiling"
+
+STAGE7A_MODULES = {
+    REACHABILITY_COMPOSITION_MODULE,
+    PROVIDER_MEASUREMENT_MODULE,
+    RUNTIME_PROFILING_MODULE,
+}
+
+LOWER_LAYER_MODULES = {
+    f"{DOMAIN_PREFIX}.canonical_json",
+    f"{DOMAIN_PREFIX}.contracts",
+    f"{DOMAIN_PREFIX}.pixel_digest",
+    f"{DOMAIN_PREFIX}.transformations",
+    f"{DOMAIN_PREFIX}.arcade_observation",
+    f"{DOMAIN_PREFIX}.observation_universe",
+    f"{DOMAIN_PREFIX}.observation_provenance_dto",
+    f"{DOMAIN_PREFIX}.observation_legacy_adapters",
+    f"{DOMAIN_PREFIX}.observation_provenance",
+    f"{DOMAIN_PREFIX}.observation_replay",
+    f"{DOMAIN_PREFIX}.episode_families",
+    f"{DOMAIN_PREFIX}.frame_family_kernels",
+    f"{DOMAIN_PREFIX}.family_provenance",
+    f"{DOMAIN_PREFIX}.family_validation",
+    f"{DOMAIN_PREFIX}.control_histories",
+    f"{DOMAIN_PREFIX}.family_intervention_planning",
+    f"{DOMAIN_PREFIX}.episode_planning",
+    f"{DOMAIN_PREFIX}.materialization_reachability",
+    f"{DOMAIN_PREFIX}.materialization_kernels",
+    f"{DOMAIN_PREFIX}.episode_materialization",
+    f"{DOMAIN_PREFIX}.materialization_validation",
+    f"{DOMAIN_PREFIX}.dto",
+    f"{DOMAIN_PREFIX}.observation_common",
+    f"{DOMAIN_PREFIX}.observation_dto",
+    f"{DOMAIN_PREFIX}.observation_materialization",
+    f"{DOMAIN_PREFIX}.provider_observation_dto",
+    "zeromodel.video_complete_row_evidence",
+    "zeromodel.video_prospective_providers",
+    "zeromodel.video_discriminative_evidence",
+    "zeromodel.video_discriminative_joint_evidence",
+    "zeromodel.video_local_correlation",
+}
+
+PLANNING_MODULES = {
+    f"{DOMAIN_PREFIX}.control_histories",
+    f"{DOMAIN_PREFIX}.family_intervention_planning",
+    f"{DOMAIN_PREFIX}.episode_planning",
+}
+
+MATERIALIZATION_MODULES = {
+    f"{DOMAIN_PREFIX}.materialization_kernels",
+    f"{DOMAIN_PREFIX}.episode_materialization",
+    f"{DOMAIN_PREFIX}.materialization_validation",
+}
+
+PROVIDER_SCORING_MODULES = {
+    "zeromodel.video_complete_row_evidence",
+    "zeromodel.video_prospective_providers",
+    "zeromodel.video_discriminative_evidence",
+    "zeromodel.video_discriminative_joint_evidence",
+    "zeromodel.video_local_correlation",
+}
+
+VERIFICATION_OR_AUDIT_PREFIXES = {
+    f"{DOMAIN_PREFIX}.evidence_audit",
+    f"{DOMAIN_PREFIX}.mutation_audit",
+    f"{DOMAIN_PREFIX}.mutation_matrix",
+    f"{DOMAIN_PREFIX}.reference_verification",
+    f"{DOMAIN_PREFIX}.verification",
+    "zeromodel.video_action_equivalence",
+    "zeromodel.video_action_set.mutation_audit",
+    "zeromodel.video_action_set.verification",
+}
+
+FILESYSTEM_OR_DATABASE_MODULES = {
+    "json",
+    "pathlib",
+    "sqlite3",
+}
+
+
+def _is_under(module: str, prefix: str) -> bool:
+    return module == prefix or module.startswith(f"{prefix}.")
+
+
+def _is_sqlalchemy_import(module: str) -> bool:
+    return module == "sqlalchemy" or module.startswith("sqlalchemy.")
+
+
+def _is_forbidden_infrastructure_import(module: str) -> bool:
+    return (
+        _is_under(module, DB_ORM_PREFIX)
+        or _is_under(module, DB_STORES_PREFIX)
+        or _is_under(module, "zeromodel.db.session")
+        or _is_under(module, "zeromodel.stores")
+        or module == "zeromodel.runtime"
+        or _is_sqlalchemy_import(module)
+        or module in FILESYSTEM_OR_DATABASE_MODULES
+    )
+
+
+def _is_verification_or_audit_import(module: str) -> bool:
+    return any(_is_under(module, prefix) for prefix in VERIFICATION_OR_AUDIT_PREFIXES)
+
+
+def stage7a_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    violations: list[Any] = []
+    importer = edge.importer
+    imported = edge.imported
+
+    def reject(rule: str) -> None:
+        violations.append(violation_factory(rule, edge))
+
+    if importer in LOWER_LAYER_MODULES and imported in STAGE7A_MODULES:
+        reject("lower video action-set modules must not import Stage 7A modules")
+
+    if importer == REACHABILITY_COMPOSITION_MODULE and (
+        imported == BENCHMARK_MODULE
+        or imported in {PROVIDER_MEASUREMENT_MODULE, RUNTIME_PROFILING_MODULE}
+        or imported in PROVIDER_SCORING_MODULES
+        or imported in PLANNING_MODULES
+        or imported in MATERIALIZATION_MODULES
+        or _is_forbidden_infrastructure_import(imported)
+        or _is_verification_or_audit_import(imported)
+    ):
+        reject(
+            "reachability_composition must not import benchmark, provider measurement, profiling, scoring, planning, materialization execution, verification, mutation audit, persistence, runtime, or filesystem layers"
+        )
+
+    if importer == PROVIDER_MEASUREMENT_MODULE and (
+        imported == BENCHMARK_MODULE
+        or imported == RUNTIME_PROFILING_MODULE
+        or imported in PLANNING_MODULES
+        or imported in MATERIALIZATION_MODULES
+        or _is_forbidden_infrastructure_import(imported)
+        or _is_verification_or_audit_import(imported)
+    ):
+        reject(
+            "provider_measurement must not import benchmark, profiling, planning, materialization execution, verification, mutation audit, persistence, runtime, or filesystem layers"
+        )
+
+    if importer == RUNTIME_PROFILING_MODULE and (
+        imported == BENCHMARK_MODULE
+        or imported == REACHABILITY_COMPOSITION_MODULE
+        or imported in PLANNING_MODULES
+        or imported in MATERIALIZATION_MODULES
+        or _is_forbidden_infrastructure_import(imported)
+        or _is_verification_or_audit_import(imported)
+    ):
+        reject(
+            "runtime_profiling must not import benchmark, reachability composition, planning, materialization, verification, mutation audit, persistence, runtime, or filesystem/report layers"
+        )
+
+    if importer == PROVIDER_OBSERVATION_BOUNDARY_MODULE and imported in {
+        PROVIDER_MEASUREMENT_MODULE,
+        RUNTIME_PROFILING_MODULE,
+    }:
+        reject("provider_observation_boundary must remain below Stage 7A modules")
+
+    if importer == MATERIALIZATION_REACHABILITY_MODULE and imported in STAGE7A_MODULES:
+        reject("materialization_reachability must remain below Stage 7A modules")
+
+    return violations
+
+
+__all__ = ["stage7a_forbidden_edge_violations"]

--- a/scripts/architecture_rules/video_science_layers.py
+++ b/scripts/architecture_rules/video_science_layers.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+
+class ImportEdgeLike(Protocol):
+    importer: str
+    imported: str
+    line: int
+
+
+ViolationFactory = Callable[[str, ImportEdgeLike], Any]
+
+
+VIDEO_ACTION_SET_PREFIX = "zeromodel.video_action_set"
+VIDEO_ACTION_SET_BENCHMARK_MODULE = "zeromodel.video_action_set_benchmark"
+DOMAIN_VIDEO_ACTION_SET_PREFIX = "zeromodel.domains.video_action_set"
+DB_ORM_PREFIX = "zeromodel.db.orm"
+DB_STORES_PREFIX = "zeromodel.db.stores"
+ARCADE_OBSERVATION_MODULE = "zeromodel.domains.video_action_set.arcade_observation"
+CANONICAL_JSON_MODULE = "zeromodel.domains.video_action_set.canonical_json"
+CONTRACTS_MODULE = "zeromodel.domains.video_action_set.contracts"
+OBSERVATION_LEGACY_ADAPTERS_MODULE = (
+    "zeromodel.domains.video_action_set.observation_legacy_adapters"
+)
+OBSERVATION_PROVENANCE_DTO_MODULE = (
+    "zeromodel.domains.video_action_set.observation_provenance_dto"
+)
+OBSERVATION_PROVENANCE_MODULE = (
+    "zeromodel.domains.video_action_set.observation_provenance"
+)
+OBSERVATION_REPLAY_MODULE = "zeromodel.domains.video_action_set.observation_replay"
+OBSERVATION_UNIVERSE_MODULE = "zeromodel.domains.video_action_set.observation_universe"
+PIXEL_DIGEST_MODULE = "zeromodel.domains.video_action_set.pixel_digest"
+TRANSFORMATIONS_MODULE = "zeromodel.domains.video_action_set.transformations"
+EPISODE_FAMILIES_MODULE = "zeromodel.domains.video_action_set.episode_families"
+FRAME_FAMILY_KERNELS_MODULE = "zeromodel.domains.video_action_set.frame_family_kernels"
+FAMILY_PROVENANCE_MODULE = "zeromodel.domains.video_action_set.family_provenance"
+FAMILY_VALIDATION_MODULE = "zeromodel.domains.video_action_set.family_validation"
+CONTROL_HISTORIES_MODULE = "zeromodel.domains.video_action_set.control_histories"
+FAMILY_INTERVENTION_PLANNING_MODULE = (
+    "zeromodel.domains.video_action_set.family_intervention_planning"
+)
+EPISODE_PLANNING_MODULE = "zeromodel.domains.video_action_set.episode_planning"
+FAMILY_SCIENCE_MODULES = {
+    EPISODE_FAMILIES_MODULE,
+    FRAME_FAMILY_KERNELS_MODULE,
+    FAMILY_PROVENANCE_MODULE,
+    FAMILY_VALIDATION_MODULE,
+}
+EPISODE_PLANNING_MODULES = {
+    CONTROL_HISTORIES_MODULE,
+    FAMILY_INTERVENTION_PLANNING_MODULE,
+    EPISODE_PLANNING_MODULE,
+}
+VIDEO_OBSERVATION_KERNEL_MODULES = {
+    ARCADE_OBSERVATION_MODULE,
+    OBSERVATION_PROVENANCE_MODULE,
+    OBSERVATION_REPLAY_MODULE,
+    OBSERVATION_UNIVERSE_MODULE,
+    PIXEL_DIGEST_MODULE,
+    TRANSFORMATIONS_MODULE,
+}
+LOWER_OBSERVATION_MODULES = {
+    CANONICAL_JSON_MODULE,
+    CONTRACTS_MODULE,
+    PIXEL_DIGEST_MODULE,
+    TRANSFORMATIONS_MODULE,
+    ARCADE_OBSERVATION_MODULE,
+    OBSERVATION_UNIVERSE_MODULE,
+    OBSERVATION_PROVENANCE_DTO_MODULE,
+    OBSERVATION_LEGACY_ADAPTERS_MODULE,
+}
+VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
+    "zeromodel.domains.video_action_set.episode_plan_service",
+    "zeromodel.domains.video_action_set.identity_service",
+    "zeromodel.domains.video_action_set.observation_service",
+    "zeromodel.domains.video_action_set.engine",
+    "zeromodel.domains.video_action_set.facade",
+    "zeromodel.runtime",
+}
+VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
+    ARCADE_OBSERVATION_MODULE,
+    CANONICAL_JSON_MODULE,
+    CONTROL_HISTORIES_MODULE,
+    CONTRACTS_MODULE,
+    EPISODE_FAMILIES_MODULE,
+    EPISODE_PLANNING_MODULE,
+    FAMILY_INTERVENTION_PLANNING_MODULE,
+    FAMILY_PROVENANCE_MODULE,
+    FAMILY_VALIDATION_MODULE,
+    FRAME_FAMILY_KERNELS_MODULE,
+    "zeromodel.domains.video_action_set.dto",
+    "zeromodel.domains.video_action_set.episode_plan_service",
+    "zeromodel.domains.video_action_set.observation_common",
+    "zeromodel.domains.video_action_set.observation_dto",
+    OBSERVATION_LEGACY_ADAPTERS_MODULE,
+    "zeromodel.domains.video_action_set.observation_materialization",
+    OBSERVATION_PROVENANCE_DTO_MODULE,
+    OBSERVATION_PROVENANCE_MODULE,
+    OBSERVATION_REPLAY_MODULE,
+    "zeromodel.domains.video_action_set.observation_service",
+    OBSERVATION_UNIVERSE_MODULE,
+    PIXEL_DIGEST_MODULE,
+    "zeromodel.domains.video_action_set.provider_observation_dto",
+    TRANSFORMATIONS_MODULE,
+}
+VIDEO_ACTION_SET_POLICY_MODULES = {
+    f"{VIDEO_ACTION_SET_PREFIX}.contracts",
+    f"{VIDEO_ACTION_SET_PREFIX}.mutation_audit",
+    f"{VIDEO_ACTION_SET_PREFIX}.verification",
+}
+
+
+def is_video_action_set_runtime_module(module: str) -> bool:
+    prefix = f"{VIDEO_ACTION_SET_PREFIX}."
+    if not module.startswith(prefix):
+        return False
+    if module in VIDEO_ACTION_SET_POLICY_MODULES:
+        return False
+    suffix = module[len(prefix) :]
+    return not (
+        suffix.startswith("contracts.")
+        or suffix.startswith("mutation_audit.")
+        or suffix.startswith("verification.")
+    )
+
+
+def is_module_under(module: str, prefix: str) -> bool:
+    return module == prefix or module.startswith(f"{prefix}.")
+
+
+def is_sqlalchemy_import(module: str) -> bool:
+    return module == "sqlalchemy" or module.startswith("sqlalchemy.")
+
+
+def legacy_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    violations: list[Any] = []
+    if edge.imported == "tests" or edge.imported.startswith("tests."):
+        violations.append(violation_factory("zeromodel/ must not import tests.*", edge))
+    if edge.importer == "zeromodel.artifact" and (
+        edge.imported.startswith("zeromodel.video_")
+        or edge.imported == VIDEO_ACTION_SET_PREFIX
+        or edge.imported.startswith(f"{VIDEO_ACTION_SET_PREFIX}.")
+    ):
+        violations.append(
+            violation_factory(
+                "zeromodel.artifact must not import video research modules",
+                edge,
+            )
+        )
+    if edge.importer == f"{VIDEO_ACTION_SET_PREFIX}.contracts" and (
+        edge.imported == VIDEO_ACTION_SET_PREFIX
+        or edge.imported.startswith(f"{VIDEO_ACTION_SET_PREFIX}.")
+    ):
+        violations.append(
+            violation_factory(
+                "video_action_set/contracts.py must not import implementation modules",
+                edge,
+            )
+        )
+    if is_video_action_set_runtime_module(edge.importer) and (
+        edge.imported == f"{VIDEO_ACTION_SET_PREFIX}.verification"
+        or edge.imported.startswith(f"{VIDEO_ACTION_SET_PREFIX}.verification.")
+        or edge.imported == f"{VIDEO_ACTION_SET_PREFIX}.mutation_audit"
+        or edge.imported.startswith(f"{VIDEO_ACTION_SET_PREFIX}.mutation_audit.")
+    ):
+        violations.append(
+            violation_factory(
+                "runtime modules must not depend on verification or mutation_audit",
+                edge,
+            )
+        )
+    return violations
+
+
+def transformation_kernel_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    violations: list[Any] = []
+    if edge.importer == PIXEL_DIGEST_MODULE and edge.imported == TRANSFORMATIONS_MODULE:
+        violations.append(
+            violation_factory(
+                "pixel_digest must not import transformations",
+                edge,
+            )
+        )
+    if edge.importer == PIXEL_DIGEST_MODULE and edge.imported in {
+        ARCADE_OBSERVATION_MODULE,
+        OBSERVATION_UNIVERSE_MODULE,
+    }:
+        violations.append(
+            violation_factory(
+                "pixel_digest must not import arcade_observation or observation_universe",
+                edge,
+            )
+        )
+    if edge.importer == TRANSFORMATIONS_MODULE and edge.imported in {
+        ARCADE_OBSERVATION_MODULE,
+        OBSERVATION_UNIVERSE_MODULE,
+    }:
+        violations.append(
+            violation_factory(
+                "transformations must not import arcade_observation or observation_universe",
+                edge,
+            )
+        )
+    if (
+        edge.importer == ARCADE_OBSERVATION_MODULE
+        and edge.imported == OBSERVATION_UNIVERSE_MODULE
+    ):
+        violations.append(
+            violation_factory(
+                "arcade_observation must not import observation_universe",
+                edge,
+            )
+        )
+    if edge.importer in VIDEO_OBSERVATION_KERNEL_MODULES and (
+        is_module_under(edge.imported, DB_ORM_PREFIX)
+        or is_module_under(edge.imported, DB_STORES_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db.session")
+        or is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+        or is_sqlalchemy_import(edge.imported)
+    ):
+        violations.append(
+            violation_factory(
+                "video observation kernel modules must not import persistence or runtime layers",
+                edge,
+            )
+        )
+    if edge.importer in VIDEO_OBSERVATION_KERNEL_MODULES and edge.imported == (
+        VIDEO_ACTION_SET_BENCHMARK_MODULE
+    ):
+        violations.append(
+            violation_factory(
+                "video observation kernel modules must not import legacy benchmark facade",
+                edge,
+            )
+        )
+    return violations
+
+
+def observation_provenance_replay_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    violations: list[Any] = []
+    if (
+        edge.importer == OBSERVATION_PROVENANCE_MODULE
+        and edge.imported == OBSERVATION_REPLAY_MODULE
+    ):
+        violations.append(
+            violation_factory(
+                "observation_provenance must not import observation_replay",
+                edge,
+            )
+        )
+    if (
+        edge.importer == OBSERVATION_REPLAY_MODULE
+        and edge.imported == OBSERVATION_PROVENANCE_MODULE
+    ):
+        violations.append(
+            violation_factory(
+                "observation_replay must not import observation_provenance",
+                edge,
+            )
+        )
+    if (
+        edge.importer
+        in {
+            OBSERVATION_PROVENANCE_MODULE,
+            OBSERVATION_REPLAY_MODULE,
+        }
+        and edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+    ):
+        violations.append(
+            violation_factory(
+                "observation provenance/replay modules must not import legacy benchmark",
+                edge,
+            )
+        )
+    if edge.importer in {
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+    } and (
+        is_module_under(edge.imported, DB_ORM_PREFIX)
+        or is_module_under(edge.imported, DB_STORES_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db.session")
+        or is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+        or is_sqlalchemy_import(edge.imported)
+    ):
+        violations.append(
+            violation_factory(
+                "observation provenance/replay modules must not import persistence or runtime layers",
+                edge,
+            )
+        )
+    if edge.importer in LOWER_OBSERVATION_MODULES and edge.imported in {
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+    }:
+        violations.append(
+            violation_factory(
+                "lower observation modules must not import observation provenance/replay",
+                edge,
+            )
+        )
+    return violations
+
+
+def family_science_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    violations: list[Any] = []
+    if edge.importer in FAMILY_SCIENCE_MODULES and (
+        edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+        or is_module_under(edge.imported, DB_ORM_PREFIX)
+        or is_module_under(edge.imported, DB_STORES_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db.session")
+        or is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+        or is_sqlalchemy_import(edge.imported)
+    ):
+        violations.append(
+            violation_factory(
+                "family science modules must not import legacy benchmark, persistence, or runtime",
+                edge,
+            )
+        )
+    if (
+        edge.importer in FAMILY_SCIENCE_MODULES
+        and edge.imported in EPISODE_PLANNING_MODULES
+    ):
+        violations.append(
+            violation_factory("family science must not import planning", edge)
+        )
+    if edge.importer == EPISODE_FAMILIES_MODULE and edge.imported in {
+        ARCADE_OBSERVATION_MODULE,
+        FAMILY_PROVENANCE_MODULE,
+        FAMILY_VALIDATION_MODULE,
+        FRAME_FAMILY_KERNELS_MODULE,
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+        OBSERVATION_UNIVERSE_MODULE,
+        TRANSFORMATIONS_MODULE,
+    }:
+        violations.append(
+            violation_factory(
+                "episode_families must not import higher family or observation kernels",
+                edge,
+            )
+        )
+    if edge.importer == FRAME_FAMILY_KERNELS_MODULE and edge.imported in {
+        FAMILY_PROVENANCE_MODULE,
+        FAMILY_VALIDATION_MODULE,
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+        "zeromodel.domains.video_action_set.dto",
+        "zeromodel.domains.video_action_set.episode_plan_service",
+    }:
+        violations.append(
+            violation_factory(
+                "frame_family_kernels must not import provenance, replay, validation, or planning",
+                edge,
+            )
+        )
+    if edge.importer == FAMILY_PROVENANCE_MODULE and edge.imported in {
+        FAMILY_VALIDATION_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+    }:
+        violations.append(
+            violation_factory(
+                "family_provenance must not import replay or validation",
+                edge,
+            )
+        )
+    if edge.importer == FAMILY_VALIDATION_MODULE and edge.imported in {
+        FAMILY_PROVENANCE_MODULE,
+        FRAME_FAMILY_KERNELS_MODULE,
+    }:
+        violations.append(
+            violation_factory(
+                "family_validation must not import family provenance or frame kernels",
+                edge,
+            )
+        )
+    if (
+        edge.importer == OBSERVATION_REPLAY_MODULE
+        and edge.imported in FAMILY_SCIENCE_MODULES
+    ):
+        violations.append(
+            violation_factory(
+                "observation_replay must not import family implementation modules",
+                edge,
+            )
+        )
+    if (
+        edge.importer in LOWER_OBSERVATION_MODULES
+        and edge.imported in FAMILY_SCIENCE_MODULES
+    ):
+        violations.append(
+            violation_factory(
+                "lower observation modules must not import family implementation modules",
+                edge,
+            )
+        )
+    return violations
+
+
+def episode_planning_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    violations: list[Any] = []
+    importer = edge.importer
+    imported = edge.imported
+
+    def reject(rule: str) -> None:
+        violations.append(violation_factory(rule, edge))
+
+    if (
+        importer in VIDEO_OBSERVATION_KERNEL_MODULES
+        and imported in EPISODE_PLANNING_MODULES
+    ):
+        reject("video observation kernels must not import episode planning modules")
+    if importer in EPISODE_PLANNING_MODULES and (
+        imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+        or is_module_under(imported, DB_ORM_PREFIX)
+        or is_module_under(imported, DB_STORES_PREFIX)
+        or is_module_under(imported, "zeromodel.db.session")
+        or is_module_under(imported, "zeromodel.stores")
+        or imported == "zeromodel.runtime"
+        or is_sqlalchemy_import(imported)
+    ):
+        reject("planning must not import benchmark/persistence/runtime")
+    if importer in EPISODE_PLANNING_MODULES and imported in {
+        ARCADE_OBSERVATION_MODULE,
+        FAMILY_PROVENANCE_MODULE,
+        FAMILY_VALIDATION_MODULE,
+        OBSERVATION_PROVENANCE_MODULE,
+        OBSERVATION_REPLAY_MODULE,
+        PIXEL_DIGEST_MODULE,
+    }:
+        reject("planning must not import rendering/replay/provenance/pixels")
+    if importer == CONTROL_HISTORIES_MODULE and imported in {
+        FAMILY_INTERVENTION_PLANNING_MODULE,
+        EPISODE_PLANNING_MODULE,
+    }:
+        reject("control_histories must not import higher episode planning modules")
+    if (
+        importer == FAMILY_INTERVENTION_PLANNING_MODULE
+        and imported == EPISODE_PLANNING_MODULE
+    ):
+        reject("family_intervention_planning must not import episode_planning")
+    return violations
+
+
+def rmdto_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    violations: list[Any] = []
+
+    def reject(rule: str) -> None:
+        violations.append(violation_factory(rule, edge))
+
+    if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
+        is_module_under(edge.imported, DB_ORM_PREFIX)
+        or is_module_under(edge.imported, DB_STORES_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db.session")
+        or is_sqlalchemy_import(edge.imported)
+    ):
+        reject("video_action_set domain modules must not import persistence layers")
+    if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
+        edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+    ):
+        reject("video_action_set domain modules must not import legacy benchmark")
+    if edge.importer in VIDEO_ACTION_SET_PURE_DOMAIN_MODULES and (
+        is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+    ):
+        reject(
+            "video_action_set DTO, contracts, and Services must not import runtime layers"
+        )
+    if edge.importer == "zeromodel.runtime" and (
+        is_module_under(edge.imported, "zeromodel.db")
+        or is_sqlalchemy_import(edge.imported)
+    ):
+        violations.append(
+            violation_factory(
+                "zeromodel.runtime must not import database or SQLAlchemy modules",
+                edge,
+            )
+        )
+    if edge.importer == "zeromodel.matrix_blob" and (
+        is_module_under(edge.imported, DOMAIN_VIDEO_ACTION_SET_PREFIX)
+        or is_module_under(edge.imported, "zeromodel.db")
+        or is_module_under(edge.imported, "zeromodel.stores")
+        or edge.imported == "zeromodel.runtime"
+    ):
+        violations.append(
+            violation_factory(
+                "zeromodel.matrix_blob must remain independent of video_action_set, stores, database, and runtime",
+                edge,
+            )
+        )
+    if is_module_under(edge.importer, DB_ORM_PREFIX) and (
+        edge.imported in VIDEO_ACTION_SET_ORCHESTRATION_MODULES
+        or edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+    ):
+        violations.append(
+            violation_factory(
+                "ORM modules must not import Services, Engines, Facades, Runtime, or legacy benchmark",
+                edge,
+            )
+        )
+    if is_module_under(edge.importer, DB_STORES_PREFIX) and (
+        edge.imported in VIDEO_ACTION_SET_ORCHESTRATION_MODULES
+        or edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
+    ):
+        violations.append(
+            violation_factory(
+                "database Store implementations must not import orchestration or legacy benchmark layers",
+                edge,
+            )
+        )
+    return violations
+
+
+def video_science_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    violations: list[Any] = []
+    violations.extend(legacy_forbidden_edge_violations(edge, violation_factory))
+    violations.extend(
+        transformation_kernel_forbidden_edge_violations(edge, violation_factory)
+    )
+    violations.extend(
+        observation_provenance_replay_forbidden_edge_violations(edge, violation_factory)
+    )
+    violations.extend(family_science_forbidden_edge_violations(edge, violation_factory))
+    violations.extend(
+        episode_planning_forbidden_edge_violations(edge, violation_factory)
+    )
+    violations.extend(rmdto_forbidden_edge_violations(edge, violation_factory))
+    return violations
+
+
+__all__ = ["video_science_forbidden_edge_violations"]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -4,108 +4,10 @@ import ast
 from dataclasses import dataclass
 from pathlib import Path
 
-from architecture_rules import print_violations
+from architecture_rules import TRACKED_EXTERNAL_MODULES, print_violations
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_ROOT = REPO_ROOT / "zeromodel"
-VIDEO_ACTION_SET_PREFIX = "zeromodel.video_action_set"
-VIDEO_ACTION_SET_BENCHMARK_MODULE = "zeromodel.video_action_set_benchmark"
-DOMAIN_VIDEO_ACTION_SET_PREFIX = "zeromodel.domains.video_action_set"
-DB_ORM_PREFIX = "zeromodel.db.orm"
-DB_STORES_PREFIX = "zeromodel.db.stores"
-ARCADE_OBSERVATION_MODULE = "zeromodel.domains.video_action_set.arcade_observation"
-CANONICAL_JSON_MODULE = "zeromodel.domains.video_action_set.canonical_json"
-CONTRACTS_MODULE = "zeromodel.domains.video_action_set.contracts"
-OBSERVATION_LEGACY_ADAPTERS_MODULE = (
-    "zeromodel.domains.video_action_set.observation_legacy_adapters"
-)
-OBSERVATION_PROVENANCE_DTO_MODULE = (
-    "zeromodel.domains.video_action_set.observation_provenance_dto"
-)
-OBSERVATION_PROVENANCE_MODULE = (
-    "zeromodel.domains.video_action_set.observation_provenance"
-)
-OBSERVATION_REPLAY_MODULE = "zeromodel.domains.video_action_set.observation_replay"
-OBSERVATION_UNIVERSE_MODULE = "zeromodel.domains.video_action_set.observation_universe"
-PIXEL_DIGEST_MODULE = "zeromodel.domains.video_action_set.pixel_digest"
-TRANSFORMATIONS_MODULE = "zeromodel.domains.video_action_set.transformations"
-EPISODE_FAMILIES_MODULE = "zeromodel.domains.video_action_set.episode_families"
-FRAME_FAMILY_KERNELS_MODULE = "zeromodel.domains.video_action_set.frame_family_kernels"
-FAMILY_PROVENANCE_MODULE = "zeromodel.domains.video_action_set.family_provenance"
-FAMILY_VALIDATION_MODULE = "zeromodel.domains.video_action_set.family_validation"
-CONTROL_HISTORIES_MODULE = "zeromodel.domains.video_action_set.control_histories"
-FAMILY_INTERVENTION_PLANNING_MODULE = (
-    "zeromodel.domains.video_action_set.family_intervention_planning"
-)
-EPISODE_PLANNING_MODULE = "zeromodel.domains.video_action_set.episode_planning"
-FAMILY_SCIENCE_MODULES = {
-    EPISODE_FAMILIES_MODULE,
-    FRAME_FAMILY_KERNELS_MODULE,
-    FAMILY_PROVENANCE_MODULE,
-    FAMILY_VALIDATION_MODULE,
-}
-EPISODE_PLANNING_MODULES = {
-    CONTROL_HISTORIES_MODULE,
-    FAMILY_INTERVENTION_PLANNING_MODULE,
-    EPISODE_PLANNING_MODULE,
-}
-VIDEO_OBSERVATION_KERNEL_MODULES = {
-    ARCADE_OBSERVATION_MODULE,
-    OBSERVATION_PROVENANCE_MODULE,
-    OBSERVATION_REPLAY_MODULE,
-    OBSERVATION_UNIVERSE_MODULE,
-    PIXEL_DIGEST_MODULE,
-    TRANSFORMATIONS_MODULE,
-}
-LOWER_OBSERVATION_MODULES = {
-    CANONICAL_JSON_MODULE,
-    CONTRACTS_MODULE,
-    PIXEL_DIGEST_MODULE,
-    TRANSFORMATIONS_MODULE,
-    ARCADE_OBSERVATION_MODULE,
-    OBSERVATION_UNIVERSE_MODULE,
-    OBSERVATION_PROVENANCE_DTO_MODULE,
-    OBSERVATION_LEGACY_ADAPTERS_MODULE,
-}
-VIDEO_ACTION_SET_ORCHESTRATION_MODULES = {
-    "zeromodel.domains.video_action_set.episode_plan_service",
-    "zeromodel.domains.video_action_set.identity_service",
-    "zeromodel.domains.video_action_set.observation_service",
-    "zeromodel.domains.video_action_set.engine",
-    "zeromodel.domains.video_action_set.facade",
-    "zeromodel.runtime",
-}
-VIDEO_ACTION_SET_PURE_DOMAIN_MODULES = {
-    ARCADE_OBSERVATION_MODULE,
-    CANONICAL_JSON_MODULE,
-    CONTROL_HISTORIES_MODULE,
-    CONTRACTS_MODULE,
-    EPISODE_FAMILIES_MODULE,
-    EPISODE_PLANNING_MODULE,
-    FAMILY_INTERVENTION_PLANNING_MODULE,
-    FAMILY_PROVENANCE_MODULE,
-    FAMILY_VALIDATION_MODULE,
-    FRAME_FAMILY_KERNELS_MODULE,
-    "zeromodel.domains.video_action_set.dto",
-    "zeromodel.domains.video_action_set.episode_plan_service",
-    "zeromodel.domains.video_action_set.observation_common",
-    "zeromodel.domains.video_action_set.observation_dto",
-    OBSERVATION_LEGACY_ADAPTERS_MODULE,
-    "zeromodel.domains.video_action_set.observation_materialization",
-    OBSERVATION_PROVENANCE_DTO_MODULE,
-    OBSERVATION_PROVENANCE_MODULE,
-    OBSERVATION_REPLAY_MODULE,
-    "zeromodel.domains.video_action_set.observation_service",
-    OBSERVATION_UNIVERSE_MODULE,
-    PIXEL_DIGEST_MODULE,
-    "zeromodel.domains.video_action_set.provider_observation_dto",
-    TRANSFORMATIONS_MODULE,
-}
-VIDEO_ACTION_SET_POLICY_MODULES = {
-    f"{VIDEO_ACTION_SET_PREFIX}.contracts",
-    f"{VIDEO_ACTION_SET_PREFIX}.mutation_audit",
-    f"{VIDEO_ACTION_SET_PREFIX}.verification",
-}
 
 
 @dataclass(frozen=True)
@@ -175,6 +77,17 @@ def best_known_module(candidate: str, known_modules: set[str]) -> str | None:
     return None
 
 
+def tracked_external_module(candidate: str) -> str | None:
+    return next(
+        (
+            module
+            for module in sorted(TRACKED_EXTERNAL_MODULES)
+            if candidate == module or candidate.startswith(f"{module}.")
+        ),
+        None,
+    )
+
+
 def import_from_candidates(
     node: ast.ImportFrom, module_name: str, path: Path
 ) -> list[str]:
@@ -188,8 +101,7 @@ def import_from_candidates(
         base == "zeromodel"
         or base.startswith("zeromodel.")
         or base.startswith("tests")
-        or base == "sqlalchemy"
-        or base.startswith("sqlalchemy.")
+        or tracked_external_module(base) is not None
     ):
         return (
             [base]
@@ -208,32 +120,24 @@ def collect_import_edges(
         if isinstance(node, ast.Import):
             for alias in node.names:
                 imported = best_known_module(alias.name, known_modules)
-                if (
-                    imported is not None
-                    or alias.name.startswith("tests")
-                    or alias.name == "sqlalchemy"
-                    or alias.name.startswith("sqlalchemy.")
-                ):
+                tracked = tracked_external_module(alias.name)
+                if imported is not None or alias.name.startswith("tests") or tracked:
                     edges.append(
                         ImportEdge(
                             importer=module_name,
-                            imported=imported or alias.name,
+                            imported=imported or tracked or alias.name,
                             line=node.lineno,
                         )
                     )
         elif isinstance(node, ast.ImportFrom):
             for candidate in import_from_candidates(node, module_name, path):
                 imported = best_known_module(candidate, known_modules)
-                if (
-                    imported is not None
-                    or candidate.startswith("tests")
-                    or candidate == "sqlalchemy"
-                    or candidate.startswith("sqlalchemy.")
-                ):
+                tracked = tracked_external_module(candidate)
+                if imported is not None or candidate.startswith("tests") or tracked:
                     edges.append(
                         ImportEdge(
                             importer=module_name,
-                            imported=imported or candidate,
+                            imported=imported or tracked or candidate,
                             line=node.lineno,
                         )
                     )
@@ -346,28 +250,6 @@ def cycle_violations(graph: dict[str, set[str]]) -> list[Violation]:
     return violations
 
 
-def is_video_action_set_runtime_module(module: str) -> bool:
-    prefix = f"{VIDEO_ACTION_SET_PREFIX}."
-    if not module.startswith(prefix):
-        return False
-    if module in VIDEO_ACTION_SET_POLICY_MODULES:
-        return False
-    suffix = module[len(prefix) :]
-    return not (
-        suffix.startswith("contracts.")
-        or suffix.startswith("mutation_audit.")
-        or suffix.startswith("verification.")
-    )
-
-
-def is_module_under(module: str, prefix: str) -> bool:
-    return module == prefix or module.startswith(f"{prefix}.")
-
-
-def is_sqlalchemy_import(module: str) -> bool:
-    return module == "sqlalchemy" or module.startswith("sqlalchemy.")
-
-
 def edge_violation(rule: str, edge: ImportEdge) -> Violation:
     return Violation(
         rule=rule,
@@ -377,404 +259,20 @@ def edge_violation(rule: str, edge: ImportEdge) -> Violation:
     )
 
 
-def legacy_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
-    violations: list[Violation] = []
-    if edge.imported == "tests" or edge.imported.startswith("tests."):
-        violations.append(edge_violation("zeromodel/ must not import tests.*", edge))
-    if edge.importer == "zeromodel.artifact" and (
-        edge.imported.startswith("zeromodel.video_")
-        or edge.imported == VIDEO_ACTION_SET_PREFIX
-        or edge.imported.startswith(f"{VIDEO_ACTION_SET_PREFIX}.")
-    ):
-        violations.append(
-            edge_violation(
-                "zeromodel.artifact must not import video research modules",
-                edge,
-            )
-        )
-    if edge.importer == f"{VIDEO_ACTION_SET_PREFIX}.contracts" and (
-        edge.imported == VIDEO_ACTION_SET_PREFIX
-        or edge.imported.startswith(f"{VIDEO_ACTION_SET_PREFIX}.")
-    ):
-        violations.append(
-            edge_violation(
-                "video_action_set/contracts.py must not import implementation modules",
-                edge,
-            )
-        )
-    if is_video_action_set_runtime_module(edge.importer) and (
-        edge.imported == f"{VIDEO_ACTION_SET_PREFIX}.verification"
-        or edge.imported.startswith(f"{VIDEO_ACTION_SET_PREFIX}.verification.")
-        or edge.imported == f"{VIDEO_ACTION_SET_PREFIX}.mutation_audit"
-        or edge.imported.startswith(f"{VIDEO_ACTION_SET_PREFIX}.mutation_audit.")
-    ):
-        violations.append(
-            edge_violation(
-                "runtime modules must not depend on verification or mutation_audit",
-                edge,
-            )
-        )
-    return violations
-
-
-def transformation_kernel_forbidden_edge_violations(
-    edge: ImportEdge,
-) -> list[Violation]:
-    violations: list[Violation] = []
-    if edge.importer == PIXEL_DIGEST_MODULE and edge.imported == TRANSFORMATIONS_MODULE:
-        violations.append(
-            edge_violation(
-                "pixel_digest must not import transformations",
-                edge,
-            )
-        )
-    if edge.importer == PIXEL_DIGEST_MODULE and edge.imported in {
-        ARCADE_OBSERVATION_MODULE,
-        OBSERVATION_UNIVERSE_MODULE,
-    }:
-        violations.append(
-            edge_violation(
-                "pixel_digest must not import arcade_observation or observation_universe",
-                edge,
-            )
-        )
-    if edge.importer == TRANSFORMATIONS_MODULE and edge.imported in {
-        ARCADE_OBSERVATION_MODULE,
-        OBSERVATION_UNIVERSE_MODULE,
-    }:
-        violations.append(
-            edge_violation(
-                "transformations must not import arcade_observation or observation_universe",
-                edge,
-            )
-        )
-    if (
-        edge.importer == ARCADE_OBSERVATION_MODULE
-        and edge.imported == OBSERVATION_UNIVERSE_MODULE
-    ):
-        violations.append(
-            edge_violation(
-                "arcade_observation must not import observation_universe",
-                edge,
-            )
-        )
-    if edge.importer in VIDEO_OBSERVATION_KERNEL_MODULES and (
-        is_module_under(edge.imported, DB_ORM_PREFIX)
-        or is_module_under(edge.imported, DB_STORES_PREFIX)
-        or is_module_under(edge.imported, "zeromodel.db.session")
-        or is_module_under(edge.imported, "zeromodel.stores")
-        or edge.imported == "zeromodel.runtime"
-        or is_sqlalchemy_import(edge.imported)
-    ):
-        violations.append(
-            edge_violation(
-                "video observation kernel modules must not import persistence or runtime layers",
-                edge,
-            )
-        )
-    if edge.importer in VIDEO_OBSERVATION_KERNEL_MODULES and edge.imported == (
-        VIDEO_ACTION_SET_BENCHMARK_MODULE
-    ):
-        violations.append(
-            edge_violation(
-                "video observation kernel modules must not import legacy benchmark facade",
-                edge,
-            )
-        )
-    return violations
-
-
-def observation_provenance_replay_forbidden_edge_violations(
-    edge: ImportEdge,
-) -> list[Violation]:
-    violations: list[Violation] = []
-    if (
-        edge.importer == OBSERVATION_PROVENANCE_MODULE
-        and edge.imported == OBSERVATION_REPLAY_MODULE
-    ):
-        violations.append(
-            edge_violation(
-                "observation_provenance must not import observation_replay",
-                edge,
-            )
-        )
-    if (
-        edge.importer == OBSERVATION_REPLAY_MODULE
-        and edge.imported == OBSERVATION_PROVENANCE_MODULE
-    ):
-        violations.append(
-            edge_violation(
-                "observation_replay must not import observation_provenance",
-                edge,
-            )
-        )
-    if (
-        edge.importer
-        in {
-            OBSERVATION_PROVENANCE_MODULE,
-            OBSERVATION_REPLAY_MODULE,
-        }
-        and edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
-    ):
-        violations.append(
-            edge_violation(
-                "observation provenance/replay modules must not import legacy benchmark",
-                edge,
-            )
-        )
-    if edge.importer in {
-        OBSERVATION_PROVENANCE_MODULE,
-        OBSERVATION_REPLAY_MODULE,
-    } and (
-        is_module_under(edge.imported, DB_ORM_PREFIX)
-        or is_module_under(edge.imported, DB_STORES_PREFIX)
-        or is_module_under(edge.imported, "zeromodel.db.session")
-        or is_module_under(edge.imported, "zeromodel.stores")
-        or edge.imported == "zeromodel.runtime"
-        or is_sqlalchemy_import(edge.imported)
-    ):
-        violations.append(
-            edge_violation(
-                "observation provenance/replay modules must not import persistence or runtime layers",
-                edge,
-            )
-        )
-    if edge.importer in LOWER_OBSERVATION_MODULES and edge.imported in {
-        OBSERVATION_PROVENANCE_MODULE,
-        OBSERVATION_REPLAY_MODULE,
-    }:
-        violations.append(
-            edge_violation(
-                "lower observation modules must not import observation provenance/replay",
-                edge,
-            )
-        )
-    return violations
-
-
-def family_science_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
-    violations: list[Violation] = []
-    if edge.importer in FAMILY_SCIENCE_MODULES and (
-        edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
-        or is_module_under(edge.imported, DB_ORM_PREFIX)
-        or is_module_under(edge.imported, DB_STORES_PREFIX)
-        or is_module_under(edge.imported, "zeromodel.db.session")
-        or is_module_under(edge.imported, "zeromodel.stores")
-        or edge.imported == "zeromodel.runtime"
-        or is_sqlalchemy_import(edge.imported)
-    ):
-        violations.append(
-            edge_violation(
-                "family science modules must not import legacy benchmark, persistence, or runtime",
-                edge,
-            )
-        )
-    if (
-        edge.importer in FAMILY_SCIENCE_MODULES
-        and edge.imported in EPISODE_PLANNING_MODULES
-    ):
-        violations.append(
-            edge_violation("family science must not import planning", edge)
-        )
-    if edge.importer == EPISODE_FAMILIES_MODULE and edge.imported in {
-        ARCADE_OBSERVATION_MODULE,
-        FAMILY_PROVENANCE_MODULE,
-        FAMILY_VALIDATION_MODULE,
-        FRAME_FAMILY_KERNELS_MODULE,
-        OBSERVATION_PROVENANCE_MODULE,
-        OBSERVATION_REPLAY_MODULE,
-        OBSERVATION_UNIVERSE_MODULE,
-        TRANSFORMATIONS_MODULE,
-    }:
-        violations.append(
-            edge_violation(
-                "episode_families must not import higher family or observation kernels",
-                edge,
-            )
-        )
-    if edge.importer == FRAME_FAMILY_KERNELS_MODULE and edge.imported in {
-        FAMILY_PROVENANCE_MODULE,
-        FAMILY_VALIDATION_MODULE,
-        OBSERVATION_PROVENANCE_MODULE,
-        OBSERVATION_REPLAY_MODULE,
-        "zeromodel.domains.video_action_set.dto",
-        "zeromodel.domains.video_action_set.episode_plan_service",
-    }:
-        violations.append(
-            edge_violation(
-                "frame_family_kernels must not import provenance, replay, validation, or planning",
-                edge,
-            )
-        )
-    if edge.importer == FAMILY_PROVENANCE_MODULE and edge.imported in {
-        FAMILY_VALIDATION_MODULE,
-        OBSERVATION_REPLAY_MODULE,
-    }:
-        violations.append(
-            edge_violation(
-                "family_provenance must not import replay or validation",
-                edge,
-            )
-        )
-    if edge.importer == FAMILY_VALIDATION_MODULE and edge.imported in {
-        FAMILY_PROVENANCE_MODULE,
-        FRAME_FAMILY_KERNELS_MODULE,
-    }:
-        violations.append(
-            edge_violation(
-                "family_validation must not import family provenance or frame kernels",
-                edge,
-            )
-        )
-    if (
-        edge.importer == OBSERVATION_REPLAY_MODULE
-        and edge.imported in FAMILY_SCIENCE_MODULES
-    ):
-        violations.append(
-            edge_violation(
-                "observation_replay must not import family implementation modules",
-                edge,
-            )
-        )
-    if (
-        edge.importer in LOWER_OBSERVATION_MODULES
-        and edge.imported in FAMILY_SCIENCE_MODULES
-    ):
-        violations.append(
-            edge_violation(
-                "lower observation modules must not import family implementation modules",
-                edge,
-            )
-        )
-    return violations
-
-
-def episode_planning_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
-    violations: list[Violation] = []
-    importer = edge.importer
-    imported = edge.imported
-
-    def reject(rule: str) -> None:
-        violations.append(edge_violation(rule, edge))
-
-    if (
-        importer in VIDEO_OBSERVATION_KERNEL_MODULES
-        and imported in EPISODE_PLANNING_MODULES
-    ):
-        reject("video observation kernels must not import episode planning modules")
-    if importer in EPISODE_PLANNING_MODULES and (
-        imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
-        or is_module_under(imported, DB_ORM_PREFIX)
-        or is_module_under(imported, DB_STORES_PREFIX)
-        or is_module_under(imported, "zeromodel.db.session")
-        or is_module_under(imported, "zeromodel.stores")
-        or imported == "zeromodel.runtime"
-        or is_sqlalchemy_import(imported)
-    ):
-        reject("planning must not import benchmark/persistence/runtime")
-    if importer in EPISODE_PLANNING_MODULES and imported in {
-        ARCADE_OBSERVATION_MODULE,
-        FAMILY_PROVENANCE_MODULE,
-        FAMILY_VALIDATION_MODULE,
-        OBSERVATION_PROVENANCE_MODULE,
-        OBSERVATION_REPLAY_MODULE,
-        PIXEL_DIGEST_MODULE,
-    }:
-        reject("planning must not import rendering/replay/provenance/pixels")
-    if importer == CONTROL_HISTORIES_MODULE and imported in {
-        FAMILY_INTERVENTION_PLANNING_MODULE,
-        EPISODE_PLANNING_MODULE,
-    }:
-        reject("control_histories must not import higher episode planning modules")
-    if (
-        importer == FAMILY_INTERVENTION_PLANNING_MODULE
-        and imported == EPISODE_PLANNING_MODULE
-    ):
-        reject("family_intervention_planning must not import episode_planning")
-    return violations
-
-
-def rmdto_forbidden_edge_violations(edge: ImportEdge) -> list[Violation]:
-    violations: list[Violation] = []
-
-    def reject(rule: str) -> None:
-        violations.append(edge_violation(rule, edge))
-
-    if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
-        is_module_under(edge.imported, DB_ORM_PREFIX)
-        or is_module_under(edge.imported, DB_STORES_PREFIX)
-        or is_module_under(edge.imported, "zeromodel.db.session")
-        or is_sqlalchemy_import(edge.imported)
-    ):
-        reject("video_action_set domain modules must not import persistence layers")
-    if is_module_under(edge.importer, DOMAIN_VIDEO_ACTION_SET_PREFIX) and (
-        edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
-    ):
-        reject("video_action_set domain modules must not import legacy benchmark")
-    if edge.importer in VIDEO_ACTION_SET_PURE_DOMAIN_MODULES and (
-        is_module_under(edge.imported, "zeromodel.stores")
-        or edge.imported == "zeromodel.runtime"
-    ):
-        reject(
-            "video_action_set DTO, contracts, and Services must not import runtime layers"
-        )
-    if edge.importer == "zeromodel.runtime" and (
-        is_module_under(edge.imported, "zeromodel.db")
-        or is_sqlalchemy_import(edge.imported)
-    ):
-        violations.append(
-            edge_violation(
-                "zeromodel.runtime must not import database or SQLAlchemy modules",
-                edge,
-            )
-        )
-    if edge.importer == "zeromodel.matrix_blob" and (
-        is_module_under(edge.imported, DOMAIN_VIDEO_ACTION_SET_PREFIX)
-        or is_module_under(edge.imported, "zeromodel.db")
-        or is_module_under(edge.imported, "zeromodel.stores")
-        or edge.imported == "zeromodel.runtime"
-    ):
-        violations.append(
-            edge_violation(
-                "zeromodel.matrix_blob must remain independent of video_action_set, stores, database, and runtime",
-                edge,
-            )
-        )
-    if is_module_under(edge.importer, DB_ORM_PREFIX) and (
-        edge.imported in VIDEO_ACTION_SET_ORCHESTRATION_MODULES
-        or edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
-    ):
-        violations.append(
-            edge_violation(
-                "ORM modules must not import Services, Engines, Facades, Runtime, or legacy benchmark",
-                edge,
-            )
-        )
-    if is_module_under(edge.importer, DB_STORES_PREFIX) and (
-        edge.imported in VIDEO_ACTION_SET_ORCHESTRATION_MODULES
-        or edge.imported == VIDEO_ACTION_SET_BENCHMARK_MODULE
-    ):
-        violations.append(
-            edge_violation(
-                "database Store implementations must not import orchestration or legacy benchmark layers",
-                edge,
-            )
-        )
-    return violations
-
-
 def forbidden_edge_violations(edges: list[ImportEdge]) -> list[Violation]:
     from architecture_rules.video_action_set import stage6_forbidden_edge_violations
+    from architecture_rules.video_action_set_modules import (
+        stage7a_forbidden_edge_violations,
+    )
+    from architecture_rules.video_science_layers import (
+        video_science_forbidden_edge_violations,
+    )
 
     violations: list[Violation] = []
     for edge in edges:
-        violations.extend(legacy_forbidden_edge_violations(edge))
-        violations.extend(transformation_kernel_forbidden_edge_violations(edge))
-        violations.extend(observation_provenance_replay_forbidden_edge_violations(edge))
-        violations.extend(family_science_forbidden_edge_violations(edge))
-        violations.extend(episode_planning_forbidden_edge_violations(edge))
-        violations.extend(rmdto_forbidden_edge_violations(edge))
+        violations.extend(video_science_forbidden_edge_violations(edge, edge_violation))
         violations.extend(stage6_forbidden_edge_violations(edge, edge_violation))
+        violations.extend(stage7a_forbidden_edge_violations(edge, edge_violation))
     return violations
 
 

--- a/tests/integration/test_video_provider_measurement_real.py
+++ b/tests/integration/test_video_provider_measurement_real.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.domains.video_action_set import provider_measurement as measurement
+
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PROVIDER_ROW_KEYS = [
+    "benchmark_version",
+    "generator_version",
+    "split",
+    "episode_id",
+    "clip_id",
+    "frame_id",
+    "sequence_number",
+    "event_type",
+    "family",
+    "expected_disposition",
+    "episode_family",
+    "episode_disposition",
+    "frame_disposition",
+    "denominator_class",
+    "expected_row",
+    "expected_action",
+    "actual_executed_action",
+    "action_known",
+    "gap_declaration",
+    "observation_pixel_digest",
+    "metadata",
+    "provider_id",
+    "provider_version",
+    "policy_artifact_id",
+    "reachability_tile_digest",
+    "all_112_row_ids",
+    "all_112_raw_scores",
+    "all_112_quantized_scores",
+    "complete_ordered_ranking",
+    "tie_groups",
+    "semantic_top_set_outcome",
+    "semantic_status",
+    "resolved_row",
+    "resolved_action",
+    "top_quantized_score",
+    "top_row_ids",
+    "top_action_ids",
+    "semantic_outcome_digest",
+    "reachability_composition_trace",
+    "winner_row",
+    "winner_action",
+    "winner_quantized_score",
+    "runner_up_row",
+    "runner_up_quantized_score",
+    "policy_row_universe_digest",
+    "quantized_score_vector_digest",
+    "raw_score_diagnostic_digest",
+    "score_vector_digest",
+    "ranking_digest",
+    "observation_digest",
+    "provider_observation_descriptor",
+    "provider_observation_digest",
+    "episode_seed",
+    "generator_identity",
+    "provider_diagnostics",
+]
+
+
+def _digest(value: Any) -> str:
+    return benchmark._sha256(value)
+
+
+def _real_measurement_context() -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    identity = benchmark.load_identity(REPO_ROOT)
+    policy = benchmark.compile_policy_artifact()
+    lookup = benchmark.VPMPolicyLookup(policy, action_metric_ids=benchmark.ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
+    tile = benchmark._load_reachability_tile(REPO_ROOT)
+    plans = benchmark._episode_plans_for_split(
+        identity,
+        "selection",
+        row_ids,
+        row_actions,
+    )
+    valid_plan = next(
+        plan for plan in plans if str(plan["family_label"]) == "valid"
+    )
+    record = deepcopy(benchmark._materialize_plan(valid_plan, identity, tile)[0])
+    rows = measurement.score_record(
+        record,
+        benchmark.canonical_prototypes(),
+        policy.artifact_id,
+    )
+    return record, rows
+
+
+def test_real_score_record_p1_p2_p3_evidence_row_goldens() -> None:
+    record, rows = _real_measurement_context()
+
+    assert [row["provider_id"] for row in rows] == ["P1", "P2", "P3"]
+    assert [list(row) for row in rows] == [PROVIDER_ROW_KEYS] * 3
+    assert [row["reachability_composition_trace"] for row in rows] == [None] * 3
+    assert [row["provider_observation_digest"] for row in rows] == [
+        "sha256:bb6de887ea70ccd7c410547b46967c331b19186365a4d0eac3accf7240926e7b"
+    ] * 3
+    assert [row["score_vector_digest"] for row in rows] == [
+        "sha256:408790b154e367f9219d6c0642a6f1898fdac81a4debfd393e6776e275345068",
+        "sha256:92ceb62f8c2f34ecae3201f4c5f50f8808f7cd46052c2afb32460ca1cb1306ec",
+        "sha256:6661e1d699dc3ad69f6f7a762ed69d8337968c64657b4217d5484fbf298e86cd",
+    ]
+    assert [row["ranking_digest"] for row in rows] == [
+        "sha256:5b3de33e450fe82f2c1f84c33e01ad0385574a6316f570f3c9b408c4b84b289e",
+        "sha256:acea571945f2cc3b9380a9c4e69c1a6cc24a3b3fd401be5a81b13a4f2bf63cdd",
+        "sha256:727c629453acc104b613247e981133edad6791a75d91e21f26f215cf015b2325",
+    ]
+    assert [row["semantic_outcome_digest"] for row in rows] == [
+        "sha256:07c17a5055aac46a737fb2ae70ca9999986b7890b4e9f490e85cf3533998fb98",
+        "sha256:58b3cee4f9a7fa91fe472e327a0f69c5345ef3c017d5cb26ba860f55f4a926c0",
+        "sha256:3025f3b2ab75402d7dc71b76221354094e4733886949b8c09c5e40db1411ddb4",
+    ]
+    assert [_digest(row) for row in rows] == [
+        "sha256:398166f89a64f92dce703a4508a48b709bd170a165658c16b4892b90fa48bd1f",
+        "sha256:e2e803531537df79d052d86faae6560954a92c730240266ff740ee0e6f676d35",
+        "sha256:43ee89557951e23b2fc30d15d2664e8e660c5dbbdc4879bdf70e4c37b23af90b",
+    ]
+    assert rows[1]["semantic_status"] == "action_unanimous_tie"
+    assert rows[1]["resolved_action"] == "STAY"
+    assert rows[1]["resolved_row"] is None
+    assert rows[1]["winner_quantized_score"] is None
+    assert rows[0]["metadata"] is record["metadata"]

--- a/tests/test_architecture_checker_stage7a.py
+++ b/tests/test_architecture_checker_stage7a.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+STAGE7A_IMPORTER = "zeromodel.domains.video_action_set.provider_measurement"
+
+
+def _load_checker() -> ModuleType:
+    if str(SCRIPTS_ROOT) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "stage7a_check_architecture", SCRIPTS_ROOT / "check_architecture.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECKER = _load_checker()
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_import"),
+    [
+        ("from pathlib import Path\n", "pathlib"),
+        ("import sqlite3\n", "sqlite3"),
+        ("from json import dumps\n", "json"),
+    ],
+)
+def test_stage7a_tracked_external_imports_are_collected_and_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    source: str,
+    expected_import: str,
+) -> None:
+    module_path = tmp_path / "provider_measurement.py"
+    module_path.write_text(source, encoding="utf-8")
+    monkeypatch.setattr(CHECKER, "relative_path", lambda path: path.name)
+
+    edges = CHECKER.collect_import_edges(
+        STAGE7A_IMPORTER,
+        module_path,
+        {STAGE7A_IMPORTER},
+    )
+    assert [(edge.importer, edge.imported) for edge in edges] == [
+        (STAGE7A_IMPORTER, expected_import)
+    ]
+
+    violations = CHECKER.forbidden_edge_violations(edges)
+
+    assert any(
+        violation.importer == STAGE7A_IMPORTER
+        and violation.imported == expected_import
+        and violation.rule.startswith("provider_measurement must not import")
+        for violation in violations
+    )
+
+
+@pytest.mark.parametrize(
+    "imported",
+    [
+        "zeromodel.runtime",
+        "zeromodel.db.orm.video_action_set",
+        "zeromodel.db.stores.video_action_set",
+        "zeromodel.domains.video_action_set.episode_planning",
+        "zeromodel.domains.video_action_set.episode_materialization",
+        "zeromodel.video_action_equivalence",
+        "zeromodel.video_action_set.mutation_audit",
+    ],
+)
+def test_stage7a_forbidden_layers_are_rejected(imported: str) -> None:
+    edge = CHECKER.ImportEdge(
+        importer=STAGE7A_IMPORTER,
+        imported=imported,
+        line=7,
+    )
+
+    violations = CHECKER.forbidden_edge_violations([edge])
+
+    assert any(
+        violation.importer == STAGE7A_IMPORTER
+        and violation.imported == imported
+        and violation.rule.startswith("provider_measurement must not import")
+        for violation in violations
+    )

--- a/tests/test_video_action_set_benchmark.py
+++ b/tests/test_video_action_set_benchmark.py
@@ -9,7 +9,10 @@ import pytest
 
 import zeromodel.video_action_set_benchmark as benchmark
 from zeromodel.artifact import VPMValidationError
-from zeromodel.video_complete_row_evidence import build_complete_row_evidence, build_semantic_top_set_outcome
+from zeromodel.video_complete_row_evidence import (
+    build_complete_row_evidence,
+    build_semantic_top_set_outcome,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -64,9 +67,14 @@ def _fake_provider_output() -> list[dict[str, object]]:
 
 def _contains_forbidden_materialized_payload(value: object) -> bool:
     if isinstance(value, dict):
-        if any(key in {"pixels", "ImageObservation", "score_vector", "candidate_set"} for key in value):
+        if any(
+            key in {"pixels", "ImageObservation", "score_vector", "candidate_set"}
+            for key in value
+        ):
             return True
-        return any(_contains_forbidden_materialized_payload(item) for item in value.values())
+        return any(
+            _contains_forbidden_materialized_payload(item) for item in value.values()
+        )
     if isinstance(value, list):
         return any(_contains_forbidden_materialized_payload(item) for item in value)
     return False
@@ -80,10 +88,14 @@ def test_materialized_split_counts_and_final_freeze(tmp_path: Path) -> None:
     assert len(development) == 112
     assert len(calibration) == 448
     assert len(selection) == 1008
-    split_manifest = json.loads((tmp_path / "split-manifest.json").read_text(encoding="utf-8"))
+    split_manifest = json.loads(
+        (tmp_path / "split-manifest.json").read_text(encoding="utf-8")
+    )
     assert split_manifest["calibration_episode_count"] == 112
     assert split_manifest["selection_valid_episode_count"] == 112
-    phase_access = json.loads((tmp_path / "phase-access-audits.json").read_text(encoding="utf-8"))
+    phase_access = json.loads(
+        (tmp_path / "phase-access-audits.json").read_text(encoding="utf-8")
+    )
     assert phase_access["final_materialization_count"] == 0
     assert phase_access["final_score_access_count"] == 0
 
@@ -106,12 +118,26 @@ def test_build_split_writes_overlap_and_observation_manifests(tmp_path: Path) ->
             "actual_executed_action": "left",
             "action_known": True,
             "gap_declaration": None,
-            "metadata": {"episode_seed": 1, "seed_digest": "sha256:test", "reachability_trace": {"reachable_row_ids": ["row-000"]}},
+            "metadata": {
+                "episode_seed": 1,
+                "seed_digest": "sha256:test",
+                "reachability_trace": {"reachable_row_ids": ["row-000"]},
+            },
             "pixels": [[0]],
         }
     ]
-    fake_records_calibration = [{**record, "split": "calibration", "frame_id": "calibration:episode-001:frame-00"} for record in fake_records]
-    fake_records_selection = [{**record, "split": "selection", "frame_id": "selection:episode-001:frame-00"} for record in fake_records]
+    fake_records_calibration = [
+        {
+            **record,
+            "split": "calibration",
+            "frame_id": "calibration:episode-001:frame-00",
+        }
+        for record in fake_records
+    ]
+    fake_records_selection = [
+        {**record, "split": "selection", "frame_id": "selection:episode-001:frame-00"}
+        for record in fake_records
+    ]
     monkeypatch.setattr(
         benchmark,
         "_materialize_records",
@@ -121,17 +147,25 @@ def test_build_split_writes_overlap_and_observation_manifests(tmp_path: Path) ->
             "selection": fake_records_selection,
         }[split],
     )
-    monkeypatch.setattr(benchmark, "_score_record", lambda record, prototypes, policy_artifact_id, **_kwargs: fake_output)
+    monkeypatch.setattr(
+        benchmark,
+        "measure_record_collection",
+        lambda records, prototypes, policy_artifact_id, **_kwargs: fake_output,
+    )
     monkeypatch.setattr(benchmark, "canonical_prototypes", lambda: {})
     benchmark.build_split("development", tmp_path, REPO_ROOT)
     benchmark.build_split("calibration", tmp_path, REPO_ROOT)
     benchmark.build_split("selection", tmp_path, REPO_ROOT)
     monkeypatch.undo()
-    overlap = json.loads((tmp_path / "split-overlap-audit.json").read_text(encoding="utf-8"))
+    overlap = json.loads(
+        (tmp_path / "split-overlap-audit.json").read_text(encoding="utf-8")
+    )
     assert overlap["development_calibration_overlap"] == 0
     assert overlap["development_selection_overlap"] == 0
     assert overlap["calibration_selection_overlap"] == 0
-    observation_manifest = json.loads((tmp_path / "observation-identity-manifest.json").read_text(encoding="utf-8"))
+    observation_manifest = json.loads(
+        (tmp_path / "observation-identity-manifest.json").read_text(encoding="utf-8")
+    )
     assert observation_manifest["development_observation_count"] == 1
     assert observation_manifest["calibration_observation_count"] == 1
     assert observation_manifest["selection_observation_count"] == 1
@@ -142,8 +176,13 @@ def test_seed_material_determines_episode_identity_and_trace(tmp_path: Path) -> 
     first = benchmark._materialize_records("development", REPO_ROOT)
     second = benchmark._materialize_records("development", REPO_ROOT)
     assert [row["episode_id"] for row in first] == [row["episode_id"] for row in second]
-    assert [row["observation_pixel_digest"] for row in first] == [row["observation_pixel_digest"] for row in second]
-    assert first[0]["metadata"]["reachability_trace"]["executed_action"] == first[0]["expected_action"]
+    assert [row["observation_pixel_digest"] for row in first] == [
+        row["observation_pixel_digest"] for row in second
+    ]
+    assert (
+        first[0]["metadata"]["reachability_trace"]["executed_action"]
+        == first[0]["expected_action"]
+    )
     assert first[0]["metadata"]["derived_seed_identity"].startswith("sha256:")
     assert first[0]["metadata"]["episode_plan_digest"].startswith("sha256:")
 
@@ -155,20 +194,31 @@ def test_changing_root_seed_material_changes_sealed_episode_identities() -> None
     changed = benchmark.BenchmarkIdentity(
         contract_commit=identity.contract_commit,
         seed_material=changed_material,
-        seed_digest="sha256:" + hashlib.sha256(changed_material.encode("utf-8")).hexdigest(),
+        seed_digest="sha256:"
+        + hashlib.sha256(changed_material.encode("utf-8")).hexdigest(),
         policy_artifact_id=identity.policy_artifact_id,
         parent_audit_sha=identity.parent_audit_sha,
         parent_v3_sha=identity.parent_v3_sha,
     )
-    original = benchmark._episode_plans_for_split(identity, "selection", row_ids, row_actions)
-    changed_plans = benchmark._episode_plans_for_split(changed, "selection", row_ids, row_actions)
-    assert [plan["episode_id"] for plan in original] != [plan["episode_id"] for plan in changed_plans]
+    original = benchmark._episode_plans_for_split(
+        identity, "selection", row_ids, row_actions
+    )
+    changed_plans = benchmark._episode_plans_for_split(
+        changed, "selection", row_ids, row_actions
+    )
+    assert [plan["episode_id"] for plan in original] != [
+        plan["episode_id"] for plan in changed_plans
+    ]
 
 
 def test_changing_derived_seed_without_declared_parent_is_rejected() -> None:
     row_ids, row_actions = _row_actions()
     identity = benchmark.load_identity(REPO_ROOT)
-    plan = copy.deepcopy(benchmark._episode_plans_for_split(identity, "selection", row_ids, row_actions)[0])
+    plan = copy.deepcopy(
+        benchmark._episode_plans_for_split(identity, "selection", row_ids, row_actions)[
+            0
+        ]
+    )
     plan["seed_lineage"]["concrete_episode_seed"]["seed_digest"] = "sha256:" + "0" * 64
     with pytest.raises(VPMValidationError):
         benchmark._validate_episode_plan(identity, plan, row_actions)
@@ -177,25 +227,45 @@ def test_changing_derived_seed_without_declared_parent_is_rejected() -> None:
 def test_duplicate_episode_ids_are_rejected() -> None:
     row_ids, row_actions = _row_actions()
     identity = benchmark.load_identity(REPO_ROOT)
-    plan = benchmark._episode_plans_for_split(identity, "development", row_ids, row_actions)[0]
+    plan = benchmark._episode_plans_for_split(
+        identity, "development", row_ids, row_actions
+    )[0]
     with pytest.raises(VPMValidationError):
-        benchmark._validate_episode_plan_collection(identity, {"development": [plan, plan]}, row_actions)
+        benchmark._validate_episode_plan_collection(
+            identity, {"development": [plan, plan]}, row_actions
+        )
 
 
 def test_moving_episode_id_between_splits_is_rejected() -> None:
     row_ids, row_actions = _row_actions()
     identity = benchmark.load_identity(REPO_ROOT)
-    development = benchmark._episode_plans_for_split(identity, "development", row_ids, row_actions)[0]
-    calibration = copy.deepcopy(benchmark._episode_plans_for_split(identity, "calibration", row_ids, row_actions)[0])
+    development = benchmark._episode_plans_for_split(
+        identity, "development", row_ids, row_actions
+    )[0]
+    calibration = copy.deepcopy(
+        benchmark._episode_plans_for_split(
+            identity, "calibration", row_ids, row_actions
+        )[0]
+    )
     calibration["episode_id"] = development["episode_id"]
     with pytest.raises(VPMValidationError):
-        benchmark._validate_episode_plan_collection(identity, {"development": [development], "calibration": [calibration]}, row_actions)
+        benchmark._validate_episode_plan_collection(
+            identity,
+            {"development": [development], "calibration": [calibration]},
+            row_actions,
+        )
 
 
-def test_measured_phase_access_and_final_plan_remain_zero_access(tmp_path: Path) -> None:
+def test_measured_phase_access_and_final_plan_remain_zero_access(
+    tmp_path: Path,
+) -> None:
     benchmark.freeze_benchmark(tmp_path, REPO_ROOT)
-    phase_access = json.loads((tmp_path / "phase-access-audits.json").read_text(encoding="utf-8"))
-    sealed = json.loads((tmp_path / "final-split-sealed-plan.json").read_text(encoding="utf-8"))
+    phase_access = json.loads(
+        (tmp_path / "phase-access-audits.json").read_text(encoding="utf-8")
+    )
+    sealed = json.loads(
+        (tmp_path / "final-split-sealed-plan.json").read_text(encoding="utf-8")
+    )
     assert phase_access["forbidden_final_access_counter"] == 0
     assert phase_access["final_materialization_count"] == 0
     assert phase_access["final_score_access_count"] == 0
@@ -206,14 +276,20 @@ def test_measured_phase_access_and_final_plan_remain_zero_access(tmp_path: Path)
     assert not _contains_forbidden_materialized_payload(sealed)
 
 
-def test_final_plan_creation_does_not_render_score_or_access_final_observations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_final_plan_creation_does_not_render_score_or_access_final_observations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     def fail(*_args: object, **_kwargs: object) -> None:
-        raise AssertionError("final plan creation must not materialize observations or scores")
+        raise AssertionError(
+            "final plan creation must not materialize observations or scores"
+        )
 
     monkeypatch.setattr(benchmark, "render_state_frame", fail)
     monkeypatch.setattr(benchmark, "score_normalized_pixel", fail)
     monkeypatch.setattr(benchmark, "score_registered_local_correlation", fail)
     monkeypatch.setattr(benchmark, "score_b3_joint_fit", fail)
     benchmark.freeze_benchmark(tmp_path, REPO_ROOT)
-    phase_access = json.loads((tmp_path / "phase-access-audits.json").read_text(encoding="utf-8"))
+    phase_access = json.loads(
+        (tmp_path / "phase-access-audits.json").read_text(encoding="utf-8")
+    )
     assert phase_access["forbidden_final_access_counter"] == 0

--- a/tests/test_video_action_set_instrument.py
+++ b/tests/test_video_action_set_instrument.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import pytest
 
 import zeromodel.video_action_set_benchmark as benchmark
-from zeromodel.video_complete_row_evidence import build_complete_row_evidence, build_semantic_top_set_outcome
+from zeromodel.video_complete_row_evidence import (
+    build_complete_row_evidence,
+    build_semantic_top_set_outcome,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -74,12 +77,26 @@ def test_instrument_audits_and_verification(tmp_path: Path) -> None:
             "actual_executed_action": "left",
             "action_known": True,
             "gap_declaration": None,
-            "metadata": {"episode_seed": 1, "seed_digest": "sha256:test", "reachability_trace": {"reachable_row_ids": ["row-000"]}},
+            "metadata": {
+                "episode_seed": 1,
+                "seed_digest": "sha256:test",
+                "reachability_trace": {"reachable_row_ids": ["row-000"]},
+            },
             "pixels": [[0]],
         }
     ]
-    fake_records_calibration = [{**record, "split": "calibration", "frame_id": "calibration:episode-001:frame-00"} for record in fake_records]
-    fake_records_selection = [{**record, "split": "selection", "frame_id": "selection:episode-001:frame-00"} for record in fake_records]
+    fake_records_calibration = [
+        {
+            **record,
+            "split": "calibration",
+            "frame_id": "calibration:episode-001:frame-00",
+        }
+        for record in fake_records
+    ]
+    fake_records_selection = [
+        {**record, "split": "selection", "frame_id": "selection:episode-001:frame-00"}
+        for record in fake_records
+    ]
     monkeypatch.setattr(
         benchmark,
         "_materialize_records",
@@ -89,7 +106,11 @@ def test_instrument_audits_and_verification(tmp_path: Path) -> None:
             "selection": fake_records_selection,
         }[split],
     )
-    monkeypatch.setattr(benchmark, "_score_record", lambda record, prototypes, policy_artifact_id, **_kwargs: fake_provider_rows)
+    monkeypatch.setattr(
+        benchmark,
+        "measure_record_collection",
+        lambda records, prototypes, policy_artifact_id, **_kwargs: fake_provider_rows,
+    )
     monkeypatch.setattr(benchmark, "canonical_prototypes", lambda: {})
     benchmark.build_split("development", tmp_path, REPO_ROOT)
     benchmark.build_split("calibration", tmp_path, REPO_ROOT)
@@ -97,22 +118,61 @@ def test_instrument_audits_and_verification(tmp_path: Path) -> None:
     monkeypatch.undo()
     evidence = benchmark.audit_evidence_completeness(tmp_path)
     monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(benchmark, "audit_canonical_providers", lambda output_dir: {"P1": {"exact_top1_count": 112}, "P2": {"exact_top1_count": 112}, "P3": {"exact_top1_count": 112}})
-    monkeypatch.setattr(benchmark, "verify_instrument", lambda output_dir, repo_root: {"verified": True, "final_materialization_count": 0})
+    monkeypatch.setattr(
+        benchmark,
+        "audit_canonical_providers",
+        lambda output_dir: {
+            "P1": {"exact_top1_count": 112},
+            "P2": {"exact_top1_count": 112},
+            "P3": {"exact_top1_count": 112},
+        },
+    )
+    monkeypatch.setattr(
+        benchmark,
+        "verify_instrument",
+        lambda output_dir, repo_root: {
+            "verified": True,
+            "final_materialization_count": 0,
+        },
+    )
     canonical = benchmark.audit_canonical_providers(tmp_path)
     verification = benchmark.verify_instrument(tmp_path, REPO_ROOT)
     monkeypatch.undo()
     assert evidence["complete_score_evidence"] is True
     assert canonical["P3"]["exact_top1_count"] == 112
     assert verification["verified"] is True
-    assert json.loads((tmp_path / "phase-access-audits.json").read_text(encoding="utf-8"))["final_materialization_count"] == 0
+    assert (
+        json.loads((tmp_path / "phase-access-audits.json").read_text(encoding="utf-8"))[
+            "final_materialization_count"
+        ]
+        == 0
+    )
     assert not (tmp_path / "selected-method.json").exists()
     assert not (tmp_path / "reachability-replay.json").exists()
     assert not (tmp_path / "final-results.json").exists()
+
+
 def test_mutation_gate_detects_protected_field_changes() -> None:
     cases = {case["name"]: case for case in benchmark._MUTATION_CASES}
-    assert cases["evidence_quantized_score_changed"]["expected_primary_failure_code"] == "quantized_score_vector_mismatch"
-    assert cases["semantic_resolved_row_for_action_unanimous_tie"]["expected_primary_failure_code"] == "resolved_row_not_permitted"
-    assert cases["seed_alter_final_sealed_identity"]["expected_primary_failure_code"] == "sealed_episode_identity_mismatch"
-    assert cases["reachability_change_executed_action"]["expected_primary_failure_code"] == "executed_action_mismatch"
-    assert cases["access_add_final_observation_artifact"]["expected_primary_failure_code"] == "forbidden_final_materialization"
+    assert (
+        cases["evidence_quantized_score_changed"]["expected_primary_failure_code"]
+        == "quantized_score_vector_mismatch"
+    )
+    assert (
+        cases["semantic_resolved_row_for_action_unanimous_tie"][
+            "expected_primary_failure_code"
+        ]
+        == "resolved_row_not_permitted"
+    )
+    assert (
+        cases["seed_alter_final_sealed_identity"]["expected_primary_failure_code"]
+        == "sealed_episode_identity_mismatch"
+    )
+    assert (
+        cases["reachability_change_executed_action"]["expected_primary_failure_code"]
+        == "executed_action_mismatch"
+    )
+    assert (
+        cases["access_add_final_observation_artifact"]["expected_primary_failure_code"]
+        == "forbidden_final_materialization"
+    )

--- a/tests/test_video_provider_measurement_kernel.py
+++ b/tests/test_video_provider_measurement_kernel.py
@@ -1,0 +1,668 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import inspect
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set import provider_measurement as measurement
+from zeromodel.video_prospective_providers import score_all_rows_reference
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PROVIDER_ROW_KEYS = [
+    "benchmark_version",
+    "generator_version",
+    "split",
+    "episode_id",
+    "clip_id",
+    "frame_id",
+    "sequence_number",
+    "event_type",
+    "family",
+    "expected_disposition",
+    "episode_family",
+    "episode_disposition",
+    "frame_disposition",
+    "denominator_class",
+    "expected_row",
+    "expected_action",
+    "actual_executed_action",
+    "action_known",
+    "gap_declaration",
+    "observation_pixel_digest",
+    "metadata",
+    "provider_id",
+    "provider_version",
+    "policy_artifact_id",
+    "reachability_tile_digest",
+    "all_112_row_ids",
+    "all_112_raw_scores",
+    "all_112_quantized_scores",
+    "complete_ordered_ranking",
+    "tie_groups",
+    "semantic_top_set_outcome",
+    "semantic_status",
+    "resolved_row",
+    "resolved_action",
+    "top_quantized_score",
+    "top_row_ids",
+    "top_action_ids",
+    "semantic_outcome_digest",
+    "reachability_composition_trace",
+    "winner_row",
+    "winner_action",
+    "winner_quantized_score",
+    "runner_up_row",
+    "runner_up_quantized_score",
+    "policy_row_universe_digest",
+    "quantized_score_vector_digest",
+    "raw_score_diagnostic_digest",
+    "score_vector_digest",
+    "ranking_digest",
+    "observation_digest",
+    "provider_observation_descriptor",
+    "provider_observation_digest",
+    "episode_seed",
+    "generator_identity",
+    "provider_diagnostics",
+]
+
+
+def _fake_digest(*parts: object) -> str:
+    payload = "|".join(str(part) for part in parts)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class FrozenRowScore:
+    row_id: str
+    raw_score: float
+    quantized_score: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "row_id": self.row_id,
+            "raw_score": self.raw_score,
+            "quantized_score": self.quantized_score,
+        }
+
+
+@dataclass(frozen=True)
+class FrozenTieGroup:
+    tie_group_index: int
+    quantized_score: int
+    row_ids: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tie_group_index": self.tie_group_index,
+            "quantized_score": self.quantized_score,
+            "row_ids": list(self.row_ids),
+        }
+
+
+@dataclass(frozen=True)
+class FrozenRanking:
+    ranked_row_ids: tuple[str, ...]
+    tie_groups: tuple[FrozenTieGroup, ...]
+    ranking_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ranking_digest": self.ranking_digest,
+            "ranked_row_ids": list(self.ranked_row_ids),
+            "tie_groups": [group.to_dict() for group in self.tie_groups],
+        }
+
+
+@dataclass(frozen=True)
+class FrozenEvidence:
+    row_scores: tuple[FrozenRowScore, ...]
+    ranking: FrozenRanking
+    policy_row_universe_digest: str
+    quantized_score_vector_digest: str
+    raw_score_diagnostic_digest: str
+
+    @property
+    def score_vector_digest(self) -> str:
+        return self.quantized_score_vector_digest
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"row_scores": [item.to_dict() for item in self.row_scores]}
+
+
+@dataclass(frozen=True)
+class FrozenOutcome:
+    provider_id: str
+    provider_version: str
+    top_quantized_score: int
+    top_row_ids: tuple[str, ...]
+    top_action_ids: tuple[str, ...]
+    top_row_actions: tuple[tuple[str, str], ...]
+    status: str
+    resolved_row_id: str | None
+    resolved_action_id: str | None
+    semantic_outcome_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider_id": self.provider_id,
+            "provider_version": self.provider_version,
+            "top_quantized_score": self.top_quantized_score,
+            "top_row_ids": list(self.top_row_ids),
+            "top_row_actions": [
+                {"row_id": row_id, "action_id": action_id}
+                for row_id, action_id in self.top_row_actions
+            ],
+            "top_action_ids": list(self.top_action_ids),
+            "status": self.status,
+            "resolved_row_id": self.resolved_row_id,
+            "resolved_action_id": self.resolved_action_id,
+            "semantic_outcome_digest": self.semantic_outcome_digest,
+        }
+
+
+@dataclass(frozen=True)
+class FrozenProviderResult:
+    provider_id: str
+    provider_version: str
+    evidence: FrozenEvidence
+    winner_row_id: str
+    winner_action_id: str
+    maximum_tie_size: int
+    semantic_top_set_outcome: FrozenOutcome
+    diagnostics: dict[str, Any]
+
+
+def _frozen_provider_result(
+    provider_id: str,
+    *,
+    row_ids: list[str],
+    row_actions: dict[str, str],
+) -> FrozenProviderResult:
+    provider_version = measurement.provider_version(provider_id)
+    if provider_id == "P2":
+        top_rows = tuple(row_id for row_id in row_ids if row_actions[row_id] == "STAY")[
+            :2
+        ]
+        status = "action_unanimous_tie"
+        resolved_row = None
+        resolved_action = "STAY"
+    else:
+        top_rows = (row_ids[0],)
+        status = "unique_row"
+        resolved_row = row_ids[0]
+        resolved_action = row_actions[row_ids[0]]
+    top_actions = tuple(sorted({row_actions[row_id] for row_id in top_rows}))
+    ranking_rows = (
+        *top_rows,
+        *(row_id for row_id in row_ids if row_id not in top_rows),
+    )
+    lower_rows = tuple(row_id for row_id in row_ids if row_id not in top_rows)
+    score_by_row = {
+        row_id: (
+            0.9 if row_id in top_rows else 0.1,
+            900_000 if row_id in top_rows else 100_000,
+        )
+        for row_id in row_ids
+    }
+    row_scores = tuple(
+        FrozenRowScore(row_id, score_by_row[row_id][0], score_by_row[row_id][1])
+        for row_id in row_ids
+    )
+    evidence = FrozenEvidence(
+        row_scores=row_scores,
+        ranking=FrozenRanking(
+            ranked_row_ids=tuple(ranking_rows),
+            tie_groups=(
+                FrozenTieGroup(0, 900_000, top_rows),
+                FrozenTieGroup(1, 100_000, lower_rows),
+            ),
+            ranking_digest=_fake_digest(provider_id, "ranking"),
+        ),
+        policy_row_universe_digest=_fake_digest(provider_id, "policy-row-universe"),
+        quantized_score_vector_digest=_fake_digest(provider_id, "quantized"),
+        raw_score_diagnostic_digest=_fake_digest(provider_id, "raw"),
+    )
+    winner_row = top_rows[0]
+    outcome = FrozenOutcome(
+        provider_id=provider_id,
+        provider_version=provider_version,
+        top_quantized_score=900_000,
+        top_row_ids=top_rows,
+        top_action_ids=top_actions,
+        top_row_actions=tuple((row_id, row_actions[row_id]) for row_id in top_rows),
+        status=status,
+        resolved_row_id=resolved_row,
+        resolved_action_id=resolved_action,
+        semantic_outcome_digest=_fake_digest(provider_id, "semantic"),
+    )
+    return FrozenProviderResult(
+        provider_id=provider_id,
+        provider_version=provider_version,
+        evidence=evidence,
+        winner_row_id=winner_row,
+        winner_action_id=row_actions[winner_row],
+        maximum_tie_size=len(top_rows),
+        semantic_top_set_outcome=outcome,
+        diagnostics={"frozen_provider_result": provider_id},
+    )
+
+
+def _frozen_provider_results(
+    *,
+    row_ids: list[str],
+    row_actions: dict[str, str],
+) -> tuple[FrozenProviderResult, ...]:
+    return tuple(
+        _frozen_provider_result(provider_id, row_ids=row_ids, row_actions=row_actions)
+        for provider_id in ("P1", "P2", "P3")
+    )
+
+
+def _score_record_with_provider_results(
+    record: dict[str, Any],
+    prototypes: dict[str, tuple[str, str, str, Any]],
+    policy_artifact_id: str,
+    provider_results: tuple[Any, ...],
+    **kwargs: Any,
+) -> list[dict[str, Any]]:
+    with patch.object(
+        measurement, "_score_all_providers", return_value=provider_results
+    ):
+        return measurement.score_record(
+            record,
+            prototypes,
+            policy_artifact_id,
+            **kwargs,
+        )
+
+
+def _measure_collection_with_provider_results(
+    records: list[dict[str, Any]],
+    prototypes: dict[str, tuple[str, str, str, Any]],
+    policy_artifact_id: str,
+    provider_results: tuple[Any, ...],
+    **kwargs: Any,
+) -> list[dict[str, Any]]:
+    with patch.object(
+        measurement, "_score_all_providers", return_value=provider_results
+    ):
+        return measurement.measure_record_collection(
+            records,
+            prototypes,
+            policy_artifact_id,
+            **kwargs,
+        )
+
+
+@pytest.fixture(scope="module")
+def measurement_context() -> dict[str, Any]:
+    identity = benchmark.load_identity(REPO_ROOT)
+    policy = benchmark.compile_policy_artifact()
+    lookup = benchmark.VPMPolicyLookup(policy, action_metric_ids=benchmark.ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
+    tile = benchmark._load_reachability_tile(REPO_ROOT)
+    plans = benchmark._episode_plans_for_split(
+        identity, "selection", row_ids, row_actions
+    )
+    by_key: dict[str, dict[str, Any]] = {}
+    for plan in plans:
+        key = str(plan["family_label"])
+        if key in {"frame_invalid", "temporal_negative"}:
+            key = f"{key}:{plan['mutation_kind']}"
+        by_key.setdefault(key, plan)
+    valid_records = benchmark._materialize_plan(by_key["valid"], identity, tile)
+    gap_records = benchmark._materialize_plan(
+        by_key["temporal_negative:declared_gap_or_unknown_action"], identity, tile
+    )
+    control_records = benchmark._materialize_plan(
+        by_key["information_control"], identity, tile
+    )
+    prototypes = benchmark.canonical_prototypes()
+    first_valid = deepcopy(valid_records[0])
+    frozen_provider_results = _frozen_provider_results(
+        row_ids=row_ids,
+        row_actions=row_actions,
+    )
+    score_rows = _score_record_with_provider_results(
+        first_valid,
+        prototypes,
+        policy.artifact_id,
+        frozen_provider_results,
+    )
+    stream_rows = _measure_collection_with_provider_results(
+        [
+            deepcopy(valid_records[0]),
+            deepcopy(gap_records[2]),
+            deepcopy(valid_records[1]),
+        ],
+        prototypes,
+        policy.artifact_id,
+        frozen_provider_results,
+        reachability_tile=tile,
+        row_actions=row_actions,
+    )
+    first_control = _score_record_with_provider_results(
+        deepcopy(control_records[0]),
+        prototypes,
+        policy.artifact_id,
+        frozen_provider_results,
+    )
+    second_control = _score_record_with_provider_results(
+        deepcopy(control_records[1]),
+        prototypes,
+        policy.artifact_id,
+        frozen_provider_results,
+    )
+    return {
+        "policy": policy,
+        "row_actions": row_actions,
+        "tile": tile,
+        "prototypes": prototypes,
+        "valid_records": valid_records,
+        "gap_records": gap_records,
+        "control_records": control_records,
+        "score_record_input": first_valid,
+        "score_rows": score_rows,
+        "stream_rows": stream_rows,
+        "control_rows": (first_control, second_control),
+    }
+
+
+def _digest(value: object) -> str:
+    return benchmark._sha256(value)
+
+
+def test_provider_measurement_aliases_and_signatures_are_direct() -> None:
+    assert benchmark._provider_version is measurement.provider_version
+    assert benchmark._score_vector_to_payload is measurement.score_vector_to_payload
+    assert benchmark._score_record is measurement.score_record
+    assert benchmark.SOURCE_SCOPE == measurement.SOURCE_SCOPE
+    assert inspect.signature(benchmark._score_record) == inspect.signature(
+        measurement.score_record
+    )
+    assert inspect.signature(benchmark._score_vector_to_payload) == inspect.signature(
+        measurement.score_vector_to_payload
+    )
+
+
+def test_provider_version_and_score_vector_payload_goldens(
+    measurement_context: dict[str, Any],
+) -> None:
+    assert {
+        provider_id: measurement.provider_version(provider_id)
+        for provider_id in ("P1", "P2", "P3")
+    } == {
+        "P1": "zeromodel-video-prospective-normalized-pixel/v1",
+        "P2": "zeromodel-video-prospective-local-correlation/v1",
+        "P3": "zeromodel-video-prospective-b3-joint-fit/v1",
+    }
+    with pytest.raises(KeyError) as excinfo:
+        measurement.provider_version("PX")
+    assert excinfo.value.args == ("PX",)
+
+    first_observation = next(iter(measurement_context["prototypes"].values()))[3]
+    vector = score_all_rows_reference(
+        provider_id="P1",
+        observation=first_observation,
+        prototypes=measurement_context["prototypes"],
+        policy_artifact_id=measurement_context["policy"].artifact_id,
+        source_scope=measurement.SOURCE_SCOPE,
+    )
+    payload = measurement.score_vector_to_payload(vector)
+
+    assert list(payload) == [
+        "provider_id",
+        "provider_version",
+        "row_ids",
+        "raw_scores",
+        "quantized_scores",
+        "ranking",
+        "tie_groups",
+        "score_vector_digest",
+        "ranking_digest",
+    ]
+    assert _digest(payload) == (
+        "sha256:51d3e8ffe7b955511b78b5d0ae010c8f32d4471fb118da598ff7d95fa6d75ec4"
+    )
+    assert _digest(payload["row_ids"]) == (
+        "sha256:10369de0f84b28852b5956a893cd92f8106f2f095c96db7525c0c363f9b9a816"
+    )
+    assert _digest(payload["raw_scores"]) == (
+        "sha256:064def264c67cc57f4109bcaa155e1810967f7a89624be0c2cf50c3362547025"
+    )
+    assert _digest(payload["quantized_scores"]) == (
+        "sha256:8c0a26808337d6101b202d427f2e9359409afe4b2dc3c90f2374217630e2ab15"
+    )
+    assert payload["ranking_digest"] == (
+        "sha256:59031a77435a6711ab548aabeaaf2ae27cf8370e5a7d7c205b741970a5777bfd"
+    )
+    with pytest.raises(AttributeError):
+        measurement.score_vector_to_payload({"provider_id": "P1"})
+
+
+def test_score_record_goldens_and_reachability_state(
+    measurement_context: dict[str, Any],
+) -> None:
+    record = measurement_context["score_record_input"]
+    rows = measurement_context["score_rows"]
+
+    assert [row["provider_id"] for row in rows] == ["P1", "P2", "P3"]
+    assert [list(row) for row in rows] == [PROVIDER_ROW_KEYS] * 3
+    assert [row["reachability_composition_trace"] for row in rows] == [None] * 3
+    assert [row["provider_observation_digest"] for row in rows] == [
+        "sha256:bb6de887ea70ccd7c410547b46967c331b19186365a4d0eac3accf7240926e7b"
+    ] * 3
+    assert [row["provider_observation_descriptor"] for row in rows] == [
+        rows[0]["provider_observation_descriptor"]
+    ] * 3
+    assert (
+        rows[0]["provider_observation_descriptor"]
+        is rows[1]["provider_observation_descriptor"]
+    )
+    assert [row["score_vector_digest"] for row in rows] == [
+        "sha256:7000f400486036f41341e783675b7033c8eedb7e07700c3ed5e77920daeb67e3",
+        "sha256:2c0c5ee11e871b7b4323e229a64237fc0adae74ca7705e68db7a2d29bd3b8e8a",
+        "sha256:50a096dc86fd28708bde7132a95750c27c31ae7d1960cb055156bf138008bfdb",
+    ]
+    assert [_digest(row) for row in rows] == [
+        "sha256:d931cf814bbd896f5a1ac8c8d4f5caa096d8223a6e8a889f220c57bd3d5c8e66",
+        "sha256:c85006dba9bc6e098883991cb91bbbdccebf3284d7348ccea2777801e75ba1a5",
+        "sha256:0fce0f3da58bb19f1f67d8eed014101b48562be18a844bfc7d7f627bf3f17725",
+    ]
+    assert rows[1]["semantic_status"] == "action_unanimous_tie"
+    assert rows[1]["resolved_action"] == "STAY"
+    assert rows[1]["resolved_row"] is None
+    assert rows[1]["winner_quantized_score"] is None
+    assert rows[0]["metadata"] is record["metadata"]
+
+    rows_with_reachability = measurement_context["stream_rows"][:3]
+    assert [
+        row["reachability_composition_trace"]["trace_digest"]
+        for row in rows_with_reachability
+    ] == [
+        "sha256:a5aa53d1e4a339d7eba7f4076006a920ebc2a83069f21c886861faad04a89b50",
+        "sha256:ac99a15deb2b185f84dcbb85e0c5d08ea9086459a3c282a66ef2ed65a5122475",
+        "sha256:d5a9f5a46a2f0a9b9f0f550c1e6849b2668b07ee8b3851ae229d83cd6661408b",
+    ]
+    assert (
+        rows_with_reachability[0]["reachability_composition_trace"]["status"]
+        == "resolved"
+    )
+    assert rows_with_reachability[1]["resolved_action"] == "STAY"
+
+
+def test_score_record_validation_and_partial_reachability_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    measurement_context: dict[str, Any],
+) -> None:
+    with pytest.raises(VPMValidationError, match="materialized record missing pixels"):
+        measurement.score_record(
+            {"metadata": {}},
+            measurement_context["prototypes"],
+            measurement_context["policy"].artifact_id,
+        )
+    gap = deepcopy(measurement_context["gap_records"][2])
+    with pytest.raises(
+        VPMValidationError,
+        match="typed gap events cannot be provider-scored as ordinary frames",
+    ):
+        measurement.score_record(
+            gap,
+            measurement_context["prototypes"],
+            measurement_context["policy"].artifact_id,
+        )
+
+    class FakeResult:
+        provider_id = "P1"
+
+    monkeypatch.setattr(
+        measurement, "_score_all_providers", lambda **_kwargs: (FakeResult(),)
+    )
+    monkeypatch.setattr(
+        measurement,
+        "_provider_evidence_row",
+        lambda **kwargs: {
+            "reachability_composition_trace": kwargs["operational_trace"]
+        },
+    )
+    state = {"P1": {"status": "sentinel", "candidate_rows": ("row",)}}
+    rows = measurement.score_record(
+        deepcopy(measurement_context["valid_records"][0]),
+        measurement_context["prototypes"],
+        measurement_context["policy"].artifact_id,
+        reachability_tile=measurement_context["tile"],
+        reachability_state=state,
+        row_actions=None,
+    )
+    assert [row["reachability_composition_trace"] for row in rows] == [None]
+    assert state == {"P1": {"status": "sentinel", "candidate_rows": ("row",)}}
+
+
+def test_measure_record_collection_gap_stream_and_final_split_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+    measurement_context: dict[str, Any],
+) -> None:
+    rows = measurement_context["stream_rows"]
+
+    assert len(rows) == 6
+    assert [(row["frame_id"], row["provider_id"]) for row in rows] == [
+        ("selection:selection:valid:3b017d7e360a1086:frame-00", "P1"),
+        ("selection:selection:valid:3b017d7e360a1086:frame-00", "P2"),
+        ("selection:selection:valid:3b017d7e360a1086:frame-00", "P3"),
+        ("selection:selection:valid:3b017d7e360a1086:frame-01", "P1"),
+        ("selection:selection:valid:3b017d7e360a1086:frame-01", "P2"),
+        ("selection:selection:valid:3b017d7e360a1086:frame-01", "P3"),
+    ]
+    assert [
+        row["reachability_composition_trace"]["rejection_reason"] for row in rows
+    ] == [
+        None,
+        None,
+        None,
+        "prior_state_unresolved",
+        "prior_state_unresolved",
+        "prior_state_unresolved",
+    ]
+    assert _digest(rows) == (
+        "sha256:367990ec5badbefe05e72c8880e0d4bbd884036fa2c59f7cf5f2bd2276f57c61"
+    )
+
+    final_record = deepcopy(measurement_context["valid_records"][0])
+    final_record["split"] = "final"
+    monkeypatch.setattr(measurement, "_score_all_providers", lambda **_kwargs: tuple())
+    final_rows = measurement.score_record(
+        final_record,
+        measurement_context["prototypes"],
+        measurement_context["policy"].artifact_id,
+    )
+    assert final_rows == []
+
+
+def test_information_controls_share_provider_visible_measurement(
+    measurement_context: dict[str, Any],
+) -> None:
+    first, second = measurement_context["control_rows"]
+
+    assert {row["provider_observation_digest"] for row in first + second} == {
+        "sha256:198009840efffc970b1da1c9d5fd66937ddd499897340f55980223354b917805"
+    }
+    assert [(row["provider_id"], row["score_vector_digest"]) for row in first] == [
+        (row["provider_id"], row["score_vector_digest"]) for row in second
+    ]
+    assert [(row["provider_id"], row["semantic_outcome_digest"]) for row in first] == [
+        (row["provider_id"], row["semantic_outcome_digest"]) for row in second
+    ]
+    assert (
+        measurement_context["control_records"][0]["metadata"][
+            "hidden_source_history_id"
+        ]
+        != measurement_context["control_records"][1]["metadata"][
+            "hidden_source_history_id"
+        ]
+    )
+
+
+def test_provider_call_order_and_error_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    measurement_context: dict[str, Any],
+) -> None:
+    calls: list[str] = []
+
+    class FakeObservation:
+        def to_descriptor(self) -> dict[str, object]:
+            calls.append("descriptor")
+            return {"raw_digest": "sha256:" + "0" * 64, "shape": [16, 28]}
+
+    def fake_observation(_record: dict[str, Any]) -> FakeObservation:
+        calls.append("observation")
+        return FakeObservation()
+
+    def fake_p1(**_kwargs: object) -> object:
+        calls.append("P1")
+        return object()
+
+    def fake_p2(**_kwargs: object) -> object:
+        calls.append("P2")
+        raise RuntimeError("synthetic P2 failure")
+
+    def fake_p3(**_kwargs: object) -> object:
+        calls.append("P3")
+        return object()
+
+    monkeypatch.setattr(
+        measurement, "provider_observation_for_record", fake_observation
+    )
+    monkeypatch.setattr(
+        measurement,
+        "provider_observation_digest",
+        lambda _descriptor: "sha256:" + "1" * 64,
+    )
+    monkeypatch.setattr(measurement, "score_normalized_pixel", fake_p1)
+    monkeypatch.setattr(measurement, "score_registered_local_correlation", fake_p2)
+    monkeypatch.setattr(measurement, "score_b3_joint_fit", fake_p3)
+    state = {"P1": None, "P2": None, "P3": None}
+
+    with pytest.raises(RuntimeError, match="synthetic P2 failure"):
+        measurement.score_record(
+            deepcopy(measurement_context["valid_records"][0]),
+            measurement_context["prototypes"],
+            measurement_context["policy"].artifact_id,
+            reachability_tile=measurement_context["tile"],
+            reachability_state=state,
+            row_actions=measurement_context["row_actions"],
+        )
+
+    assert calls == ["observation", "descriptor", "P1", "P2"]
+    assert state == {"P1": None, "P2": None, "P3": None}

--- a/tests/test_video_reachability_composition_kernel.py
+++ b/tests/test_video_reachability_composition_kernel.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set import reachability_composition as reach
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+TRACE_KEYS = [
+    "version",
+    "composition_version",
+    "frame_id",
+    "semantic_outcome_digest",
+    "input_candidate_rows",
+    "input_candidate_actions",
+    "prior_reachable_rows",
+    "prior_state_status",
+    "reachability_tile_identity",
+    "consulted_edges",
+    "reachable_candidate_pairs",
+    "removed_rows",
+    "removed_actions",
+    "retained_rows",
+    "retained_actions",
+    "resulting_candidate_set",
+    "resolved_row_id",
+    "resolved_action_id",
+    "rejection_reason",
+    "executed_action",
+    "status",
+    "trace_digest",
+]
+
+
+@pytest.fixture(scope="module")
+def reachability_context() -> dict[str, Any]:
+    policy = benchmark.compile_policy_artifact()
+    lookup = benchmark.VPMPolicyLookup(policy, action_metric_ids=benchmark.ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
+    tile = benchmark._load_reachability_tile(REPO_ROOT)
+    return {"row_ids": row_ids, "row_actions": row_actions, "tile": tile}
+
+
+def _outcome(
+    rows: list[str],
+    row_actions: dict[str, str],
+    *,
+    status: str | None = None,
+) -> dict[str, object]:
+    status = status or ("unique_row" if len(rows) == 1 else "conflicting_action_tie")
+    return {
+        "semantic_outcome_digest": benchmark._sha256({"rows": rows, "status": status}),
+        "status": status,
+        "top_row_ids": rows,
+        "top_row_actions": [
+            {"row_id": row_id, "action_id": row_actions[row_id]} for row_id in rows
+        ],
+    }
+
+
+def _reachable_fixture_cases(
+    row_ids: list[str],
+    row_actions: dict[str, str],
+    tile: dict[str, Any],
+) -> tuple[tuple[str, list[str]], tuple[str, list[str]]]:
+    conflict_case = None
+    same_action_case = None
+    for prior in row_ids:
+        reachable = list(
+            benchmark._tile_edge(tile, prior, row_actions[prior])["reachable_row_ids"]
+        )
+        by_action: dict[str, list[str]] = {}
+        for row in reachable:
+            by_action.setdefault(row_actions[row], []).append(row)
+        if same_action_case is None:
+            same = next(
+                (rows[:2] for rows in by_action.values() if len(rows) >= 2), None
+            )
+            if same:
+                same_action_case = (prior, same)
+        if conflict_case is None and len(by_action) >= 2:
+            actions = list(by_action)
+            conflict_case = (
+                prior,
+                [by_action[actions[0]][0], by_action[actions[1]][0]],
+            )
+        if conflict_case and same_action_case:
+            break
+    assert conflict_case is not None
+    assert same_action_case is not None
+    return conflict_case, same_action_case
+
+
+def _trace_cases(context: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    row_ids = context["row_ids"]
+    row_actions = context["row_actions"]
+    tile = context["tile"]
+    source = row_ids[0]
+    edge = benchmark._tile_edge(tile, source, row_actions[source])
+    ordinary_dest = edge["reachable_row_ids"][0]
+    missing_dest = next(
+        row for row in row_ids if row not in set(edge["reachable_row_ids"])
+    )
+    conflict_case, same_action_case = _reachable_fixture_cases(
+        row_ids, row_actions, tile
+    )
+
+    return {
+        "first_frame": reach.compose_reachability_trace(
+            frame_id="frame-first",
+            semantic_outcome=_outcome([ordinary_dest], row_actions),
+            previous_state=None,
+            reachability_tile=tile,
+            row_actions=row_actions,
+        ),
+        "ordinary_reachable": reach.compose_reachability_trace(
+            frame_id="frame-ordinary",
+            semantic_outcome=_outcome([ordinary_dest], row_actions),
+            previous_state={"status": "resolved", "candidate_rows": (source,)},
+            reachability_tile=tile,
+            row_actions=row_actions,
+        ),
+        "prior_unresolved": reach.compose_reachability_trace(
+            frame_id="frame-prior-unresolved",
+            semantic_outcome=_outcome([ordinary_dest], row_actions),
+            previous_state={
+                "status": "unresolved",
+                "candidate_rows": tuple(),
+                "reason": "typed_gap_event",
+            },
+            reachability_tile=tile,
+            row_actions=row_actions,
+        ),
+        "no_reachable_candidate": reach.compose_reachability_trace(
+            frame_id="frame-no-reach",
+            semantic_outcome=_outcome([missing_dest], row_actions),
+            previous_state={"status": "resolved", "candidate_rows": (source,)},
+            reachability_tile=tile,
+            row_actions=row_actions,
+        ),
+        "conflicting_reachable_actions": reach.compose_reachability_trace(
+            frame_id="frame-conflict",
+            semantic_outcome=_outcome(
+                conflict_case[1], row_actions, status="conflicting_action_tie"
+            ),
+            previous_state={
+                "status": "resolved",
+                "candidate_rows": (conflict_case[0],),
+            },
+            reachability_tile=tile,
+            row_actions=row_actions,
+        ),
+        "multiple_retained_one_action": reach.compose_reachability_trace(
+            frame_id="frame-same-action",
+            semantic_outcome=_outcome(
+                same_action_case[1], row_actions, status="action_unanimous_tie"
+            ),
+            previous_state={
+                "status": "resolved",
+                "candidate_rows": (same_action_case[0],),
+            },
+            reachability_tile=tile,
+            row_actions=row_actions,
+        ),
+        "empty_top_set": reach.compose_reachability_trace(
+            frame_id="frame-empty",
+            semantic_outcome=_outcome([], row_actions, status="unresolved"),
+            previous_state=None,
+            reachability_tile=tile,
+            row_actions=row_actions,
+        ),
+    }
+
+
+def _ordinary_validation_fixture(
+    reachability_context: dict[str, Any],
+) -> tuple[
+    dict[str, Any], dict[str, object], dict[str, object], dict[str, Any], dict[str, str]
+]:
+    row_actions = reachability_context["row_actions"]
+    tile = reachability_context["tile"]
+    source = reachability_context["row_ids"][0]
+    destination = benchmark._tile_edge(tile, source, row_actions[source])[
+        "reachable_row_ids"
+    ][0]
+    semantic = _outcome([destination], row_actions)
+    previous = {"status": "resolved", "candidate_rows": (source,)}
+    trace = reach.compose_reachability_trace(
+        frame_id="frame-ordinary",
+        semantic_outcome=semantic,
+        previous_state=previous,
+        reachability_tile=tile,
+        row_actions=row_actions,
+    )
+    return trace, semantic, previous, tile, row_actions
+
+
+def _validate_trace(
+    trace: dict[str, Any],
+    semantic: dict[str, object],
+    previous: dict[str, object],
+    tile: dict[str, Any],
+    row_actions: dict[str, str],
+) -> str:
+    return reach.validate_reachability_trace(
+        trace,
+        semantic_outcome=semantic,
+        previous_state=previous,
+        reachability_tile=tile,
+        row_actions=row_actions,
+    )
+
+
+def test_reachability_aliases_are_direct() -> None:
+    assert benchmark._trace_digest is reach.trace_digest
+    assert benchmark._top_row_action_map is reach.top_row_action_map
+    assert benchmark.compose_reachability_trace is reach.compose_reachability_trace
+    assert benchmark.validate_reachability_trace is reach.validate_reachability_trace
+    assert benchmark._state_from_trace is reach.state_from_trace
+    assert benchmark._gap_reachability_state is reach.gap_reachability_state
+    assert (
+        benchmark.REACHABILITY_COMPOSITION_VERSION
+        == reach.REACHABILITY_COMPOSITION_VERSION
+    )
+    assert benchmark.REACHABILITY_TRACE_VERSION == reach.REACHABILITY_TRACE_VERSION
+
+
+def test_trace_variants_and_digests_are_frozen(
+    reachability_context: dict[str, Any],
+) -> None:
+    traces = _trace_cases(reachability_context)
+
+    assert {name: trace["trace_digest"] for name, trace in traces.items()} == {
+        "first_frame": "sha256:ffaf0407aa1ff213b0c5203b8fab43f8a0231e5f55c61bcf3516a7d6cf81208b",
+        "ordinary_reachable": "sha256:3380df273b057f6667369f05a9864a683aebecb219b93e5c711bfccda8e95155",
+        "prior_unresolved": "sha256:727dbbaf8ddb85bc12ba5d309d042269167bd8160e4360a00a418295ecd8bec9",
+        "no_reachable_candidate": "sha256:e25068a215bae51f7ce66717e39c2879b0ea8b5da1dc235de3646c1651481dd0",
+        "conflicting_reachable_actions": "sha256:aa2eca16e15dc6cb4898ca12fc07fa5e0df197ed81ec368e5c6eeefab8728dfd",
+        "multiple_retained_one_action": "sha256:7fbe2d435e73d7908c2adf7366218f7640ae6e917d3e0b82d732dcd95f84a987",
+        "empty_top_set": "sha256:39107f8e7351f3f404f46a0a4bd9802e8807bc481d4ff90565a0083cbc5c3cf5",
+    }
+    assert list(traces["ordinary_reachable"]) == TRACE_KEYS
+    assert traces["first_frame"]["consulted_edges"] == []
+    assert traces["first_frame"]["reachable_candidate_pairs"] == []
+    assert traces["prior_unresolved"]["rejection_reason"] == "prior_state_unresolved"
+    assert (
+        traces["no_reachable_candidate"]["rejection_reason"] == "no_reachable_candidate"
+    )
+    assert traces["conflicting_reachable_actions"]["rejection_reason"] == (
+        "conflicting_reachable_actions"
+    )
+    assert traces["multiple_retained_one_action"]["resolved_action_id"] == "STAY"
+    assert traces["multiple_retained_one_action"]["resolved_row_id"] is None
+    assert traces["empty_top_set"]["status"] == "unresolved"
+    assert reach.state_from_trace(traces["empty_top_set"]) == {
+        "status": "resolved",
+        "candidate_rows": tuple(),
+    }
+
+
+def test_trace_validation_status_precedence_is_frozen(
+    reachability_context: dict[str, Any],
+) -> None:
+    trace, semantic, previous, tile, row_actions = _ordinary_validation_fixture(
+        reachability_context
+    )
+
+    assert _validate_trace(trace, semantic, previous, tile, row_actions) == "ok"
+
+    foreign_tile = deepcopy(tile)
+    foreign_tile["tile_digest"] = "sha256:" + "0" * 64
+    assert (
+        _validate_trace(trace, semantic, previous, foreign_tile, row_actions)
+        == "foreign_reachability_tile"
+    )
+
+    bad_semantic = dict(semantic)
+    bad_semantic["top_row_actions"] = []
+    assert (
+        _validate_trace(trace, bad_semantic, previous, tile, row_actions)
+        == "reachability_trace_recompute_failed"
+    )
+
+    tampered = deepcopy(trace)
+    tampered["trace_digest"] = "sha256:" + "1" * 64
+    assert (
+        _validate_trace(tampered, semantic, previous, tile, row_actions)
+        == "foreign_reachability_trace_digest"
+    )
+
+    tampered = deepcopy(trace)
+    tampered["consulted_edges"] = []
+    tampered["trace_digest"] = reach.trace_digest(tampered)
+    assert (
+        _validate_trace(tampered, semantic, previous, tile, row_actions)
+        == "consulted_edge_mismatch"
+    )
+
+    tampered = deepcopy(trace)
+    tampered["reachable_candidate_pairs"] = []
+    tampered["trace_digest"] = reach.trace_digest(tampered)
+    assert (
+        _validate_trace(tampered, semantic, previous, tile, row_actions)
+        == "reachable_pair_mismatch"
+    )
+
+    tampered = deepcopy(trace)
+    tampered["removed_rows"] = ["synthetic-row"]
+    tampered["trace_digest"] = reach.trace_digest(tampered)
+    assert (
+        _validate_trace(tampered, semantic, previous, tile, row_actions)
+        == "reachability_trace_mismatch"
+    )
+
+    with pytest.raises(KeyError):
+        reach.validate_reachability_trace(
+            {},
+            semantic_outcome=semantic,
+            previous_state=previous,
+            reachability_tile=tile,
+            row_actions=row_actions,
+        )
+
+
+def test_malformed_composition_order_and_gap_state(
+    reachability_context: dict[str, Any],
+) -> None:
+    row_actions = reachability_context["row_actions"]
+    tile = reachability_context["tile"]
+    top_row = reachability_context["row_ids"][0]
+    malformed = {
+        "semantic_outcome_digest": "sha256:" + "0" * 64,
+        "top_row_ids": [top_row],
+        "top_row_actions": [],
+    }
+    foreign_tile = deepcopy(tile)
+    foreign_tile["tile_digest"] = "sha256:" + "0" * 64
+    with pytest.raises(VPMValidationError, match="reachability tile digest"):
+        reach.compose_reachability_trace(
+            frame_id="frame",
+            semantic_outcome=malformed,
+            previous_state=None,
+            reachability_tile=foreign_tile,
+            row_actions=row_actions,
+        )
+    with pytest.raises(
+        VPMValidationError, match="semantic top rows and row/action mapping disagree"
+    ):
+        reach.compose_reachability_trace(
+            frame_id="frame",
+            semantic_outcome=malformed,
+            previous_state=None,
+            reachability_tile=tile,
+            row_actions=row_actions,
+        )
+    assert reach.gap_reachability_state(
+        {"gap_declaration": "declared_gap", "metadata": {"gap_declaration": "wrong"}}
+    ) == {"status": "unresolved", "candidate_rows": tuple(), "reason": "declared_gap"}

--- a/tests/test_video_runtime_profiling_kernel.py
+++ b/tests/test_video_runtime_profiling_kernel.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.domains.video_action_set import runtime_profiling as profiling
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _record(frame_id: str, disposition: str) -> dict[str, Any]:
+    return {
+        "frame_id": frame_id,
+        "expected_disposition": disposition,
+        "pixels": [[0]],
+        "metadata": {"episode_seed": 1, "seed_digest": "sha256:test"},
+        "observation_pixel_digest": "sha256:" + "0" * 64,
+    }
+
+
+def _profiling_fixture_records() -> list[dict[str, Any]]:
+    return [
+        *[
+            _record(frame_id, "valid")
+            for frame_id in [
+                "selection:selection:valid:3b017d7e360a1086:frame-00",
+                "selection:selection:valid:3b017d7e360a1086:frame-01",
+                "selection:selection:valid:3b017d7e360a1086:frame-02",
+                "selection:selection:valid:3b017d7e360a1086:frame-03",
+                "selection:selection:valid:8397b393db8e9235:frame-00",
+                "selection:selection:valid:8397b393db8e9235:frame-01",
+            ]
+        ],
+        *[
+            _record(frame_id, "distinguishable_invalid_input")
+            for frame_id in [
+                "selection:selection:frame_invalid:d404ad591f7282e2:frame-00",
+                "selection:selection:frame_invalid:d404ad591f7282e2:frame-01",
+            ]
+        ],
+        *[
+            _record(frame_id, "information_theoretic_control")
+            for frame_id in [
+                "selection:selection:information_control:b333ebf38f849061:frame-00",
+                "selection:selection:information_control:b333ebf38f849061:frame-01",
+            ]
+        ],
+    ]
+
+
+def test_runtime_profiling_aliases_and_benchmark_wrappers() -> None:
+    assert benchmark._profile_provider is profiling.profile_provider
+    assert benchmark._profiling_records is not profiling.select_profiling_records
+    assert benchmark.profile_runtime is not profiling.runtime_profile_payload
+
+
+def test_select_profiling_records_preserves_category_order_and_limits() -> None:
+    records = _profiling_fixture_records()
+
+    assert [
+        row["frame_id"] for row in profiling.select_profiling_records(records, -1)
+    ] == ["selection:selection:valid:3b017d7e360a1086:frame-00"]
+    assert [
+        row["frame_id"] for row in profiling.select_profiling_records(records, 0)
+    ] == ["selection:selection:valid:3b017d7e360a1086:frame-00"]
+    assert [
+        row["frame_id"] for row in profiling.select_profiling_records(records, 1)
+    ] == ["selection:selection:valid:3b017d7e360a1086:frame-00"]
+    assert [
+        row["frame_id"] for row in profiling.select_profiling_records(records, 8)
+    ] == [
+        "selection:selection:valid:3b017d7e360a1086:frame-00",
+        "selection:selection:valid:3b017d7e360a1086:frame-01",
+        "selection:selection:valid:3b017d7e360a1086:frame-02",
+        "selection:selection:valid:3b017d7e360a1086:frame-03",
+        "selection:selection:valid:8397b393db8e9235:frame-00",
+        "selection:selection:valid:8397b393db8e9235:frame-01",
+        "selection:selection:frame_invalid:d404ad591f7282e2:frame-00",
+        "selection:selection:frame_invalid:d404ad591f7282e2:frame-01",
+    ]
+    assert [
+        row["frame_id"] for row in profiling.select_profiling_records(records, 10)
+    ] == [row["frame_id"] for row in records]
+    assert [
+        row["frame_id"] for row in profiling.select_profiling_records(records, 12)
+    ] == [row["frame_id"] for row in records]
+
+    reduced = [_record("invalid-0", "distinguishable_invalid_input")]
+    assert [
+        row["frame_id"] for row in profiling.select_profiling_records(reduced, 8)
+    ] == ["invalid-0"]
+    assert profiling.select_profiling_records([], 8) == []
+
+
+def test_profiling_records_remains_materialization_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = _profiling_fixture_records()
+    calls: list[tuple[str, Path]] = []
+
+    def fake_materialize(split: str, repo_root: Path) -> list[dict[str, Any]]:
+        calls.append((split, repo_root))
+        return records
+
+    monkeypatch.setattr(benchmark, "_materialize_records", fake_materialize)
+
+    selected = benchmark._profiling_records(REPO_ROOT, 1)
+
+    assert calls == [("selection", REPO_ROOT)]
+    assert [row["frame_id"] for row in selected] == [
+        "selection:selection:valid:3b017d7e360a1086:frame-00"
+    ]
+
+
+def test_profile_provider_timing_boundary_and_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: list[str] = []
+
+    class FakeObservation:
+        pass
+
+    def fake_observation(record: dict[str, Any]) -> FakeObservation:
+        log.append(f"observation:{record['frame_id']}")
+        return FakeObservation()
+
+    times = iter([10.0, 11.5, 20.0, 20.5])
+
+    def fake_perf_counter() -> float:
+        log.append("timer")
+        return next(times)
+
+    def fake_reference(**kwargs: object) -> object:
+        log.append(f"reference:{kwargs['provider_id']}")
+        return object()
+
+    def fake_optimized(**kwargs: object) -> object:
+        log.append(f"optimized:{kwargs['provider_id']}")
+        return object()
+
+    monkeypatch.setattr(profiling, "provider_observation_for_record", fake_observation)
+    monkeypatch.setattr(profiling.time, "perf_counter", fake_perf_counter)
+    monkeypatch.setattr(profiling, "score_all_rows_reference", fake_reference)
+    monkeypatch.setattr(profiling, "score_all_rows_optimized", fake_optimized)
+    records = [_record("frame-0", "valid"), _record("frame-1", "valid")]
+
+    profile = profiling.profile_provider(
+        provider_id="P1",
+        records=records,
+        prototypes={},
+        policy_artifact_id="policy",
+        implementation="reference",
+    )
+
+    assert log == [
+        "observation:frame-0",
+        "timer",
+        "reference:P1",
+        "timer",
+        "observation:frame-1",
+        "timer",
+        "reference:P1",
+        "timer",
+    ]
+    assert profile == {
+        "provider_id": "P1",
+        "implementation": "reference",
+        "frame_count": 2,
+        "total_seconds": 2.0,
+        "mean_seconds_per_frame": 1.0,
+        "mean_seconds_per_candidate": 1.0 / 112.0,
+        "provider_scoring_call_count": 2,
+        "candidate_comparison_count": 224,
+    }
+
+    log.clear()
+    times = iter([1.0, 1.25])
+    fallback = profiling.profile_provider(
+        provider_id="P2",
+        records=[_record("frame-2", "valid")],
+        prototypes={},
+        policy_artifact_id="policy",
+        implementation="anything-else",
+    )
+    assert "optimized:P2" in log
+    assert fallback["total_seconds"] == 0.25
+
+    empty = profiling.profile_provider(
+        provider_id="P3",
+        records=[],
+        prototypes={},
+        policy_artifact_id="policy",
+        implementation="reference",
+    )
+    assert empty == {
+        "provider_id": "P3",
+        "implementation": "reference",
+        "frame_count": 0,
+        "total_seconds": 0.0,
+        "mean_seconds_per_frame": 0.0,
+        "mean_seconds_per_candidate": 0.0,
+        "provider_scoring_call_count": 0,
+        "candidate_comparison_count": 0,
+    }
+
+
+def test_runtime_profile_payload_is_frozen() -> None:
+    reference = [
+        {
+            "provider_id": "P1",
+            "implementation": "reference",
+            "frame_count": 3,
+            "total_seconds": 0.9,
+            "mean_seconds_per_frame": 0.3,
+            "mean_seconds_per_candidate": 0.3 / 112.0,
+            "provider_scoring_call_count": 3,
+            "candidate_comparison_count": 336,
+        },
+        {
+            "provider_id": "P2",
+            "implementation": "reference",
+            "frame_count": 3,
+            "total_seconds": 1.5,
+            "mean_seconds_per_frame": 0.5,
+            "mean_seconds_per_candidate": 0.5 / 112.0,
+            "provider_scoring_call_count": 3,
+            "candidate_comparison_count": 336,
+        },
+    ]
+    optimized = [
+        {
+            "provider_id": "P1",
+            "implementation": "optimized",
+            "frame_count": 3,
+            "total_seconds": 0.3,
+            "mean_seconds_per_frame": 0.1,
+            "mean_seconds_per_candidate": 0.1 / 112.0,
+            "provider_scoring_call_count": 3,
+            "candidate_comparison_count": 336,
+        },
+        {
+            "provider_id": "P2",
+            "implementation": "optimized",
+            "frame_count": 3,
+            "total_seconds": 0.0,
+            "mean_seconds_per_frame": 0.0,
+            "mean_seconds_per_candidate": 0.0,
+            "provider_scoring_call_count": 3,
+            "candidate_comparison_count": 336,
+        },
+    ]
+
+    payload = profiling.runtime_profile_payload(
+        provider_scope="custom",
+        provider_ids=("P1", "P2"),
+        profile_frame_count=3,
+        reference=reference,
+        optimized=optimized,
+    )
+
+    assert list(payload) == [
+        "profile_frame_count",
+        "provider_scope",
+        "reference",
+        "optimized",
+        "comparison",
+        "projected_runtime_seconds",
+    ]
+    assert payload["comparison"]["P1"]["speedup"] == 2.9999999999999996
+    assert payload["comparison"]["P2"]["speedup"] is None
+    assert payload["projected_runtime_seconds"] == {
+        "development": 11.200000000000001,
+        "calibration": 44.800000000000004,
+        "selection": 100.80000000000001,
+    }
+    assert benchmark._sha256(payload) == (
+        "sha256:01bdb0155964b3a8b77bdb3e6ead18c7b7285a6d2f908c24e5bcc3a609322505"
+    )

--- a/zeromodel/domains/video_action_set/provider_measurement.py
+++ b/zeromodel/domains/video_action_set/provider_measurement.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from ...artifact import VPMValidationError
+from ...video_prospective_providers import (
+    PROSPECTIVE_P1_VERSION,
+    PROSPECTIVE_P2_VERSION,
+    PROSPECTIVE_P3_VERSION,
+    score_b3_joint_fit,
+    score_normalized_pixel,
+    score_registered_local_correlation,
+)
+from ...visual_address import ImageObservation
+from .contracts import GENERATOR_VERSION, REACHABILITY_TILE_DIGEST
+from .provider_observation_boundary import (
+    provider_observation_digest,
+    provider_observation_for_record,
+)
+from .reachability_composition import (
+    compose_reachability_trace,
+    gap_reachability_state,
+    state_from_trace,
+)
+
+
+SOURCE_SCOPE = "zeromodel-video-action-set-reachability-benchmark-v1"
+
+
+def provider_version(provider_id: str) -> str:
+    return {
+        "P1": PROSPECTIVE_P1_VERSION,
+        "P2": PROSPECTIVE_P2_VERSION,
+        "P3": PROSPECTIVE_P3_VERSION,
+    }[provider_id]
+
+
+def score_vector_to_payload(vector: Any) -> dict[str, Any]:
+    return {
+        "provider_id": vector.provider_id,
+        "provider_version": vector.provider_version,
+        "row_ids": list(vector.row_ids),
+        "raw_scores": list(vector.raw_scores),
+        "quantized_scores": list(vector.quantized_scores),
+        "ranking": list(vector.evidence.ranking.ranked_row_ids),
+        "tie_groups": [group.to_dict() for group in vector.evidence.ranking.tie_groups],
+        "score_vector_digest": vector.evidence.score_vector_digest,
+        "ranking_digest": vector.evidence.ranking.to_dict()["ranking_digest"],
+    }
+
+
+def _score_all_providers(
+    *,
+    observation: ImageObservation,
+    prototypes: Mapping[str, tuple[str, str, str, ImageObservation]],
+    policy_artifact_id: str,
+) -> tuple[Any, Any, Any]:
+    p1 = score_normalized_pixel(
+        observation=observation,
+        prototypes=prototypes,
+        policy_artifact_id=policy_artifact_id,
+    )
+    p2 = score_registered_local_correlation(
+        observation=observation,
+        prototypes=prototypes,
+        policy_artifact_id=policy_artifact_id,
+        source_scope=SOURCE_SCOPE,
+    )
+    p3 = score_b3_joint_fit(
+        observation=observation,
+        prototypes=prototypes,
+        policy_artifact_id=policy_artifact_id,
+        source_scope=SOURCE_SCOPE,
+    )
+    return p1, p2, p3
+
+
+def _reachability_trace_for_result(
+    *,
+    record: dict[str, Any],
+    result: Any,
+    reachability_tile: Mapping[str, Any] | None,
+    reachability_state: dict[str, Mapping[str, Any] | None] | None,
+    row_actions: Mapping[str, str] | None,
+) -> dict[str, Any] | None:
+    if reachability_tile is None or reachability_state is None or row_actions is None:
+        return None
+    previous = reachability_state.get(result.provider_id)
+    operational_trace = compose_reachability_trace(
+        frame_id=record["frame_id"],
+        semantic_outcome=result.semantic_top_set_outcome.to_dict(),
+        previous_state=previous,
+        reachability_tile=reachability_tile,
+        row_actions=row_actions,
+    )
+    reachability_state[result.provider_id] = state_from_trace(operational_trace)
+    return operational_trace
+
+
+def _provider_evidence_row(
+    *,
+    record: dict[str, Any],
+    result: Any,
+    policy_artifact_id: str,
+    observation_descriptor: dict[str, Any],
+    observation_descriptor_digest: str,
+    operational_trace: dict[str, Any] | None,
+) -> dict[str, Any]:
+    outcome = result.semantic_top_set_outcome
+    winner_quantized_score = (
+        outcome.top_quantized_score if outcome.resolved_row_id is not None else None
+    )
+    row_scores = result.evidence.to_dict()["row_scores"]
+    runner_up_row = result.evidence.ranking.ranked_row_ids[1]
+    runner_up_index = [item.row_id for item in result.evidence.row_scores].index(
+        runner_up_row
+    )
+    return {
+        **{key: value for key, value in record.items() if key != "pixels"},
+        "provider_id": result.provider_id,
+        "provider_version": result.provider_version,
+        "policy_artifact_id": policy_artifact_id,
+        "reachability_tile_digest": REACHABILITY_TILE_DIGEST,
+        "all_112_row_ids": [item["row_id"] for item in row_scores],
+        "all_112_raw_scores": [item["raw_score"] for item in row_scores],
+        "all_112_quantized_scores": [item["quantized_score"] for item in row_scores],
+        "complete_ordered_ranking": list(result.evidence.ranking.ranked_row_ids),
+        "tie_groups": [group.to_dict() for group in result.evidence.ranking.tie_groups],
+        "semantic_top_set_outcome": outcome.to_dict(),
+        "semantic_status": outcome.status,
+        "resolved_row": outcome.resolved_row_id,
+        "resolved_action": outcome.resolved_action_id,
+        "top_quantized_score": outcome.top_quantized_score,
+        "top_row_ids": list(outcome.top_row_ids),
+        "top_action_ids": list(outcome.top_action_ids),
+        "semantic_outcome_digest": outcome.semantic_outcome_digest,
+        "reachability_composition_trace": operational_trace,
+        "winner_row": result.winner_row_id,
+        "winner_action": result.winner_action_id,
+        "winner_quantized_score": winner_quantized_score,
+        "runner_up_row": runner_up_row,
+        "runner_up_quantized_score": result.evidence.row_scores[
+            runner_up_index
+        ].quantized_score,
+        "policy_row_universe_digest": result.evidence.policy_row_universe_digest,
+        "quantized_score_vector_digest": result.evidence.quantized_score_vector_digest,
+        "raw_score_diagnostic_digest": result.evidence.raw_score_diagnostic_digest,
+        "score_vector_digest": result.evidence.score_vector_digest,
+        "ranking_digest": result.evidence.ranking.to_dict()["ranking_digest"],
+        "observation_digest": record["observation_pixel_digest"],
+        "provider_observation_descriptor": observation_descriptor,
+        "provider_observation_digest": observation_descriptor_digest,
+        "episode_seed": record["metadata"]["episode_seed"],
+        "generator_identity": {
+            "generator_version": GENERATOR_VERSION,
+            "seed_digest": record["metadata"]["seed_digest"],
+        },
+        "provider_diagnostics": dict(result.diagnostics),
+    }
+
+
+def score_record(
+    record: dict[str, Any],
+    prototypes: Mapping[str, tuple[str, str, str, ImageObservation]],
+    policy_artifact_id: str,
+    *,
+    reachability_tile: Mapping[str, Any] | None = None,
+    reachability_state: dict[str, Mapping[str, Any] | None] | None = None,
+    row_actions: Mapping[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    if "pixels" not in record:
+        raise VPMValidationError("materialized record missing pixels")
+    if record["pixels"] is None:
+        raise VPMValidationError(
+            "typed gap events cannot be provider-scored as ordinary frames"
+        )
+    observation = provider_observation_for_record(record)
+    observation_descriptor = observation.to_descriptor()
+    observation_descriptor_digest = provider_observation_digest(observation_descriptor)
+    provider_results = _score_all_providers(
+        observation=observation,
+        prototypes=prototypes,
+        policy_artifact_id=policy_artifact_id,
+    )
+    outputs = []
+    for result in provider_results:
+        operational_trace = _reachability_trace_for_result(
+            record=record,
+            result=result,
+            reachability_tile=reachability_tile,
+            reachability_state=reachability_state,
+            row_actions=row_actions,
+        )
+        outputs.append(
+            _provider_evidence_row(
+                record=record,
+                result=result,
+                policy_artifact_id=policy_artifact_id,
+                observation_descriptor=observation_descriptor,
+                observation_descriptor_digest=observation_descriptor_digest,
+                operational_trace=operational_trace,
+            )
+        )
+    return outputs
+
+
+def measure_record_collection(
+    records: Sequence[dict[str, Any]],
+    prototypes: Mapping[str, tuple[str, str, str, ImageObservation]],
+    policy_artifact_id: str,
+    *,
+    reachability_tile: Mapping[str, Any],
+    row_actions: Mapping[str, str],
+) -> list[dict[str, Any]]:
+    reachability_state: dict[str, Mapping[str, Any] | None] = {
+        "P1": None,
+        "P2": None,
+        "P3": None,
+    }
+    scored_rows: list[dict[str, Any]] = []
+    for record in records:
+        if record.get("event_type") == "gap_unknown" or record.get("pixels") is None:
+            for provider_id in reachability_state:
+                reachability_state[provider_id] = gap_reachability_state(record)
+            continue
+        scored_rows.extend(
+            score_record(
+                record,
+                prototypes,
+                policy_artifact_id,
+                reachability_tile=reachability_tile,
+                reachability_state=reachability_state,
+                row_actions=row_actions,
+            )
+        )
+    return scored_rows
+
+
+__all__ = [
+    "SOURCE_SCOPE",
+    "measure_record_collection",
+    "provider_version",
+    "score_record",
+    "score_vector_to_payload",
+]

--- a/zeromodel/domains/video_action_set/reachability_composition.py
+++ b/zeromodel/domains/video_action_set/reachability_composition.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ...artifact import VPMValidationError
+from .canonical_json import canonical_sha256
+from .materialization_reachability import (
+    tile_edge,
+    validate_reachability_tile_identity,
+)
+
+
+REACHABILITY_COMPOSITION_VERSION = (
+    "zeromodel-video-action-set-reachability-composition/v1"
+)
+REACHABILITY_TRACE_VERSION = "zeromodel-video-action-set-reachability-trace/v1"
+
+
+def trace_digest(payload: Mapping[str, Any]) -> str:
+    return canonical_sha256(
+        {key: value for key, value in payload.items() if key != "trace_digest"}
+    )
+
+
+def top_row_action_map(outcome: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        str(item["row_id"]): str(item["action_id"])
+        for item in outcome.get("top_row_actions", [])
+    }
+
+
+def _prior_rows_and_status(
+    previous_state: Mapping[str, Any] | None,
+) -> tuple[tuple[str, ...], str | None]:
+    prior_rows = tuple(
+        str(row_id) for row_id in (previous_state or {}).get("candidate_rows", ())
+    )
+    prior_status = (
+        None
+        if previous_state is None
+        else str(previous_state.get("status", "unresolved"))
+    )
+    return prior_rows, prior_status
+
+
+def _reachable_candidate_filter(
+    *,
+    top_rows: tuple[str, ...],
+    prior_rows: tuple[str, ...],
+    prior_status: str | None,
+    previous_state: Mapping[str, Any] | None,
+    reachability_tile: Mapping[str, Any],
+    row_actions: Mapping[str, str],
+) -> tuple[
+    list[dict[str, Any]], list[dict[str, str]], list[str], tuple[str, ...], str | None
+]:
+    consulted_edges: list[dict[str, Any]] = []
+    reachable_pairs: list[dict[str, str]] = []
+    removed_rows: list[str] = []
+    rejection_reason = None
+    if previous_state is not None and prior_status == "unresolved":
+        return (
+            consulted_edges,
+            reachable_pairs,
+            list(top_rows),
+            (),
+            "prior_state_unresolved",
+        )
+    if previous_state is None:
+        return (
+            consulted_edges,
+            reachable_pairs,
+            removed_rows,
+            tuple(sorted(top_rows)),
+            None,
+        )
+
+    retained = set()
+    for prior_row in prior_rows:
+        prior_action = row_actions[prior_row]
+        edge = tile_edge(reachability_tile, prior_row, prior_action)
+        consulted_edges.append(
+            {
+                "source_row_id": edge["source_row_id"],
+                "action_id": edge["action_id"],
+                "reachable_row_ids": list(edge["reachable_row_ids"]),
+            }
+        )
+        reachable = set(edge["reachable_row_ids"])
+        for current_row in top_rows:
+            if current_row in reachable:
+                retained.add(current_row)
+                reachable_pairs.append(
+                    {
+                        "source_row_id": prior_row,
+                        "action_id": prior_action,
+                        "destination_row_id": current_row,
+                    }
+                )
+    retained_rows = tuple(sorted(retained))
+    removed_rows = sorted(set(top_rows) - set(retained_rows))
+    if not retained_rows:
+        rejection_reason = "no_reachable_candidate"
+    return (
+        consulted_edges,
+        reachable_pairs,
+        removed_rows,
+        retained_rows,
+        rejection_reason,
+    )
+
+
+def _resolution_fields(
+    *,
+    semantic_outcome: Mapping[str, Any],
+    retained_rows: tuple[str, ...],
+    rejection_reason: str | None,
+    row_actions: Mapping[str, str],
+) -> tuple[tuple[str, ...], str | None, str | None, str | None, str]:
+    retained_actions = tuple(sorted({row_actions[row_id] for row_id in retained_rows}))
+    if (
+        rejection_reason is None
+        and semantic_outcome.get("status") == "conflicting_action_tie"
+        and len(retained_actions) > 1
+    ):
+        rejection_reason = "conflicting_reachable_actions"
+    resolved_action = (
+        retained_actions[0]
+        if rejection_reason is None and len(retained_actions) == 1
+        else None
+    )
+    resolved_row = (
+        retained_rows[0]
+        if rejection_reason is None and len(retained_rows) == 1
+        else None
+    )
+    status = (
+        "rejected"
+        if rejection_reason
+        else ("resolved" if resolved_action is not None else "unresolved")
+    )
+    return retained_actions, rejection_reason, resolved_row, resolved_action, status
+
+
+def compose_reachability_trace(
+    *,
+    frame_id: str,
+    semantic_outcome: Mapping[str, Any],
+    previous_state: Mapping[str, Any] | None,
+    reachability_tile: Mapping[str, Any],
+    row_actions: Mapping[str, str],
+) -> dict[str, Any]:
+    validate_reachability_tile_identity(reachability_tile)
+    top_rows = tuple(str(row_id) for row_id in semantic_outcome.get("top_row_ids", ()))
+    top_row_actions = top_row_action_map(semantic_outcome)
+    if set(top_rows) != set(top_row_actions):
+        raise VPMValidationError("semantic top rows and row/action mapping disagree")
+    if any(row_actions[row_id] != top_row_actions[row_id] for row_id in top_rows):
+        raise VPMValidationError(
+            "semantic outcome row/action mapping is inconsistent with policy"
+        )
+    prior_rows, prior_status = _prior_rows_and_status(previous_state)
+    (
+        consulted_edges,
+        reachable_pairs,
+        removed_rows,
+        retained_rows,
+        rejection_reason,
+    ) = _reachable_candidate_filter(
+        top_rows=top_rows,
+        prior_rows=prior_rows,
+        prior_status=prior_status,
+        previous_state=previous_state,
+        reachability_tile=reachability_tile,
+        row_actions=row_actions,
+    )
+    (
+        retained_actions,
+        rejection_reason,
+        resolved_row,
+        resolved_action,
+        status,
+    ) = _resolution_fields(
+        semantic_outcome=semantic_outcome,
+        retained_rows=retained_rows,
+        rejection_reason=rejection_reason,
+        row_actions=row_actions,
+    )
+    trace = {
+        "version": REACHABILITY_TRACE_VERSION,
+        "composition_version": REACHABILITY_COMPOSITION_VERSION,
+        "frame_id": frame_id,
+        "semantic_outcome_digest": semantic_outcome["semantic_outcome_digest"],
+        "input_candidate_rows": list(top_rows),
+        "input_candidate_actions": sorted(
+            {top_row_actions[row_id] for row_id in top_rows}
+        ),
+        "prior_reachable_rows": list(prior_rows),
+        "prior_state_status": prior_status,
+        "reachability_tile_identity": reachability_tile["tile_digest"],
+        "consulted_edges": consulted_edges,
+        "reachable_candidate_pairs": reachable_pairs,
+        "removed_rows": removed_rows,
+        "removed_actions": sorted({row_actions[row_id] for row_id in removed_rows}),
+        "retained_rows": list(retained_rows),
+        "retained_actions": list(retained_actions),
+        "resulting_candidate_set": list(retained_rows),
+        "resolved_row_id": resolved_row,
+        "resolved_action_id": resolved_action,
+        "rejection_reason": rejection_reason,
+        "executed_action": resolved_action,
+        "status": status,
+    }
+    trace["trace_digest"] = trace_digest(trace)
+    return trace
+
+
+def validate_reachability_trace(
+    trace: Mapping[str, Any],
+    *,
+    semantic_outcome: Mapping[str, Any],
+    previous_state: Mapping[str, Any] | None,
+    reachability_tile: Mapping[str, Any],
+    row_actions: Mapping[str, str],
+) -> str:
+    try:
+        expected = compose_reachability_trace(
+            frame_id=str(trace["frame_id"]),
+            semantic_outcome=semantic_outcome,
+            previous_state=previous_state,
+            reachability_tile=reachability_tile,
+            row_actions=row_actions,
+        )
+    except VPMValidationError as exc:
+        if "reachability tile digest" in str(exc):
+            return "foreign_reachability_tile"
+        return "reachability_trace_recompute_failed"
+    if str(trace.get("reachability_tile_identity")) != str(
+        reachability_tile["tile_digest"]
+    ):
+        return "foreign_reachability_tile"
+    if str(trace.get("trace_digest")) != trace_digest(trace):
+        return "foreign_reachability_trace_digest"
+    if list(trace.get("consulted_edges", [])) != expected["consulted_edges"]:
+        return "consulted_edge_mismatch"
+    if (
+        list(trace.get("reachable_candidate_pairs", []))
+        != expected["reachable_candidate_pairs"]
+    ):
+        return "reachable_pair_mismatch"
+    if dict(trace) != expected:
+        return "reachability_trace_mismatch"
+    return "ok"
+
+
+def state_from_trace(trace: Mapping[str, Any]) -> dict[str, Any]:
+    if trace["status"] == "rejected":
+        return {
+            "status": "unresolved",
+            "candidate_rows": tuple(),
+            "reason": trace["rejection_reason"],
+        }
+    return {
+        "status": "resolved",
+        "candidate_rows": tuple(str(row_id) for row_id in trace["retained_rows"]),
+    }
+
+
+def gap_reachability_state(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "unresolved",
+        "candidate_rows": tuple(),
+        "reason": record.get("gap_declaration") or "typed_gap_event",
+    }
+
+
+__all__ = [
+    "REACHABILITY_COMPOSITION_VERSION",
+    "REACHABILITY_TRACE_VERSION",
+    "compose_reachability_trace",
+    "gap_reachability_state",
+    "state_from_trace",
+    "top_row_action_map",
+    "trace_digest",
+    "validate_reachability_trace",
+]

--- a/zeromodel/domains/video_action_set/runtime_profiling.py
+++ b/zeromodel/domains/video_action_set/runtime_profiling.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Mapping, Sequence
+
+from ...video_prospective_providers import (
+    score_all_rows_optimized,
+    score_all_rows_reference,
+)
+from ...visual_address import ImageObservation
+from .provider_measurement import SOURCE_SCOPE
+from .provider_observation_boundary import provider_observation_for_record
+
+
+def select_profiling_records(
+    records: Sequence[dict[str, Any]],
+    frame_count: int,
+) -> list[dict[str, Any]]:
+    candidates = []
+    valid_records = [
+        record for record in records if record["expected_disposition"] == "valid"
+    ]
+    invalid_records = [
+        record
+        for record in records
+        if record["expected_disposition"] == "distinguishable_invalid_input"
+    ]
+    control_records = [
+        record
+        for record in records
+        if record["expected_disposition"] == "information_theoretic_control"
+    ]
+    candidates.extend(valid_records[:4])
+    candidates.extend(valid_records[4:6])
+    candidates.extend(invalid_records[:2])
+    candidates.extend(control_records[:2])
+    return candidates[: max(1, frame_count)]
+
+
+def profile_provider(
+    *,
+    provider_id: str,
+    records: Sequence[dict[str, Any]],
+    prototypes: Mapping[str, tuple[str, str, str, ImageObservation]],
+    policy_artifact_id: str,
+    implementation: str,
+) -> dict[str, Any]:
+    scorer = (
+        score_all_rows_reference
+        if implementation == "reference"
+        else score_all_rows_optimized
+    )
+    durations = []
+    for record in records:
+        observation = provider_observation_for_record(record)
+        start = time.perf_counter()
+        scorer(
+            provider_id=provider_id,
+            observation=observation,
+            prototypes=prototypes,
+            policy_artifact_id=policy_artifact_id,
+            source_scope=SOURCE_SCOPE,
+        )
+        durations.append(time.perf_counter() - start)
+    total = float(sum(durations))
+    mean_frame = total / float(len(durations) or 1)
+    return {
+        "provider_id": provider_id,
+        "implementation": implementation,
+        "frame_count": len(durations),
+        "total_seconds": total,
+        "mean_seconds_per_frame": mean_frame,
+        "mean_seconds_per_candidate": mean_frame / 112.0,
+        "provider_scoring_call_count": len(durations),
+        "candidate_comparison_count": len(durations) * 112,
+    }
+
+
+def runtime_profile_payload(
+    *,
+    provider_scope: str,
+    provider_ids: Sequence[str],
+    profile_frame_count: int,
+    reference: Sequence[Mapping[str, Any]],
+    optimized: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    reference_map = {item["provider_id"]: item for item in reference}
+    optimized_map = {item["provider_id"]: item for item in optimized}
+    comparison = {
+        provider_id: {
+            "reference_mean_seconds_per_frame": reference_map[provider_id][
+                "mean_seconds_per_frame"
+            ],
+            "optimized_mean_seconds_per_frame": optimized_map[provider_id][
+                "mean_seconds_per_frame"
+            ],
+            "speedup": (
+                reference_map[provider_id]["mean_seconds_per_frame"]
+                / optimized_map[provider_id]["mean_seconds_per_frame"]
+                if optimized_map[provider_id]["mean_seconds_per_frame"] > 0.0
+                else None
+            ),
+        }
+        for provider_id in provider_ids
+    }
+    projected_observations = {"development": 112, "calibration": 448, "selection": 1008}
+    projected_runtime = {
+        split: sum(
+            optimized_map[provider_id]["mean_seconds_per_frame"] * frame_count
+            for provider_id, frame_count in (
+                (provider_id, count) for provider_id in provider_ids
+            )
+        )
+        for split, count in projected_observations.items()
+    }
+    return {
+        "profile_frame_count": profile_frame_count,
+        "provider_scope": provider_scope,
+        "reference": list(reference),
+        "optimized": list(optimized),
+        "comparison": comparison,
+        "projected_runtime_seconds": projected_runtime,
+    }
+
+
+__all__ = [
+    "profile_provider",
+    "runtime_profile_payload",
+    "select_profiling_records",
+]

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import time
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -168,6 +167,28 @@ from .domains.video_action_set.provider_observation_boundary import (
     provider_observation_for_record,
     refresh_provider_observation_metadata as _refresh_provider_observation_metadata,
 )
+from .domains.video_action_set.provider_measurement import (
+    SOURCE_SCOPE,
+    measure_record_collection,
+    provider_version as _provider_version,
+    score_record as _score_record,
+    score_vector_to_payload as _score_vector_to_payload,
+)
+from .domains.video_action_set.reachability_composition import (
+    REACHABILITY_COMPOSITION_VERSION,
+    REACHABILITY_TRACE_VERSION,
+    compose_reachability_trace,
+    gap_reachability_state as _gap_reachability_state,
+    state_from_trace as _state_from_trace,
+    top_row_action_map as _top_row_action_map,
+    trace_digest as _trace_digest,
+    validate_reachability_trace,
+)
+from .domains.video_action_set.runtime_profiling import (
+    profile_provider as _profile_provider,
+    runtime_profile_payload,
+    select_profiling_records,
+)
 from .domains.video_action_set.arcade_observation import (
     render_row_frame as _render_row_frame,
     renderer_identity as _renderer_identity,
@@ -255,14 +276,11 @@ _STAGE4B_LEGACY_COMPATIBILITY_ALIASES = (
 
 
 EPISODE_SCHEMA_VERSION = "zeromodel-video-policy-episode/v1"
-REACHABILITY_COMPOSITION_VERSION = "zeromodel-video-action-set-reachability-composition/v1"
-REACHABILITY_TRACE_VERSION = "zeromodel-video-action-set-reachability-trace/v1"
 PHASE_ACCESS_VERSION = "zeromodel-video-prospective-phase-access/v1"
 REFERENCE_VERIFICATION_VERSION = "zeromodel-video-action-set-reference-verification/v1"
 MUTATION_AUDIT_VERSION = "zeromodel-video-action-set-reference-mutation-audit/v1"
 CLOSURE_REPORT_VERSION = "zeromodel-video-action-set-reference-closure/v1"
 MUTATION_MATRIX_VERSION = "zeromodel-video-action-set-reference-mutation-matrix/v3"
-SOURCE_SCOPE = "zeromodel-video-action-set-reachability-benchmark-v1"
 SEMANTIC_OUTCOME_VERSION = VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION
 
 
@@ -322,14 +340,6 @@ def _build_durable_runtime(output_dir: Path):
     output_dir.mkdir(parents=True, exist_ok=True)
     database_url = f"sqlite:///{(output_dir / 'benchmark.sqlite3').as_posix()}"
     return build_sqlite_runtime(database_url, initialize_schema=True)
-
-
-def _provider_version(provider_id: str) -> str:
-    return {
-        "P1": PROSPECTIVE_P1_VERSION,
-        "P2": PROSPECTIVE_P2_VERSION,
-        "P3": PROSPECTIVE_P3_VERSION,
-    }[provider_id]
 
 
 def _load_reachability_tile(repo_root: Path) -> dict[str, Any]:
@@ -492,64 +502,7 @@ def _materialize_records(split: str, repo_root: Path) -> list[dict[str, Any]]:
 
 def _profiling_records(repo_root: Path, frame_count: int) -> list[dict[str, Any]]:
     selection = _materialize_records("selection", repo_root)
-    candidates = []
-    valid_records = [record for record in selection if record["expected_disposition"] == "valid"]
-    invalid_records = [record for record in selection if record["expected_disposition"] == "distinguishable_invalid_input"]
-    control_records = [record for record in selection if record["expected_disposition"] == "information_theoretic_control"]
-    candidates.extend(valid_records[:4])
-    candidates.extend(valid_records[4:6])
-    candidates.extend(invalid_records[:2])
-    candidates.extend(control_records[:2])
-    return candidates[: max(1, frame_count)]
-
-
-def _score_vector_to_payload(vector: Any) -> dict[str, Any]:
-    return {
-        "provider_id": vector.provider_id,
-        "provider_version": vector.provider_version,
-        "row_ids": list(vector.row_ids),
-        "raw_scores": list(vector.raw_scores),
-        "quantized_scores": list(vector.quantized_scores),
-        "ranking": list(vector.evidence.ranking.ranked_row_ids),
-        "tie_groups": [group.to_dict() for group in vector.evidence.ranking.tie_groups],
-        "score_vector_digest": vector.evidence.score_vector_digest,
-        "ranking_digest": vector.evidence.ranking.to_dict()["ranking_digest"],
-    }
-
-
-def _profile_provider(
-    *,
-    provider_id: str,
-    records: list[dict[str, Any]],
-    prototypes: Mapping[str, tuple[str, str, str, ImageObservation]],
-    policy_artifact_id: str,
-    implementation: str,
-) -> dict[str, Any]:
-    scorer = score_all_rows_reference if implementation == "reference" else score_all_rows_optimized
-    durations = []
-    for record in records:
-        observation = provider_observation_for_record(record)
-        start = time.perf_counter()
-        scorer(
-            provider_id=provider_id,
-            observation=observation,
-            prototypes=prototypes,
-            policy_artifact_id=policy_artifact_id,
-            source_scope=SOURCE_SCOPE,
-        )
-        durations.append(time.perf_counter() - start)
-    total = float(sum(durations))
-    mean_frame = total / float(len(durations) or 1)
-    return {
-        "provider_id": provider_id,
-        "implementation": implementation,
-        "frame_count": len(durations),
-        "total_seconds": total,
-        "mean_seconds_per_frame": mean_frame,
-        "mean_seconds_per_candidate": mean_frame / 112.0,
-        "provider_scoring_call_count": len(durations),
-        "candidate_comparison_count": len(durations) * 112,
-    }
+    return select_profiling_records(selection, frame_count)
 
 
 def profile_runtime(
@@ -568,33 +521,13 @@ def profile_runtime(
     for provider_id in provider_ids:
         reference.append(_profile_provider(provider_id=provider_id, records=records, prototypes=prototypes, policy_artifact_id=policy_artifact_id, implementation="reference"))
         optimized.append(_profile_provider(provider_id=provider_id, records=records, prototypes=prototypes, policy_artifact_id=policy_artifact_id, implementation="optimized"))
-    reference_map = {item["provider_id"]: item for item in reference}
-    optimized_map = {item["provider_id"]: item for item in optimized}
-    comparison = {
-        provider_id: {
-            "reference_mean_seconds_per_frame": reference_map[provider_id]["mean_seconds_per_frame"],
-            "optimized_mean_seconds_per_frame": optimized_map[provider_id]["mean_seconds_per_frame"],
-            "speedup": (
-                reference_map[provider_id]["mean_seconds_per_frame"] / optimized_map[provider_id]["mean_seconds_per_frame"]
-                if optimized_map[provider_id]["mean_seconds_per_frame"] > 0.0
-                else None
-            ),
-        }
-        for provider_id in provider_ids
-    }
-    projected_observations = {"development": 112, "calibration": 448, "selection": 1008}
-    projected_runtime = {
-        split: sum(optimized_map[provider_id]["mean_seconds_per_frame"] * frame_count for provider_id, frame_count in ((provider_id, count) for provider_id in provider_ids))
-        for split, count in projected_observations.items()
-    }
-    payload = {
-        "profile_frame_count": len(records),
-        "provider_scope": provider,
-        "reference": reference,
-        "optimized": optimized,
-        "comparison": comparison,
-        "projected_runtime_seconds": projected_runtime,
-    }
+    payload = runtime_profile_payload(
+        provider_scope=provider,
+        provider_ids=provider_ids,
+        profile_frame_count=len(records),
+        reference=reference,
+        optimized=optimized,
+    )
     _write_json(output_dir / "runtime-profile-reference.json", {"profiles": reference, "profile_frame_count": len(records)})
     _write_json(output_dir / "runtime-profile-optimized.json", {"profiles": optimized, "profile_frame_count": len(records)})
     _write_json(output_dir / "runtime-comparison.json", payload)
@@ -683,216 +616,6 @@ def verify_provider_runtime_equivalence(output_dir: Path, repo_root: Path) -> di
     return payload
 
 
-def _trace_digest(payload: Mapping[str, Any]) -> str:
-    return _sha256({key: value for key, value in payload.items() if key != "trace_digest"})
-
-
-def _top_row_action_map(outcome: Mapping[str, Any]) -> dict[str, str]:
-    return {str(item["row_id"]): str(item["action_id"]) for item in outcome.get("top_row_actions", [])}
-
-
-def compose_reachability_trace(
-    *,
-    frame_id: str,
-    semantic_outcome: Mapping[str, Any],
-    previous_state: Mapping[str, Any] | None,
-    reachability_tile: Mapping[str, Any],
-    row_actions: Mapping[str, str],
-) -> dict[str, Any]:
-    _validate_reachability_tile_identity(reachability_tile)
-    top_rows = tuple(str(row_id) for row_id in semantic_outcome.get("top_row_ids", ()))
-    top_row_actions = _top_row_action_map(semantic_outcome)
-    if set(top_rows) != set(top_row_actions):
-        raise VPMValidationError("semantic top rows and row/action mapping disagree")
-    if any(row_actions[row_id] != top_row_actions[row_id] for row_id in top_rows):
-        raise VPMValidationError("semantic outcome row/action mapping is inconsistent with policy")
-    consulted_edges = []
-    reachable_pairs = []
-    removed_rows = []
-    retained_rows: tuple[str, ...]
-    rejection_reason = None
-
-    prior_rows = tuple(str(row_id) for row_id in (previous_state or {}).get("candidate_rows", ()))
-    prior_status = None if previous_state is None else str(previous_state.get("status", "unresolved"))
-    if previous_state is not None and prior_status == "unresolved":
-        retained_rows = ()
-        removed_rows = list(top_rows)
-        rejection_reason = "prior_state_unresolved"
-    elif previous_state is None:
-        retained_rows = tuple(sorted(top_rows))
-    else:
-        retained = set()
-        for prior_row in prior_rows:
-            prior_action = row_actions[prior_row]
-            edge = _tile_edge(reachability_tile, prior_row, prior_action)
-            edge_payload = {
-                "source_row_id": edge["source_row_id"],
-                "action_id": edge["action_id"],
-                "reachable_row_ids": list(edge["reachable_row_ids"]),
-            }
-            consulted_edges.append(edge_payload)
-            reachable = set(edge["reachable_row_ids"])
-            for current_row in top_rows:
-                if current_row in reachable:
-                    retained.add(current_row)
-                    reachable_pairs.append({"source_row_id": prior_row, "action_id": prior_action, "destination_row_id": current_row})
-        retained_rows = tuple(sorted(retained))
-        removed_rows = sorted(set(top_rows) - set(retained_rows))
-        if not retained_rows:
-            rejection_reason = "no_reachable_candidate"
-
-    retained_actions = tuple(sorted({row_actions[row_id] for row_id in retained_rows}))
-    if rejection_reason is None and semantic_outcome.get("status") == "conflicting_action_tie" and len(retained_actions) > 1:
-        rejection_reason = "conflicting_reachable_actions"
-    resolved_action = retained_actions[0] if rejection_reason is None and len(retained_actions) == 1 else None
-    resolved_row = retained_rows[0] if rejection_reason is None and len(retained_rows) == 1 else None
-    status = "rejected" if rejection_reason else ("resolved" if resolved_action is not None else "unresolved")
-    trace = {
-        "version": REACHABILITY_TRACE_VERSION,
-        "composition_version": REACHABILITY_COMPOSITION_VERSION,
-        "frame_id": frame_id,
-        "semantic_outcome_digest": semantic_outcome["semantic_outcome_digest"],
-        "input_candidate_rows": list(top_rows),
-        "input_candidate_actions": sorted({top_row_actions[row_id] for row_id in top_rows}),
-        "prior_reachable_rows": list(prior_rows),
-        "prior_state_status": prior_status,
-        "reachability_tile_identity": reachability_tile["tile_digest"],
-        "consulted_edges": consulted_edges,
-        "reachable_candidate_pairs": reachable_pairs,
-        "removed_rows": removed_rows,
-        "removed_actions": sorted({row_actions[row_id] for row_id in removed_rows}),
-        "retained_rows": list(retained_rows),
-        "retained_actions": list(retained_actions),
-        "resulting_candidate_set": list(retained_rows),
-        "resolved_row_id": resolved_row,
-        "resolved_action_id": resolved_action,
-        "rejection_reason": rejection_reason,
-        "executed_action": resolved_action,
-        "status": status,
-    }
-    trace["trace_digest"] = _trace_digest(trace)
-    return trace
-
-
-def validate_reachability_trace(
-    trace: Mapping[str, Any],
-    *,
-    semantic_outcome: Mapping[str, Any],
-    previous_state: Mapping[str, Any] | None,
-    reachability_tile: Mapping[str, Any],
-    row_actions: Mapping[str, str],
-) -> str:
-    try:
-        expected = compose_reachability_trace(
-            frame_id=str(trace["frame_id"]),
-            semantic_outcome=semantic_outcome,
-            previous_state=previous_state,
-            reachability_tile=reachability_tile,
-            row_actions=row_actions,
-        )
-    except VPMValidationError as exc:
-        if "reachability tile digest" in str(exc):
-            return "foreign_reachability_tile"
-        return "reachability_trace_recompute_failed"
-    if str(trace.get("reachability_tile_identity")) != str(reachability_tile["tile_digest"]):
-        return "foreign_reachability_tile"
-    if str(trace.get("trace_digest")) != _trace_digest(trace):
-        return "foreign_reachability_trace_digest"
-    if list(trace.get("consulted_edges", [])) != expected["consulted_edges"]:
-        return "consulted_edge_mismatch"
-    if list(trace.get("reachable_candidate_pairs", [])) != expected["reachable_candidate_pairs"]:
-        return "reachable_pair_mismatch"
-    if dict(trace) != expected:
-        return "reachability_trace_mismatch"
-    return "ok"
-
-
-def _state_from_trace(trace: Mapping[str, Any]) -> dict[str, Any]:
-    if trace["status"] == "rejected":
-        return {"status": "unresolved", "candidate_rows": tuple(), "reason": trace["rejection_reason"]}
-    return {"status": "resolved", "candidate_rows": tuple(str(row_id) for row_id in trace["retained_rows"])}
-
-
-def _gap_reachability_state(record: Mapping[str, Any]) -> dict[str, Any]:
-    return {"status": "unresolved", "candidate_rows": tuple(), "reason": record.get("gap_declaration") or "typed_gap_event"}
-
-
-def _score_record(
-    record: dict[str, Any],
-    prototypes: Mapping[str, tuple[str, str, str, ImageObservation]],
-    policy_artifact_id: str,
-    *,
-    reachability_tile: Mapping[str, Any] | None = None,
-    reachability_state: dict[str, Mapping[str, Any] | None] | None = None,
-    row_actions: Mapping[str, str] | None = None,
-) -> list[dict[str, Any]]:
-    if "pixels" not in record:
-        raise VPMValidationError("materialized record missing pixels")
-    if record["pixels"] is None:
-        raise VPMValidationError("typed gap events cannot be provider-scored as ordinary frames")
-    observation = provider_observation_for_record(record)
-    observation_descriptor = observation.to_descriptor()
-    observation_descriptor_digest = _provider_observation_digest(observation_descriptor)
-    p1 = score_normalized_pixel(observation=observation, prototypes=prototypes, policy_artifact_id=policy_artifact_id)
-    p2 = score_registered_local_correlation(observation=observation, prototypes=prototypes, policy_artifact_id=policy_artifact_id, source_scope=SOURCE_SCOPE)
-    p3 = score_b3_joint_fit(observation=observation, prototypes=prototypes, policy_artifact_id=policy_artifact_id, source_scope=SOURCE_SCOPE)
-    outputs = []
-    for result in (p1, p2, p3):
-        outcome = result.semantic_top_set_outcome
-        operational_trace = None
-        if reachability_tile is not None and reachability_state is not None and row_actions is not None:
-            previous = reachability_state.get(result.provider_id)
-            operational_trace = compose_reachability_trace(
-                frame_id=record["frame_id"],
-                semantic_outcome=outcome.to_dict(),
-                previous_state=previous,
-                reachability_tile=reachability_tile,
-                row_actions=row_actions,
-            )
-            reachability_state[result.provider_id] = _state_from_trace(operational_trace)
-        winner_quantized_score = outcome.top_quantized_score if outcome.resolved_row_id is not None else None
-        outputs.append(
-            {
-                **{key: value for key, value in record.items() if key != "pixels"},
-                "provider_id": result.provider_id,
-                "provider_version": result.provider_version,
-                "policy_artifact_id": policy_artifact_id,
-                "reachability_tile_digest": REACHABILITY_TILE_DIGEST,
-                "all_112_row_ids": [item["row_id"] for item in result.evidence.to_dict()["row_scores"]],
-                "all_112_raw_scores": [item["raw_score"] for item in result.evidence.to_dict()["row_scores"]],
-                "all_112_quantized_scores": [item["quantized_score"] for item in result.evidence.to_dict()["row_scores"]],
-                "complete_ordered_ranking": list(result.evidence.ranking.ranked_row_ids),
-                "tie_groups": [group.to_dict() for group in result.evidence.ranking.tie_groups],
-                "semantic_top_set_outcome": outcome.to_dict(),
-                "semantic_status": outcome.status,
-                "resolved_row": outcome.resolved_row_id,
-                "resolved_action": outcome.resolved_action_id,
-                "top_quantized_score": outcome.top_quantized_score,
-                "top_row_ids": list(outcome.top_row_ids),
-                "top_action_ids": list(outcome.top_action_ids),
-                "semantic_outcome_digest": outcome.semantic_outcome_digest,
-                "reachability_composition_trace": operational_trace,
-                "winner_row": result.winner_row_id,
-                "winner_action": result.winner_action_id,
-                "winner_quantized_score": winner_quantized_score,
-                "runner_up_row": result.evidence.ranking.ranked_row_ids[1],
-                "runner_up_quantized_score": result.evidence.row_scores[[item.row_id for item in result.evidence.row_scores].index(result.evidence.ranking.ranked_row_ids[1])].quantized_score,
-                "policy_row_universe_digest": result.evidence.policy_row_universe_digest,
-                "quantized_score_vector_digest": result.evidence.quantized_score_vector_digest,
-                "raw_score_diagnostic_digest": result.evidence.raw_score_diagnostic_digest,
-                "score_vector_digest": result.evidence.score_vector_digest,
-                "ranking_digest": result.evidence.ranking.to_dict()["ranking_digest"],
-                "observation_digest": record["observation_pixel_digest"],
-                "provider_observation_descriptor": observation_descriptor,
-                "provider_observation_digest": observation_descriptor_digest,
-                "episode_seed": record["metadata"]["episode_seed"],
-                "generator_identity": {"generator_version": GENERATOR_VERSION, "seed_digest": record["metadata"]["seed_digest"]},
-                "provider_diagnostics": dict(result.diagnostics),
-            }
-        )
-    return outputs
-
-
 def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]:
     split_dir = output_dir / split
     runtime = _build_durable_runtime(output_dir)
@@ -909,23 +632,13 @@ def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]
     records = _materialize_records(split, repo_root)
     runtime.video_action_set.save_observation_records(records)
     records = list(runtime.video_action_set.list_observation_records(benchmark_seed_digest=identity.seed_digest, split=split, include_pixels=True))
-    reachability_state: dict[str, Mapping[str, Any] | None] = {"P1": None, "P2": None, "P3": None}
-    scored_rows: list[dict[str, Any]] = []
-    for record in records:
-        if record.get("event_type") == "gap_unknown" or record.get("pixels") is None:
-            for provider_id in reachability_state:
-                reachability_state[provider_id] = _gap_reachability_state(record)
-            continue
-        scored_rows.extend(
-            _score_record(
-                record,
-                prototypes,
-                policy_artifact_id,
-                reachability_tile=reachability_tile,
-                reachability_state=reachability_state,
-                row_actions=row_actions,
-            )
-        )
+    scored_rows = measure_record_collection(
+        records,
+        prototypes,
+        policy_artifact_id,
+        reachability_tile=reachability_tile,
+        row_actions=row_actions,
+    )
     _write_jsonl(split_dir / "frame-metadata.jsonl", [{key: value for key, value in record.items() if key != "pixels"} for record in records])
     _write_jsonl(split_dir / "provider-evidence.jsonl", scored_rows)
     manifest = {


### PR DESCRIPTION
Audit-Exempt: behavior-preserving extraction of provider identity lookup,
score-vector projection, per-record provider measurement, semantic evidence-row
construction, temporal reachability composition, reachability-trace
self-validation, ordered record-stream measurement, bounded profiling-record
selection, provider runtime timing, and runtime comparison payload
construction. No provider formulas, score vectors, rankings, tie groups,
semantic outcomes, reachability traces, evidence-row identities, benchmark
evidence, claims, or conclusions changed.

## Scope

- reachability composition extracted
- reachability trace validation extracted
- provider evidence-row construction extracted
- ordered record-stream measurement extracted
- runtime profiling primitives extracted
- build_split remains orchestration
- profile_runtime remains filesystem/report orchestration
- _profiling_records remains materialization wrapper
- provider science remains unchanged
- reference verification remains legacy
- mutation audit remains legacy
- persistence remains unchanged
- quality ceiling reduced
- architecture checker decomposed further
- integration and slow tests not run
- complete split scoring not run

## Test-tier note

- fast Stage 7A measurement tests use frozen provider-result objects for orchestration, evidence-row, reachability-state, gap, control, and error-order contracts
- the single real P1/P2/P3 `score_record()` evidence-row golden is retained in `tests/integration/test_video_provider_measurement_real.py`
- `tests/test_visual_system_b.py::test_system_b_candidate_enumeration_and_selection_are_deterministic` was not assertion-failing; it was the active test when the previous 60-second fast-suite watchdog expired

## Validation

- focused Stage 7A tests passed before the integration-tier adjustment
- `python scripts/check_architecture.py`: passed
- `python scripts/check_quality.py`: passed
- `python -m build`: passed
- GitHub Python package matrix: passed on Python 3.10, 3.11, and 3.12
- Claims audit guard: passed
- Lua edge policy fixture: passed

## Not run

- integration or slow tests
- real provider measurement integration golden
- complete development, calibration, selection, or final materialization/scoring
- provider runtime equivalence, canonical-provider audit, reference verification, mutation audit, mutation matrix, evidence completeness audit, complete family closure, or full benchmark build