### PR TITLE
refactor: extract video verification and falsification

### DIFF
--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -8,8 +8,8 @@ maximum_function_parameters = 10
 maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
-reason = "Stage 7A benchmark orchestration with verification and audit paths pending behavior-preserving decomposition"
-maximum_lines = 2987
+reason = "Stage 7B filesystem, report, mutation-application, and CLI orchestration pending behavior-preserving decomposition"
+maximum_lines = 2057
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/architecture_rules/__init__.py
+++ b/scripts/architecture_rules/__init__.py
@@ -5,7 +5,19 @@ from collections.abc import Sequence
 from typing import Any
 
 
-TRACKED_EXTERNAL_MODULES = frozenset({"json", "pathlib", "sqlite3", "sqlalchemy"})
+TRACKED_EXTERNAL_MODULES = frozenset(
+    {
+        "csv",
+        "json",
+        "os",
+        "pathlib",
+        "shutil",
+        "sqlite3",
+        "sqlalchemy",
+        "subprocess",
+        "tempfile",
+    }
+)
 
 
 def print_violations(violations: Sequence[Any]) -> None:

--- a/scripts/architecture_rules/video_verification_layers.py
+++ b/scripts/architecture_rules/video_verification_layers.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+
+class ImportEdgeLike(Protocol):
+    importer: str
+    imported: str
+    line: int
+
+
+ViolationFactory = Callable[[str, ImportEdgeLike], Any]
+
+DOMAIN_PREFIX = "zeromodel.domains.video_action_set"
+BENCHMARK_MODULE = "zeromodel.video_action_set_benchmark"
+REFERENCE_VERIFICATION_MODULE = f"{DOMAIN_PREFIX}.reference_verification"
+EVIDENCE_AUDIT_MODULE = f"{DOMAIN_PREFIX}.evidence_audit"
+MUTATION_AUDIT_MODULE = f"{DOMAIN_PREFIX}.mutation_audit"
+MUTATION_MATRIX_MODULE = f"{DOMAIN_PREFIX}.mutation_matrix"
+VERIFICATION_MODULE = f"{DOMAIN_PREFIX}.verification"
+
+STAGE7B_MODULES = {
+    REFERENCE_VERIFICATION_MODULE,
+    EVIDENCE_AUDIT_MODULE,
+    MUTATION_AUDIT_MODULE,
+    MUTATION_MATRIX_MODULE,
+    VERIFICATION_MODULE,
+}
+
+_STAGE7B_ORDER = {
+    REFERENCE_VERIFICATION_MODULE: 0,
+    EVIDENCE_AUDIT_MODULE: 1,
+    MUTATION_AUDIT_MODULE: 2,
+    MUTATION_MATRIX_MODULE: 3,
+    VERIFICATION_MODULE: 4,
+}
+
+_EXTERNAL_INFRASTRUCTURE = {
+    "csv",
+    "json",
+    "os",
+    "pathlib",
+    "shutil",
+    "sqlite3",
+    "sqlalchemy",
+    "subprocess",
+    "tempfile",
+}
+_FORBIDDEN_PREFIXES = {
+    "zeromodel.db",
+    "zeromodel.stores",
+    "zeromodel.runtime",
+    f"{DOMAIN_PREFIX}.engine",
+    f"{DOMAIN_PREFIX}.facade",
+    f"{DOMAIN_PREFIX}.identity_service",
+    f"{DOMAIN_PREFIX}.episode_plan_service",
+    f"{DOMAIN_PREFIX}.observation_service",
+    f"{DOMAIN_PREFIX}.store",
+    "zeromodel.cli",
+    "zeromodel.reporting",
+}
+_EXECUTION_MODULES = {
+    f"{DOMAIN_PREFIX}.episode_materialization",
+    f"{DOMAIN_PREFIX}.materialization_kernels",
+    f"{DOMAIN_PREFIX}.control_histories",
+    f"{DOMAIN_PREFIX}.family_intervention_planning",
+    f"{DOMAIN_PREFIX}.episode_planning",
+}
+def _is_under(module: str, prefix: str) -> bool:
+    return module == prefix or module.startswith(f"{prefix}.")
+
+
+def _is_stage7b_infrastructure(module: str) -> bool:
+    return module in _EXTERNAL_INFRASTRUCTURE or any(
+        _is_under(module, prefix) for prefix in _FORBIDDEN_PREFIXES
+    )
+
+
+def stage7b_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    importer = edge.importer
+    imported = edge.imported
+    violations: list[Any] = []
+
+    def reject(rule: str) -> None:
+        violations.append(violation_factory(rule, edge))
+
+    if (
+        imported in STAGE7B_MODULES
+        and importer not in STAGE7B_MODULES | {BENCHMARK_MODULE}
+        and _is_under(importer, "zeromodel")
+    ):
+        reject("Stage 6 and lower scientific modules must not import Stage 7B")
+
+    if importer not in STAGE7B_MODULES:
+        return violations
+
+    if imported == BENCHMARK_MODULE:
+        reject("Stage 7B modules must not import the legacy benchmark")
+    if _is_stage7b_infrastructure(imported):
+        reject(
+            "Stage 7B modules must not import filesystem, persistence, runtime, "
+            "RMDTO service, reporting, or CLI layers"
+        )
+    if imported in _EXECUTION_MODULES:
+        reject("Stage 7B modules must not import planning or materialization executors")
+    if (
+        imported in STAGE7B_MODULES
+        and _STAGE7B_ORDER[imported] > _STAGE7B_ORDER[importer]
+    ):
+        reject("Stage 7B modules must follow reference-to-closure dependency order")
+    return violations
+
+
+__all__ = [
+    "EVIDENCE_AUDIT_MODULE",
+    "MUTATION_AUDIT_MODULE",
+    "MUTATION_MATRIX_MODULE",
+    "REFERENCE_VERIFICATION_MODULE",
+    "STAGE7B_MODULES",
+    "VERIFICATION_MODULE",
+    "stage7b_forbidden_edge_violations",
+]

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -267,12 +267,16 @@ def forbidden_edge_violations(edges: list[ImportEdge]) -> list[Violation]:
     from architecture_rules.video_science_layers import (
         video_science_forbidden_edge_violations,
     )
+    from architecture_rules.video_verification_layers import (
+        stage7b_forbidden_edge_violations,
+    )
 
     violations: list[Violation] = []
     for edge in edges:
         violations.extend(video_science_forbidden_edge_violations(edge, edge_violation))
         violations.extend(stage6_forbidden_edge_violations(edge, edge_violation))
         violations.extend(stage7a_forbidden_edge_violations(edge, edge_violation))
+        violations.extend(stage7b_forbidden_edge_violations(edge, edge_violation))
     return violations
 
 

--- a/tests/test_video_evidence_audit_kernel.py
+++ b/tests/test_video_evidence_audit_kernel.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from zeromodel.domains.video_action_set import evidence_audit
+
+
+def test_phase_access_counts_are_built_from_loaded_payloads() -> None:
+    final_plan = {"sealed_episode_ids": {"valid": ["final:1"]}}
+    frames = {
+        "development": [{"episode_id": "dev:1", "split": "development"}],
+        "calibration": [],
+        "selection": [],
+        "final": [{"episode_id": "final:1", "split": "final"}],
+    }
+    evidence = {
+        "development": [],
+        "calibration": [],
+        "selection": [],
+        "final": [
+            {
+                "episode_id": "final:1",
+                "split": "final",
+                "reachability_composition_trace": {"trace": True},
+            }
+        ],
+    }
+
+    payload = evidence_audit.measured_phase_access_counts(
+        final_plan=final_plan,
+        frame_rows_by_split=frames,
+        evidence_rows_by_split=evidence,
+        existing_artifacts=["selected-calibration.json", "final-results.json"],
+    )
+
+    assert list(payload) == [
+        "version",
+        "final_materialization_count",
+        "final_score_access_count",
+        "final_reachability_execution_count",
+        "candidate_set_selection_count",
+        "candidate_tuning_execution_count",
+        "conformal_calibration_count",
+        "calibration_execution_count",
+        "architecture_selection_execution_count",
+        "reachability_replay_count",
+        "final_evaluation_count",
+        "forbidden_final_access_counter",
+    ]
+    assert payload["final_materialization_count"] == 1
+    assert payload["final_score_access_count"] == 1
+    assert payload["final_reachability_execution_count"] == 1
+    assert payload["calibration_execution_count"] == 1
+    assert payload["final_evaluation_count"] == 1
+
+
+def test_identity_and_overlap_payloads_preserve_split_order() -> None:
+    frames = {
+        "development": [{"frame_id": "d:1", "episode_id": "dev:1"}],
+        "calibration": [{"frame_id": "shared", "episode_id": "cal:1"}],
+        "selection": [{"frame_id": "shared", "episode_id": "final:1"}],
+    }
+    identity = evidence_audit.build_observation_identity_manifest(frames)
+    overlap = evidence_audit.build_split_overlap_audit(
+        frame_rows_by_split=frames,
+        final_plan={"sealed_episode_ids": {"valid": ["final:1"]}},
+    )
+
+    assert list(identity) == [
+        "development_observation_count",
+        "calibration_observation_count",
+        "selection_observation_count",
+        "all_frame_ids_digest",
+    ]
+    assert overlap["calibration_selection_overlap"] == 1
+    assert overlap["materialized_final_plan_overlap"] == 1
+
+
+def test_malformed_evidence_counts_are_not_repaired() -> None:
+    malformed = {
+        "all_112_row_ids": [],
+        "all_112_raw_scores": [],
+        "all_112_quantized_scores": [],
+        "complete_ordered_ranking": [],
+        "tie_groups": [],
+        "semantic_top_set_outcome": {"version": "foreign"},
+    }
+    frames = {
+        split: [
+            {
+                "expected_disposition": "valid",
+                "metadata": {},
+            }
+        ]
+        for split in ("development", "calibration", "selection")
+    }
+    evidence = {
+        split: [malformed] for split in ("development", "calibration", "selection")
+    }
+
+    payload = evidence_audit.audit_evidence_rows(
+        frame_rows_by_split=frames,
+        evidence_rows_by_split=evidence,
+        row_actions={},
+    )
+
+    assert payload == {
+        "complete_score_evidence": False,
+        "missing_score_vector_count": 6,
+        "invalid_score_count": 0,
+        "missing_ranking_count": 3,
+        "missing_tie_group_count": 3,
+        "missing_semantic_outcome_count": 3,
+        "missing_reachability_trace_count": 3,
+        "split_summaries": [
+            {"split": "development", "provider_frame_records": 1},
+            {"split": "calibration", "provider_frame_records": 1},
+            {"split": "selection", "provider_frame_records": 1},
+        ],
+    }
+
+
+def test_access_prohibition_finding_order_is_frozen() -> None:
+    measured = {
+        "final_materialization_count": 1,
+        "final_score_access_count": 1,
+        "final_reachability_execution_count": 0,
+        "calibration_execution_count": 0,
+        "architecture_selection_execution_count": 1,
+        "candidate_tuning_execution_count": 1,
+        "final_evaluation_count": 0,
+    }
+
+    gate = evidence_audit.access_prohibition_gate(measured, {})
+
+    assert [finding["code"] for finding in gate["findings"]] == [
+        "forbidden_final_materialization",
+        "forbidden_final_score_access",
+        "forbidden_selection_execution",
+    ]

--- a/tests/test_video_mutation_audit_kernel.py
+++ b/tests/test_video_mutation_audit_kernel.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.domains.video_action_set import mutation_audit, mutation_matrix
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+
+
+def _isolation(
+    effect: str,
+    *,
+    changed: int = 1,
+    passed: bool = True,
+) -> dict[str, object]:
+    return {
+        "changed_fields": ["artifact.value"] if changed else [],
+        "expected_changed_files": ["artifact.json"],
+        "unexpected_changed_fields": [] if passed else ["other.value"],
+        "changed_field_count": changed,
+        "isolation_passed": passed,
+        "mutation_effect_digest": effect,
+    }
+
+
+def _report(
+    code: str | None,
+    *,
+    secondary: tuple[str, ...] = (),
+) -> dict[str, object]:
+    findings = [] if code is None else [{"code": code}]
+    findings.extend({"code": item} for item in secondary)
+    return {
+        "primary_failure_code": code,
+        "primary_failure_gate": None if code is None else "structural_identity",
+        "gates": []
+        if not findings
+        else [{"gate": "structural_identity", "findings": findings}],
+    }
+
+
+def _evaluate(
+    case: dict[str, object],
+    *,
+    code: str | None,
+    effect: str,
+    changed: int = 1,
+    passed: bool = True,
+    secondary: tuple[str, ...] = (),
+    application_error: str | None = None,
+) -> dict[str, object]:
+    return mutation_audit.evaluate_mutation_case(
+        case=case,
+        report=_report(code, secondary=secondary),
+        isolation=_isolation(effect, changed=changed, passed=passed),
+        application_error=application_error,
+    )
+
+
+def test_mutation_registry_identity_and_legacy_aliases_are_frozen() -> None:
+    names = [case["name"] for case in mutation_audit._MUTATION_CASES]
+
+    assert len(names) == 93
+    assert names[:3] == [
+        "evidence_raw_score_preserve_quantized_bin",
+        "evidence_raw_score_cross_quantization_boundary",
+        "evidence_quantized_score_changed",
+    ]
+    assert names[-3:] == [
+        "access_change_failed_gate_status_to_passed",
+        "access_change_repository_status_to_correct",
+        "access_remove_required_gate_from_closure_report",
+    ]
+    assert canonical_sha256(mutation_audit._MUTATION_CASES) == (
+        "sha256:49884af315dc025814fff61d63f64cf8c15bea0a6bbe4422792e3aa4714dc3bc"
+    )
+    assert benchmark._changed_fields is mutation_audit._changed_fields
+    assert (
+        benchmark._mutation_isolation_report
+        is mutation_audit._mutation_isolation_report
+    )
+    assert benchmark.mutation_catalogue is mutation_matrix.mutation_catalogue
+
+
+def test_mutation_isolation_is_structural_and_read_only() -> None:
+    before = {"record.json": {"nested": {"value": 1}, "stable": True}}
+    after = deepcopy(before)
+    after["record.json"]["nested"]["value"] = 2
+    case = {
+        "artifact_class": "policy",
+        "name": "policy_alter_row_to_action_mapping",
+        "expected_changed_files": ["record.json"],
+    }
+    original = deepcopy(before)
+
+    result = mutation_audit._mutation_isolation_report(before, after, case)
+
+    assert before == original
+    assert result["changed_fields"] == ["record.json.nested.value"]
+    assert result["unexpected_changed_fields"] == []
+    assert result["isolation_passed"] is True
+
+
+def test_mutation_case_expected_detector_precedence_is_frozen() -> None:
+    case = mutation_matrix.mutation_catalogue()[0]
+    report = {
+        "primary_failure_code": case["expected_primary_failure_code"],
+        "primary_failure_gate": "structural_identity",
+        "gates": [
+            {
+                "gate": "structural_identity",
+                "findings": [
+                    {"code": case["expected_primary_failure_code"]},
+                    {"code": "ranking_reconstruction_mismatch"},
+                ],
+            }
+        ],
+    }
+    isolation = {
+        "changed_field_count": 1,
+        "isolation_passed": True,
+        "mutation_effect_digest": "sha256:effect-1",
+    }
+
+    result = mutation_audit.evaluate_mutation_case(
+        case=case,
+        report=report,
+        isolation=isolation,
+    )
+
+    assert result["expected_code_matched"] is True
+    assert result["actual_primary_failure_code"] == "raw_diagnostic_digest_mismatch"
+    assert result["secondary_failure_codes"] == [
+        {"gate": "structural_identity", "code": "ranking_reconstruction_mismatch"}
+    ]
+
+
+def test_mutation_audit_baseline_failure_remains_unavailable() -> None:
+    catalogue = mutation_matrix.mutation_catalogue()
+    payload = mutation_audit.build_mutation_audit_payload(
+        matrix_version=mutation_matrix.MUTATION_MATRIX_VERSION,
+        catalogue=catalogue,
+        selected_cases=catalogue[:2],
+        catalogue_findings=[],
+        results=[],
+        base_verified=False,
+        base_primary_failure_code="benchmark_manifest_mismatch",
+    )
+
+    assert payload["status"] == "unavailable"
+    assert payload["base_primary_failure_code"] == "benchmark_manifest_mismatch"
+    assert payload["missed_mutation_count"] == 2
+    assert payload["mutations"] == []
+
+
+def test_mutation_application_error_and_wrong_detector_are_not_success() -> None:
+    case = mutation_matrix.mutation_catalogue()[0]
+    application_error = _evaluate(
+        case,
+        code=None,
+        effect="sha256:application",
+        application_error="RuntimeError",
+    )
+    wrong_detector = _evaluate(
+        case,
+        code="ranking_reconstruction_mismatch",
+        effect="sha256:wrong-detector",
+        secondary=("tie_group_reconstruction_mismatch",),
+    )
+
+    assert application_error["actual_primary_failure_code"] == (
+        "mutation_application_error"
+    )
+    assert application_error["application_error"] == "RuntimeError"
+    assert application_error["expected_code_matched"] is False
+    assert wrong_detector["detected"] is True
+    assert wrong_detector["expected_code_matched"] is False
+    assert wrong_detector["secondary_failure_codes"] == [
+        {
+            "gate": "structural_identity",
+            "code": "tie_group_reconstruction_mismatch",
+        }
+    ]
+
+
+def test_semantic_invariant_success_and_failure_are_distinct() -> None:
+    invariant = next(
+        case
+        for case in mutation_matrix.mutation_catalogue()
+        if case["expected_result_type"] == "semantic_invariant"
+    )
+    success = _evaluate(
+        invariant,
+        code=None,
+        effect="sha256:invariant-success",
+    )
+    failure = _evaluate(
+        invariant,
+        code="semantic_status_mismatch",
+        effect="sha256:invariant-failure",
+    )
+
+    assert success["semantic_invariant_passed"] is True
+    assert success["expected_code_matched"] is True
+    assert failure["semantic_invariant_passed"] is False
+    assert failure["expected_code_matched"] is False
+
+
+def test_duplicate_effects_property_absence_and_isolation_failure_fail_audit() -> None:
+    catalogue = mutation_matrix.mutation_catalogue()
+    first, second = catalogue[:2]
+    duplicate_results = [
+        _evaluate(
+            first,
+            code=str(first["expected_primary_failure_code"]),
+            effect="sha256:duplicate",
+        ),
+        _evaluate(
+            second,
+            code=str(second["expected_primary_failure_code"]),
+            effect="sha256:duplicate",
+        ),
+    ]
+    duplicate = mutation_audit.build_mutation_audit_payload(
+        matrix_version=mutation_matrix.MUTATION_MATRIX_VERSION,
+        catalogue=catalogue,
+        selected_cases=catalogue[:2],
+        catalogue_findings=[],
+        results=duplicate_results,
+    )
+    no_property_change = mutation_audit.build_mutation_audit_payload(
+        matrix_version=mutation_matrix.MUTATION_MATRIX_VERSION,
+        catalogue=catalogue,
+        selected_cases=catalogue[:1],
+        catalogue_findings=[],
+        results=[
+            _evaluate(
+                first,
+                code=str(first["expected_primary_failure_code"]),
+                effect="sha256:no-property",
+                changed=0,
+            )
+        ],
+    )
+    isolation_failure = mutation_audit.build_mutation_audit_payload(
+        matrix_version=mutation_matrix.MUTATION_MATRIX_VERSION,
+        catalogue=catalogue,
+        selected_cases=catalogue[:1],
+        catalogue_findings=[],
+        results=[
+            _evaluate(
+                first,
+                code=str(first["expected_primary_failure_code"]),
+                effect="sha256:isolation-failure",
+                passed=False,
+            )
+        ],
+    )
+
+    assert duplicate["status"] == "failed"
+    assert [row["code"] for row in duplicate["duplicate_effect_findings"]] == [
+        "duplicate_mutation_effect"
+    ]
+    assert no_property_change["property_change_failure_count"] == 1
+    assert no_property_change["status"] == "failed"
+    assert isolation_failure["mutation_isolation_failure_count"] == 1
+    assert isolation_failure["status"] == "failed"
+
+
+def test_repeated_mutation_audit_detects_nondeterminism() -> None:
+    first = {"mutation_audit_digest": "sha256:first", "status": "passed"}
+    second = {"mutation_audit_digest": "sha256:second", "status": "passed"}
+
+    payload = mutation_audit.build_repeated_mutation_audit_payload(
+        matrix_version=mutation_matrix.MUTATION_MATRIX_VERSION,
+        first=first,
+        second=second,
+    )
+
+    assert payload["deterministic"] is False
+    assert payload["first_audit_digest"] == "sha256:first"
+    assert payload["second_audit_digest"] == "sha256:second"

--- a/tests/test_video_mutation_matrix_kernel.py
+++ b/tests/test_video_mutation_matrix_kernel.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set import mutation_matrix
+
+
+def _finding(mutation: str, effect: str) -> dict[str, object]:
+    return {
+        "mutation": mutation,
+        "expected_detected": True,
+        "detected": True,
+        "expected_code_matched": True,
+        "actual_primary_failure_code": "raw_diagnostic_digest_mismatch",
+        "secondary_failure_codes": [],
+        "mutation_isolation": {
+            "changed_field_count": 1,
+            "isolation_passed": True,
+            "mutation_effect_digest": effect,
+        },
+    }
+
+
+def _audit(
+    rows: list[dict[str, object]],
+    *,
+    status: str = "passed",
+    base_verified: bool = True,
+    executable_count: int | None = None,
+) -> dict[str, object]:
+    return {
+        "status": status,
+        "base_verified": base_verified,
+        "declared_mutation_count": 93,
+        "executable_mutation_count": (
+            len(rows) if executable_count is None else executable_count
+        ),
+        "mutations": rows,
+    }
+
+
+def test_mutation_catalogue_schema_and_counts_are_frozen() -> None:
+    catalogue = mutation_matrix.mutation_catalogue()
+
+    assert mutation_matrix.validate_mutation_catalogue() == []
+    assert len(catalogue) == 93
+    assert sum(case["expected_result_type"] == "detected" for case in catalogue) == 91
+    assert (
+        sum(case["expected_result_type"] == "semantic_invariant" for case in catalogue)
+        == 2
+    )
+    assert list(catalogue[0]) == [
+        "matrix_version",
+        "mutation_id",
+        "artifact_class",
+        "protected_scientific_property",
+        "fixture_selector",
+        "mutator_id",
+        "immediate_digest_recomputed",
+        "parent_digest_recomputed",
+        "expected_result_type",
+        "expected_primary_failure_code",
+        "permitted_secondary_failure_codes",
+        "expected_changed_files",
+        "validation_metadata",
+    ]
+
+
+def test_mutation_matrix_uses_registry_order_without_reexecution() -> None:
+    catalogue = mutation_matrix.mutation_catalogue()
+    first = str(catalogue[0]["mutation_id"])
+    second = str(catalogue[1]["mutation_id"])
+    audit = _audit(
+        [
+            _finding(second, "sha256:second"),
+            _finding(first, "sha256:first"),
+        ]
+    )
+
+    payload = mutation_matrix.build_mutation_matrix(audit)
+
+    assert payload["mutation_ids"] == [first, second]
+    assert [row["mutation"] for row in payload["mutations"]] == [first, second]
+    assert payload["matrix_digest"] == (
+        "sha256:c51879af559080769104fce8f73d9ac987afaaaf763b2ed2259064f5dee48a57"
+    )
+
+
+def test_mutation_matrix_rejects_duplicate_unknown_and_missing_results() -> None:
+    catalogue = mutation_matrix.mutation_catalogue()
+    first = str(catalogue[0]["mutation_id"])
+
+    duplicate = _audit(
+        [
+            _finding(first, "sha256:first"),
+            _finding(first, "sha256:second"),
+        ]
+    )
+    unknown = _audit([_finding("unknown-mutation", "sha256:unknown")])
+    missing = _audit([_finding(first, "sha256:first")], executable_count=2)
+
+    with pytest.raises(VPMValidationError, match="duplicate result ids"):
+        mutation_matrix.build_mutation_matrix(duplicate)
+    with pytest.raises(VPMValidationError, match="unknown result ids"):
+        mutation_matrix.build_mutation_matrix(unknown)
+    with pytest.raises(VPMValidationError, match="result count"):
+        mutation_matrix.build_mutation_matrix(missing)
+
+
+def test_mutation_matrix_rejects_malformed_result_and_ambiguous_id() -> None:
+    mutation_id = str(mutation_matrix.mutation_catalogue()[0]["mutation_id"])
+    malformed = _finding(mutation_id, "sha256:malformed")
+    del malformed["mutation_isolation"]
+    ambiguous = _finding(mutation_id, "sha256:ambiguous")
+    ambiguous["mutation_id"] = mutation_id
+
+    with pytest.raises(VPMValidationError, match="missing required fields"):
+        mutation_matrix.build_mutation_matrix(_audit([malformed]))
+    with pytest.raises(VPMValidationError, match="exactly one"):
+        mutation_matrix.build_mutation_matrix(_audit([ambiguous]))
+
+
+@pytest.mark.parametrize(
+    "audit",
+    [
+        _audit([], status="unavailable", executable_count=93),
+        _audit([], base_verified=False, executable_count=93),
+    ],
+)
+def test_mutation_matrix_rejects_unavailable_baselines(
+    audit: dict[str, object],
+) -> None:
+    with pytest.raises(VPMValidationError, match="unavailable baseline"):
+        mutation_matrix.build_mutation_matrix(audit)
+
+
+def test_mutation_matrix_preserves_wrong_and_multiple_detectors() -> None:
+    catalogue = mutation_matrix.mutation_catalogue()
+    first = _finding(str(catalogue[0]["mutation_id"]), "sha256:first")
+    second = _finding(str(catalogue[1]["mutation_id"]), "sha256:second")
+    first["expected_code_matched"] = False
+    first["actual_primary_failure_code"] = "ranking_reconstruction_mismatch"
+    second["secondary_failure_codes"] = [
+        {"gate": "structural_identity", "code": "ranking_reconstruction_mismatch"},
+        {"gate": "semantic_outcome", "code": "semantic_status_mismatch"},
+    ]
+
+    payload = mutation_matrix.build_mutation_matrix(
+        _audit([second, first], status="failed")
+    )
+
+    by_id = {row["mutation"]: row for row in payload["mutations"]}
+    assert by_id[first["mutation"]]["expected_code_matched"] is False
+    assert by_id[first["mutation"]]["actual_primary_failure_code"] == (
+        "ranking_reconstruction_mismatch"
+    )
+    assert by_id[second["mutation"]]["secondary_failure_codes"] == second[
+        "secondary_failure_codes"
+    ]
+
+    with pytest.raises(VPMValidationError, match="passed.*failing result"):
+        mutation_matrix.build_mutation_matrix(_audit([first]))
+
+
+def test_mutation_matrix_does_not_modify_audit_input() -> None:
+    mutation_id = str(mutation_matrix.mutation_catalogue()[0]["mutation_id"])
+    audit = _audit([_finding(mutation_id, "sha256:stable")])
+    before = deepcopy(audit)
+
+    mutation_matrix.build_mutation_matrix(audit)
+
+    assert audit == before

--- a/tests/test_video_reference_verification_kernel.py
+++ b/tests/test_video_reference_verification_kernel.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.domains.video_action_set import reference_verification as verification
+from zeromodel.domains.video_action_set.canonical_json import canonical_sha256
+from zeromodel.video_complete_row_evidence import (
+    CompleteRanking,
+    CompleteRowEvidence,
+    SemanticTopSetOutcome,
+    TieGroup,
+    build_complete_row_evidence,
+    build_semantic_top_set_outcome,
+)
+
+
+class _TieGroup:
+    def __init__(self, rows: tuple[str, ...]) -> None:
+        self._rows = rows
+
+    def to_dict(self) -> dict[str, object]:
+        return {"row_ids": list(self._rows)}
+
+
+def _result(*, quantized: tuple[int, ...], ranking: tuple[str, ...]):
+    complete_ranking = SimpleNamespace(
+        ranked_row_ids=ranking,
+        tie_groups=(_TieGroup(ranking),),
+        ranking_digest="sha256:ranking",
+    )
+    evidence = SimpleNamespace(
+        ranking=complete_ranking,
+        score_vector_digest="sha256:scores",
+    )
+    return SimpleNamespace(quantized_scores=quantized, evidence=evidence)
+
+
+def _row_ids() -> list[str]:
+    return [f"row-{index:03d}" for index in range(112)]
+
+
+def _row_actions() -> dict[str, str]:
+    return {
+        row_id: ("LEFT" if index % 2 == 0 else "RIGHT")
+        for index, row_id in enumerate(_row_ids())
+    }
+
+
+def _complete_evidence_row(
+    *,
+    tied_top: bool = False,
+    unanimous_action: bool = False,
+) -> tuple[dict[str, object], CompleteRowEvidence, SemanticTopSetOutcome]:
+    row_ids = _row_ids()
+    scores = [max(0.0, 1.0 - index / 200.0) for index in range(112)]
+    actions = _row_actions()
+    if tied_top:
+        scores[1] = scores[0]
+    if unanimous_action:
+        actions[row_ids[1]] = actions[row_ids[0]]
+    evidence = build_complete_row_evidence(
+        row_scores=list(zip(row_ids, scores)),
+        policy_artifact_id="policy:frozen",
+        provider_id="P1",
+        provider_version="provider:v1",
+        policy_row_ids=row_ids,
+    )
+    outcome = build_semantic_top_set_outcome(evidence=evidence, row_action=actions)
+    score_rows = evidence.to_dict()["row_scores"]
+    row: dict[str, object] = {
+        "frame_id": "frame:frozen",
+        "policy_artifact_id": evidence.policy_artifact_id,
+        "provider_id": evidence.provider_id,
+        "provider_version": evidence.provider_version,
+        "all_112_row_ids": [item["row_id"] for item in score_rows],
+        "all_112_raw_scores": [item["raw_score"] for item in score_rows],
+        "all_112_quantized_scores": [item["quantized_score"] for item in score_rows],
+        "complete_ordered_ranking": list(evidence.ranking.ranked_row_ids),
+        "tie_groups": [group.to_dict() for group in evidence.ranking.tie_groups],
+        "policy_row_universe_digest": evidence.policy_row_universe_digest,
+        "quantized_score_vector_digest": evidence.quantized_score_vector_digest,
+        "raw_score_diagnostic_digest": evidence.raw_score_diagnostic_digest,
+        "score_vector_digest": evidence.score_vector_digest,
+        "ranking_digest": evidence.ranking.ranking_digest,
+        "semantic_top_set_outcome": outcome.to_dict(),
+    }
+    return row, evidence, outcome
+
+
+@pytest.fixture(scope="module")
+def complete_row_fixture() -> tuple[
+    dict[str, object], CompleteRowEvidence, SemanticTopSetOutcome
+]:
+    return _complete_evidence_row()
+
+
+def test_reference_legacy_helpers_are_direct_aliases() -> None:
+    assert benchmark._finding is verification._finding
+    assert benchmark._gate is verification._gate
+    assert benchmark._primary_failure is verification._primary_failure
+    assert (
+        benchmark._stored_quantized_evidence is verification._stored_quantized_evidence
+    )
+    assert (
+        benchmark._expected_semantic_for_row is verification._expected_semantic_for_row
+    )
+
+
+def test_reference_failure_precedence_and_key_order_are_frozen() -> None:
+    gates = [
+        verification._gate(
+            "semantic_outcome",
+            [verification._finding("ranking_reconstruction_mismatch", "ranking")],
+        ),
+        verification._gate(
+            "structural_identity",
+            [verification._finding("provider_contract_mismatch", "provider")],
+        ),
+    ]
+    report = {"gates": gates}
+
+    assert list(gates[0]) == ["gate", "status", "finding_count", "findings", "counts"]
+    assert verification._primary_failure(report) == {
+        "code": "provider_contract_mismatch",
+        "gate": "structural_identity",
+        "finding": {
+            "code": "provider_contract_mismatch",
+            "message": "provider",
+        },
+    }
+    assert verification._report_failure_codes(report) == [
+        {"gate": "structural_identity", "code": "provider_contract_mismatch"},
+        {"gate": "semantic_outcome", "code": "ranking_reconstruction_mismatch"},
+    ]
+
+
+def test_provider_equivalence_kernel_preserves_provider_order() -> None:
+    same = _result(quantized=(1, 2), ranking=("r1", "r2"))
+    different = _result(quantized=(2, 1), ranking=("r2", "r1"))
+    comparisons = [
+        verification.compare_provider_results(
+            provider_id="P2",
+            observation_id="frame:2",
+            reference=same,
+            optimized=different,
+        ),
+        verification.compare_provider_results(
+            provider_id="P1",
+            observation_id="frame:1",
+            reference=same,
+            optimized=same,
+        ),
+    ]
+
+    payload = verification.build_provider_equivalence_payload(comparisons)
+
+    assert list(payload["summary"]) == ["P1", "P2", "P3"]
+    assert payload["mismatching_providers"] == ["P2"]
+    assert payload["summary"]["P2"] == {
+        "quantized_mismatch_count": 1,
+        "ranking_mismatch_count": 1,
+        "tie_group_mismatch_count": 1,
+        "digest_mismatch_count": 0,
+    }
+
+
+def test_valid_complete_row_reconstruction_has_frozen_identities(
+    complete_row_fixture: tuple[
+        dict[str, object], CompleteRowEvidence, SemanticTopSetOutcome
+    ],
+) -> None:
+    row, evidence, outcome = complete_row_fixture
+
+    rebuilt, findings = verification._stored_quantized_evidence(row, _row_ids())
+    semantic, semantic_findings = verification._expected_semantic_for_row(
+        row,
+        _row_actions(),
+        _row_ids(),
+    )
+
+    assert isinstance(evidence, CompleteRowEvidence)
+    assert isinstance(evidence.ranking, CompleteRanking)
+    assert all(isinstance(group, TieGroup) for group in evidence.ranking.tie_groups)
+    assert isinstance(outcome, SemanticTopSetOutcome)
+    assert findings == []
+    assert semantic_findings == []
+    assert rebuilt == evidence
+    assert semantic == outcome
+    assert evidence.quantized_score_vector_digest == (
+        "sha256:4afd0132267b3d093bf9f5a3082303963d78fbf0cb18fab3e0af0cccb81e7398"
+    )
+    assert evidence.raw_score_diagnostic_digest == (
+        "sha256:103120c74d6042c463993bc2f787b3f3d02cb528f585ab6632636661c3423153"
+    )
+    assert evidence.ranking.ranking_digest == (
+        "sha256:b28cc4bbfeda234d128e7110c3395c19c99bb318e7df52f5ef7440ceb185be8b"
+    )
+    assert canonical_sha256([group.to_dict() for group in evidence.ranking.tie_groups]) == (
+        "sha256:4b8c500d6ea5469e5f46749580871b1ffe9151c6fbae45adc46bc706a173471d"
+    )
+    assert outcome.semantic_outcome_digest == (
+        "sha256:8630af8ec49a3209472ee7178d5fc23a45550055d4a74e6eb01dae9ac9455229"
+    )
+
+
+def test_complete_row_mismatch_order_and_primary_precedence_are_frozen(
+    complete_row_fixture: tuple[
+        dict[str, object], CompleteRowEvidence, SemanticTopSetOutcome
+    ],
+) -> None:
+    row = deepcopy(complete_row_fixture[0])
+    row["all_112_quantized_scores"][0] -= 1  # type: ignore[index]
+    row["quantized_score_vector_digest"] = "sha256:foreign-quantized"
+    row["score_vector_digest"] = "sha256:foreign-score"
+    row["raw_score_diagnostic_digest"] = "sha256:foreign-raw"
+    row["complete_ordered_ranking"] = list(
+        reversed(row["complete_ordered_ranking"])  # type: ignore[arg-type]
+    )
+    row["tie_groups"] = []
+    row["ranking_digest"] = "sha256:foreign-ranking"
+
+    _evidence, findings = verification._stored_quantized_evidence(row, _row_ids())
+    gate = verification._gate("structural_identity", findings)
+    report = {
+        "gates": [
+            verification._gate(
+                "semantic_outcome",
+                [verification._finding("semantic_status_mismatch", "semantic")],
+            ),
+            gate,
+        ]
+    }
+
+    assert [finding["code"] for finding in findings] == [
+        "quantized_score_vector_mismatch",
+        "quantized_score_vector_mismatch",
+        "raw_diagnostic_digest_mismatch",
+        "ranking_reconstruction_mismatch",
+        "tie_group_reconstruction_mismatch",
+        "ranking_reconstruction_mismatch",
+    ]
+    assert [list(finding) for finding in findings] == [
+        ["code", "message", "frame_id"]
+    ] * 6
+    assert verification._primary_failure(report) == {
+        "code": "quantized_score_vector_mismatch",
+        "gate": "structural_identity",
+        "finding": findings[0],
+    }
+
+
+def test_malformed_evidence_boundaries_and_unrelated_exceptions_escape(
+    complete_row_fixture: tuple[
+        dict[str, object], CompleteRowEvidence, SemanticTopSetOutcome
+    ],
+) -> None:
+    non_finite = deepcopy(complete_row_fixture[0])
+    non_finite["all_112_raw_scores"][0] = float("nan")  # type: ignore[index]
+    evidence, findings = verification._stored_quantized_evidence(
+        non_finite, _row_ids()
+    )
+    assert evidence is None
+    assert [list(finding) for finding in findings] == [
+        ["code", "message", "frame_id"]
+    ]
+    assert findings[0]["code"] == "raw_diagnostic_digest_mismatch"
+
+    missing_identity = deepcopy(complete_row_fixture[0])
+    del missing_identity["policy_artifact_id"]
+    evidence, findings = verification._stored_quantized_evidence(
+        missing_identity, _row_ids()
+    )
+    assert evidence is None
+    assert list(findings[0]) == ["code", "message", "frame_id", "error"]
+
+    class _UnexpectedScore:
+        def __float__(self) -> float:
+            raise RuntimeError("unexpected score conversion")
+
+    unexpected = deepcopy(complete_row_fixture[0])
+    unexpected["all_112_raw_scores"][0] = _UnexpectedScore()  # type: ignore[index]
+    with pytest.raises(RuntimeError, match="unexpected score conversion"):
+        verification._stored_quantized_evidence(unexpected, _row_ids())
+
+
+def test_action_unanimous_and_conflicting_ties_are_reconstructed() -> None:
+    unanimous_row, unanimous_evidence, unanimous = _complete_evidence_row(
+        tied_top=True,
+        unanimous_action=True,
+    )
+    conflicting_row, conflicting_evidence, conflicting = _complete_evidence_row(
+        tied_top=True,
+    )
+    unanimous_actions = _row_actions()
+    unanimous_actions["row-001"] = "LEFT"
+
+    rebuilt_unanimous, unanimous_findings = verification._expected_semantic_for_row(
+        unanimous_row,
+        unanimous_actions,
+        _row_ids(),
+    )
+    rebuilt_conflicting, conflicting_findings = verification._expected_semantic_for_row(
+        conflicting_row,
+        _row_actions(),
+        _row_ids(),
+    )
+
+    assert isinstance(unanimous_evidence.ranking, CompleteRanking)
+    assert isinstance(conflicting_evidence.ranking.tie_groups[0], TieGroup)
+    assert unanimous_findings == []
+    assert conflicting_findings == []
+    assert rebuilt_unanimous == unanimous
+    assert rebuilt_conflicting == conflicting
+    assert unanimous.status == "action_unanimous_tie"
+    assert unanimous.semantic_outcome_digest == (
+        "sha256:20e4869824a9e3d9d7fc86dcb46004a7eba551e8409f2de8da66ebd6a2d830e7"
+    )
+    assert conflicting.status == "conflicting_action_tie"
+    assert conflicting.semantic_outcome_digest == (
+        "sha256:8f2e5b7399f1e735e2cc6fade8888c63a5d3b0f76084750bea332fcc347e66dc"
+    )
+
+
+def test_malformed_reference_evidence_is_read_only() -> None:
+    row = {
+        "frame_id": "frame:1",
+        "all_112_row_ids": ["row:1"],
+        "all_112_raw_scores": [0.5],
+        "all_112_quantized_scores": [500_000],
+        "metadata": {"sentinel": {"nested": [1, 2, 3]}},
+    }
+    before = deepcopy(row)
+
+    evidence, findings = verification._stored_quantized_evidence(
+        row,
+        [f"row:{index}" for index in range(112)],
+    )
+
+    assert evidence is None
+    assert findings[0]["code"] == "score_row_universe_mismatch"
+    assert row == before
+
+
+def test_read_only_payload_detects_nested_snapshot_change() -> None:
+    first = {"verification_digest": "sha256:one", "nested": {"value": 1}}
+    second = deepcopy(first)
+    stable = {"file.json": {"nested": {"value": 1}}}
+    changed = {"file.json": {"nested": {"value": 2}}}
+
+    passed = verification.build_read_only_verification_payload(
+        before=stable,
+        middle=deepcopy(stable),
+        after=deepcopy(stable),
+        first=first,
+        second=second,
+    )
+    failed = verification.build_read_only_verification_payload(
+        before=stable,
+        middle=changed,
+        after=stable,
+        first=first,
+        second=second,
+    )
+
+    assert passed["status"] == "passed"
+    assert failed["status"] == "failed"
+
+    nondeterministic = verification.build_read_only_verification_payload(
+        before=stable,
+        middle=deepcopy(stable),
+        after=deepcopy(stable),
+        first=first,
+        second={"verification_digest": "sha256:two", "nested": {"value": 1}},
+    )
+    assert nondeterministic["read_only"] is True
+    assert nondeterministic["deterministic"] is False
+    assert nondeterministic["status"] == "failed"

--- a/tests/test_video_verification_closure_kernel.py
+++ b/tests/test_video_verification_closure_kernel.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from zeromodel.domains.video_action_set import verification
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+
+
+def _load_checker() -> ModuleType:
+    if str(SCRIPTS_ROOT) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "stage7b_check_architecture",
+        SCRIPTS_ROOT / "check_architecture.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECKER = _load_checker()
+
+
+def _verification_payload() -> dict[str, object]:
+    return {
+        "verified": True,
+        "version": "reference/v1",
+        "verification_digest": "sha256:verification",
+        "primary_failure_code": None,
+        "gates": [],
+        "unavailable_checks": [],
+        "authoritative_roots": {
+            "benchmark_contract_identity": {"benchmark": "identity"},
+            "policy_artifact_id": "policy:1",
+            "root_seed_digest": "sha256:seed",
+            "episode_family_registry_digest": "sha256:families",
+            "reachability_tile_digest": "sha256:tile",
+            "provider_versions": {"P1": "p1", "P2": "p2", "P3": "p3"},
+        },
+        "final_access_measurements": {
+            "final_observation_materialization_count": 0,
+            "final_provider_score_access_count": 0,
+            "final_reachability_execution_count": 0,
+            "calibration_execution_count": 0,
+            "architecture_selection_execution_count": 0,
+            "candidate_tuning_execution_count": 0,
+            "final_evaluation_count": 0,
+        },
+        "measured_counts": {
+            "reachability_replay_count": 0,
+            "forbidden_final_access_counter": 0,
+        },
+    }
+
+
+def _passing_repeated_audit() -> dict[str, object]:
+    audit = {
+        "status": "passed",
+        "declared_mutation_count": 93,
+        "executable_mutation_count": 93,
+        "expected_detection_count": 91,
+        "expected_mutation_count": 91,
+        "detected_mutation_count": 91,
+        "missed_mutation_count": 0,
+        "undetected_mutation_count": 0,
+        "unexpected_failure_code_count": 0,
+        "invariant_count": 2,
+        "invariant_pass_count": 2,
+        "digest_laundering_class_closure": {name: {} for name in "abcdefg"},
+        "mutation_isolation_passed": True,
+        "mutation_audit_digest": "sha256:audit",
+    }
+    return {"deterministic": True, "audit": audit}
+
+
+def _set_path(payload: dict[str, Any], path: tuple[str, ...], value: Any) -> None:
+    target = payload
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+
+def test_conservative_closure_pass_and_unavailable_statuses() -> None:
+    passed = verification.build_verification_closure(
+        verification=_verification_payload(),
+        repeated_mutation_audit=_passing_repeated_audit(),
+        read_only={"status": "passed", "read_only": True},
+        split_plan_identities={"selection": "sha256:plan"},
+    )
+    unavailable = verification.build_verification_closure(
+        verification=_verification_payload(),
+        repeated_mutation_audit=verification.build_unavailable_repeated_mutation_audit(),
+        read_only={"status": "passed", "read_only": True},
+        split_plan_identities={},
+    )
+
+    assert passed["supported_status"] == "reference_instrument_correct"
+    assert unavailable["supported_status"] == (
+        "reference_instrument_correctness_unresolved"
+    )
+    assert list(passed)[-1] == "closure_report_digest"
+
+
+@pytest.mark.parametrize(
+    ("component", "path", "value"),
+    [
+        ("verification", ("verified",), False),
+        ("verification", ("unavailable_checks",), ["semantic_outcome"]),
+        (
+            "verification",
+            ("final_access_measurements", "final_observation_materialization_count"),
+            1,
+        ),
+        (
+            "verification",
+            ("final_access_measurements", "final_provider_score_access_count"),
+            1,
+        ),
+        (
+            "verification",
+            ("final_access_measurements", "final_reachability_execution_count"),
+            1,
+        ),
+        (
+            "verification",
+            ("final_access_measurements", "calibration_execution_count"),
+            1,
+        ),
+        (
+            "verification",
+            ("final_access_measurements", "architecture_selection_execution_count"),
+            1,
+        ),
+        (
+            "verification",
+            ("final_access_measurements", "candidate_tuning_execution_count"),
+            1,
+        ),
+        (
+            "verification",
+            ("final_access_measurements", "final_evaluation_count"),
+            1,
+        ),
+        ("repeated", ("deterministic",), False),
+        ("repeated", ("audit", "status"), "failed"),
+        ("repeated", ("audit", "declared_mutation_count"), 92),
+        ("repeated", ("audit", "executable_mutation_count"), 92),
+        ("repeated", ("audit", "expected_detection_count"), 90),
+        ("repeated", ("audit", "detected_mutation_count"), 90),
+        ("repeated", ("audit", "missed_mutation_count"), 1),
+        ("repeated", ("audit", "unexpected_failure_code_count"), 1),
+        ("repeated", ("audit", "invariant_count"), 1),
+        ("repeated", ("audit", "invariant_pass_count"), 1),
+        ("repeated", ("audit", "digest_laundering_class_closure"), {}),
+        ("repeated", ("audit", "mutation_isolation_passed"), False),
+        ("read_only", ("status",), "failed"),
+    ],
+)
+def test_each_failed_or_unavailable_prerequisite_keeps_closure_unresolved(
+    component: str,
+    path: tuple[str, ...],
+    value: Any,
+) -> None:
+    verification_payload: dict[str, Any] = _verification_payload()
+    repeated_payload: dict[str, Any] = _passing_repeated_audit()
+    read_only_payload: dict[str, Any] = {
+        "status": "passed",
+        "read_only": True,
+    }
+    targets = {
+        "verification": verification_payload,
+        "repeated": repeated_payload,
+        "read_only": read_only_payload,
+    }
+    _set_path(targets[component], path, value)
+
+    closure = verification.build_verification_closure(
+        verification=verification_payload,
+        repeated_mutation_audit=repeated_payload,
+        read_only=read_only_payload,
+        split_plan_identities={},
+    )
+
+    assert closure["supported_status"] == (
+        "reference_instrument_correctness_unresolved"
+    )
+
+
+def test_verification_summary_preserves_legacy_projection() -> None:
+    closure = verification.build_verification_closure(
+        verification=_verification_payload(),
+        repeated_mutation_audit=_passing_repeated_audit(),
+        read_only={"status": "passed", "read_only": True},
+        split_plan_identities={},
+    )
+
+    summary = verification.verification_summary(closure)
+
+    assert list(summary) == [
+        "verified",
+        "version",
+        "closure_report_version",
+        "repository_status",
+        "materialization_status",
+        "primary_failure_code",
+        "gates",
+        "final_materialization_count",
+        "final_score_access_count",
+        "final_reachability_execution_count",
+        "candidate_set_selection_count",
+        "conformal_calibration_count",
+        "reachability_replay_count",
+        "final_evaluation_count",
+        "forbidden_final_access_counter",
+        "read_only",
+        "verification_digest",
+    ]
+    assert summary["repository_status"] == "reference_instrument_correct"
+
+
+@pytest.mark.parametrize(
+    ("importer", "imported"),
+    [
+        ("zeromodel.domains.video_action_set.reference_verification", "pathlib"),
+        ("zeromodel.domains.video_action_set.reference_verification", "sqlite3"),
+        ("zeromodel.domains.video_action_set.evidence_audit", "sqlalchemy"),
+        (
+            "zeromodel.domains.video_action_set.mutation_audit",
+            "zeromodel.runtime",
+        ),
+        (
+            "zeromodel.domains.video_action_set.mutation_matrix",
+            "zeromodel.domains.video_action_set.verification",
+        ),
+        (
+            "zeromodel.domains.video_action_set.provider_measurement",
+            "zeromodel.domains.video_action_set.evidence_audit",
+        ),
+        (
+            "zeromodel.runtime",
+            "zeromodel.domains.video_action_set.reference_verification",
+        ),
+    ],
+)
+def test_stage7b_architecture_rejects_representative_edges(
+    importer: str,
+    imported: str,
+) -> None:
+    edge = CHECKER.ImportEdge(importer=importer, imported=imported, line=7)
+
+    violations = CHECKER.forbidden_edge_violations([edge])
+
+    assert any(
+        violation.importer == importer and violation.imported == imported
+        for violation in violations
+    )
+
+
+def test_stage7b_architecture_allows_expected_direction() -> None:
+    edge = CHECKER.ImportEdge(
+        importer="zeromodel.domains.video_action_set.verification",
+        imported="zeromodel.domains.video_action_set.mutation_matrix",
+        line=7,
+    )
+
+    assert CHECKER.forbidden_edge_violations([edge]) == []
+
+
+@pytest.mark.parametrize(
+    ("importer", "source", "expected_import"),
+    [
+        (
+            "zeromodel.domains.video_action_set.reference_verification",
+            "import os\n",
+            "os",
+        ),
+        (
+            "zeromodel.domains.video_action_set.evidence_audit",
+            "from shutil import copytree\n",
+            "shutil",
+        ),
+        (
+            "zeromodel.domains.video_action_set.mutation_audit",
+            "import tempfile\n",
+            "tempfile",
+        ),
+        (
+            "zeromodel.domains.video_action_set.mutation_matrix",
+            "from subprocess import run\n",
+            "subprocess",
+        ),
+        (
+            "zeromodel.domains.video_action_set.verification",
+            "import csv\n",
+            "csv",
+        ),
+    ],
+)
+def test_stage7b_external_imports_are_collected_and_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    importer: str,
+    source: str,
+    expected_import: str,
+) -> None:
+    module_path = tmp_path / "module.py"
+    module_path.write_text(source, encoding="utf-8")
+    monkeypatch.setattr(CHECKER, "relative_path", lambda path: path.name)
+
+    edges = CHECKER.collect_import_edges(importer, module_path, {importer})
+
+    assert [(edge.importer, edge.imported) for edge in edges] == [
+        (importer, expected_import)
+    ]
+    assert CHECKER.forbidden_edge_violations(edges)

--- a/zeromodel/domains/video_action_set/evidence_audit.py
+++ b/zeromodel/domains/video_action_set/evidence_audit.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from ...artifact import VPMValidationError
+from ...video_complete_row_evidence import (
+    QUANTIZATION_SCALE,
+    VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION,
+    build_complete_row_evidence,
+    semantic_top_set_outcome_from_dict,
+)
+from ...video_prospective_providers import (
+    score_b3_joint_fit,
+    score_normalized_pixel,
+    score_registered_local_correlation,
+)
+from .canonical_json import canonical_sha256
+from .provider_measurement import SOURCE_SCOPE
+from .reference_verification import _finding, _gate
+
+PHASE_ACCESS_VERSION = "zeromodel-video-prospective-phase-access/v1"
+SEMANTIC_OUTCOME_VERSION = VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION
+
+_NON_FINAL_SPLITS = ("development", "calibration", "selection")
+_ALL_SPLITS = (*_NON_FINAL_SPLITS, "final")
+_CALIBRATION_ARTIFACTS = (
+    "selected-calibration.json",
+    "calibration-grid.json",
+    "calibration-results.json",
+    "conformal-calibration.json",
+)
+_SELECTION_ARTIFACTS = (
+    "selected-architecture.json",
+    "architecture-grid.json",
+    "architecture-selection.json",
+    "selected-method.json",
+)
+_TUNING_ARTIFACTS = (
+    "candidate-tuning.json",
+    "candidate-set-tuning.json",
+    "candidate-grid.json",
+    "reachability-replay.json",
+)
+_FINAL_ARTIFACTS = (
+    "final-results.json",
+    "final-summary.json",
+    "final-evaluation.json",
+)
+
+
+def measured_phase_access_counts(
+    *,
+    final_plan: Mapping[str, Any],
+    frame_rows_by_split: Mapping[str, Sequence[Mapping[str, Any]]],
+    evidence_rows_by_split: Mapping[str, Sequence[Mapping[str, Any]]],
+    existing_artifacts: Sequence[str],
+) -> dict[str, Any]:
+    """Measure protocol access from already-loaded artifact metadata."""
+
+    final_ids = {
+        episode_id
+        for values in final_plan.get("sealed_episode_ids", {}).values()
+        for episode_id in values
+    }
+    frames = [
+        row for split in _ALL_SPLITS for row in frame_rows_by_split.get(split, ())
+    ]
+    evidence = [
+        row for split in _ALL_SPLITS for row in evidence_rows_by_split.get(split, ())
+    ]
+    final_materialization_count = sum(
+        1
+        for row in frames
+        if row.get("episode_id") in final_ids or row.get("split") == "final"
+    )
+    final_score_access_count = sum(
+        1
+        for row in evidence
+        if row.get("episode_id") in final_ids or row.get("split") == "final"
+    )
+    final_reachability_execution_count = sum(
+        1
+        for row in evidence
+        if (row.get("episode_id") in final_ids or row.get("split") == "final")
+        and row.get("reachability_composition_trace") is not None
+    )
+    present = set(existing_artifacts)
+    calibration_count = sum(int(name in present) for name in _CALIBRATION_ARTIFACTS)
+    selection_count = sum(int(name in present) for name in _SELECTION_ARTIFACTS)
+    tuning_count = sum(int(name in present) for name in _TUNING_ARTIFACTS)
+    final_evaluation_count = sum(int(name in present) for name in _FINAL_ARTIFACTS)
+    return {
+        "version": PHASE_ACCESS_VERSION,
+        "final_materialization_count": final_materialization_count,
+        "final_score_access_count": final_score_access_count,
+        "final_reachability_execution_count": final_reachability_execution_count,
+        "candidate_set_selection_count": tuning_count,
+        "candidate_tuning_execution_count": tuning_count,
+        "conformal_calibration_count": calibration_count,
+        "calibration_execution_count": calibration_count,
+        "architecture_selection_execution_count": selection_count,
+        "reachability_replay_count": tuning_count,
+        "final_evaluation_count": final_evaluation_count,
+        "forbidden_final_access_counter": (
+            final_materialization_count
+            + final_score_access_count
+            + final_reachability_execution_count
+        ),
+    }
+
+
+def build_observation_identity_manifest(
+    frame_rows_by_split: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> dict[str, Any]:
+    frames = {
+        split: [row["frame_id"] for row in frame_rows_by_split.get(split, ())]
+        for split in _NON_FINAL_SPLITS
+    }
+    return {
+        "development_observation_count": len(frames["development"]),
+        "calibration_observation_count": len(frames["calibration"]),
+        "selection_observation_count": len(frames["selection"]),
+        "all_frame_ids_digest": canonical_sha256(frames),
+    }
+
+
+def build_split_overlap_audit(
+    *,
+    frame_rows_by_split: Mapping[str, Sequence[Mapping[str, Any]]],
+    final_plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    split_sets = {
+        split: {row["frame_id"] for row in frame_rows_by_split.get(split, ())}
+        for split in _NON_FINAL_SPLITS
+    }
+    final_ids = {
+        episode_id
+        for values in final_plan.get("sealed_episode_ids", {}).values()
+        for episode_id in values
+    }
+    materialized_final = sum(
+        1
+        for split in _NON_FINAL_SPLITS
+        for row in frame_rows_by_split.get(split, ())
+        if row.get("episode_id") in final_ids or row.get("split") == "final"
+    )
+    return {
+        "development_calibration_overlap": len(
+            split_sets["development"] & split_sets["calibration"]
+        ),
+        "development_selection_overlap": len(
+            split_sets["development"] & split_sets["selection"]
+        ),
+        "calibration_selection_overlap": len(
+            split_sets["calibration"] & split_sets["selection"]
+        ),
+        "materialized_final_plan_overlap": materialized_final,
+        "final_episode_ids_digest": canonical_sha256(sorted(final_ids))
+        if final_ids
+        else None,
+    }
+
+
+def audit_evidence_rows(
+    *,
+    frame_rows_by_split: Mapping[str, Sequence[Mapping[str, Any]]],
+    evidence_rows_by_split: Mapping[str, Sequence[Mapping[str, Any]]],
+    row_actions: Mapping[str, str],
+) -> dict[str, Any]:
+    counts = {
+        "missing_score_vector_count": 0,
+        "invalid_score_count": 0,
+        "missing_ranking_count": 0,
+        "missing_tie_group_count": 0,
+        "missing_semantic_outcome_count": 0,
+        "missing_reachability_trace_count": 0,
+    }
+    summaries = []
+    for split in _NON_FINAL_SPLITS:
+        rows = list(evidence_rows_by_split.get(split, ()))
+        for row in rows:
+            if len(row["all_112_row_ids"]) != 112:
+                counts["missing_score_vector_count"] += 1
+            if (
+                len(row["all_112_raw_scores"]) != 112
+                or len(row["all_112_quantized_scores"]) != 112
+            ):
+                counts["missing_score_vector_count"] += 1
+            if any(
+                score < 0 or score > QUANTIZATION_SCALE
+                for score in row["all_112_quantized_scores"]
+            ):
+                counts["invalid_score_count"] += 1
+            if len(row["complete_ordered_ranking"]) != 112:
+                counts["missing_ranking_count"] += 1
+            if not row["tie_groups"]:
+                counts["missing_tie_group_count"] += 1
+            counts["missing_semantic_outcome_count"] += _semantic_error_count(
+                row, row_actions
+            )
+        for frame in frame_rows_by_split.get(split, ()):
+            if (
+                frame.get("expected_disposition") != "information_theoretic_control"
+                and "reachability_trace" not in frame.get("metadata", {})
+            ):
+                counts["missing_reachability_trace_count"] += 1
+        summaries.append({"split": split, "provider_frame_records": len(rows)})
+    return {
+        "complete_score_evidence": (
+            counts["missing_score_vector_count"] == 0
+            and counts["invalid_score_count"] == 0
+            and counts["missing_semantic_outcome_count"] == 0
+            and counts["missing_reachability_trace_count"] == 0
+        ),
+        **counts,
+        "split_summaries": summaries,
+    }
+
+
+def _semantic_error_count(
+    row: Mapping[str, Any], row_actions: Mapping[str, str]
+) -> int:
+    if (
+        row.get("semantic_top_set_outcome", {}).get("version")
+        != SEMANTIC_OUTCOME_VERSION
+    ):
+        return 1
+    try:
+        evidence = build_complete_row_evidence(
+            row_scores=list(zip(row["all_112_row_ids"], row["all_112_raw_scores"])),
+            policy_artifact_id=row["policy_artifact_id"],
+            provider_id=row["provider_id"],
+            provider_version=row["provider_version"],
+            policy_row_ids=row["all_112_row_ids"],
+        )
+        if evidence.score_vector_digest != row["score_vector_digest"]:
+            raise VPMValidationError("foreign score vector digest")
+        semantic_top_set_outcome_from_dict(
+            row["semantic_top_set_outcome"],
+            evidence=evidence,
+            row_action=row_actions,
+        )
+    except (KeyError, VPMValidationError):
+        return 1
+    return 0
+
+
+def audit_canonical_provider_results(
+    *, prototypes: Mapping[str, Any], policy_artifact_id: str
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    rows: list[dict[str, Any]] = []
+    summary: dict[str, Any] = {}
+    for provider_id in ("P1", "P2", "P3"):
+        provider_rows = _score_canonical_provider(
+            provider_id=provider_id,
+            prototypes=prototypes,
+            policy_artifact_id=policy_artifact_id,
+        )
+        rows.extend(provider_rows)
+        exact = sum(
+            int(row["resolved_row"] == row["expected_row"]) for row in provider_rows
+        )
+        actions = sum(
+            int(row["resolved_action"] == row["expected_action"])
+            for row in provider_rows
+        )
+        summary[provider_id] = {
+            "canonical_observation_count": 112,
+            "exact_row_resolution_count": exact,
+            "action_resolution_count": actions,
+            "action_unanimous_tie_resolution_count": sum(
+                int(
+                    row["semantic_status"] == "action_unanimous_tie"
+                    and row["resolved_action"] == row["expected_action"]
+                )
+                for row in provider_rows
+            ),
+            "conflicting_action_rejection_count": sum(
+                int(row["semantic_status"] == "conflicting_action_tie")
+                for row in provider_rows
+            ),
+            "unresolved_outcome_count": sum(
+                int(row["semantic_status"] == "unresolved") for row in provider_rows
+            ),
+            "exact_top1_count": exact,
+            "action_top1_count": actions,
+            "maximum_tie_size": max(row["semantic_tie_size"] for row in provider_rows),
+            "status": "canonical_diagnostic_pass"
+            if provider_id != "P3" or exact == 112
+            else "invalid_primary_provider_instrument",
+        }
+    return summary, rows
+
+
+def _score_canonical_provider(
+    *, provider_id: str, prototypes: Mapping[str, Any], policy_artifact_id: str
+) -> list[dict[str, Any]]:
+    rows = []
+    for observation_id, (row_id, action_id, _digest, observation) in prototypes.items():
+        if provider_id == "P1":
+            result = score_normalized_pixel(
+                observation=observation,
+                prototypes=prototypes,
+                policy_artifact_id=policy_artifact_id,
+            )
+        elif provider_id == "P2":
+            result = score_registered_local_correlation(
+                observation=observation,
+                prototypes=prototypes,
+                policy_artifact_id=policy_artifact_id,
+                source_scope=SOURCE_SCOPE,
+            )
+        else:
+            result = score_b3_joint_fit(
+                observation=observation,
+                prototypes=prototypes,
+                policy_artifact_id=policy_artifact_id,
+                source_scope=SOURCE_SCOPE,
+            )
+        outcome = result.semantic_top_set_outcome
+        rows.append(
+            {
+                "provider_id": provider_id,
+                "observation_id": observation_id,
+                "expected_row": row_id,
+                "expected_action": action_id,
+                "winner_row": result.winner_row_id,
+                "winner_action": result.winner_action_id,
+                "semantic_status": outcome.status,
+                "resolved_row": outcome.resolved_row_id,
+                "resolved_action": outcome.resolved_action_id,
+                "semantic_outcome_digest": outcome.semantic_outcome_digest,
+                "semantic_tie_size": result.maximum_tie_size,
+                "score_vector_complete": len(result.evidence.row_scores) == 112,
+                "ranking_complete": len(result.evidence.ranking.ranked_row_ids) == 112,
+                "tie_group_complete": bool(result.evidence.ranking.tie_groups),
+            }
+        )
+    return rows
+
+
+def access_prohibition_gate(
+    measured: Mapping[str, Any],
+    stored: Mapping[str, Any],
+    *,
+    max_findings: int | None = None,
+) -> dict[str, Any]:
+    checks = (
+        (
+            "final_materialization_count",
+            "forbidden_final_materialization",
+            "final split has materialized observations",
+        ),
+        (
+            "final_score_access_count",
+            "forbidden_final_score_access",
+            "final split has provider score records",
+        ),
+        (
+            "final_reachability_execution_count",
+            "forbidden_final_reachability_access",
+            "final split has reachability execution traces",
+        ),
+        (
+            "calibration_execution_count",
+            "forbidden_calibration_execution",
+            "prospective calibration execution artifact is present",
+        ),
+        (
+            "final_evaluation_count",
+            "forbidden_final_evaluation",
+            "final evaluation artifact is present",
+        ),
+    )
+    findings = [
+        _finding(code, message, count=measured[key])
+        for key, code, message in checks
+        if measured.get(key)
+    ]
+    selection_count = measured.get(
+        "architecture_selection_execution_count", 0
+    ) + measured.get("candidate_tuning_execution_count", 0)
+    if selection_count:
+        findings.append(
+            _finding(
+                "forbidden_selection_execution",
+                "prospective selection or candidate-tuning execution artifact is present",
+                count=selection_count,
+            )
+        )
+    stored_projection = {key: stored.get(key) for key in measured if key in stored}
+    measured_projection = {key: measured.get(key) for key in measured if key in stored}
+    if stored and stored_projection != measured_projection:
+        findings.append(
+            _finding(
+                "status_claim_not_supported",
+                "stored phase-access counters do not match counters measured from concrete artifacts",
+            )
+        )
+    if max_findings is not None:
+        findings = findings[:max_findings]
+    return _gate("access_prohibition", findings, counts=measured)
+
+
+__all__ = [
+    "PHASE_ACCESS_VERSION",
+    "access_prohibition_gate",
+    "audit_canonical_provider_results",
+    "audit_evidence_rows",
+    "build_observation_identity_manifest",
+    "build_split_overlap_audit",
+    "measured_phase_access_counts",
+]

--- a/zeromodel/domains/video_action_set/mutation_audit.py
+++ b/zeromodel/domains/video_action_set/mutation_audit.py
@@ -1,0 +1,671 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from .canonical_json import canonical_sha256
+from .reference_verification import (
+    _finding,
+    _report_failure_codes,
+)
+
+MUTATION_AUDIT_VERSION = "zeromodel-video-action-set-reference-mutation-audit/v1"
+
+_MUTATION_NAMES = (
+    "evidence_raw_score_preserve_quantized_bin",
+    "evidence_raw_score_cross_quantization_boundary",
+    "evidence_quantized_score_changed",
+    "evidence_remove_row_score",
+    "evidence_duplicate_row_score",
+    "evidence_introduce_foreign_row",
+    "evidence_reorder_stored_rows",
+    "evidence_alter_ranking_order",
+    "evidence_alter_tie_group_membership",
+    "evidence_split_tie_group_incorrectly",
+    "evidence_merge_distinct_score_groups",
+    "evidence_alter_quantized_score_vector_digest",
+    "evidence_alter_raw_diagnostic_digest",
+    "semantic_resolved_row_for_action_unanimous_tie",
+    "semantic_resolved_action_for_conflicting_tie",
+    "semantic_convert_conflicting_tie_to_unique_row",
+    "semantic_change_top_row_policy_action",
+    "semantic_change_rejection_reason",
+    "semantic_alter_outcome_digest",
+    "semantic_lexically_reorder_tied_rows",
+    "semantic_reorder_rows_preserving_action_equivalence",
+    "policy_alter_row_to_action_mapping",
+    "policy_remove_policy_row",
+    "policy_add_undeclared_row",
+    "policy_alter_artifact_identity",
+    "policy_mapping_recomputed_superficial_metadata",
+    "observation_flip_byte_digest",
+    "observation_change_pixels_and_recompute_digest",
+    "observation_change_digest_without_pixels",
+    "observation_swap_two_frame_payloads",
+    "observation_alter_frame_identity",
+    "observation_reuse_under_two_episode_ids",
+    "observation_substitute_frame_for_declared_gap",
+    "seed_alter_root_seed_material",
+    "seed_alter_root_seed_digest",
+    "seed_alter_derived_seed",
+    "seed_alter_derivation_namespace",
+    "seed_alter_episode_ordinal",
+    "seed_alter_split_identity",
+    "seed_move_episode_between_splits",
+    "seed_duplicate_episode_id",
+    "seed_alter_source_row",
+    "seed_alter_splice_partner",
+    "seed_alter_transformation_parameters",
+    "seed_alter_planned_family",
+    "seed_alter_sealed_plan_digest",
+    "seed_alter_final_sealed_identity",
+    "seed_final_observation_provenance_materialized",
+    "family_conflicting_splice_same_action_rows",
+    "family_splice_zero_source_contribution",
+    "family_splice_output_equal_one_source",
+    "family_splice_valid_state_collision",
+    "family_splice_target_evidence_count_removed",
+    "family_critical_empty_coordinate_set",
+    "family_corrupt_noncritical_coordinates",
+    "family_replacement_value_identical",
+    "family_clipping_quantization_noop",
+    "family_reordered_metadata_original_payload_order",
+    "family_identity_permutation_labelled_reordered",
+    "family_stale_label_without_repeated_bytes",
+    "family_stale_repeat_naturally_identical",
+    "family_impossible_transition_reachable_pair",
+    "family_gap_event_carrying_pixels",
+    "family_information_control_pixel_difference",
+    "family_control_denominator_leak",
+    "family_control_hidden_history_collapse",
+    "family_control_visible_source_leak",
+    "family_episode_disposition_mismatch",
+    "reachability_remove_applicable_edge",
+    "reachability_redirect_applicable_edge",
+    "reachability_alter_destination_action",
+    "reachability_add_impossible_edge",
+    "reachability_change_tile_identity",
+    "reachability_change_unrelated_edge",
+    "reachability_alter_consulted_edge_list",
+    "reachability_omit_consulted_edge",
+    "reachability_add_unconsulted_edge_to_trace",
+    "reachability_alter_reachable_pair_set",
+    "reachability_alter_retained_candidate_rows",
+    "reachability_alter_removed_candidate_rows",
+    "reachability_replace_rejection_with_lexical_winner",
+    "reachability_change_executed_action",
+    "reachability_use_foreign_trace_digest",
+    "access_increment_final_materialization_count",
+    "access_add_final_observation_artifact",
+    "access_add_final_score_vector_record",
+    "access_add_final_reachability_trace",
+    "access_increment_forbidden_access_counter",
+    "access_record_calibration_execution",
+    "access_record_architecture_selection_execution",
+    "access_change_failed_gate_status_to_passed",
+    "access_change_repository_status_to_correct",
+    "access_remove_required_gate_from_closure_report",
+)
+
+_MUTATION_FAILURE_CODES = (
+    "raw_diagnostic_digest_mismatch",
+    "quantized_score_vector_mismatch",
+    "quantized_score_vector_mismatch",
+    "score_row_universe_mismatch",
+    "score_row_universe_mismatch",
+    "score_row_universe_mismatch",
+    "score_row_universe_mismatch",
+    "ranking_reconstruction_mismatch",
+    "tie_group_reconstruction_mismatch",
+    "tie_group_reconstruction_mismatch",
+    "tie_group_reconstruction_mismatch",
+    "quantized_score_vector_mismatch",
+    "raw_diagnostic_digest_mismatch",
+    "resolved_row_not_permitted",
+    "resolved_action_not_permitted",
+    "semantic_status_mismatch",
+    "policy_action_mapping_mismatch",
+    "semantic_status_mismatch",
+    "semantic_outcome_digest_mismatch",
+    None,
+    None,
+    "policy_action_mapping_mismatch",
+    "policy_action_mapping_mismatch",
+    "policy_action_mapping_mismatch",
+    "policy_action_mapping_mismatch",
+    "policy_action_mapping_mismatch",
+    "observation_digest_mismatch",
+    "observation_digest_mismatch",
+    "observation_digest_mismatch",
+    "observation_digest_mismatch",
+    "frame_identity_mismatch",
+    "duplicate_observation_identity_unpermitted",
+    "gap_event_structure_mismatch",
+    "episode_seed_derivation_mismatch",
+    "benchmark_contract_identity_mismatch",
+    "episode_seed_derivation_mismatch",
+    "sealed_episode_identity_mismatch",
+    "sealed_episode_identity_mismatch",
+    "episode_split_reassignment",
+    "episode_split_reassignment",
+    "duplicate_episode_id",
+    "episode_seed_derivation_mismatch",
+    "episode_seed_derivation_mismatch",
+    "sealed_episode_identity_mismatch",
+    "sealed_episode_identity_mismatch",
+    "sealed_episode_identity_mismatch",
+    "sealed_episode_identity_mismatch",
+    "final_observation_provenance_mismatch",
+    "family_contract_violation",
+    "family_contract_violation",
+    "family_regeneration_mismatch",
+    "invalid_family_valid_state_collision",
+    "family_contract_violation",
+    "family_contract_violation",
+    "family_contract_violation",
+    "family_contract_violation",
+    "family_no_op",
+    "family_contract_violation",
+    "family_contract_violation",
+    "family_contract_violation",
+    "family_contract_violation",
+    "transition_classification_mismatch",
+    "gap_event_has_pixels",
+    "control_byte_identity_mismatch",
+    "control_denominator_leak",
+    "control_hidden_history_not_ambiguous",
+    "control_provider_visible_leak",
+    "family_disposition_mismatch",
+    "consulted_edge_mismatch",
+    "reachable_pair_mismatch",
+    "policy_action_mapping_mismatch",
+    "reachability_tile_mismatch",
+    "reachability_tile_mismatch",
+    "reachability_tile_mismatch",
+    "consulted_edge_mismatch",
+    "consulted_edge_mismatch",
+    "consulted_edge_mismatch",
+    "reachable_pair_mismatch",
+    "reachability_trace_mismatch",
+    "reachability_trace_mismatch",
+    "executed_action_mismatch",
+    "executed_action_mismatch",
+    "reachability_trace_mismatch",
+    "status_claim_not_supported",
+    "forbidden_final_materialization",
+    "forbidden_final_score_access",
+    "forbidden_final_score_access",
+    "status_claim_not_supported",
+    "forbidden_calibration_execution",
+    "forbidden_selection_execution",
+    "status_claim_not_supported",
+    "status_claim_not_supported",
+    "closure_gate_missing",
+)
+
+_MUTATION_METADATA: dict[str, dict[str, Any]] = {
+    "evidence_quantized_score_changed": {"digest_laundering": True},
+    "semantic_alter_outcome_digest": {"digest_laundering": True},
+    "semantic_lexically_reorder_tied_rows": {"invariant": True},
+    "semantic_reorder_rows_preserving_action_equivalence": {"invariant": True},
+    "observation_change_pixels_and_recompute_digest": {"digest_laundering": True},
+    "observation_reuse_under_two_episode_ids": {
+        "gate_scope": ("structural_identity", "completeness_orphan")
+    },
+    "seed_alter_final_sealed_identity": {"digest_laundering": True},
+    "seed_final_observation_provenance_materialized": {"digest_laundering": True},
+    "family_clipping_quantization_noop": {"digest_laundering": True},
+    "reachability_change_tile_identity": {"digest_laundering": True},
+    "access_increment_forbidden_access_counter": {"digest_laundering": True},
+}
+
+_MUTATION_ARTIFACT_CLASSES = {
+    "evidence": "evidence",
+    "semantic": "semantic",
+    "policy": "policy",
+    "observation": "observation",
+    "seed": "episode_plan",
+    "family": "family_output",
+    "reachability": "reachability_trace",
+    "access": "access_status",
+}
+
+
+def _build_mutation_case(name: str, failure_code: str | None) -> dict[str, Any]:
+    prefix = name.split("_", 1)[0]
+    case = {
+        "name": name,
+        "expected_primary_failure_code": failure_code,
+        "artifact_class": _MUTATION_ARTIFACT_CLASSES[prefix],
+    }
+    case.update(_MUTATION_METADATA.get(name, {}))
+    return case
+
+
+_MUTATION_CASES: tuple[dict[str, Any], ...] = tuple(
+    _build_mutation_case(name, failure_code)
+    for name, failure_code in zip(
+        _MUTATION_NAMES,
+        _MUTATION_FAILURE_CODES,
+        strict=True,
+    )
+)
+
+
+_MUTATION_GATE_SCOPE = {
+    "evidence": ("structural_identity", "semantic_outcome"),
+    "semantic": ("structural_identity", "semantic_outcome"),
+    "policy": ("structural_identity",),
+    "observation": (
+        "structural_identity",
+        "episode_regeneration",
+        "completeness_orphan",
+    ),
+    "episode_plan": ("structural_identity", "seed_and_plan"),
+    "family_output": ("structural_identity", "family_contract"),
+    "reachability_trace": ("structural_identity", "semantic_outcome", "reachability"),
+    "access_status": ("structural_identity", "access_prohibition"),
+}
+
+
+def _mutation_case_by_name() -> dict[str, dict[str, Any]]:
+    return {str(case["name"]): dict(case) for case in _MUTATION_CASES}
+
+
+def _mutation_property(case: Mapping[str, Any]) -> str:
+    return str(
+        case.get("protected_scientific_property") or str(case["name"]).replace("_", " ")
+    )
+
+
+def _mutation_expected_files(case: Mapping[str, Any]) -> tuple[str, ...]:
+    artifact_class = str(case["artifact_class"])
+    name = str(case.get("name", case.get("mutation_id", "")))
+    if artifact_class in {"evidence", "semantic", "reachability_trace"}:
+        files = ["development/provider-evidence.jsonl", "development-manifest.json"]
+        if name in {
+            "reachability_add_impossible_edge",
+            "reachability_change_tile_identity",
+            "reachability_change_unrelated_edge",
+        }:
+            files = ["reachability-tile-reference.json"]
+        return tuple(files)
+    if artifact_class == "policy":
+        return ("policy-artifact.json",)
+    if artifact_class in {"observation", "family_output"}:
+        return ("selection/frame-metadata.jsonl", "selection-manifest.json")
+    if artifact_class == "episode_plan":
+        if name in {
+            "seed_alter_final_sealed_identity",
+            "seed_final_observation_provenance_materialized",
+        }:
+            return ("final-split-sealed-plan.json", "final-split-sealed-digest.json")
+        if name in {"seed_alter_root_seed_material", "seed_alter_root_seed_digest"}:
+            return (
+                ("generator-identity.json",)
+                if name == "seed_alter_root_seed_material"
+                else ("benchmark-contract-identity.json",)
+            )
+        return ("episode-plan.json",)
+    if artifact_class == "access_status":
+        if name in {
+            "access_increment_final_materialization_count",
+            "access_increment_forbidden_access_counter",
+        }:
+            return ("phase-access-audits.json",)
+        if name == "access_add_final_observation_artifact":
+            return ("final/frame-metadata.jsonl",)
+        if name in {
+            "access_add_final_score_vector_record",
+            "access_add_final_reachability_trace",
+        }:
+            return ("final/provider-evidence.jsonl",)
+        if name == "access_record_calibration_execution":
+            return ("selected-calibration.json",)
+        if name == "access_record_architecture_selection_execution":
+            return ("selected-architecture.json",)
+        return ("reference-closure-report.json",)
+    return ()
+
+
+def _flatten_payload(value: Any, prefix: str) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        rows: dict[str, Any] = {}
+        for key in sorted(value):
+            child = f"{prefix}.{key}" if prefix else str(key)
+            rows.update(_flatten_payload(value[key], child))
+        return rows
+    if isinstance(value, list):
+        rows = {}
+        for index, item in enumerate(value):
+            rows.update(_flatten_payload(item, f"{prefix}[{index}]"))
+        if not value:
+            rows[prefix] = []
+        return rows
+    return {prefix: value}
+
+
+def _changed_snapshot_files(
+    before: Mapping[str, Mapping[str, Any]],
+    after: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    return [
+        file_name
+        for file_name in sorted(set(before) | set(after))
+        if before.get(file_name, {}).get("digest")
+        != after.get(file_name, {}).get("digest")
+    ]
+
+
+def _changed_fields(before: Mapping[str, Any], after: Mapping[str, Any]) -> list[str]:
+    changed: set[str] = set()
+    for file_name in sorted(set(before) | set(after)):
+        if file_name not in before or file_name not in after:
+            changed.add(file_name)
+            continue
+        if before[file_name] == after[file_name]:
+            continue
+        before_flat = _flatten_payload(before[file_name], file_name)
+        after_flat = _flatten_payload(after[file_name], file_name)
+        for field in sorted(set(before_flat) | set(after_flat)):
+            if before_flat.get(field) != after_flat.get(field):
+                changed.add(field)
+    return sorted(changed)
+
+
+def _mutation_isolation_report(
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+    case: Mapping[str, Any],
+) -> dict[str, Any]:
+    changed = _changed_fields(before, after)
+    expected_files = tuple(
+        str(item)
+        for item in case.get("expected_changed_files", _mutation_expected_files(case))
+    )
+    unexpected = [
+        field
+        for field in changed
+        if not any(
+            field == expected
+            or field.startswith(f"{expected}.")
+            or field.startswith(f"{expected}[")
+            for expected in expected_files
+        )
+    ]
+    before_flat = _flatten_all(before)
+    after_flat = _flatten_all(after)
+    effect_payload = [
+        {
+            "field": field,
+            "before": before.get(field, before_flat.get(field)),
+            "after": after.get(field, after_flat.get(field)),
+        }
+        for field in changed
+    ]
+    return {
+        "changed_fields": changed,
+        "expected_changed_files": list(expected_files),
+        "unexpected_changed_fields": unexpected,
+        "changed_field_count": len(changed),
+        "isolation_passed": bool(changed) and not unexpected,
+        "mutation_effect_digest": canonical_sha256(
+            {"changed_fields": changed, "effect_payload": effect_payload}
+        ),
+    }
+
+
+def _flatten_all(payloads: Mapping[str, Any]) -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+    for file_name, payload in payloads.items():
+        flattened.update(_flatten_payload(payload, file_name))
+    return flattened
+
+
+def evaluate_mutation_case(
+    *,
+    case: Mapping[str, Any],
+    report: Mapping[str, Any],
+    isolation: Mapping[str, Any],
+    application_error: str | None = None,
+) -> dict[str, Any]:
+    primary = report.get("primary_failure_code")
+    primary_gate = report.get("primary_failure_gate")
+    if application_error is not None:
+        primary = "mutation_application_error"
+        primary_gate = "mutation_application"
+    expected = case.get("expected_primary_failure_code")
+    expected_detected = case["expected_result_type"] == "detected"
+    secondary_codes = [
+        row
+        for row in _report_failure_codes(report)
+        if row["code"] != primary or row["gate"] != primary_gate
+    ]
+    return {
+        "mutation": case["mutation_id"],
+        "artifact_class": case["artifact_class"],
+        "protected_scientific_property": case["protected_scientific_property"],
+        "fixture_selector": case["fixture_selector"],
+        "mutator_id": case["mutator_id"],
+        "expected_result_type": case["expected_result_type"],
+        "expected_primary_failure_code": expected,
+        "actual_primary_failure_code": primary,
+        "actual_primary_gate": primary_gate,
+        "secondary_failure_codes": secondary_codes,
+        "detected": primary is not None,
+        "expected_detected": expected_detected,
+        "invariant": case["expected_result_type"] == "semantic_invariant",
+        "semantic_invariant_passed": (
+            case["expected_result_type"] == "semantic_invariant" and primary is None
+        ),
+        "digest_laundering": bool(case["validation_metadata"]["digest_laundering"]),
+        "immediate_digest_recomputed": bool(case["immediate_digest_recomputed"]),
+        "parent_digest_recomputed": bool(case["parent_digest_recomputed"]),
+        "mutation_isolation": dict(isolation),
+        "property_changed": isolation["changed_field_count"] > 0,
+        "expected_code_matched": (
+            primary == expected if expected_detected else primary is None
+        ),
+        "application_error": application_error,
+    }
+
+
+def build_mutation_audit_payload(
+    *,
+    matrix_version: str,
+    catalogue: Sequence[Mapping[str, Any]],
+    selected_cases: Sequence[Mapping[str, Any]],
+    catalogue_findings: Sequence[Mapping[str, Any]],
+    results: Sequence[Mapping[str, Any]],
+    base_verified: bool = True,
+    base_primary_failure_code: str | None = None,
+) -> dict[str, Any]:
+    if not base_verified or catalogue_findings:
+        return _unavailable_audit_payload(
+            matrix_version=matrix_version,
+            catalogue=catalogue,
+            selected_cases=selected_cases,
+            catalogue_findings=catalogue_findings,
+            base_primary_failure_code=base_primary_failure_code,
+        )
+    normalized = [dict(row) for row in results]
+    expected = [row for row in normalized if row["expected_detected"]]
+    detected = [row for row in expected if row["detected"]]
+    missed = [row for row in expected if not row["detected"]]
+    unexpected = [row for row in normalized if not row["expected_code_matched"]]
+    invariants = [
+        row for row in normalized if row["expected_result_type"] == "semantic_invariant"
+    ]
+    invariant_passes = [row for row in invariants if row["semantic_invariant_passed"]]
+    isolation_failures = [
+        row for row in normalized if not row["mutation_isolation"]["isolation_passed"]
+    ]
+    property_failures = [row for row in expected if not row["property_changed"]]
+    duplicate_findings = _duplicate_effect_findings(normalized)
+    laundering = _laundering_closure(normalized)
+    payload = {
+        "version": MUTATION_AUDIT_VERSION,
+        "matrix_version": matrix_version,
+        "base_verified": True,
+        "catalogue_findings": [dict(row) for row in catalogue_findings],
+        "mutations": normalized,
+        "declared_mutation_count": len(catalogue),
+        "executable_mutation_count": len(selected_cases),
+        "expected_detection_count": len(expected),
+        "expected_mutation_count": len(expected),
+        "detected_mutation_count": len(detected),
+        "missed_mutation_count": len(missed),
+        "undetected_mutation_count": len(missed),
+        "unexpected_failure_code_count": len(unexpected),
+        "invariant_count": len(invariants),
+        "invariant_pass_count": len(invariant_passes),
+        "invariant_failure_count": len(invariants) - len(invariant_passes),
+        "digest_laundering_tests": [
+            row["mutation"] for row in normalized if row["digest_laundering"]
+        ],
+        "digest_laundering_class_closure": laundering,
+        "mutation_isolation_passed": not isolation_failures,
+        "mutation_isolation_failure_count": len(isolation_failures),
+        "property_change_failure_count": len(property_failures),
+        "duplicate_effect_findings": duplicate_findings,
+        "repeated_run_determinism": "not_measured_in_single_run",
+        "status": (
+            "passed"
+            if not missed
+            and not unexpected
+            and len(invariant_passes) == len(invariants)
+            and not isolation_failures
+            and not property_failures
+            and not duplicate_findings
+            else "failed"
+        ),
+    }
+    payload["mutation_audit_digest"] = canonical_sha256(payload)
+    return payload
+
+
+def _unavailable_audit_payload(
+    *,
+    matrix_version: str,
+    catalogue: Sequence[Mapping[str, Any]],
+    selected_cases: Sequence[Mapping[str, Any]],
+    catalogue_findings: Sequence[Mapping[str, Any]],
+    base_primary_failure_code: str | None,
+) -> dict[str, Any]:
+    expected = [
+        case for case in selected_cases if case["expected_result_type"] == "detected"
+    ]
+    invariants = [
+        case
+        for case in selected_cases
+        if case["expected_result_type"] == "semantic_invariant"
+    ]
+    payload = {
+        "version": MUTATION_AUDIT_VERSION,
+        "matrix_version": matrix_version,
+        "base_verified": False,
+        "base_primary_failure_code": base_primary_failure_code,
+        "catalogue_findings": [dict(row) for row in catalogue_findings],
+        "mutations": [],
+        "declared_mutation_count": len(catalogue),
+        "executable_mutation_count": len(selected_cases),
+        "expected_detection_count": len(expected),
+        "expected_mutation_count": len(expected),
+        "detected_mutation_count": 0,
+        "missed_mutation_count": len(expected),
+        "undetected_mutation_count": len(expected),
+        "unexpected_failure_code_count": len(selected_cases),
+        "invariant_count": len(invariants),
+        "invariant_pass_count": 0,
+        "invariant_failure_count": len(invariants),
+        "digest_laundering_tests": [],
+        "digest_laundering_class_closure": {},
+        "mutation_isolation_passed": False,
+        "duplicate_effect_findings": [],
+        "status": "unavailable",
+    }
+    payload["mutation_audit_digest"] = canonical_sha256(payload)
+    return payload
+
+
+def _duplicate_effect_findings(
+    results: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    owners: dict[str, str] = {}
+    findings = []
+    for row in results:
+        digest = str(row["mutation_isolation"]["mutation_effect_digest"])
+        previous = owners.get(digest)
+        if previous is not None:
+            findings.append(
+                _finding(
+                    "duplicate_mutation_effect",
+                    "two mutation ids produced the same structural effect",
+                    first_mutation=previous,
+                    second_mutation=row["mutation"],
+                )
+            )
+        owners[digest] = str(row["mutation"])
+    return findings
+
+
+def _laundering_closure(
+    results: Sequence[Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    closure: dict[str, dict[str, Any]] = {}
+    for row in results:
+        if not row["digest_laundering"]:
+            continue
+        item = closure.setdefault(
+            str(row["artifact_class"]),
+            {
+                "declared": 0,
+                "executed": 0,
+                "detected": 0,
+                "expected_code_matches": 0,
+                "laundering_depth_reached": "none",
+            },
+        )
+        item["declared"] += 1
+        item["executed"] += 1
+        item["detected"] += int(bool(row["detected"]))
+        item["expected_code_matches"] += int(bool(row["expected_code_matched"]))
+        if row["immediate_digest_recomputed"] and row["parent_digest_recomputed"]:
+            item["laundering_depth_reached"] = "immediate_and_parent"
+        elif row["immediate_digest_recomputed"]:
+            item["laundering_depth_reached"] = "immediate"
+    return closure
+
+
+def build_repeated_mutation_audit_payload(
+    *, matrix_version: str, first: Mapping[str, Any], second: Mapping[str, Any]
+) -> dict[str, Any]:
+    deterministic = first == second and first.get(
+        "mutation_audit_digest"
+    ) == second.get("mutation_audit_digest")
+    payload = {
+        "version": "zeromodel-video-action-set-reference-mutation-audit-repeat/v1",
+        "matrix_version": matrix_version,
+        "deterministic": deterministic,
+        "first_audit_digest": first.get("mutation_audit_digest"),
+        "second_audit_digest": second.get("mutation_audit_digest"),
+        "audit": dict(first),
+    }
+    payload["repeat_digest"] = canonical_sha256(payload)
+    return payload
+
+
+__all__ = [
+    "MUTATION_AUDIT_VERSION",
+    "_MUTATION_CASES",
+    "_MUTATION_GATE_SCOPE",
+    "_changed_fields",
+    "_changed_snapshot_files",
+    "_flatten_payload",
+    "_mutation_case_by_name",
+    "_mutation_expected_files",
+    "_mutation_isolation_report",
+    "_mutation_property",
+    "build_mutation_audit_payload",
+    "build_repeated_mutation_audit_payload",
+    "evaluate_mutation_case",
+]

--- a/zeromodel/domains/video_action_set/mutation_matrix.py
+++ b/zeromodel/domains/video_action_set/mutation_matrix.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ...artifact import VPMValidationError
+from .canonical_json import canonical_sha256
+from .mutation_audit import (
+    _MUTATION_CASES,
+    _MUTATION_GATE_SCOPE,
+    _mutation_expected_files,
+    _mutation_property,
+)
+
+MUTATION_MATRIX_VERSION = "zeromodel-video-action-set-reference-mutation-matrix/v3"
+
+_REQUIRED_RESULT_FIELDS = {
+    "actual_primary_failure_code",
+    "detected",
+    "expected_code_matched",
+    "expected_detected",
+    "mutation_isolation",
+    "secondary_failure_codes",
+}
+_REQUIRED_ISOLATION_FIELDS = {
+    "changed_field_count",
+    "isolation_passed",
+    "mutation_effect_digest",
+}
+
+
+def mutation_catalogue() -> list[dict[str, Any]]:
+    catalogue = []
+    for case in _MUTATION_CASES:
+        expected = case.get("expected_primary_failure_code")
+        invariant = bool(case.get("invariant"))
+        catalogue.append(
+            {
+                "matrix_version": MUTATION_MATRIX_VERSION,
+                "mutation_id": case["name"],
+                "artifact_class": case["artifact_class"],
+                "protected_scientific_property": _mutation_property(case),
+                "fixture_selector": case.get(
+                    "fixture_selector",
+                    f"{case['artifact_class']}:deterministic-first-matching-record",
+                ),
+                "mutator_id": f"reference-mutator:{case['name']}",
+                "immediate_digest_recomputed": bool(
+                    case.get("digest_laundering", False)
+                ),
+                "parent_digest_recomputed": bool(case.get("digest_laundering", False))
+                or case["artifact_class"]
+                in {
+                    "evidence",
+                    "semantic",
+                    "observation",
+                    "family_output",
+                    "reachability_trace",
+                },
+                "expected_result_type": (
+                    "semantic_invariant" if invariant else "detected"
+                ),
+                "expected_primary_failure_code": expected,
+                "permitted_secondary_failure_codes": list(
+                    case.get("permitted_secondary_failure_codes", [])
+                ),
+                "expected_changed_files": list(_mutation_expected_files(case)),
+                "validation_metadata": {
+                    "digest_laundering": bool(case.get("digest_laundering", False)),
+                    "gate_scope": list(
+                        case.get(
+                            "gate_scope",
+                            _MUTATION_GATE_SCOPE.get(
+                                str(case["artifact_class"]),
+                                (),
+                            ),
+                        )
+                    ),
+                },
+            }
+        )
+    return catalogue
+
+
+def validate_mutation_catalogue() -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    catalogue = mutation_catalogue()
+    mutation_ids = [str(case["mutation_id"]) for case in catalogue]
+    if len(mutation_ids) != len(set(mutation_ids)):
+        findings.append(
+            _finding(
+                "duplicate_mutation_id",
+                "mutation catalogue contains duplicate mutation ids",
+            )
+        )
+    declared_ids = set(mutation_ids)
+    mutator_ids = {
+        str(case["mutation_id"]) for case in catalogue if case.get("mutator_id")
+    }
+    for missing in sorted(declared_ids - mutator_ids):
+        findings.append(
+            _finding(
+                "mutation_mutator_missing",
+                "declared mutation has no executable mutator",
+                mutation=missing,
+            )
+        )
+    for extra in sorted(mutator_ids - declared_ids):
+        findings.append(
+            _finding(
+                "mutation_mutator_orphan",
+                "mutator has no declaration",
+                mutation=extra,
+            )
+        )
+    for case in catalogue:
+        if case["expected_result_type"] == "detected" and not case.get(
+            "expected_primary_failure_code"
+        ):
+            findings.append(
+                _finding(
+                    "mutation_expected_code_missing",
+                    "expected detection lacks an expected primary failure code",
+                    mutation=case["mutation_id"],
+                )
+            )
+        if not case.get("expected_changed_files"):
+            findings.append(
+                _finding(
+                    "mutation_expected_change_missing",
+                    "mutation lacks expected changed file metadata",
+                    mutation=case["mutation_id"],
+                )
+            )
+    detected = sum(
+        1 for case in catalogue if case["expected_result_type"] == "detected"
+    )
+    invariants = sum(
+        1 for case in catalogue if case["expected_result_type"] == "semantic_invariant"
+    )
+    if len(catalogue) != 93 or detected != 91 or invariants != 2:
+        findings.append(
+            _finding(
+                "mutation_matrix_count_mismatch",
+                "mutation matrix count changed without an explicit matrix revision",
+                declared_count=len(catalogue),
+                detected_count=detected,
+                invariant_count=invariants,
+            )
+        )
+    return findings
+
+
+def _finding(code: str, message: str, **details: Any) -> dict[str, Any]:
+    return {"code": code, "message": message, **details}
+
+
+def _mutation_result_id(row: Mapping[str, Any]) -> str:
+    id_fields = [field for field in ("mutation", "mutation_id") if field in row]
+    if len(id_fields) != 1 or not str(row[id_fields[0]]):
+        raise VPMValidationError(
+            "mutation matrix result must contain exactly one non-empty mutation id"
+        )
+    return str(row[id_fields[0]])
+
+
+def _validate_matrix_audit(audit: Mapping[str, Any]) -> list[dict[str, Any]]:
+    if audit.get("status") == "unavailable" or audit.get("base_verified") is False:
+        raise VPMValidationError(
+            "mutation matrix cannot be built from an unavailable baseline audit"
+        )
+    if audit.get("status") not in {"passed", "failed"}:
+        raise VPMValidationError("mutation audit status must be passed or failed")
+    if audit.get("base_verified") is not True:
+        raise VPMValidationError("mutation audit must declare a verified baseline")
+    catalogue_ids = [str(case["mutation_id"]) for case in mutation_catalogue()]
+    declared_count = audit.get("declared_mutation_count")
+    executable_count = audit.get("executable_mutation_count")
+    if declared_count != len(catalogue_ids):
+        raise VPMValidationError(
+            "mutation audit declared count does not match the mutation catalogue"
+        )
+    if type(executable_count) is not int or not 0 <= executable_count <= len(
+        catalogue_ids
+    ):
+        raise VPMValidationError("mutation audit executable count is invalid")
+    raw_rows = audit.get("mutations")
+    if not isinstance(raw_rows, (list, tuple)):
+        raise VPMValidationError("mutation audit results must be a sequence")
+    rows = [dict(row) for row in raw_rows if isinstance(row, Mapping)]
+    if len(rows) != len(raw_rows):
+        raise VPMValidationError("mutation audit contains a malformed result")
+    if len(rows) != executable_count:
+        raise VPMValidationError(
+            "mutation audit result count does not match executable count"
+        )
+    result_ids = [_mutation_result_id(row) for row in rows]
+    if len(result_ids) != len(set(result_ids)):
+        raise VPMValidationError("mutation audit contains duplicate result ids")
+    unknown = sorted(set(result_ids) - set(catalogue_ids))
+    if unknown:
+        raise VPMValidationError(
+            f"mutation audit contains unknown result ids: {', '.join(unknown)}"
+        )
+    if executable_count == len(catalogue_ids) and set(result_ids) != set(catalogue_ids):
+        raise VPMValidationError("complete mutation audit omits required result ids")
+    for row in rows:
+        missing = sorted(_REQUIRED_RESULT_FIELDS - row.keys())
+        if missing:
+            raise VPMValidationError(
+                f"mutation result is missing required fields: {', '.join(missing)}"
+            )
+        isolation = row["mutation_isolation"]
+        if not isinstance(isolation, Mapping):
+            raise VPMValidationError("mutation result isolation must be a mapping")
+        missing_isolation = sorted(_REQUIRED_ISOLATION_FIELDS - isolation.keys())
+        if missing_isolation:
+            raise VPMValidationError(
+                "mutation result isolation is missing required fields: "
+                + ", ".join(missing_isolation)
+            )
+        if not isinstance(row["secondary_failure_codes"], (list, tuple)):
+            raise VPMValidationError(
+                "mutation result secondary failure codes must be a sequence"
+            )
+        for field in ("detected", "expected_code_matched", "expected_detected"):
+            if type(row[field]) is not bool:
+                raise VPMValidationError(f"mutation result {field} must be a boolean")
+        if any(
+            not isinstance(item, Mapping)
+            or not isinstance(item.get("code"), str)
+            or not isinstance(item.get("gate"), str)
+            for item in row["secondary_failure_codes"]
+        ):
+            raise VPMValidationError(
+                "mutation result secondary failure codes are malformed"
+            )
+        if (
+            type(isolation["changed_field_count"]) is not int
+            or int(isolation["changed_field_count"]) < 0
+        ):
+            raise VPMValidationError(
+                "mutation result changed field count must be non-negative"
+            )
+        if type(isolation["isolation_passed"]) is not bool:
+            raise VPMValidationError(
+                "mutation result isolation status must be a boolean"
+            )
+        if (
+            not isinstance(isolation["mutation_effect_digest"], str)
+            or not isolation["mutation_effect_digest"]
+        ):
+            raise VPMValidationError(
+                "mutation result effect digest must be a non-empty string"
+            )
+    if audit["status"] == "passed" and any(
+        not row["expected_code_matched"]
+        or not row["mutation_isolation"]["isolation_passed"]
+        for row in rows
+    ):
+        raise VPMValidationError("passed mutation audit contains a failing result")
+    return rows
+
+
+def build_mutation_matrix(audit: Mapping[str, Any]) -> dict[str, Any]:
+    """Project mutation findings into their stable registry order."""
+
+    validated = _validate_matrix_audit(audit)
+    findings = {_mutation_result_id(row): row for row in validated}
+    rows = [
+        findings[case["mutation_id"]]
+        for case in mutation_catalogue()
+        if case["mutation_id"] in findings
+    ]
+    payload = {
+        "version": MUTATION_MATRIX_VERSION,
+        "mutation_count": len(rows),
+        "mutation_ids": [row.get("mutation") or row.get("mutation_id") for row in rows],
+        "mutations": rows,
+    }
+    payload["matrix_digest"] = canonical_sha256(payload)
+    return payload
+
+
+__all__ = [
+    "MUTATION_MATRIX_VERSION",
+    "build_mutation_matrix",
+    "mutation_catalogue",
+    "validate_mutation_catalogue",
+]

--- a/zeromodel/domains/video_action_set/reference_verification.py
+++ b/zeromodel/domains/video_action_set/reference_verification.py
@@ -1,0 +1,664 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from ...artifact import VPMValidationError
+from ...video_complete_row_evidence import (
+    RowScore,
+    VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION,
+    build_complete_ranking,
+    build_complete_row_evidence,
+    build_semantic_top_set_outcome,
+    quantize_similarity,
+)
+from ...video_prospective_providers import (
+    PROSPECTIVE_P1_VERSION,
+    PROSPECTIVE_P2_VERSION,
+    PROSPECTIVE_P3_VERSION,
+)
+from .canonical_json import canonical_json_value, canonical_sha256
+from .contracts import EPISODE_PLAN_VERSION
+from .episode_families import episode_family_registry as _episode_family_registry
+from .reachability_composition import REACHABILITY_TRACE_VERSION
+
+REFERENCE_VERIFICATION_VERSION = "zeromodel-video-action-set-reference-verification/v1"
+SEMANTIC_OUTCOME_VERSION = VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION
+
+
+def _json_ready(value: Any) -> Any:
+    return canonical_json_value(value)
+
+
+def _sha256(value: Any) -> str:
+    return canonical_sha256(value)
+
+
+_NON_FINAL_SPLITS = ("development", "calibration", "selection")
+_ALL_SPLITS = ("development", "calibration", "selection", "final")
+_REQUIRED_VERIFICATION_GATES = (
+    "structural_identity",
+    "semantic_outcome",
+    "seed_and_plan",
+    "episode_regeneration",
+    "family_contract",
+    "reachability",
+    "completeness_orphan",
+    "access_prohibition",
+)
+_PRIMARY_GATE_PRECEDENCE = {
+    name: index for index, name in enumerate(_REQUIRED_VERIFICATION_GATES)
+}
+_PRIMARY_FAILURE_CODE_PRECEDENCE = {
+    code: index
+    for index, code in enumerate(
+        (
+            "expected_file_missing",
+            "benchmark_contract_identity_mismatch",
+            "benchmark_manifest_mismatch",
+            "policy_action_mapping_mismatch",
+            "provider_contract_mismatch",
+            "reachability_tile_mismatch",
+            "score_quantizer_mismatch",
+            "evidence_schema_mismatch",
+            "closure_gate_missing",
+            "score_row_universe_mismatch",
+            "quantized_score_vector_mismatch",
+            "raw_diagnostic_digest_mismatch",
+            "ranking_reconstruction_mismatch",
+            "tie_group_reconstruction_mismatch",
+            "semantic_status_mismatch",
+            "resolved_row_not_permitted",
+            "resolved_action_not_permitted",
+            "semantic_outcome_digest_mismatch",
+            "episode_seed_derivation_mismatch",
+            "episode_split_reassignment",
+            "duplicate_episode_id",
+            "final_observation_provenance_mismatch",
+            "sealed_episode_identity_mismatch",
+            "expected_record_missing",
+            "orphan_observation_record",
+            "frame_identity_mismatch",
+            "gap_event_structure_mismatch",
+            "observation_bytes_mismatch",
+            "observation_digest_mismatch",
+            "family_contract_violation",
+            "family_regeneration_mismatch",
+            "family_no_op",
+            "transition_classification_mismatch",
+            "gap_event_has_pixels",
+            "control_byte_identity_mismatch",
+            "control_denominator_leak",
+            "control_provider_visible_leak",
+            "control_hidden_history_not_ambiguous",
+            "control_hidden_label_not_ambiguous",
+            "control_hidden_history_cardinality_mismatch",
+            "family_disposition_mismatch",
+            "frame_disposition_mismatch",
+            "invalid_family_valid_state_collision",
+            "invalid_family_valid_transformation_collision",
+            "conflicting_action_evidence_absent",
+            "consulted_edge_mismatch",
+            "reachable_pair_mismatch",
+            "reachability_trace_mismatch",
+            "executed_action_mismatch",
+            "duplicate_observation_record",
+            "duplicate_observation_identity_unpermitted",
+            "orphan_score_vector_record",
+            "forbidden_final_materialization",
+            "forbidden_final_score_access",
+            "forbidden_final_reachability_access",
+            "forbidden_calibration_execution",
+            "forbidden_selection_execution",
+            "forbidden_final_evaluation",
+            "status_claim_not_supported",
+        )
+    )
+}
+
+
+def policy_row_action_digest(
+    policy_artifact_id: str, row_ids: Sequence[str], row_actions: Mapping[str, str]
+) -> str:
+    return _sha256(
+        {
+            "policy_artifact_id": policy_artifact_id,
+            "row_action": [
+                {"row_id": row_id, "action_id": row_actions[row_id]}
+                for row_id in row_ids
+            ],
+        }
+    )
+
+
+def build_reference_context(
+    *,
+    identity: Any,
+    policy: Any,
+    row_ids: Sequence[str],
+    row_actions: Mapping[str, str],
+    reachability_tile: Mapping[str, Any],
+    plans: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> dict[str, Any]:
+    """Build the verifier context from authoritative, already-loaded inputs."""
+
+    normalized_row_ids = [str(row_id) for row_id in row_ids]
+    return {
+        "identity": identity,
+        "policy": policy,
+        "row_ids": normalized_row_ids,
+        "row_actions": dict(row_actions),
+        "reachability_tile": dict(reachability_tile),
+        "plans": {split: list(split_plans) for split, split_plans in plans.items()},
+        "policy_row_action_digest": policy_row_action_digest(
+            policy.artifact_id, normalized_row_ids, row_actions
+        ),
+    }
+
+
+_policy_row_action_digest = policy_row_action_digest
+
+
+def _finding(code: str, message: str, **details: Any) -> dict[str, Any]:
+    payload = {"code": code, "message": message}
+    payload.update(
+        {key: _json_ready(value) for key, value in details.items() if value is not None}
+    )
+    return payload
+
+
+def _gate(
+    name: str,
+    findings: Sequence[Mapping[str, Any]],
+    *,
+    counts: Mapping[str, Any] | None = None,
+    unavailable: bool = False,
+) -> dict[str, Any]:
+    status = "unavailable" if unavailable else ("failed" if findings else "passed")
+    return {
+        "gate": name,
+        "status": status,
+        "finding_count": len(findings),
+        "findings": [dict(item) for item in findings],
+        "counts": dict(counts or {}),
+    }
+
+
+def _first_failure_code(report: Mapping[str, Any]) -> str | None:
+    primary = _primary_failure(report)
+    return None if primary is None else str(primary["code"])
+
+
+def _primary_failure(report: Mapping[str, Any]) -> dict[str, Any] | None:
+    candidates = []
+    for gate in report.get("gates", []):
+        gate_name = str(gate.get("gate"))
+        for finding in gate.get("findings", []):
+            code = str(finding["code"])
+            candidates.append(
+                (
+                    _PRIMARY_GATE_PRECEDENCE.get(gate_name, 10_000),
+                    _PRIMARY_FAILURE_CODE_PRECEDENCE.get(code, 10_000),
+                    code,
+                    gate_name,
+                    dict(finding),
+                )
+            )
+    if not candidates:
+        return None
+    _gate_index, _code_index, code, gate_name, finding = sorted(
+        candidates, key=lambda item: item[:4]
+    )[0]
+    return {"code": code, "gate": gate_name, "finding": finding}
+
+
+def _report_failure_codes(report: Mapping[str, Any]) -> list[dict[str, str]]:
+    rows = []
+    for gate in report.get("gates", []):
+        for finding in gate.get("findings", []):
+            rows.append(
+                {"gate": str(gate.get("gate")), "code": str(finding.get("code"))}
+            )
+    return sorted(
+        rows,
+        key=lambda row: (
+            _PRIMARY_GATE_PRECEDENCE.get(row["gate"], 10_000),
+            _PRIMARY_FAILURE_CODE_PRECEDENCE.get(row["code"], 10_000),
+            row["gate"],
+            row["code"],
+        ),
+    )
+
+
+def _raw_score_diagnostic_from_row(
+    row: Mapping[str, Any], policy_row_ids: Sequence[str]
+) -> str:
+    scores = {
+        str(row_id): float(score)
+        for row_id, score in zip(row["all_112_row_ids"], row["all_112_raw_scores"])
+    }
+    return build_complete_row_evidence(
+        row_scores=[(row_id, scores[row_id]) for row_id in policy_row_ids],
+        policy_artifact_id=str(row["policy_artifact_id"]),
+        provider_id=str(row["provider_id"]),
+        provider_version=str(row["provider_version"]),
+        policy_row_ids=policy_row_ids,
+    ).raw_score_diagnostic_digest
+
+
+def _stored_quantized_evidence(
+    row: Mapping[str, Any], policy_row_ids: Sequence[str]
+) -> tuple[Any | None, list[dict[str, Any]]]:
+    vectors, findings = _validated_score_vectors(row, policy_row_ids)
+    if vectors is None:
+        return None, findings
+    row_ids, raw_scores, quantized_scores = vectors
+    evidence, build_findings = _build_stored_evidence(
+        row,
+        policy_row_ids,
+        row_ids,
+        raw_scores,
+    )
+    findings.extend(build_findings)
+    if evidence is None:
+        return None, findings
+    findings.extend(_evidence_identity_findings(row, evidence))
+    findings.extend(
+        _ranking_findings(
+            row,
+            row_ids,
+            raw_scores,
+            quantized_scores,
+        )
+    )
+    return evidence, findings
+
+
+def _validated_score_vectors(
+    row: Mapping[str, Any],
+    policy_row_ids: Sequence[str],
+) -> tuple[
+    tuple[list[str], list[Any], list[Any]] | None,
+    list[dict[str, Any]],
+]:
+    row_ids = [str(row_id) for row_id in row.get("all_112_row_ids", [])]
+    raw_scores = list(row.get("all_112_raw_scores", []))
+    quantized_scores = list(row.get("all_112_quantized_scores", []))
+    if (
+        row_ids != list(policy_row_ids)
+        or len(row_ids) != 112
+        or len(set(row_ids)) != 112
+        or len(raw_scores) != 112
+        or len(quantized_scores) != 112
+    ):
+        return None, [
+            _finding(
+                "score_row_universe_mismatch",
+                "score vector does not contain the exact frozen 112-row policy universe",
+                frame_id=row.get("frame_id"),
+            )
+        ]
+    try:
+        expected_quantized = [quantize_similarity(float(score)) for score in raw_scores]
+    except VPMValidationError:
+        return None, [
+            _finding(
+                "raw_diagnostic_digest_mismatch",
+                "raw scores are not finite or quantizable",
+                frame_id=row.get("frame_id"),
+            )
+        ]
+    findings = []
+    if [int(score) for score in quantized_scores] != expected_quantized:
+        findings.append(
+            _finding(
+                "quantized_score_vector_mismatch",
+                "stored quantized scores do not reconstruct from raw scores",
+                frame_id=row.get("frame_id"),
+            )
+        )
+    return (row_ids, raw_scores, quantized_scores), findings
+
+
+def _build_stored_evidence(
+    row: Mapping[str, Any],
+    policy_row_ids: Sequence[str],
+    row_ids: Sequence[str],
+    raw_scores: Sequence[Any],
+) -> tuple[Any | None, list[dict[str, Any]]]:
+    try:
+        evidence = build_complete_row_evidence(
+            row_scores=[
+                (row_id, float(score)) for row_id, score in zip(row_ids, raw_scores)
+            ],
+            policy_artifact_id=str(row["policy_artifact_id"]),
+            provider_id=str(row["provider_id"]),
+            provider_version=str(row["provider_version"]),
+            policy_row_ids=policy_row_ids,
+        )
+    except (KeyError, VPMValidationError) as exc:
+        return None, [
+            _finding(
+                "quantized_score_vector_mismatch",
+                "complete row evidence could not be reconstructed",
+                frame_id=row.get("frame_id"),
+                error=str(exc),
+            )
+        ]
+    return evidence, []
+
+
+def _evidence_identity_findings(
+    row: Mapping[str, Any],
+    evidence: Any,
+) -> list[dict[str, Any]]:
+    findings = []
+    stored_score_digest = str(
+        row.get("quantized_score_vector_digest", row.get("score_vector_digest"))
+    )
+    if (
+        stored_score_digest != evidence.quantized_score_vector_digest
+        or str(row.get("score_vector_digest")) != evidence.quantized_score_vector_digest
+    ):
+        findings.append(
+            _finding(
+                "quantized_score_vector_mismatch",
+                "quantized score-vector identity does not match reconstructed evidence",
+                frame_id=row.get("frame_id"),
+            )
+        )
+    if (
+        row.get("raw_score_diagnostic_digest") is not None
+        and str(row.get("raw_score_diagnostic_digest"))
+        != evidence.raw_score_diagnostic_digest
+    ):
+        findings.append(
+            _finding(
+                "raw_diagnostic_digest_mismatch",
+                "raw diagnostic identity does not match reconstructed raw scores",
+                frame_id=row.get("frame_id"),
+            )
+        )
+    return findings
+
+
+def _ranking_findings(
+    row: Mapping[str, Any],
+    row_ids: Sequence[str],
+    raw_scores: Sequence[Any],
+    quantized_scores: Sequence[Any],
+) -> list[dict[str, Any]]:
+    ranking_scores = tuple(
+        RowScore(row_id=row_id, raw_score=float(raw), quantized_score=int(quantized))
+        for row_id, raw, quantized in zip(row_ids, raw_scores, quantized_scores)
+    )
+    expected_ranking = build_complete_ranking(ranking_scores)
+    findings = []
+    if list(row.get("complete_ordered_ranking", [])) != list(
+        expected_ranking.ranked_row_ids
+    ):
+        findings.append(
+            _finding(
+                "ranking_reconstruction_mismatch",
+                "stored ranking does not reconstruct from quantized scores",
+                frame_id=row.get("frame_id"),
+            )
+        )
+    if list(row.get("tie_groups", [])) != [
+        group.to_dict() for group in expected_ranking.tie_groups
+    ]:
+        findings.append(
+            _finding(
+                "tie_group_reconstruction_mismatch",
+                "stored tie groups do not reconstruct from quantized scores",
+                frame_id=row.get("frame_id"),
+            )
+        )
+    if (
+        row.get("ranking_digest") is not None
+        and str(row.get("ranking_digest")) != expected_ranking.ranking_digest
+    ):
+        findings.append(
+            _finding(
+                "ranking_reconstruction_mismatch",
+                "ranking digest does not match reconstructed ranking",
+                frame_id=row.get("frame_id"),
+            )
+        )
+    return findings
+
+
+def _semantic_cache_key(row: Mapping[str, Any]) -> str:
+    return _sha256(
+        {
+            "policy_artifact_id": row.get("policy_artifact_id"),
+            "provider_id": row.get("provider_id"),
+            "provider_version": row.get("provider_version"),
+            "all_112_row_ids": row.get("all_112_row_ids"),
+            "all_112_raw_scores": row.get("all_112_raw_scores"),
+            "all_112_quantized_scores": row.get("all_112_quantized_scores"),
+            "complete_ordered_ranking": row.get("complete_ordered_ranking"),
+            "tie_groups": row.get("tie_groups"),
+            "score_vector_digest": row.get("score_vector_digest"),
+            "quantized_score_vector_digest": row.get("quantized_score_vector_digest"),
+            "raw_score_diagnostic_digest": row.get("raw_score_diagnostic_digest"),
+            "ranking_digest": row.get("ranking_digest"),
+        }
+    )
+
+
+def _expected_semantic_for_row(
+    row: Mapping[str, Any],
+    row_actions: Mapping[str, str],
+    policy_row_ids: Sequence[str],
+    cache: dict[str, Any] | None = None,
+) -> tuple[Any | None, list[dict[str, Any]]]:
+    key = _semantic_cache_key(row)
+    if cache is not None and key in cache:
+        return cache[key], []
+    evidence, findings = _stored_quantized_evidence(row, policy_row_ids)
+    if evidence is None:
+        return None, findings
+    try:
+        outcome = build_semantic_top_set_outcome(
+            evidence=evidence, row_action=row_actions
+        )
+    except VPMValidationError as exc:
+        return None, findings + [
+            _finding(
+                "semantic_status_mismatch",
+                "semantic outcome could not be reconstructed",
+                frame_id=row.get("frame_id"),
+                error=str(exc),
+            )
+        ]
+    if cache is not None and not findings:
+        cache[key] = outcome
+    return outcome, findings
+
+
+def compare_provider_results(
+    *,
+    provider_id: str,
+    observation_id: str,
+    reference: Any,
+    optimized: Any,
+) -> dict[str, Any]:
+    """Compare one optimized result with its independently scored reference result."""
+
+    quantized_equal = reference.quantized_scores == optimized.quantized_scores
+    ranking_equal = (
+        reference.evidence.ranking.ranked_row_ids
+        == optimized.evidence.ranking.ranked_row_ids
+    )
+    tie_groups_equal = tuple(
+        group.to_dict() for group in reference.evidence.ranking.tie_groups
+    ) == tuple(group.to_dict() for group in optimized.evidence.ranking.tie_groups)
+    digests_equal = (
+        reference.evidence.score_vector_digest == optimized.evidence.score_vector_digest
+        and reference.evidence.ranking.ranking_digest
+        == optimized.evidence.ranking.ranking_digest
+    )
+    return {
+        "provider_id": provider_id,
+        "observation_id": observation_id,
+        "quantized_equal": quantized_equal,
+        "ranking_equal": ranking_equal,
+        "tie_groups_equal": tie_groups_equal,
+        "digests_equal": digests_equal,
+    }
+
+
+def build_provider_equivalence_payload(
+    comparisons: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    provider_order = ("P1", "P2", "P3")
+    summary: dict[str, Any] = {}
+    mismatches: list[str] = []
+    for provider_id in provider_order:
+        rows = [row for row in comparisons if row.get("provider_id") == provider_id]
+        provider_summary = {
+            "quantized_mismatch_count": sum(
+                int(not bool(row["quantized_equal"])) for row in rows
+            ),
+            "ranking_mismatch_count": sum(
+                int(not bool(row["ranking_equal"])) for row in rows
+            ),
+            "tie_group_mismatch_count": sum(
+                int(not bool(row["tie_groups_equal"])) for row in rows
+            ),
+            "digest_mismatch_count": sum(
+                int(not bool(row["digests_equal"])) for row in rows
+            ),
+        }
+        summary[provider_id] = provider_summary
+        if any(provider_summary.values()):
+            mismatches.append(provider_id)
+    return {
+        "providers_verified": not mismatches,
+        "mismatching_providers": mismatches,
+        "summary": summary,
+    }
+
+
+def build_reference_verification_payload(
+    *,
+    context: Mapping[str, Any],
+    gates: Sequence[Mapping[str, Any]],
+    phase_counts: Mapping[str, Any],
+) -> dict[str, Any]:
+    normalized_gates = [dict(gate) for gate in gates]
+    passed = [gate["gate"] for gate in normalized_gates if gate["status"] == "passed"]
+    failed = [gate["gate"] for gate in normalized_gates if gate["status"] == "failed"]
+    unavailable = [
+        gate["gate"] for gate in normalized_gates if gate["status"] == "unavailable"
+    ]
+    identity = context["identity"]
+    policy = context["policy"]
+    payload: dict[str, Any] = {
+        "version": REFERENCE_VERIFICATION_VERSION,
+        "authoritative_roots": {
+            "benchmark_contract_identity": identity.to_dict(),
+            "root_seed_digest": identity.seed_digest,
+            "policy_artifact_id": policy.artifact_id,
+            "policy_row_action_digest": context["policy_row_action_digest"],
+            "episode_family_registry_digest": _episode_family_registry()[
+                "registry_digest"
+            ],
+            "reachability_tile_digest": context["reachability_tile"]["tile_digest"],
+            "provider_versions": {
+                "P1": PROSPECTIVE_P1_VERSION,
+                "P2": PROSPECTIVE_P2_VERSION,
+                "P3": PROSPECTIVE_P3_VERSION,
+            },
+            "evidence_schema_versions": {
+                "complete_row_evidence": "zeromodel-video-complete-row-evidence/v2",
+                "semantic_top_set_outcome": SEMANTIC_OUTCOME_VERSION,
+                "reachability_trace": REACHABILITY_TRACE_VERSION,
+                "sealed_episode_plan": EPISODE_PLAN_VERSION,
+            },
+        },
+        "checks_executed": [gate["gate"] for gate in normalized_gates],
+        "passed_checks": passed,
+        "failed_checks": failed,
+        "unavailable_checks": unavailable,
+        "gates": normalized_gates,
+        "measured_counts": dict(phase_counts),
+        "final_access_measurements": {
+            "final_plan_count": len(context["plans"]["final"]),
+            "final_observation_materialization_count": phase_counts[
+                "final_materialization_count"
+            ],
+            "final_provider_score_access_count": phase_counts[
+                "final_score_access_count"
+            ],
+            "final_reachability_execution_count": phase_counts[
+                "final_reachability_execution_count"
+            ],
+            "final_evaluation_count": phase_counts["final_evaluation_count"],
+            "calibration_execution_count": phase_counts["calibration_execution_count"],
+            "architecture_selection_execution_count": phase_counts[
+                "architecture_selection_execution_count"
+            ],
+            "candidate_tuning_execution_count": phase_counts[
+                "candidate_tuning_execution_count"
+            ],
+        },
+        "verified": not failed and not unavailable,
+        "primary_failure_code": None,
+        "primary_failure_gate": None,
+    }
+    primary = _primary_failure(payload)
+    payload["primary_failure_code"] = None if primary is None else primary["code"]
+    payload["primary_failure_gate"] = None if primary is None else primary["gate"]
+    payload["verification_digest"] = _sha256(
+        {key: value for key, value in payload.items() if key != "verification_digest"}
+    )
+    return payload
+
+
+def build_read_only_verification_payload(
+    *,
+    before: Mapping[str, Any],
+    middle: Mapping[str, Any],
+    after: Mapping[str, Any],
+    first: Mapping[str, Any],
+    second: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload = {
+        "read_only": before == middle == after,
+        "deterministic": (
+            first.get("verification_digest") == second.get("verification_digest")
+            and first == second
+        ),
+        "first_verification_digest": first.get("verification_digest"),
+        "second_verification_digest": second.get("verification_digest"),
+        "path_count": len(before),
+    }
+    payload["status"] = (
+        "passed" if payload["read_only"] and payload["deterministic"] else "failed"
+    )
+    payload["digest"] = _sha256(payload)
+    return payload
+
+
+__all__ = [
+    "REFERENCE_VERIFICATION_VERSION",
+    "SEMANTIC_OUTCOME_VERSION",
+    "_REQUIRED_VERIFICATION_GATES",
+    "_expected_semantic_for_row",
+    "_finding",
+    "_first_failure_code",
+    "_gate",
+    "_policy_row_action_digest",
+    "_primary_failure",
+    "_raw_score_diagnostic_from_row",
+    "_report_failure_codes",
+    "_semantic_cache_key",
+    "_sha256",
+    "_stored_quantized_evidence",
+    "build_provider_equivalence_payload",
+    "build_read_only_verification_payload",
+    "build_reference_context",
+    "build_reference_verification_payload",
+    "compare_provider_results",
+]

--- a/zeromodel/domains/video_action_set/verification.py
+++ b/zeromodel/domains/video_action_set/verification.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .canonical_json import canonical_sha256
+from .mutation_audit import MUTATION_AUDIT_VERSION, _MUTATION_CASES
+from .mutation_matrix import MUTATION_MATRIX_VERSION
+
+CLOSURE_REPORT_VERSION = "zeromodel-video-action-set-reference-closure/v1"
+
+
+def build_unavailable_repeated_mutation_audit() -> dict[str, Any]:
+    detected = [case for case in _MUTATION_CASES if not case.get("invariant")]
+    invariants = [case for case in _MUTATION_CASES if case.get("invariant")]
+    audit = {
+        "version": MUTATION_AUDIT_VERSION,
+        "matrix_version": MUTATION_MATRIX_VERSION,
+        "status": "unavailable",
+        "declared_mutation_count": len(_MUTATION_CASES),
+        "executable_mutation_count": len(_MUTATION_CASES),
+        "expected_detection_count": len(detected),
+        "expected_mutation_count": len(detected),
+        "detected_mutation_count": 0,
+        "missed_mutation_count": len(detected),
+        "undetected_mutation_count": len(detected),
+        "unexpected_failure_code_count": 0,
+        "invariant_count": len(invariants),
+        "invariant_pass_count": 0,
+        "invariant_failure_count": len(invariants),
+        "mutations": [],
+        "digest_laundering_tests": [],
+        "digest_laundering_class_closure": {},
+        "mutation_isolation_passed": False,
+        "mutation_audit_digest": None,
+    }
+    return {
+        "version": "zeromodel-video-action-set-reference-mutation-audit-repeat/v1",
+        "matrix_version": MUTATION_MATRIX_VERSION,
+        "deterministic": False,
+        "first_audit_digest": None,
+        "second_audit_digest": None,
+        "audit": audit,
+    }
+
+
+def build_verification_closure(
+    *,
+    verification: Mapping[str, Any],
+    repeated_mutation_audit: Mapping[str, Any],
+    read_only: Mapping[str, Any],
+    split_plan_identities: Mapping[str, str],
+) -> dict[str, Any]:
+    mutation_audit = repeated_mutation_audit["audit"]
+    final_counts = verification["final_access_measurements"]
+    required_zero = _required_access_counts_are_zero(final_counts)
+    supported = (
+        verification["verified"]
+        and mutation_audit.get("status") == "passed"
+        and mutation_audit.get("declared_mutation_count") == 93
+        and mutation_audit.get("executable_mutation_count") == 93
+        and mutation_audit.get("expected_detection_count") == 91
+        and mutation_audit.get("detected_mutation_count") == 91
+        and mutation_audit.get("missed_mutation_count") == 0
+        and mutation_audit.get("unexpected_failure_code_count") == 0
+        and mutation_audit.get("invariant_count") == 2
+        and mutation_audit.get("invariant_pass_count") == 2
+        and len(mutation_audit.get("digest_laundering_class_closure", {})) >= 7
+        and mutation_audit.get("mutation_isolation_passed") is True
+        and repeated_mutation_audit.get("deterministic") is True
+        and read_only["status"] == "passed"
+        and required_zero
+        and not verification["unavailable_checks"]
+    )
+    roots = verification["authoritative_roots"]
+    payload: dict[str, Any] = {
+        "version": CLOSURE_REPORT_VERSION,
+        "contract_identity": roots["benchmark_contract_identity"],
+        "policy_identity": roots["policy_artifact_id"],
+        "root_seed_identity": roots["root_seed_digest"],
+        "split_plan_identities": dict(split_plan_identities),
+        "family_registry_identity": roots["episode_family_registry_digest"],
+        "reachability_identity": roots["reachability_tile_digest"],
+        "provider_identities": roots["provider_versions"],
+        "verification": dict(verification),
+        "mutation_audit": dict(mutation_audit),
+        "repeated_mutation_audit": dict(repeated_mutation_audit),
+        "read_only_verification": dict(read_only),
+        "declared_mutation_count": mutation_audit.get("declared_mutation_count", 0),
+        "executable_mutation_count": mutation_audit.get("executable_mutation_count", 0),
+        "expected_detection_count": mutation_audit.get("expected_detection_count", 0),
+        "expected_mutation_count": mutation_audit.get("expected_mutation_count", 0),
+        "detected_mutation_count": mutation_audit.get("detected_mutation_count", 0),
+        "missed_mutation_count": mutation_audit.get("missed_mutation_count", 0),
+        "undetected_mutation_count": mutation_audit.get("undetected_mutation_count", 0),
+        "unexpected_failure_code_count": mutation_audit.get(
+            "unexpected_failure_code_count", 0
+        ),
+        "invariant_count": mutation_audit.get("invariant_count", 0),
+        "invariant_pass_count": mutation_audit.get("invariant_pass_count", 0),
+        "digest_laundering_class_closure": mutation_audit.get(
+            "digest_laundering_class_closure", {}
+        ),
+        "mutation_audit_report_digest": mutation_audit.get("mutation_audit_digest"),
+        "final_materialization_access_counts": final_counts,
+        "supported_status": (
+            "reference_instrument_correct"
+            if supported
+            else "reference_instrument_correctness_unresolved"
+        ),
+        "unsupported_statuses": [
+            "materialization_ready",
+            "benchmark_utility_verified",
+            "provider_selected",
+            "calibration_complete",
+            "final_evaluation_complete",
+        ],
+        "materialization_status": "prospective_materialization_prohibited",
+    }
+    payload["closure_report_digest"] = canonical_sha256(payload)
+    return payload
+
+
+def _required_access_counts_are_zero(counts: Mapping[str, Any]) -> bool:
+    return (
+        counts["final_observation_materialization_count"] == 0
+        and counts["final_provider_score_access_count"] == 0
+        and counts["final_reachability_execution_count"] == 0
+        and counts["calibration_execution_count"] == 0
+        and counts["architecture_selection_execution_count"] == 0
+        and counts["candidate_tuning_execution_count"] == 0
+        and counts["final_evaluation_count"] == 0
+    )
+
+
+def verification_summary(closure: Mapping[str, Any]) -> dict[str, Any]:
+    verification = closure["verification"]
+    access = verification["final_access_measurements"]
+    measured = verification["measured_counts"]
+    return {
+        "verified": verification["verified"],
+        "version": verification["version"],
+        "closure_report_version": closure["version"],
+        "repository_status": closure["supported_status"],
+        "materialization_status": closure["materialization_status"],
+        "primary_failure_code": verification["primary_failure_code"],
+        "gates": verification["gates"],
+        "final_materialization_count": access[
+            "final_observation_materialization_count"
+        ],
+        "final_score_access_count": access["final_provider_score_access_count"],
+        "final_reachability_execution_count": access[
+            "final_reachability_execution_count"
+        ],
+        "candidate_set_selection_count": access["candidate_tuning_execution_count"],
+        "conformal_calibration_count": access["calibration_execution_count"],
+        "reachability_replay_count": measured["reachability_replay_count"],
+        "final_evaluation_count": access["final_evaluation_count"],
+        "forbidden_final_access_counter": measured["forbidden_final_access_counter"],
+        "read_only": closure["read_only_verification"]["read_only"],
+        "verification_digest": verification["verification_digest"],
+    }
+
+
+__all__ = [
+    "CLOSURE_REPORT_VERSION",
+    "build_unavailable_repeated_mutation_audit",
+    "build_verification_closure",
+    "verification_summary",
+]

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -189,6 +189,60 @@ from .domains.video_action_set.runtime_profiling import (
     runtime_profile_payload,
     select_profiling_records,
 )
+from .domains.video_action_set.evidence_audit import (
+    PHASE_ACCESS_VERSION,
+    access_prohibition_gate as _build_access_prohibition_gate,
+    audit_canonical_provider_results as _audit_canonical_provider_results,
+    audit_evidence_rows as _audit_evidence_rows,
+    build_observation_identity_manifest as _build_observation_identity_manifest,
+    build_split_overlap_audit as _build_split_overlap_audit,
+    measured_phase_access_counts as _build_measured_phase_access_counts,
+)
+from .domains.video_action_set.mutation_audit import (
+    MUTATION_AUDIT_VERSION,
+    _MUTATION_CASES,
+    _changed_fields,
+    _changed_snapshot_files,
+    _flatten_payload,
+    _mutation_case_by_name,
+    _mutation_expected_files,
+    _mutation_isolation_report,
+    _mutation_property,
+    build_mutation_audit_payload as _build_mutation_audit_payload,
+    build_repeated_mutation_audit_payload as _build_repeated_mutation_audit_payload,
+    evaluate_mutation_case as _evaluate_mutation_case,
+)
+from .domains.video_action_set.mutation_matrix import (
+    MUTATION_MATRIX_VERSION,
+    mutation_catalogue,
+    validate_mutation_catalogue,
+)
+from .domains.video_action_set.reference_verification import (
+    REFERENCE_VERIFICATION_VERSION,
+    SEMANTIC_OUTCOME_VERSION,
+    _REQUIRED_VERIFICATION_GATES,
+    _expected_semantic_for_row,
+    _finding,
+    _first_failure_code,
+    _gate,
+    _policy_row_action_digest,
+    _primary_failure,
+    _raw_score_diagnostic_from_row,
+    _report_failure_codes,
+    _semantic_cache_key,
+    _stored_quantized_evidence,
+    build_provider_equivalence_payload as _build_provider_equivalence_payload,
+    build_read_only_verification_payload as _build_read_only_verification_payload,
+    build_reference_context as _build_reference_context,
+    build_reference_verification_payload as _build_reference_verification_payload,
+    compare_provider_results as _compare_provider_results,
+)
+from .domains.video_action_set.verification import (
+    CLOSURE_REPORT_VERSION,
+    build_unavailable_repeated_mutation_audit as _build_unavailable_repeated_mutation_audit,
+    build_verification_closure as _build_verification_closure,
+    verification_summary as _verification_summary,
+)
 from .domains.video_action_set.arcade_observation import (
     render_row_frame as _render_row_frame,
     renderer_identity as _renderer_identity,
@@ -276,12 +330,6 @@ _STAGE4B_LEGACY_COMPATIBILITY_ALIASES = (
 
 
 EPISODE_SCHEMA_VERSION = "zeromodel-video-policy-episode/v1"
-PHASE_ACCESS_VERSION = "zeromodel-video-prospective-phase-access/v1"
-REFERENCE_VERIFICATION_VERSION = "zeromodel-video-action-set-reference-verification/v1"
-MUTATION_AUDIT_VERSION = "zeromodel-video-action-set-reference-mutation-audit/v1"
-CLOSURE_REPORT_VERSION = "zeromodel-video-action-set-reference-closure/v1"
-MUTATION_MATRIX_VERSION = "zeromodel-video-action-set-reference-mutation-matrix/v3"
-SEMANTIC_OUTCOME_VERSION = VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION
 
 
 def _json_ready(value: Any) -> Any:
@@ -553,18 +601,17 @@ def profile_runtime(
 def verify_provider_runtime_equivalence(output_dir: Path, repo_root: Path) -> dict[str, Any]:
     prototypes = canonical_prototypes()
     policy_artifact_id = compile_policy_artifact().artifact_id
-    records = list(prototypes.values())
-    sampled = []
-    for row_id, action_id, _digest, observation in records[:12]:
-        sampled.append({"frame_id": f"canonical:{row_id}", "observation": observation, "expected_row": row_id, "expected_action": action_id})
-    mismatches = []
-    summary: dict[str, Any] = {}
-    csv_rows = []
+    sampled = [
+        {
+            "frame_id": f"canonical:{row_id}",
+            "observation": observation,
+            "expected_row": row_id,
+            "expected_action": action_id,
+        }
+        for row_id, action_id, _digest, observation in list(prototypes.values())[:12]
+    ]
+    comparisons = []
     for provider_id in ("P1", "P2", "P3"):
-        quantized_mismatch_count = 0
-        ranking_mismatch_count = 0
-        tie_group_mismatch_count = 0
-        digest_mismatch_count = 0
         for record in sampled:
             reference = score_all_rows_reference(
                 provider_id=provider_id,
@@ -580,39 +627,17 @@ def verify_provider_runtime_equivalence(output_dir: Path, repo_root: Path) -> di
                 policy_artifact_id=policy_artifact_id,
                 source_scope=SOURCE_SCOPE,
             )
-            quantized_equal = reference.quantized_scores == optimized.quantized_scores
-            ranking_equal = reference.evidence.ranking.ranked_row_ids == optimized.evidence.ranking.ranked_row_ids
-            ties_equal = tuple(group.to_dict() for group in reference.evidence.ranking.tie_groups) == tuple(group.to_dict() for group in optimized.evidence.ranking.tie_groups)
-            digest_equal = reference.evidence.score_vector_digest == optimized.evidence.score_vector_digest and reference.evidence.ranking.to_dict()["ranking_digest"] == optimized.evidence.ranking.to_dict()["ranking_digest"]
-            quantized_mismatch_count += int(not quantized_equal)
-            ranking_mismatch_count += int(not ranking_equal)
-            tie_group_mismatch_count += int(not ties_equal)
-            digest_mismatch_count += int(not digest_equal)
-            csv_rows.append(
-                {
-                    "provider_id": provider_id,
-                    "observation_id": record["frame_id"],
-                    "quantized_equal": quantized_equal,
-                    "ranking_equal": ranking_equal,
-                    "tie_groups_equal": ties_equal,
-                    "digests_equal": digest_equal,
-                }
+            comparisons.append(
+                _compare_provider_results(
+                    provider_id=provider_id,
+                    observation_id=record["frame_id"],
+                    reference=reference,
+                    optimized=optimized,
+                )
             )
-        summary[provider_id] = {
-            "quantized_mismatch_count": quantized_mismatch_count,
-            "ranking_mismatch_count": ranking_mismatch_count,
-            "tie_group_mismatch_count": tie_group_mismatch_count,
-            "digest_mismatch_count": digest_mismatch_count,
-        }
-        if any(summary[provider_id].values()):
-            mismatches.append(provider_id)
-    payload = {
-        "providers_verified": not mismatches,
-        "mismatching_providers": mismatches,
-        "summary": summary,
-    }
+    payload = _build_provider_equivalence_payload(comparisons)
     _write_json(output_dir / "provider-runtime-equivalence.json", payload)
-    _write_csv(output_dir / "provider-runtime-equivalence.csv", csv_rows)
+    _write_csv(output_dir / "provider-runtime-equivalence.csv", comparisons)
     return payload
 
 
@@ -660,224 +685,75 @@ def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]
 
 
 def _measured_phase_access_counts(output_dir: Path) -> dict[str, Any]:
-    final_plan = _read_json(output_dir / "final-split-sealed-plan.json") if (output_dir / "final-split-sealed-plan.json").exists() else {}
-    final_ids = {episode_id for values in final_plan.get("sealed_episode_ids", {}).values() for episode_id in values}
-    final_materialization_count = 0
-    final_score_access_count = 0
-    final_reachability_execution_count = 0
-    for split in ("development", "calibration", "selection", "final"):
-        frame_rows = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        evidence_rows = _read_jsonl(output_dir / split / "provider-evidence.jsonl")
-        final_materialization_count += sum(1 for row in frame_rows if row.get("episode_id") in final_ids or row.get("split") == "final")
-        final_score_access_count += sum(1 for row in evidence_rows if row.get("episode_id") in final_ids or row.get("split") == "final")
-        final_reachability_execution_count += sum(
-            1
-            for row in evidence_rows
-            if (row.get("episode_id") in final_ids or row.get("split") == "final") and row.get("reachability_composition_trace") is not None
-        )
-    calibration_execution_count = sum(
-        int((output_dir / name).exists())
-        for name in (
-            "selected-calibration.json",
-            "calibration-grid.json",
-            "calibration-results.json",
-            "conformal-calibration.json",
-        )
-    )
-    architecture_selection_execution_count = sum(
-        int((output_dir / name).exists())
-        for name in (
-            "selected-architecture.json",
-            "architecture-grid.json",
-            "architecture-selection.json",
-            "selected-method.json",
-        )
-    )
-    candidate_tuning_execution_count = sum(
-        int((output_dir / name).exists())
-        for name in (
-            "candidate-tuning.json",
-            "candidate-set-tuning.json",
-            "candidate-grid.json",
-            "reachability-replay.json",
-        )
-    )
-    final_evaluation_count = sum(
-        int((output_dir / name).exists())
-        for name in (
-            "final-results.json",
-            "final-summary.json",
-            "final-evaluation.json",
-        )
-    )
-    return {
-        "version": PHASE_ACCESS_VERSION,
-        "final_materialization_count": final_materialization_count,
-        "final_score_access_count": final_score_access_count,
-        "final_reachability_execution_count": final_reachability_execution_count,
-        "candidate_set_selection_count": candidate_tuning_execution_count,
-        "candidate_tuning_execution_count": candidate_tuning_execution_count,
-        "conformal_calibration_count": calibration_execution_count,
-        "calibration_execution_count": calibration_execution_count,
-        "architecture_selection_execution_count": architecture_selection_execution_count,
-        "reachability_replay_count": candidate_tuning_execution_count,
-        "final_evaluation_count": final_evaluation_count,
-        "forbidden_final_access_counter": final_materialization_count + final_score_access_count + final_reachability_execution_count,
+    final_path = output_dir / "final-split-sealed-plan.json"
+    final_plan = _read_json(final_path) if final_path.exists() else {}
+    frame_rows = {
+        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
+        for split in ("development", "calibration", "selection", "final")
     }
+    evidence_rows = {
+        split: _read_jsonl(output_dir / split / "provider-evidence.jsonl")
+        for split in ("development", "calibration", "selection", "final")
+    }
+    return _build_measured_phase_access_counts(
+        final_plan=final_plan,
+        frame_rows_by_split=frame_rows,
+        evidence_rows_by_split=evidence_rows,
+        existing_artifacts=[path.name for path in output_dir.iterdir()],
+    )
 
 
 def _write_observation_identity_manifest(output_dir: Path) -> None:
-    frames: dict[str, list[str]] = {}
-    for split in ("development", "calibration", "selection"):
-        path = output_dir / split / "frame-metadata.jsonl"
-        rows = _read_jsonl(path)
-        frames[split] = [row["frame_id"] for row in rows]
-    payload = {
-        "development_observation_count": len(frames["development"]),
-        "calibration_observation_count": len(frames["calibration"]),
-        "selection_observation_count": len(frames["selection"]),
-        "all_frame_ids_digest": _sha256(frames),
+    frames = {
+        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
+        for split in ("development", "calibration", "selection")
     }
+    payload = _build_observation_identity_manifest(frames)
     _write_json(output_dir / "observation-identity-manifest.json", payload)
 
 
 def _write_split_overlap_audit(output_dir: Path) -> None:
-    split_sets: dict[str, set[str]] = {}
-    split_rows: dict[str, list[dict[str, Any]]] = {}
-    for split in ("development", "calibration", "selection"):
-        rows = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        split_rows[split] = rows
-        split_sets[split] = {row["frame_id"] for row in rows}
-    final_plan = _read_json(output_dir / "final-split-sealed-plan.json") if (output_dir / "final-split-sealed-plan.json").exists() else {}
-    final_ids = {episode_id for values in final_plan.get("sealed_episode_ids", {}).values() for episode_id in values}
-    payload = {
-        "development_calibration_overlap": len(split_sets["development"] & split_sets["calibration"]),
-        "development_selection_overlap": len(split_sets["development"] & split_sets["selection"]),
-        "calibration_selection_overlap": len(split_sets["calibration"] & split_sets["selection"]),
-        "materialized_final_plan_overlap": sum(
-            1 for split in ("development", "calibration", "selection") for row in split_rows[split] if row.get("episode_id") in final_ids or row.get("split") == "final"
-        ),
-        "final_episode_ids_digest": _sha256(sorted(final_ids)) if final_ids else None,
+    split_rows = {
+        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
+        for split in ("development", "calibration", "selection")
     }
+    final_path = output_dir / "final-split-sealed-plan.json"
+    final_plan = _read_json(final_path) if final_path.exists() else {}
+    payload = _build_split_overlap_audit(
+        frame_rows_by_split=split_rows,
+        final_plan=final_plan,
+    )
     _write_json(output_dir / "split-overlap-audit.json", payload)
 
 
 def audit_evidence_completeness(output_dir: Path) -> dict[str, Any]:
     policy = compile_policy_artifact()
     lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
-    row_actions = {str(row_id): lookup.choose(str(row_id)) for row_id in policy.source.row_ids}
-    summaries = []
-    missing_score_vectors = 0
-    invalid_scores = 0
-    missing_rankings = 0
-    missing_tie_groups = 0
-    missing_semantic_outcomes = 0
-    missing_reachability_traces = 0
-    for split in ("development", "calibration", "selection"):
-        path = output_dir / split / "provider-evidence.jsonl"
-        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-        for row in rows:
-            if len(row["all_112_row_ids"]) != 112:
-                missing_score_vectors += 1
-            if len(row["all_112_raw_scores"]) != 112 or len(row["all_112_quantized_scores"]) != 112:
-                missing_score_vectors += 1
-            if any((score < 0 or score > QUANTIZATION_SCALE) for score in row["all_112_quantized_scores"]):
-                invalid_scores += 1
-            if len(row["complete_ordered_ranking"]) != 112:
-                missing_rankings += 1
-            if not row["tie_groups"]:
-                missing_tie_groups += 1
-            if row.get("semantic_top_set_outcome", {}).get("version") != SEMANTIC_OUTCOME_VERSION:
-                missing_semantic_outcomes += 1
-            else:
-                try:
-                    evidence = build_complete_row_evidence(
-                        row_scores=list(zip(row["all_112_row_ids"], row["all_112_raw_scores"])),
-                        policy_artifact_id=row["policy_artifact_id"],
-                        provider_id=row["provider_id"],
-                        provider_version=row["provider_version"],
-                        policy_row_ids=row["all_112_row_ids"],
-                    )
-                    if evidence.score_vector_digest != row["score_vector_digest"]:
-                        raise VPMValidationError("foreign score vector digest")
-                    semantic_top_set_outcome_from_dict(row["semantic_top_set_outcome"], evidence=evidence, row_action=row_actions)
-                except (KeyError, VPMValidationError):
-                    missing_semantic_outcomes += 1
-        frame_rows = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        for row in frame_rows:
-            if row.get("expected_disposition") != "information_theoretic_control" and "reachability_trace" not in row.get("metadata", {}):
-                missing_reachability_traces += 1
-        summaries.append({"split": split, "provider_frame_records": len(rows)})
-    payload = {
-        "complete_score_evidence": missing_score_vectors == 0 and invalid_scores == 0 and missing_semantic_outcomes == 0 and missing_reachability_traces == 0,
-        "missing_score_vector_count": missing_score_vectors,
-        "invalid_score_count": invalid_scores,
-        "missing_ranking_count": missing_rankings,
-        "missing_tie_group_count": missing_tie_groups,
-        "missing_semantic_outcome_count": missing_semantic_outcomes,
-        "missing_reachability_trace_count": missing_reachability_traces,
-        "split_summaries": summaries,
+    row_actions = {
+        str(row_id): lookup.choose(str(row_id)) for row_id in policy.source.row_ids
     }
+    frame_rows = {
+        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
+        for split in ("development", "calibration", "selection")
+    }
+    evidence_rows = {
+        split: _read_jsonl(output_dir / split / "provider-evidence.jsonl")
+        for split in ("development", "calibration", "selection")
+    }
+    payload = _audit_evidence_rows(
+        frame_rows_by_split=frame_rows,
+        evidence_rows_by_split=evidence_rows,
+        row_actions=row_actions,
+    )
     _write_json(output_dir / "evidence-completeness-summary.json", payload)
     return payload
 
 
 def audit_canonical_providers(output_dir: Path) -> dict[str, Any]:
-    prototypes = canonical_prototypes()
-    policy_artifact_id = compile_policy_artifact().artifact_id
-    rows = []
-    summary = {}
-    for provider_id in ("P1", "P2", "P3"):
-        exact_row_resolution = 0
-        action_resolution = 0
-        action_unanimous_tie_resolution = 0
-        conflicting_action_rejection = 0
-        unresolved_outcomes = 0
-        max_tie = 0
-        for observation_id, (row_id, action_id, _digest, observation) in prototypes.items():
-            if provider_id == "P1":
-                result = score_normalized_pixel(observation=observation, prototypes=prototypes, policy_artifact_id=policy_artifact_id)
-            elif provider_id == "P2":
-                result = score_registered_local_correlation(observation=observation, prototypes=prototypes, policy_artifact_id=policy_artifact_id, source_scope=SOURCE_SCOPE)
-            else:
-                result = score_b3_joint_fit(observation=observation, prototypes=prototypes, policy_artifact_id=policy_artifact_id, source_scope=SOURCE_SCOPE)
-            outcome = result.semantic_top_set_outcome
-            exact_row_resolution += int(outcome.resolved_row_id == row_id)
-            action_resolution += int(outcome.resolved_action_id == action_id)
-            action_unanimous_tie_resolution += int(outcome.status == "action_unanimous_tie" and outcome.resolved_action_id == action_id)
-            conflicting_action_rejection += int(outcome.status == "conflicting_action_tie")
-            unresolved_outcomes += int(outcome.status == "unresolved")
-            max_tie = max(max_tie, result.maximum_tie_size)
-            rows.append(
-                {
-                    "provider_id": provider_id,
-                    "observation_id": observation_id,
-                    "expected_row": row_id,
-                    "expected_action": action_id,
-                    "winner_row": result.winner_row_id,
-                    "winner_action": result.winner_action_id,
-                    "semantic_status": outcome.status,
-                    "resolved_row": outcome.resolved_row_id,
-                    "resolved_action": outcome.resolved_action_id,
-                    "semantic_outcome_digest": outcome.semantic_outcome_digest,
-                    "semantic_tie_size": result.maximum_tie_size,
-                    "score_vector_complete": len(result.evidence.row_scores) == 112,
-                    "ranking_complete": len(result.evidence.ranking.ranked_row_ids) == 112,
-                    "tie_group_complete": bool(result.evidence.ranking.tie_groups),
-                }
-            )
-        summary[provider_id] = {
-            "canonical_observation_count": 112,
-            "exact_row_resolution_count": exact_row_resolution,
-            "action_resolution_count": action_resolution,
-            "action_unanimous_tie_resolution_count": action_unanimous_tie_resolution,
-            "conflicting_action_rejection_count": conflicting_action_rejection,
-            "unresolved_outcome_count": unresolved_outcomes,
-            "exact_top1_count": exact_row_resolution,
-            "action_top1_count": action_resolution,
-            "maximum_tie_size": max_tie,
-            "status": "canonical_diagnostic_pass" if provider_id != "P3" or exact_row_resolution == 112 else "invalid_primary_provider_instrument",
-        }
+    summary, rows = _audit_canonical_provider_results(
+        prototypes=canonical_prototypes(),
+        policy_artifact_id=compile_policy_artifact().artifact_id,
+    )
     _write_csv(output_dir / "canonical-provider-results.csv", rows)
     _write_json(output_dir / "canonical-provider-summary.json", summary)
     _write_json(output_dir / "provider-equivalence-results.json", {"providers_match_themselves": True, "quantized_evidence_exact_match": True})
@@ -887,25 +763,8 @@ def audit_canonical_providers(output_dir: Path) -> dict[str, Any]:
 
 _NON_FINAL_SPLITS = ("development", "calibration", "selection")
 _ALL_SPLITS = ("development", "calibration", "selection", "final")
-_REQUIRED_VERIFICATION_GATES = (
-    "structural_identity",
-    "semantic_outcome",
-    "seed_and_plan",
-    "episode_regeneration",
-    "family_contract",
-    "reachability",
-    "completeness_orphan",
-    "access_prohibition",
-)
 
 
-def _policy_row_action_digest(policy_artifact_id: str, row_ids: Sequence[str], row_actions: Mapping[str, str]) -> str:
-    return _sha256(
-        {
-            "policy_artifact_id": policy_artifact_id,
-            "row_action": [{"row_id": row_id, "action_id": row_actions[row_id]} for row_id in row_ids],
-        }
-    )
 
 
 def _reference_context(repo_root: Path) -> dict[str, Any]:
@@ -920,163 +779,35 @@ def _reference_context(repo_root: Path) -> dict[str, Any]:
     lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
     row_ids = [str(row_id) for row_id in policy.source.row_ids]
     row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
-    reachability_tile = _load_reachability_tile(repo_root)
     plans = {split: _episode_plans_for_split(identity, split, row_ids, row_actions) for split in _ALL_SPLITS}
-    context = {
-        "identity": identity,
-        "policy": policy,
-        "row_ids": row_ids,
-        "row_actions": row_actions,
-        "reachability_tile": reachability_tile,
-        "plans": plans,
-        "policy_row_action_digest": _policy_row_action_digest(policy.artifact_id, row_ids, row_actions),
-    }
+    context = _build_reference_context(
+        identity=identity,
+        policy=policy,
+        row_ids=row_ids,
+        row_actions=row_actions,
+        reachability_tile=_load_reachability_tile(repo_root),
+        plans=plans,
+    )
     cache[cache_key] = context
     return context
 
 
-def _finding(code: str, message: str, **details: Any) -> dict[str, Any]:
-    payload = {"code": code, "message": message}
-    payload.update({key: _json_ready(value) for key, value in details.items() if value is not None})
-    return payload
 
 
-def _gate(name: str, findings: Sequence[Mapping[str, Any]], *, counts: Mapping[str, Any] | None = None, unavailable: bool = False) -> dict[str, Any]:
-    status = "unavailable" if unavailable else ("failed" if findings else "passed")
-    return {
-        "gate": name,
-        "status": status,
-        "finding_count": len(findings),
-        "findings": [dict(item) for item in findings],
-        "counts": dict(counts or {}),
-    }
 
 
-def _first_failure_code(report: Mapping[str, Any]) -> str | None:
-    primary = _primary_failure(report)
-    return None if primary is None else str(primary["code"])
 
 
-def _primary_failure(report: Mapping[str, Any]) -> dict[str, Any] | None:
-    candidates = []
-    for gate in report.get("gates", []):
-        gate_name = str(gate.get("gate"))
-        for finding in gate.get("findings", []):
-            code = str(finding["code"])
-            candidates.append(
-                (
-                    _PRIMARY_GATE_PRECEDENCE.get(gate_name, 10_000),
-                    _PRIMARY_FAILURE_CODE_PRECEDENCE.get(code, 10_000),
-                    code,
-                    gate_name,
-                    dict(finding),
-                )
-            )
-    if not candidates:
-        return None
-    _gate_index, _code_index, code, gate_name, finding = sorted(candidates, key=lambda item: item[:4])[0]
-    return {"code": code, "gate": gate_name, "finding": finding}
 
 
-def _report_failure_codes(report: Mapping[str, Any]) -> list[dict[str, str]]:
-    rows = []
-    for gate in report.get("gates", []):
-        for finding in gate.get("findings", []):
-            rows.append({"gate": str(gate.get("gate")), "code": str(finding.get("code"))})
-    return sorted(rows, key=lambda row: (_PRIMARY_GATE_PRECEDENCE.get(row["gate"], 10_000), _PRIMARY_FAILURE_CODE_PRECEDENCE.get(row["code"], 10_000), row["gate"], row["code"]))
 
 
-def _raw_score_diagnostic_from_row(row: Mapping[str, Any], policy_row_ids: Sequence[str]) -> str:
-    scores = {str(row_id): float(score) for row_id, score in zip(row["all_112_row_ids"], row["all_112_raw_scores"])}
-    return build_complete_row_evidence(
-        row_scores=[(row_id, scores[row_id]) for row_id in policy_row_ids],
-        policy_artifact_id=str(row["policy_artifact_id"]),
-        provider_id=str(row["provider_id"]),
-        provider_version=str(row["provider_version"]),
-        policy_row_ids=policy_row_ids,
-    ).raw_score_diagnostic_digest
 
 
-def _stored_quantized_evidence(row: Mapping[str, Any], policy_row_ids: Sequence[str]) -> tuple[Any | None, list[dict[str, Any]]]:
-    findings: list[dict[str, Any]] = []
-    row_ids = [str(row_id) for row_id in row.get("all_112_row_ids", [])]
-    raw_scores = list(row.get("all_112_raw_scores", []))
-    quantized_scores = list(row.get("all_112_quantized_scores", []))
-    if row_ids != list(policy_row_ids) or len(row_ids) != 112 or len(set(row_ids)) != 112 or len(raw_scores) != 112 or len(quantized_scores) != 112:
-        findings.append(_finding("score_row_universe_mismatch", "score vector does not contain the exact frozen 112-row policy universe", frame_id=row.get("frame_id")))
-        return None, findings
-    try:
-        expected_quantized = [quantize_similarity(float(score)) for score in raw_scores]
-    except VPMValidationError:
-        findings.append(_finding("raw_diagnostic_digest_mismatch", "raw scores are not finite or quantizable", frame_id=row.get("frame_id")))
-        return None, findings
-    if [int(score) for score in quantized_scores] != expected_quantized:
-        findings.append(_finding("quantized_score_vector_mismatch", "stored quantized scores do not reconstruct from raw scores", frame_id=row.get("frame_id")))
-    try:
-        evidence = build_complete_row_evidence(
-            row_scores=[(row_id, float(score)) for row_id, score in zip(row_ids, raw_scores)],
-            policy_artifact_id=str(row["policy_artifact_id"]),
-            provider_id=str(row["provider_id"]),
-            provider_version=str(row["provider_version"]),
-            policy_row_ids=policy_row_ids,
-        )
-    except (KeyError, VPMValidationError) as exc:
-        findings.append(_finding("quantized_score_vector_mismatch", "complete row evidence could not be reconstructed", frame_id=row.get("frame_id"), error=str(exc)))
-        return None, findings
-    stored_score_digest = str(row.get("quantized_score_vector_digest", row.get("score_vector_digest")))
-    if stored_score_digest != evidence.quantized_score_vector_digest or str(row.get("score_vector_digest")) != evidence.quantized_score_vector_digest:
-        findings.append(_finding("quantized_score_vector_mismatch", "quantized score-vector identity does not match reconstructed evidence", frame_id=row.get("frame_id")))
-    if row.get("raw_score_diagnostic_digest") is not None and str(row.get("raw_score_diagnostic_digest")) != evidence.raw_score_diagnostic_digest:
-        findings.append(_finding("raw_diagnostic_digest_mismatch", "raw diagnostic identity does not match reconstructed raw scores", frame_id=row.get("frame_id")))
-    ranking_scores = tuple(RowScore(row_id=row_id, raw_score=float(raw), quantized_score=int(quantized)) for row_id, raw, quantized in zip(row_ids, raw_scores, quantized_scores))
-    expected_ranking = build_complete_ranking(ranking_scores)
-    if list(row.get("complete_ordered_ranking", [])) != list(expected_ranking.ranked_row_ids):
-        findings.append(_finding("ranking_reconstruction_mismatch", "stored ranking does not reconstruct from quantized scores", frame_id=row.get("frame_id")))
-    if list(row.get("tie_groups", [])) != [group.to_dict() for group in expected_ranking.tie_groups]:
-        findings.append(_finding("tie_group_reconstruction_mismatch", "stored tie groups do not reconstruct from quantized scores", frame_id=row.get("frame_id")))
-    if row.get("ranking_digest") is not None and str(row.get("ranking_digest")) != expected_ranking.ranking_digest:
-        findings.append(_finding("ranking_reconstruction_mismatch", "ranking digest does not match reconstructed ranking", frame_id=row.get("frame_id")))
-    return evidence, findings
 
 
-def _semantic_cache_key(row: Mapping[str, Any]) -> str:
-    return _sha256(
-        {
-            "policy_artifact_id": row.get("policy_artifact_id"),
-            "provider_id": row.get("provider_id"),
-            "provider_version": row.get("provider_version"),
-            "all_112_row_ids": row.get("all_112_row_ids"),
-            "all_112_raw_scores": row.get("all_112_raw_scores"),
-            "all_112_quantized_scores": row.get("all_112_quantized_scores"),
-            "complete_ordered_ranking": row.get("complete_ordered_ranking"),
-            "tie_groups": row.get("tie_groups"),
-            "score_vector_digest": row.get("score_vector_digest"),
-            "quantized_score_vector_digest": row.get("quantized_score_vector_digest"),
-            "raw_score_diagnostic_digest": row.get("raw_score_diagnostic_digest"),
-            "ranking_digest": row.get("ranking_digest"),
-        }
-    )
 
 
-def _expected_semantic_for_row(
-    row: Mapping[str, Any],
-    row_actions: Mapping[str, str],
-    policy_row_ids: Sequence[str],
-    cache: dict[str, Any] | None = None,
-) -> tuple[Any | None, list[dict[str, Any]]]:
-    key = _semantic_cache_key(row)
-    if cache is not None and key in cache:
-        return cache[key], []
-    evidence, findings = _stored_quantized_evidence(row, policy_row_ids)
-    if evidence is None:
-        return None, findings
-    try:
-        outcome = build_semantic_top_set_outcome(evidence=evidence, row_action=row_actions)
-    except VPMValidationError as exc:
-        return None, findings + [_finding("semantic_status_mismatch", "semantic outcome could not be reconstructed", frame_id=row.get("frame_id"), error=str(exc))]
-    if cache is not None and not findings:
-        cache[key] = outcome
-    return outcome, findings
 
 
 def _structural_identity_gate(
@@ -1641,26 +1372,10 @@ def _completeness_orphan_gate(output_dir: Path, repo_root: Path, context: Mappin
 
 
 def _access_prohibition_gate(output_dir: Path, *, max_findings: int | None = None) -> dict[str, Any]:
-    findings: list[dict[str, Any]] = []
     measured = _measured_phase_access_counts(output_dir)
-    stored = _read_json(output_dir / "phase-access-audits.json") if (output_dir / "phase-access-audits.json").exists() else {}
-    if measured["final_materialization_count"]:
-        findings.append(_finding("forbidden_final_materialization", "final split has materialized observations", count=measured["final_materialization_count"]))
-    if measured["final_score_access_count"]:
-        findings.append(_finding("forbidden_final_score_access", "final split has provider score records", count=measured["final_score_access_count"]))
-    if measured["final_reachability_execution_count"]:
-        findings.append(_finding("forbidden_final_reachability_access", "final split has reachability execution traces", count=measured["final_reachability_execution_count"]))
-    if measured["calibration_execution_count"]:
-        findings.append(_finding("forbidden_calibration_execution", "prospective calibration execution artifact is present", count=measured["calibration_execution_count"]))
-    if measured["architecture_selection_execution_count"] or measured["candidate_tuning_execution_count"]:
-        findings.append(_finding("forbidden_selection_execution", "prospective selection or candidate-tuning execution artifact is present", count=measured["architecture_selection_execution_count"] + measured["candidate_tuning_execution_count"]))
-    if measured["final_evaluation_count"]:
-        findings.append(_finding("forbidden_final_evaluation", "final evaluation artifact is present", count=measured["final_evaluation_count"]))
-    if stored and {key: stored.get(key) for key in measured if key in stored} != {key: measured.get(key) for key in measured if key in stored}:
-        findings.append(_finding("status_claim_not_supported", "stored phase-access counters do not match counters measured from concrete artifacts"))
-    if max_findings is not None and len(findings) >= max_findings:
-        return _gate("access_prohibition", findings, counts=measured)
-    return _gate("access_prohibition", findings, counts=measured)
+    stored_path = output_dir / "phase-access-audits.json"
+    stored = _read_json(stored_path) if stored_path.exists() else {}
+    return _build_access_prohibition_gate(measured, stored, max_findings=max_findings)
 
 
 def verify_reference_instrument(
@@ -1672,7 +1387,6 @@ def verify_reference_instrument(
     stop_after_first_failure: bool = False,
 ) -> dict[str, Any]:
     """Read-only independent verification of a materialized reference-instrument directory."""
-
     context = _reference_context(repo_root)
     enabled = set(enabled_gates) if enabled_gates is not None else set(_REQUIRED_VERIFICATION_GATES)
     max_findings = 1 if stop_after_first_failure else None
@@ -1694,52 +1408,11 @@ def verify_reference_instrument(
         gates.append(gate)
         if stop_after_first_failure and gate["status"] == "failed":
             break
-    passed = [gate["gate"] for gate in gates if gate["status"] == "passed"]
-    failed = [gate["gate"] for gate in gates if gate["status"] == "failed"]
-    unavailable = [gate["gate"] for gate in gates if gate["status"] == "unavailable"]
-    phase_counts = _measured_phase_access_counts(output_dir)
-    payload: dict[str, Any] = {
-        "version": REFERENCE_VERIFICATION_VERSION,
-        "authoritative_roots": {
-            "benchmark_contract_identity": context["identity"].to_dict(),
-            "root_seed_digest": context["identity"].seed_digest,
-            "policy_artifact_id": context["policy"].artifact_id,
-            "policy_row_action_digest": context["policy_row_action_digest"],
-            "episode_family_registry_digest": _episode_family_registry()["registry_digest"],
-            "reachability_tile_digest": context["reachability_tile"]["tile_digest"],
-            "provider_versions": {"P1": PROSPECTIVE_P1_VERSION, "P2": PROSPECTIVE_P2_VERSION, "P3": PROSPECTIVE_P3_VERSION},
-            "evidence_schema_versions": {
-                "complete_row_evidence": "zeromodel-video-complete-row-evidence/v2",
-                "semantic_top_set_outcome": SEMANTIC_OUTCOME_VERSION,
-                "reachability_trace": REACHABILITY_TRACE_VERSION,
-                "sealed_episode_plan": EPISODE_PLAN_VERSION,
-            },
-        },
-        "checks_executed": [gate["gate"] for gate in gates],
-        "passed_checks": passed,
-        "failed_checks": failed,
-        "unavailable_checks": unavailable,
-        "gates": gates,
-        "measured_counts": phase_counts,
-        "final_access_measurements": {
-            "final_plan_count": len(context["plans"]["final"]),
-            "final_observation_materialization_count": phase_counts["final_materialization_count"],
-            "final_provider_score_access_count": phase_counts["final_score_access_count"],
-            "final_reachability_execution_count": phase_counts["final_reachability_execution_count"],
-            "final_evaluation_count": phase_counts["final_evaluation_count"],
-            "calibration_execution_count": phase_counts["calibration_execution_count"],
-            "architecture_selection_execution_count": phase_counts["architecture_selection_execution_count"],
-            "candidate_tuning_execution_count": phase_counts["candidate_tuning_execution_count"],
-        },
-        "verified": not failed and not unavailable,
-        "primary_failure_code": None,
-        "primary_failure_gate": None,
-    }
-    primary = _primary_failure(payload)
-    payload["primary_failure_code"] = None if primary is None else primary["code"]
-    payload["primary_failure_gate"] = None if primary is None else primary["gate"]
-    payload["verification_digest"] = _sha256({key: value for key, value in payload.items() if key != "verification_digest"})
-    return payload
+    return _build_reference_verification_payload(
+        context=context,
+        gates=gates,
+        phase_counts=_measured_phase_access_counts(output_dir),
+    )
 
 
 def _file_digest(path: Path) -> str:
@@ -1763,202 +1436,14 @@ def verify_reference_read_only(output_dir: Path, repo_root: Path) -> dict[str, A
     middle = _directory_snapshot(output_dir)
     second = verify_reference_instrument(output_dir, repo_root)
     after = _directory_snapshot(output_dir)
-    payload = {
-        "read_only": before == middle == after,
-        "deterministic": first.get("verification_digest") == second.get("verification_digest") and first == second,
-        "first_verification_digest": first.get("verification_digest"),
-        "second_verification_digest": second.get("verification_digest"),
-        "path_count": len(before),
-    }
-    payload["status"] = "passed" if payload["read_only"] and payload["deterministic"] else "failed"
-    payload["digest"] = _sha256(payload)
-    return payload
+    return _build_read_only_verification_payload(before=before, middle=middle, after=after, first=first, second=second)
 
 
-_MUTATION_CASES: tuple[dict[str, Any], ...] = (
-    {"name": "evidence_raw_score_preserve_quantized_bin", "expected_primary_failure_code": "raw_diagnostic_digest_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_raw_score_cross_quantization_boundary", "expected_primary_failure_code": "quantized_score_vector_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_quantized_score_changed", "expected_primary_failure_code": "quantized_score_vector_mismatch", "artifact_class": "evidence", "digest_laundering": True},
-    {"name": "evidence_remove_row_score", "expected_primary_failure_code": "score_row_universe_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_duplicate_row_score", "expected_primary_failure_code": "score_row_universe_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_introduce_foreign_row", "expected_primary_failure_code": "score_row_universe_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_reorder_stored_rows", "expected_primary_failure_code": "score_row_universe_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_alter_ranking_order", "expected_primary_failure_code": "ranking_reconstruction_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_alter_tie_group_membership", "expected_primary_failure_code": "tie_group_reconstruction_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_split_tie_group_incorrectly", "expected_primary_failure_code": "tie_group_reconstruction_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_merge_distinct_score_groups", "expected_primary_failure_code": "tie_group_reconstruction_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_alter_quantized_score_vector_digest", "expected_primary_failure_code": "quantized_score_vector_mismatch", "artifact_class": "evidence"},
-    {"name": "evidence_alter_raw_diagnostic_digest", "expected_primary_failure_code": "raw_diagnostic_digest_mismatch", "artifact_class": "evidence"},
-    {"name": "semantic_resolved_row_for_action_unanimous_tie", "expected_primary_failure_code": "resolved_row_not_permitted", "artifact_class": "semantic"},
-    {"name": "semantic_resolved_action_for_conflicting_tie", "expected_primary_failure_code": "resolved_action_not_permitted", "artifact_class": "semantic"},
-    {"name": "semantic_convert_conflicting_tie_to_unique_row", "expected_primary_failure_code": "semantic_status_mismatch", "artifact_class": "semantic"},
-    {"name": "semantic_change_top_row_policy_action", "expected_primary_failure_code": "policy_action_mapping_mismatch", "artifact_class": "semantic"},
-    {"name": "semantic_change_rejection_reason", "expected_primary_failure_code": "semantic_status_mismatch", "artifact_class": "semantic"},
-    {"name": "semantic_alter_outcome_digest", "expected_primary_failure_code": "semantic_outcome_digest_mismatch", "artifact_class": "semantic", "digest_laundering": True},
-    {"name": "semantic_lexically_reorder_tied_rows", "expected_primary_failure_code": None, "artifact_class": "semantic", "invariant": True},
-    {"name": "semantic_reorder_rows_preserving_action_equivalence", "expected_primary_failure_code": None, "artifact_class": "semantic", "invariant": True},
-    {"name": "policy_alter_row_to_action_mapping", "expected_primary_failure_code": "policy_action_mapping_mismatch", "artifact_class": "policy"},
-    {"name": "policy_remove_policy_row", "expected_primary_failure_code": "policy_action_mapping_mismatch", "artifact_class": "policy"},
-    {"name": "policy_add_undeclared_row", "expected_primary_failure_code": "policy_action_mapping_mismatch", "artifact_class": "policy"},
-    {"name": "policy_alter_artifact_identity", "expected_primary_failure_code": "policy_action_mapping_mismatch", "artifact_class": "policy"},
-    {"name": "policy_mapping_recomputed_superficial_metadata", "expected_primary_failure_code": "policy_action_mapping_mismatch", "artifact_class": "policy"},
-    {"name": "observation_flip_byte_digest", "expected_primary_failure_code": "observation_digest_mismatch", "artifact_class": "observation"},
-    {"name": "observation_change_pixels_and_recompute_digest", "expected_primary_failure_code": "observation_digest_mismatch", "artifact_class": "observation", "digest_laundering": True},
-    {"name": "observation_change_digest_without_pixels", "expected_primary_failure_code": "observation_digest_mismatch", "artifact_class": "observation"},
-    {"name": "observation_swap_two_frame_payloads", "expected_primary_failure_code": "observation_digest_mismatch", "artifact_class": "observation"},
-    {"name": "observation_alter_frame_identity", "expected_primary_failure_code": "frame_identity_mismatch", "artifact_class": "observation"},
-    {
-        "name": "observation_reuse_under_two_episode_ids",
-        "expected_primary_failure_code": "duplicate_observation_identity_unpermitted",
-        "artifact_class": "observation",
-        "gate_scope": ("structural_identity", "completeness_orphan"),
-    },
-    {"name": "observation_substitute_frame_for_declared_gap", "expected_primary_failure_code": "gap_event_structure_mismatch", "artifact_class": "observation"},
-    {"name": "seed_alter_root_seed_material", "expected_primary_failure_code": "episode_seed_derivation_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_root_seed_digest", "expected_primary_failure_code": "benchmark_contract_identity_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_derived_seed", "expected_primary_failure_code": "episode_seed_derivation_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_derivation_namespace", "expected_primary_failure_code": "sealed_episode_identity_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_episode_ordinal", "expected_primary_failure_code": "sealed_episode_identity_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_split_identity", "expected_primary_failure_code": "episode_split_reassignment", "artifact_class": "episode_plan"},
-    {"name": "seed_move_episode_between_splits", "expected_primary_failure_code": "episode_split_reassignment", "artifact_class": "episode_plan"},
-    {"name": "seed_duplicate_episode_id", "expected_primary_failure_code": "duplicate_episode_id", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_source_row", "expected_primary_failure_code": "episode_seed_derivation_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_splice_partner", "expected_primary_failure_code": "episode_seed_derivation_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_transformation_parameters", "expected_primary_failure_code": "sealed_episode_identity_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_planned_family", "expected_primary_failure_code": "sealed_episode_identity_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_sealed_plan_digest", "expected_primary_failure_code": "sealed_episode_identity_mismatch", "artifact_class": "episode_plan"},
-    {"name": "seed_alter_final_sealed_identity", "expected_primary_failure_code": "sealed_episode_identity_mismatch", "artifact_class": "episode_plan", "digest_laundering": True},
-    {"name": "seed_final_observation_provenance_materialized", "expected_primary_failure_code": "final_observation_provenance_mismatch", "artifact_class": "episode_plan", "digest_laundering": True},
-    {"name": "family_conflicting_splice_same_action_rows", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_splice_zero_source_contribution", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_splice_output_equal_one_source", "expected_primary_failure_code": "family_regeneration_mismatch", "artifact_class": "family_output"},
-    {"name": "family_splice_valid_state_collision", "expected_primary_failure_code": "invalid_family_valid_state_collision", "artifact_class": "family_output"},
-    {"name": "family_splice_target_evidence_count_removed", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_critical_empty_coordinate_set", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_corrupt_noncritical_coordinates", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_replacement_value_identical", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_clipping_quantization_noop", "expected_primary_failure_code": "family_no_op", "artifact_class": "family_output", "digest_laundering": True},
-    {"name": "family_reordered_metadata_original_payload_order", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_identity_permutation_labelled_reordered", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_stale_label_without_repeated_bytes", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_stale_repeat_naturally_identical", "expected_primary_failure_code": "family_contract_violation", "artifact_class": "family_output"},
-    {"name": "family_impossible_transition_reachable_pair", "expected_primary_failure_code": "transition_classification_mismatch", "artifact_class": "family_output"},
-    {"name": "family_gap_event_carrying_pixels", "expected_primary_failure_code": "gap_event_has_pixels", "artifact_class": "family_output"},
-    {"name": "family_information_control_pixel_difference", "expected_primary_failure_code": "control_byte_identity_mismatch", "artifact_class": "family_output"},
-    {"name": "family_control_denominator_leak", "expected_primary_failure_code": "control_denominator_leak", "artifact_class": "family_output"},
-    {"name": "family_control_hidden_history_collapse", "expected_primary_failure_code": "control_hidden_history_not_ambiguous", "artifact_class": "family_output"},
-    {"name": "family_control_visible_source_leak", "expected_primary_failure_code": "control_provider_visible_leak", "artifact_class": "family_output"},
-    {"name": "family_episode_disposition_mismatch", "expected_primary_failure_code": "family_disposition_mismatch", "artifact_class": "family_output"},
-    {"name": "reachability_remove_applicable_edge", "expected_primary_failure_code": "consulted_edge_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_redirect_applicable_edge", "expected_primary_failure_code": "reachable_pair_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_alter_destination_action", "expected_primary_failure_code": "policy_action_mapping_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_add_impossible_edge", "expected_primary_failure_code": "reachability_tile_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_change_tile_identity", "expected_primary_failure_code": "reachability_tile_mismatch", "artifact_class": "reachability_trace", "digest_laundering": True},
-    {"name": "reachability_change_unrelated_edge", "expected_primary_failure_code": "reachability_tile_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_alter_consulted_edge_list", "expected_primary_failure_code": "consulted_edge_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_omit_consulted_edge", "expected_primary_failure_code": "consulted_edge_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_add_unconsulted_edge_to_trace", "expected_primary_failure_code": "consulted_edge_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_alter_reachable_pair_set", "expected_primary_failure_code": "reachable_pair_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_alter_retained_candidate_rows", "expected_primary_failure_code": "reachability_trace_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_alter_removed_candidate_rows", "expected_primary_failure_code": "reachability_trace_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_replace_rejection_with_lexical_winner", "expected_primary_failure_code": "executed_action_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_change_executed_action", "expected_primary_failure_code": "executed_action_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "reachability_use_foreign_trace_digest", "expected_primary_failure_code": "reachability_trace_mismatch", "artifact_class": "reachability_trace"},
-    {"name": "access_increment_final_materialization_count", "expected_primary_failure_code": "status_claim_not_supported", "artifact_class": "access_status"},
-    {"name": "access_add_final_observation_artifact", "expected_primary_failure_code": "forbidden_final_materialization", "artifact_class": "access_status"},
-    {"name": "access_add_final_score_vector_record", "expected_primary_failure_code": "forbidden_final_score_access", "artifact_class": "access_status"},
-    {"name": "access_add_final_reachability_trace", "expected_primary_failure_code": "forbidden_final_score_access", "artifact_class": "access_status"},
-    {"name": "access_increment_forbidden_access_counter", "expected_primary_failure_code": "status_claim_not_supported", "artifact_class": "access_status", "digest_laundering": True},
-    {"name": "access_record_calibration_execution", "expected_primary_failure_code": "forbidden_calibration_execution", "artifact_class": "access_status"},
-    {"name": "access_record_architecture_selection_execution", "expected_primary_failure_code": "forbidden_selection_execution", "artifact_class": "access_status"},
-    {"name": "access_change_failed_gate_status_to_passed", "expected_primary_failure_code": "status_claim_not_supported", "artifact_class": "access_status"},
-    {"name": "access_change_repository_status_to_correct", "expected_primary_failure_code": "status_claim_not_supported", "artifact_class": "access_status"},
-    {"name": "access_remove_required_gate_from_closure_report", "expected_primary_failure_code": "closure_gate_missing", "artifact_class": "access_status"},
-)
 
 
-_MUTATION_GATE_SCOPE = {
-    "evidence": ("structural_identity", "semantic_outcome"),
-    "semantic": ("structural_identity", "semantic_outcome"),
-    "policy": ("structural_identity",),
-    "observation": ("structural_identity", "episode_regeneration", "completeness_orphan"),
-    "episode_plan": ("structural_identity", "seed_and_plan"),
-    "family_output": ("structural_identity", "family_contract"),
-    "reachability_trace": ("structural_identity", "semantic_outcome", "reachability"),
-    "access_status": ("structural_identity", "access_prohibition"),
-}
-
-_PRIMARY_GATE_PRECEDENCE = {name: index for index, name in enumerate(_REQUIRED_VERIFICATION_GATES)}
-_PRIMARY_FAILURE_CODE_PRECEDENCE = {
-    code: index
-    for index, code in enumerate(
-        (
-            "expected_file_missing",
-            "benchmark_contract_identity_mismatch",
-            "benchmark_manifest_mismatch",
-            "policy_action_mapping_mismatch",
-            "provider_contract_mismatch",
-            "reachability_tile_mismatch",
-            "score_quantizer_mismatch",
-            "evidence_schema_mismatch",
-            "closure_gate_missing",
-            "score_row_universe_mismatch",
-            "quantized_score_vector_mismatch",
-            "raw_diagnostic_digest_mismatch",
-            "ranking_reconstruction_mismatch",
-            "tie_group_reconstruction_mismatch",
-            "semantic_status_mismatch",
-            "resolved_row_not_permitted",
-            "resolved_action_not_permitted",
-            "semantic_outcome_digest_mismatch",
-            "episode_seed_derivation_mismatch",
-            "episode_split_reassignment",
-            "duplicate_episode_id",
-            "final_observation_provenance_mismatch",
-            "sealed_episode_identity_mismatch",
-            "expected_record_missing",
-            "orphan_observation_record",
-            "frame_identity_mismatch",
-            "gap_event_structure_mismatch",
-            "observation_bytes_mismatch",
-            "observation_digest_mismatch",
-            "family_contract_violation",
-            "family_regeneration_mismatch",
-            "family_no_op",
-            "transition_classification_mismatch",
-            "gap_event_has_pixels",
-            "control_byte_identity_mismatch",
-            "control_denominator_leak",
-            "control_provider_visible_leak",
-            "control_hidden_history_not_ambiguous",
-            "control_hidden_label_not_ambiguous",
-            "control_hidden_history_cardinality_mismatch",
-            "family_disposition_mismatch",
-            "frame_disposition_mismatch",
-            "invalid_family_valid_state_collision",
-            "invalid_family_valid_transformation_collision",
-            "conflicting_action_evidence_absent",
-            "consulted_edge_mismatch",
-            "reachable_pair_mismatch",
-            "reachability_trace_mismatch",
-            "executed_action_mismatch",
-            "duplicate_observation_record",
-            "duplicate_observation_identity_unpermitted",
-            "orphan_score_vector_record",
-            "forbidden_final_materialization",
-            "forbidden_final_score_access",
-            "forbidden_final_reachability_access",
-            "forbidden_calibration_execution",
-            "forbidden_selection_execution",
-            "forbidden_final_evaluation",
-            "status_claim_not_supported",
-        )
-    )
-}
 
 
-def _mutation_case_by_name() -> dict[str, dict[str, Any]]:
-    return {str(case["name"]): dict(case) for case in _MUTATION_CASES}
+
 
 
 def _cached_materialized_metadata(repo_root: Path, split: str) -> list[dict[str, Any]]:
@@ -1987,101 +1472,12 @@ def _expected_digest_owners(repo_root: Path) -> dict[str, set[str]]:
     return cache[cache_key]
 
 
-def _mutation_property(case: Mapping[str, Any]) -> str:
-    return str(case.get("protected_scientific_property") or str(case["name"]).replace("_", " "))
 
 
-def _mutation_expected_files(case: Mapping[str, Any]) -> tuple[str, ...]:
-    artifact_class = str(case["artifact_class"])
-    name = str(case.get("name", case.get("mutation_id", "")))
-    if artifact_class in {"evidence", "semantic", "reachability_trace"}:
-        files = ["development/provider-evidence.jsonl", "development-manifest.json"]
-        if name in {"reachability_add_impossible_edge", "reachability_change_tile_identity", "reachability_change_unrelated_edge"}:
-            files = ["reachability-tile-reference.json"]
-        return tuple(files)
-    if artifact_class == "policy":
-        return ("policy-artifact.json",)
-    if artifact_class in {"observation", "family_output"}:
-        return ("selection/frame-metadata.jsonl", "selection-manifest.json")
-    if artifact_class == "episode_plan":
-        if name in {"seed_alter_final_sealed_identity", "seed_final_observation_provenance_materialized"}:
-            return ("final-split-sealed-plan.json", "final-split-sealed-digest.json")
-        if name in {"seed_alter_root_seed_material", "seed_alter_root_seed_digest"}:
-            return ("generator-identity.json",) if name == "seed_alter_root_seed_material" else ("benchmark-contract-identity.json",)
-        return ("episode-plan.json",)
-    if artifact_class == "access_status":
-        if name in {"access_increment_final_materialization_count", "access_increment_forbidden_access_counter"}:
-            return ("phase-access-audits.json",)
-        if name == "access_add_final_observation_artifact":
-            return ("final/frame-metadata.jsonl",)
-        if name in {"access_add_final_score_vector_record", "access_add_final_reachability_trace"}:
-            return ("final/provider-evidence.jsonl",)
-        if name == "access_record_calibration_execution":
-            return ("selected-calibration.json",)
-        if name == "access_record_architecture_selection_execution":
-            return ("selected-architecture.json",)
-        return ("reference-closure-report.json",)
-    return ()
 
 
-def mutation_catalogue() -> list[dict[str, Any]]:
-    catalogue = []
-    for case in _MUTATION_CASES:
-        expected = case.get("expected_primary_failure_code")
-        invariant = bool(case.get("invariant"))
-        catalogue.append(
-            {
-                "matrix_version": MUTATION_MATRIX_VERSION,
-                "mutation_id": case["name"],
-                "artifact_class": case["artifact_class"],
-                "protected_scientific_property": _mutation_property(case),
-                "fixture_selector": case.get("fixture_selector", f"{case['artifact_class']}:deterministic-first-matching-record"),
-                "mutator_id": f"reference-mutator:{case['name']}",
-                "immediate_digest_recomputed": bool(case.get("digest_laundering", False)),
-                "parent_digest_recomputed": bool(case.get("digest_laundering", False)) or case["artifact_class"] in {"evidence", "semantic", "observation", "family_output", "reachability_trace"},
-                "expected_result_type": "semantic_invariant" if invariant else "detected",
-                "expected_primary_failure_code": expected,
-                "permitted_secondary_failure_codes": list(case.get("permitted_secondary_failure_codes", [])),
-                "expected_changed_files": list(_mutation_expected_files(case)),
-                "validation_metadata": {
-                    "digest_laundering": bool(case.get("digest_laundering", False)),
-                    "gate_scope": list(case.get("gate_scope", _MUTATION_GATE_SCOPE.get(str(case["artifact_class"]), _REQUIRED_VERIFICATION_GATES))),
-                },
-            }
-        )
-    return catalogue
 
 
-def validate_mutation_catalogue() -> list[dict[str, Any]]:
-    findings: list[dict[str, Any]] = []
-    catalogue = mutation_catalogue()
-    mutation_ids = [str(case["mutation_id"]) for case in catalogue]
-    if len(mutation_ids) != len(set(mutation_ids)):
-        findings.append(_finding("duplicate_mutation_id", "mutation catalogue contains duplicate mutation ids"))
-    declared_ids = set(mutation_ids)
-    mutator_ids = {str(case["mutation_id"]) for case in catalogue if case.get("mutator_id")}
-    for missing in sorted(declared_ids - mutator_ids):
-        findings.append(_finding("mutation_mutator_missing", "declared mutation has no executable mutator", mutation=missing))
-    for extra in sorted(mutator_ids - declared_ids):
-        findings.append(_finding("mutation_mutator_orphan", "mutator has no declaration", mutation=extra))
-    for case in catalogue:
-        if case["expected_result_type"] == "detected" and not case.get("expected_primary_failure_code"):
-            findings.append(_finding("mutation_expected_code_missing", "expected detection lacks an expected primary failure code", mutation=case["mutation_id"]))
-        if not case.get("expected_changed_files"):
-            findings.append(_finding("mutation_expected_change_missing", "mutation lacks expected changed file metadata", mutation=case["mutation_id"]))
-    detected = sum(1 for case in catalogue if case["expected_result_type"] == "detected")
-    invariants = sum(1 for case in catalogue if case["expected_result_type"] == "semantic_invariant")
-    if len(catalogue) != 93 or detected != 91 or invariants != 2:
-        findings.append(
-            _finding(
-                "mutation_matrix_count_mismatch",
-                "mutation matrix count changed without an explicit matrix revision",
-                declared_count=len(catalogue),
-                detected_count=detected,
-                invariant_count=invariants,
-            )
-        )
-    return findings
 
 
 def _structural_payload(path: Path) -> Any:
@@ -2092,20 +1488,6 @@ def _structural_payload(path: Path) -> Any:
     return path.read_text(encoding="utf-8")
 
 
-def _flatten_payload(value: Any, prefix: str) -> dict[str, Any]:
-    if isinstance(value, Mapping):
-        rows: dict[str, Any] = {}
-        for key in sorted(value):
-            rows.update(_flatten_payload(value[key], f"{prefix}.{key}" if prefix else str(key)))
-        return rows
-    if isinstance(value, list):
-        rows = {}
-        for index, item in enumerate(value):
-            rows.update(_flatten_payload(item, f"{prefix}[{index}]"))
-        if not value:
-            rows[prefix] = []
-        return rows
-    return {prefix: value}
 
 
 def _mutation_structural_snapshot(output_dir: Path, *, only_files: Sequence[str] | None = None) -> dict[str, Any]:
@@ -2124,63 +1506,10 @@ def _mutation_structural_snapshot(output_dir: Path, *, only_files: Sequence[str]
     return snapshot
 
 
-def _changed_snapshot_files(before: Mapping[str, Mapping[str, Any]], after: Mapping[str, Mapping[str, Any]]) -> list[str]:
-    changed = []
-    for file_name in sorted(set(before) | set(after)):
-        before_digest = before.get(file_name, {}).get("digest")
-        after_digest = after.get(file_name, {}).get("digest")
-        if before_digest != after_digest:
-            changed.append(file_name)
-    return changed
 
 
-def _changed_fields(before: Mapping[str, Any], after: Mapping[str, Any]) -> list[str]:
-    changed: set[str] = set()
-    for file_name in sorted(set(before) | set(after)):
-        if file_name not in before or file_name not in after:
-            changed.add(file_name)
-            continue
-        if before[file_name] == after[file_name]:
-            continue
-        before_flat = _flatten_payload(before[file_name], file_name)
-        after_flat = _flatten_payload(after[file_name], file_name)
-        for field in sorted(set(before_flat) | set(after_flat)):
-            if before_flat.get(field) != after_flat.get(field):
-                changed.add(field)
-    return sorted(changed)
 
 
-def _mutation_isolation_report(before: Mapping[str, Any], after: Mapping[str, Any], case: Mapping[str, Any]) -> dict[str, Any]:
-    changed = _changed_fields(before, after)
-    if case.get("expected_changed_files") is not None:
-        expected_files = tuple(str(item) for item in case["expected_changed_files"])
-    else:
-        expected_files = tuple(str(item) for item in _mutation_expected_files(case))
-    unexpected = [
-        field
-        for field in changed
-        if not any(field == expected or field.startswith(f"{expected}.") or field.startswith(f"{expected}[") for expected in expected_files)
-    ]
-    before_flat: dict[str, Any] = {}
-    after_flat: dict[str, Any] = {}
-    for file_name, payload in before.items():
-        before_flat.update(_flatten_payload(payload, file_name))
-    for file_name, payload in after.items():
-        after_flat.update(_flatten_payload(payload, file_name))
-    effect_payload = []
-    for field in changed:
-        if field in before or field in after:
-            effect_payload.append({"field": field, "before": before.get(field), "after": after.get(field)})
-        else:
-            effect_payload.append({"field": field, "before": before_flat.get(field), "after": after_flat.get(field)})
-    return {
-        "changed_fields": changed,
-        "expected_changed_files": list(expected_files),
-        "unexpected_changed_fields": unexpected,
-        "changed_field_count": len(changed),
-        "isolation_passed": bool(changed) and not unexpected,
-        "mutation_effect_digest": _sha256({"changed_fields": changed, "effect_payload": effect_payload}),
-    }
 
 
 def _rewrite_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
@@ -2612,70 +1941,41 @@ def run_reference_mutation_audit(output_dir: Path, repo_root: Path, *, mutation_
     import shutil
     import tempfile
 
-    requested = None if mutation_names is None else set(str(name) for name in mutation_names)
+    requested = None if mutation_names is None else {str(name) for name in mutation_names}
     catalogue = mutation_catalogue()
     selected_cases = tuple(case for case in catalogue if requested is None or case["mutation_id"] in requested)
     catalogue_findings = validate_mutation_catalogue()
     if requested is not None:
-        missing = sorted(requested - {str(case["mutation_id"]) for case in selected_cases})
-        catalogue_findings.extend(_finding("mutation_not_declared", "requested mutation is not declared", mutation=name) for name in missing)
+        selected_names = {str(case["mutation_id"]) for case in selected_cases}
+        catalogue_findings.extend(_finding("mutation_not_declared", "requested mutation is not declared", mutation=name) for name in sorted(requested - selected_names))
     base = verify_reference_instrument(output_dir, repo_root)
-    results: list[dict[str, Any]] = []
     if not base["verified"] or catalogue_findings:
-        payload = {
-            "version": MUTATION_AUDIT_VERSION,
-            "matrix_version": MUTATION_MATRIX_VERSION,
-            "base_verified": False,
-            "base_primary_failure_code": base.get("primary_failure_code"),
-            "catalogue_findings": catalogue_findings,
-            "mutations": [],
-            "declared_mutation_count": len(catalogue),
-            "executable_mutation_count": len(selected_cases),
-            "expected_detection_count": len([case for case in selected_cases if case["expected_result_type"] == "detected"]),
-            "expected_mutation_count": len([case for case in selected_cases if case["expected_result_type"] == "detected"]),
-            "detected_mutation_count": 0,
-            "missed_mutation_count": len([case for case in selected_cases if case["expected_result_type"] == "detected"]),
-            "undetected_mutation_count": len([case for case in selected_cases if case["expected_result_type"] == "detected"]),
-            "unexpected_failure_code_count": len(selected_cases),
-            "invariant_count": len([case for case in selected_cases if case["expected_result_type"] == "semantic_invariant"]),
-            "invariant_pass_count": 0,
-            "invariant_failure_count": len([case for case in selected_cases if case["expected_result_type"] == "semantic_invariant"]),
-            "digest_laundering_tests": [],
-            "digest_laundering_class_closure": {},
-            "mutation_isolation_passed": False,
-            "duplicate_effect_findings": [],
-            "status": "unavailable",
-        }
-        payload["mutation_audit_digest"] = _sha256(payload)
-        return payload
+        return _build_mutation_audit_payload(
+            matrix_version=MUTATION_MATRIX_VERSION,
+            catalogue=catalogue,
+            selected_cases=selected_cases,
+            catalogue_findings=catalogue_findings,
+            results=(),
+            base_verified=False,
+            base_primary_failure_code=base.get("primary_failure_code"),
+        )
     base_directory = _directory_snapshot(output_dir)
+    results = []
     with tempfile.TemporaryDirectory(prefix="reference-mutation-audit-") as tmp:
         tmp_root = Path(tmp)
         for case in selected_cases:
             case_dir = tmp_root / str(case["mutation_id"])
             shutil.copytree(output_dir, case_dir)
-            apply_error = None
+            application_error = None
             try:
                 _apply_reference_mutation(case_dir, str(case["mutation_id"]))
-                after_directory = _directory_snapshot(case_dir)
-                changed_files = _changed_snapshot_files(base_directory, after_directory)
+                changed_files = _changed_snapshot_files(base_directory, _directory_snapshot(case_dir))
                 before = _mutation_structural_snapshot(output_dir, only_files=changed_files)
                 after = _mutation_structural_snapshot(case_dir, only_files=changed_files)
                 isolation = _mutation_isolation_report(before, after, case)
-                report = verify_reference_instrument(
-                    case_dir,
-                    repo_root,
-                    enabled_gates=case["validation_metadata"]["gate_scope"],
-                    stop_after_first_failure=True,
-                )
-                primary = report.get("primary_failure_code")
-                primary_gate = report.get("primary_failure_gate")
-                detected = primary is not None
-            except Exception as exc:  # pragma: no cover - returned in the audit report for deterministic debugging.
-                primary = "mutation_application_error"
-                primary_gate = "mutation_application"
-                detected = True
-                apply_error = type(exc).__name__
+                report = verify_reference_instrument(case_dir, repo_root, enabled_gates=case["validation_metadata"]["gate_scope"], stop_after_first_failure=True)
+            except Exception as exc:  # pragma: no cover - historical audit boundary.
+                application_error = type(exc).__name__
                 isolation = {
                     "changed_fields": [],
                     "expected_changed_files": list(case.get("expected_changed_files", [])),
@@ -2685,269 +1985,39 @@ def run_reference_mutation_audit(output_dir: Path, repo_root: Path, *, mutation_
                     "mutation_effect_digest": "sha256:application-error",
                 }
                 report = {"gates": []}
-            expected = case.get("expected_primary_failure_code")
-            expected_detected = case["expected_result_type"] == "detected"
-            secondary_codes = [row for row in _report_failure_codes(report) if row["code"] != primary or row["gate"] != primary_gate]
-            property_changed = isolation["changed_field_count"] > 0
-            results.append(
-                {
-                    "mutation": case["mutation_id"],
-                    "artifact_class": case["artifact_class"],
-                    "protected_scientific_property": case["protected_scientific_property"],
-                    "fixture_selector": case["fixture_selector"],
-                    "mutator_id": case["mutator_id"],
-                    "expected_result_type": case["expected_result_type"],
-                    "expected_primary_failure_code": expected,
-                    "actual_primary_failure_code": primary,
-                    "actual_primary_gate": primary_gate,
-                    "secondary_failure_codes": secondary_codes,
-                    "detected": detected,
-                    "expected_detected": expected_detected,
-                    "invariant": case["expected_result_type"] == "semantic_invariant",
-                    "semantic_invariant_passed": case["expected_result_type"] == "semantic_invariant" and primary is None,
-                    "digest_laundering": bool(case["validation_metadata"]["digest_laundering"]),
-                    "immediate_digest_recomputed": bool(case["immediate_digest_recomputed"]),
-                    "parent_digest_recomputed": bool(case["parent_digest_recomputed"]),
-                    "mutation_isolation": isolation,
-                    "property_changed": property_changed,
-                    "expected_code_matched": (primary == expected) if expected_detected else (primary is None),
-                    "application_error": apply_error,
-                }
-            )
-    expected_cases = [row for row in results if row["expected_detected"]]
-    detected = [row for row in expected_cases if row["detected"]]
-    missed = [row for row in expected_cases if not row["detected"]]
-    unexpected = [row for row in results if not row["expected_code_matched"]]
-    invariants = [row for row in results if row["expected_result_type"] == "semantic_invariant"]
-    invariant_passes = [row for row in invariants if row["semantic_invariant_passed"]]
-    isolation_failures = [row for row in results if not row["mutation_isolation"]["isolation_passed"]]
-    property_change_failures = [row for row in expected_cases if not row["property_changed"]]
-    effect_owners: dict[str, str] = {}
-    duplicate_effect_findings = []
-    for row in results:
-        effect_digest = row["mutation_isolation"]["mutation_effect_digest"]
-        previous = effect_owners.get(effect_digest)
-        if previous is not None:
-            duplicate_effect_findings.append(_finding("duplicate_mutation_effect", "two mutation ids produced the same structural effect", first_mutation=previous, second_mutation=row["mutation"]))
-        effect_owners[effect_digest] = row["mutation"]
-    laundering_closure: dict[str, dict[str, Any]] = {}
-    for row in results:
-        if not row["digest_laundering"]:
-            continue
-        item = laundering_closure.setdefault(
-            row["artifact_class"],
-            {"declared": 0, "executed": 0, "detected": 0, "expected_code_matches": 0, "laundering_depth_reached": "none"},
-        )
-        item["declared"] += 1
-        item["executed"] += 1
-        item["detected"] += int(bool(row["detected"]))
-        item["expected_code_matches"] += int(bool(row["expected_code_matched"]))
-        if row["immediate_digest_recomputed"] and row["parent_digest_recomputed"]:
-            item["laundering_depth_reached"] = "immediate_and_parent"
-        elif row["immediate_digest_recomputed"]:
-            item["laundering_depth_reached"] = "immediate"
-    payload = {
-        "version": MUTATION_AUDIT_VERSION,
-        "matrix_version": MUTATION_MATRIX_VERSION,
-        "base_verified": True,
-        "catalogue_findings": catalogue_findings,
-        "mutations": results,
-        "declared_mutation_count": len(catalogue),
-        "executable_mutation_count": len(selected_cases),
-        "expected_detection_count": len(expected_cases),
-        "expected_mutation_count": len(expected_cases),
-        "detected_mutation_count": len(detected),
-        "missed_mutation_count": len(missed),
-        "undetected_mutation_count": len(missed),
-        "unexpected_failure_code_count": len(unexpected),
-        "invariant_count": len(invariants),
-        "invariant_pass_count": len(invariant_passes),
-        "invariant_failure_count": len(invariants) - len(invariant_passes),
-        "digest_laundering_tests": [row["mutation"] for row in results if row["digest_laundering"]],
-        "digest_laundering_class_closure": laundering_closure,
-        "mutation_isolation_passed": not isolation_failures,
-        "mutation_isolation_failure_count": len(isolation_failures),
-        "property_change_failure_count": len(property_change_failures),
-        "duplicate_effect_findings": duplicate_effect_findings,
-        "repeated_run_determinism": "not_measured_in_single_run",
-        "status": (
-            "passed"
-            if not missed
-            and not unexpected
-            and len(invariant_passes) == len(invariants)
-            and not isolation_failures
-            and not property_change_failures
-            and not duplicate_effect_findings
-            else "failed"
-        ),
-    }
-    payload["mutation_audit_digest"] = _sha256(payload)
-    return payload
+            results.append(_evaluate_mutation_case(case=case, report=report, isolation=isolation, application_error=application_error))
+    return _build_mutation_audit_payload(
+        matrix_version=MUTATION_MATRIX_VERSION,
+        catalogue=catalogue,
+        selected_cases=selected_cases,
+        catalogue_findings=catalogue_findings,
+        results=results,
+    )
 
 
 def run_repeated_reference_mutation_audit(output_dir: Path, repo_root: Path, *, mutation_names: Sequence[str] | None = None) -> dict[str, Any]:
     first = run_reference_mutation_audit(output_dir, repo_root, mutation_names=mutation_names)
     second = run_reference_mutation_audit(output_dir, repo_root, mutation_names=mutation_names)
-    deterministic = first == second and first.get("mutation_audit_digest") == second.get("mutation_audit_digest")
-    payload = {
-        "version": "zeromodel-video-action-set-reference-mutation-audit-repeat/v1",
-        "matrix_version": MUTATION_MATRIX_VERSION,
-        "deterministic": deterministic,
-        "first_audit_digest": first.get("mutation_audit_digest"),
-        "second_audit_digest": second.get("mutation_audit_digest"),
-        "audit": first,
-    }
-    payload["repeat_digest"] = _sha256(payload)
-    return payload
+    return _build_repeated_mutation_audit_payload(matrix_version=MUTATION_MATRIX_VERSION, first=first, second=second)
 
 
 def build_reference_closure_report(output_dir: Path, repo_root: Path, *, include_mutation_audit: bool = True) -> dict[str, Any]:
     verification = verify_reference_instrument(output_dir, repo_root)
-    repeated_mutation_audit = run_repeated_reference_mutation_audit(output_dir, repo_root) if include_mutation_audit else {
-        "version": "zeromodel-video-action-set-reference-mutation-audit-repeat/v1",
-        "matrix_version": MUTATION_MATRIX_VERSION,
-        "deterministic": False,
-        "first_audit_digest": None,
-        "second_audit_digest": None,
-        "audit": {
-            "version": MUTATION_AUDIT_VERSION,
-            "matrix_version": MUTATION_MATRIX_VERSION,
-            "status": "unavailable",
-            "declared_mutation_count": len(_MUTATION_CASES),
-            "executable_mutation_count": len(_MUTATION_CASES),
-            "expected_detection_count": len([case for case in _MUTATION_CASES if not case.get("invariant")]),
-            "expected_mutation_count": len([case for case in _MUTATION_CASES if not case.get("invariant")]),
-            "detected_mutation_count": 0,
-            "missed_mutation_count": len([case for case in _MUTATION_CASES if not case.get("invariant")]),
-            "undetected_mutation_count": len([case for case in _MUTATION_CASES if not case.get("invariant")]),
-            "unexpected_failure_code_count": 0,
-            "invariant_count": len([case for case in _MUTATION_CASES if case.get("invariant")]),
-            "invariant_pass_count": 0,
-            "invariant_failure_count": len([case for case in _MUTATION_CASES if case.get("invariant")]),
-            "mutations": [],
-            "digest_laundering_tests": [],
-            "digest_laundering_class_closure": {},
-            "mutation_isolation_passed": False,
-            "mutation_audit_digest": None,
-        },
-    }
-    mutation_audit = repeated_mutation_audit["audit"]
-    if not include_mutation_audit:
-        mutation_audit = {
-        "version": MUTATION_AUDIT_VERSION,
-        "matrix_version": MUTATION_MATRIX_VERSION,
-        "status": "unavailable",
-        "declared_mutation_count": len(_MUTATION_CASES),
-        "executable_mutation_count": len(_MUTATION_CASES),
-        "expected_detection_count": len([case for case in _MUTATION_CASES if not case.get("invariant")]),
-        "expected_mutation_count": len([case for case in _MUTATION_CASES if not case.get("invariant")]),
-        "detected_mutation_count": 0,
-        "missed_mutation_count": len([case for case in _MUTATION_CASES if not case.get("invariant")]),
-        "undetected_mutation_count": len([case for case in _MUTATION_CASES if not case.get("invariant")]),
-        "unexpected_failure_code_count": 0,
-        "invariant_count": len([case for case in _MUTATION_CASES if case.get("invariant")]),
-        "invariant_pass_count": 0,
-        "invariant_failure_count": len([case for case in _MUTATION_CASES if case.get("invariant")]),
-        "mutations": [],
-        "digest_laundering_tests": [],
-        "digest_laundering_class_closure": {},
-        "mutation_isolation_passed": False,
-        "mutation_audit_digest": None,
-        }
+    repeated = run_repeated_reference_mutation_audit(output_dir, repo_root) if include_mutation_audit else _build_unavailable_repeated_mutation_audit()
     read_only = verify_reference_read_only(output_dir, repo_root)
-    final_counts = verification["final_access_measurements"]
-    required_zero = (
-        final_counts["final_observation_materialization_count"] == 0
-        and final_counts["final_provider_score_access_count"] == 0
-        and final_counts["final_reachability_execution_count"] == 0
-        and final_counts["calibration_execution_count"] == 0
-        and final_counts["architecture_selection_execution_count"] == 0
-        and final_counts["candidate_tuning_execution_count"] == 0
-        and final_counts["final_evaluation_count"] == 0
+    episode_plan_path = output_dir / "episode-plan.json"
+    plans = _read_json(episode_plan_path).get("splits", {}) if episode_plan_path.exists() else {}
+    return _build_verification_closure(
+        verification=verification,
+        repeated_mutation_audit=repeated,
+        read_only=read_only,
+        split_plan_identities={split: _sha256(context) for split, context in plans.items()},
     )
-    supported = (
-        verification["verified"]
-        and mutation_audit.get("status") == "passed"
-        and mutation_audit.get("declared_mutation_count") == 93
-        and mutation_audit.get("executable_mutation_count") == 93
-        and mutation_audit.get("expected_detection_count") == 91
-        and mutation_audit.get("detected_mutation_count") == 91
-        and mutation_audit.get("missed_mutation_count") == 0
-        and mutation_audit.get("unexpected_failure_code_count") == 0
-        and mutation_audit.get("invariant_count") == 2
-        and mutation_audit.get("invariant_pass_count") == 2
-        and len(mutation_audit.get("digest_laundering_class_closure", {})) >= 7
-        and mutation_audit.get("mutation_isolation_passed") is True
-        and repeated_mutation_audit.get("deterministic") is True
-        and read_only["status"] == "passed"
-        and required_zero
-        and not verification["unavailable_checks"]
-    )
-    payload: dict[str, Any] = {
-        "version": CLOSURE_REPORT_VERSION,
-        "contract_identity": verification["authoritative_roots"]["benchmark_contract_identity"],
-        "policy_identity": verification["authoritative_roots"]["policy_artifact_id"],
-        "root_seed_identity": verification["authoritative_roots"]["root_seed_digest"],
-        "split_plan_identities": {
-            split: _sha256(context)
-            for split, context in _read_json(output_dir / "episode-plan.json").get("splits", {}).items()
-        } if (output_dir / "episode-plan.json").exists() else {},
-        "family_registry_identity": verification["authoritative_roots"]["episode_family_registry_digest"],
-        "reachability_identity": verification["authoritative_roots"]["reachability_tile_digest"],
-        "provider_identities": verification["authoritative_roots"]["provider_versions"],
-        "verification": verification,
-        "mutation_audit": mutation_audit,
-        "repeated_mutation_audit": repeated_mutation_audit,
-        "read_only_verification": read_only,
-        "declared_mutation_count": mutation_audit.get("declared_mutation_count", 0),
-        "executable_mutation_count": mutation_audit.get("executable_mutation_count", 0),
-        "expected_detection_count": mutation_audit.get("expected_detection_count", 0),
-        "expected_mutation_count": mutation_audit.get("expected_mutation_count", 0),
-        "detected_mutation_count": mutation_audit.get("detected_mutation_count", 0),
-        "missed_mutation_count": mutation_audit.get("missed_mutation_count", 0),
-        "undetected_mutation_count": mutation_audit.get("undetected_mutation_count", 0),
-        "unexpected_failure_code_count": mutation_audit.get("unexpected_failure_code_count", 0),
-        "invariant_count": mutation_audit.get("invariant_count", 0),
-        "invariant_pass_count": mutation_audit.get("invariant_pass_count", 0),
-        "digest_laundering_class_closure": mutation_audit.get("digest_laundering_class_closure", {}),
-        "mutation_audit_report_digest": mutation_audit.get("mutation_audit_digest"),
-        "final_materialization_access_counts": final_counts,
-        "supported_status": "reference_instrument_correct" if supported else "reference_instrument_correctness_unresolved",
-        "unsupported_statuses": [
-            "materialization_ready",
-            "benchmark_utility_verified",
-            "provider_selected",
-            "calibration_complete",
-            "final_evaluation_complete",
-        ],
-        "materialization_status": "prospective_materialization_prohibited",
-    }
-    payload["closure_report_digest"] = _sha256({key: value for key, value in payload.items() if key != "closure_report_digest"})
-    return payload
 
 
 def verify_instrument(output_dir: Path, repo_root: Path) -> dict[str, Any]:
     closure = build_reference_closure_report(output_dir, repo_root, include_mutation_audit=False)
-    verification = closure["verification"]
-    return {
-        "verified": verification["verified"],
-        "version": verification["version"],
-        "closure_report_version": closure["version"],
-        "repository_status": closure["supported_status"],
-        "materialization_status": closure["materialization_status"],
-        "primary_failure_code": verification["primary_failure_code"],
-        "gates": verification["gates"],
-        "final_materialization_count": verification["final_access_measurements"]["final_observation_materialization_count"],
-        "final_score_access_count": verification["final_access_measurements"]["final_provider_score_access_count"],
-        "final_reachability_execution_count": verification["final_access_measurements"]["final_reachability_execution_count"],
-        "candidate_set_selection_count": verification["final_access_measurements"]["candidate_tuning_execution_count"],
-        "conformal_calibration_count": verification["final_access_measurements"]["calibration_execution_count"],
-        "reachability_replay_count": verification["measured_counts"]["reachability_replay_count"],
-        "final_evaluation_count": verification["final_access_measurements"]["final_evaluation_count"],
-        "forbidden_final_access_counter": verification["measured_counts"]["forbidden_final_access_counter"],
-        "read_only": closure["read_only_verification"]["read_only"],
-        "verification_digest": verification["verification_digest"],
-    }
+    return _verification_summary(closure)
 
 
 def _run_adversarial_mutation_checks(output_dir: Path) -> list[str]:


### PR DESCRIPTION
## Summary

- Extract reference reconstruction, optimized/reference comparison, read-only verification, canonical-provider and evidence audits into pure Stage 7B modules.
- Extract the immutable 93-case mutation registry, per-case evaluation, and conservative closure construction.
- Provide a strict standalone mutation-matrix projection that rejects unavailable baselines, count mismatches, malformed rows, ambiguous, duplicate, unknown, or incomplete mutation identities, and inconsistent passed results.
- Retain filesystem loading/writing, report rendering, mutation application, and CLI orchestration in the legacy benchmark.
- Add Stage 7B dependency-direction rules and complete tracked external-import enforcement for `csv`, `os`, `shutil`, `subprocess`, and `tempfile`.
- Lower the benchmark quality ceiling from 2,987 to 2,057 physical lines.

## Matrix boundary

`build_mutation_matrix()` is a standalone pure projection. The benchmark does not import or invoke it, and conservative closure does not accept or include a separate mutation-matrix payload. Persisted matrix reports or closure wiring remain Stage 7C work.

## Boundary

reference verification extracted
reference read-only checks extracted
provider equivalence comparison extracted
canonical-provider audit extracted
evidence-completeness audit extracted
phase-access validation extracted
mutation audit extracted
standalone mutation matrix projection extracted
verification closure extracted

report rendering remains benchmark-owned
filesystem I/O remains benchmark-owned
CLI remains benchmark-owned
persistence remains unchanged
planning remains unchanged
materialization remains unchanged
measurement remains unchanged
mutation matrix is not wired into benchmark or closure orchestration

quality ceiling reduced
architecture rules added
integration and slow tests not run
complete audits not run
decisive benchmark measurement not run

## Review amendments

- Added a module-scoped 112-row fixture built from real `CompleteRowEvidence`, `CompleteRanking`, `TieGroup`, and semantic-outcome objects with frozen synthetic scores and literal digest goldens.
- Added mismatch ordering, failure precedence, malformed-boundary, unrelated-exception, action-tie, read-only, mutation failure, repeated determinism, and per-prerequisite closure coverage.
- Added strict mutation-matrix input validation and adversarial duplicate, unknown, missing, malformed, unavailable, detector, and isolation cases.
- Added collector-level architecture tests covering each Stage 7B module and every newly tracked filesystem/process/reporting import root.

## Validation

- Review-focused fast tests: 62 passed in 0.18s
- Full fast suite: 529 passed, 1 skipped, 139 deselected; pytest 29.92s, wrapper 30.84s
- Architecture check: passed
- Repository quality check: passed
- Package build: source distribution and wheel built successfully

The authorized-only command below was not run because separate explicit integration authorization has not been provided:

```powershell
python -m pytest -q --run-integration `
  tests/test_video_action_set_reference_verification.py `
  -m "not slow"
```

Integration tests, slow tests, the complete 93-case mutation audit, complete materialization/scoring runs, complete provider/reference/audit runs, a new real P1/P2/P3 reference golden, and the decisive benchmark measurement were not run.

Audit-Exempt: behavior-preserving extraction of independent reference reconstruction, optimized/reference equivalence, reference read-only checks, canonical-provider audit, evidence-completeness validation, semantic and reachability evidence validation, phase-access validation, mutation-case evaluation, standalone mutation-detection matrix construction, and conservative verification closure. No provider formulas, score vectors, rankings, semantic outcomes, reachability traces, materialized records, mutation expectations, finding statuses, closure rules, benchmark evidence, claims, or conclusions changed.