### PR TITLE
refactor: complete video action-set instrument shell

### DIFF
--- a/docs/video-action-set-stage8-runbook.md
+++ b/docs/video-action-set-stage8-runbook.md
@@ -1,0 +1,220 @@
+# Video Action-Set Stage 8 Runbook
+
+This runbook describes the live Stage 7C instrument. It does not authorize or execute Stage 8. Commands that call verification or mutation APIs print JSON to stdout because the current CLI does not persist those return-only reports.
+
+## Preconditions
+
+- Work from a clean `main` containing merged Stage 7C and Stage 7B commit `541716d5ad55f22466837e7f5af2321b8ba49377`.
+- Use Python 3.10, 3.11, or 3.12 from the repository root.
+- Install the package with development and persistence dependencies: `python -m pip install -e ".[dev,persistence]"`.
+- Choose a new or intentionally discarded output directory. There is no resume or repair protocol.
+- Ensure the output filesystem can hold SQLite, all frame metadata, and all provider evidence. The code exposes no reliable free-space estimate.
+- The final split must remain plan-only and sealed. `build_split("final", ...)` is prohibited by the live code.
+
+Set the execution context once in PowerShell:
+
+```powershell
+$Repo = (Resolve-Path .).Path
+$Out = Join-Path $Repo "build/stage8-video-action-set"
+$env:ZEROMODEL_REPO = $Repo
+$env:ZEROMODEL_OUT = $Out
+```
+
+## Command Inventory
+
+These pytest commands require fresh, explicit human authorization. They are listed for
+operator planning only and are not authorized by this runbook:
+
+```powershell
+python -m pytest -q --run-integration
+python -m pytest -q --run-slow
+python -m pytest -q --run-integration tests/test_video_action_set_reference_verification.py -m "not slow"
+python -m pytest -q --run-integration tests/test_installed_wheel_video_instrument.py
+```
+
+### Controlled Stage 8 Sequence
+
+The controlled sequence freezes exactly once through the operational package CLI:
+
+```powershell
+python -m zeromodel.video_action_set_cli `
+  --output-dir $Out `
+  --freeze-benchmark
+```
+
+Build each non-final split directly so the frozen plans and final seal are reused:
+
+```powershell
+python -c 'import os; from pathlib import Path; from zeromodel.domains.video_action_set.build_orchestration import build_split; out=Path(os.environ["ZEROMODEL_OUT"]); repo=Path(os.environ["ZEROMODEL_REPO"]); build_split("development", out, repo)'
+python -c 'import os; from pathlib import Path; from zeromodel.domains.video_action_set.build_orchestration import build_split; out=Path(os.environ["ZEROMODEL_OUT"]); repo=Path(os.environ["ZEROMODEL_REPO"]); build_split("calibration", out, repo)'
+python -c 'import os; from pathlib import Path; from zeromodel.domains.video_action_set.build_orchestration import build_split; out=Path(os.environ["ZEROMODEL_OUT"]); repo=Path(os.environ["ZEROMODEL_REPO"]); build_split("selection", out, repo)'
+```
+
+Continue with the remaining operational CLI commands:
+
+```powershell
+python -m zeromodel.video_action_set_cli --output-dir $Out --profile-runtime --profile-provider all --profile-frame-count 8
+python -m zeromodel.video_action_set_cli --output-dir $Out --verify-provider-runtime-equivalence
+python -m zeromodel.video_action_set_cli --output-dir $Out --audit-canonical-providers
+python -m zeromodel.video_action_set_cli --output-dir $Out --audit-evidence-completeness
+python -m zeromodel.video_action_set_cli --output-dir $Out --verify-prospective-instrument
+```
+
+### Historical One-Shot Build Flags
+
+The operational CLI retains the historical `--build-development`,
+`--build-calibration`, and `--build-selection` convenience flags. Each flag calls
+`freeze_benchmark()` before `build_split()`. They are one-shot workflows and must not
+be used after the explicit freeze in the controlled Stage 8 sequence.
+
+`zeromodel.video_action_set_benchmark` retains `main` as an import compatibility
+export but is intentionally inert when executed with `python -m`. Invoke
+`python -m zeromodel.video_action_set_cli` for all operational flags.
+
+The current CLI has no flags for the detailed reference verifier, read-only verifier, mutation audits, standalone matrix, or closure payload. Their exact live API commands are:
+
+```powershell
+python -c "import json,os; from pathlib import Path; from zeromodel.domains.video_action_set.verification_orchestration import verify_reference_instrument; print(json.dumps(verify_reference_instrument(Path(os.environ['ZEROMODEL_OUT']),Path(os.environ['ZEROMODEL_REPO'])),indent=2,sort_keys=True))"
+python -c "import json,os; from pathlib import Path; from zeromodel.domains.video_action_set.verification_orchestration import verify_reference_read_only; print(json.dumps(verify_reference_read_only(Path(os.environ['ZEROMODEL_OUT']),Path(os.environ['ZEROMODEL_REPO'])),indent=2,sort_keys=True))"
+python -c "import json,os; from pathlib import Path; from zeromodel.domains.video_action_set.mutation_orchestration import run_reference_mutation_audit; print(json.dumps(run_reference_mutation_audit(Path(os.environ['ZEROMODEL_OUT']),Path(os.environ['ZEROMODEL_REPO'])),indent=2,sort_keys=True))"
+python -c "import json,os; from pathlib import Path; from zeromodel.domains.video_action_set.mutation_orchestration import run_repeated_reference_mutation_audit; print(json.dumps(run_repeated_reference_mutation_audit(Path(os.environ['ZEROMODEL_OUT']),Path(os.environ['ZEROMODEL_REPO'])),indent=2,sort_keys=True))"
+python -c "import json,os; from pathlib import Path; from zeromodel.domains.video_action_set.mutation_orchestration import run_reference_mutation_audit; from zeromodel.domains.video_action_set.mutation_matrix import build_mutation_matrix; audit=run_reference_mutation_audit(Path(os.environ['ZEROMODEL_OUT']),Path(os.environ['ZEROMODEL_REPO'])); print(json.dumps(build_mutation_matrix(audit),indent=2,sort_keys=True))"
+python -c "import json,os; from pathlib import Path; from zeromodel.domains.video_action_set.mutation_orchestration import build_reference_closure_report; print(json.dumps(build_reference_closure_report(Path(os.environ['ZEROMODEL_OUT']),Path(os.environ['ZEROMODEL_REPO'])),indent=2,sort_keys=True))"
+```
+
+No live command unlocks or evaluates final. Do not invent one in Stage 8. Final access requires a separately reviewed and explicitly authorized protocol change.
+
+## Execution Order
+
+1. Freeze the benchmark once. This compiles policy identity, generates all sealed plans, persists episode plans, seals final, and writes root contracts.
+2. Build development. Stop on any identity, overlap, persistence, materialization, or digest error.
+3. Build calibration. Do not tune provider formulas or architecture from final data.
+4. Build selection. Do not touch final and do not revise calibration after selection results are inspected.
+5. Profile providers using bounded records. Profiling is operational evidence, not provider selection.
+6. Verify reference and optimized provider equivalence.
+7. Audit canonical providers and evidence completeness.
+8. Run independent reference verification and then read-only verification.
+9. Run the mutation audit only against the verified baseline. Run the repeated audit to establish deterministic mutation results.
+10. Build the standalone mutation matrix only when independently requested. It is not part of closure.
+11. Build closure only after every required verification, read-only, and repeated mutation condition passes.
+12. Stop. The live instrument keeps final sealed and inaccessible.
+
+This order prevents calibration or selection leakage, provider tuning on final, mutation testing against an invalid baseline, and closure over unavailable evidence.
+
+## Stop Conditions
+
+Stop immediately when any of the following occurs:
+
+- benchmark, generator, policy, plan, seed, tile, provider, quantizer, or digest identity mismatch;
+- duplicate or overlapping episode, frame, observation, or split identity;
+- any verification gate is `failed` or `unavailable`;
+- provider runtime equivalence reports a mismatch;
+- evidence completeness reports missing, orphaned, malformed, or gap-scored rows;
+- reference reconstruction differs from stored pixels, scores, rankings, semantics, or reachability;
+- read-only verification changes any size, timestamp, or digest;
+- a mutation is missed, invokes the wrong primary detector, violates isolation, or produces an application error;
+- repeated mutation audits differ;
+- closure status is `reference_instrument_correctness_unresolved`;
+- any final, calibration-selection, architecture-selection, or tuning access counter is nonzero;
+- an unexpected artifact appears or an expected artifact is missing.
+
+Discard the affected output directory before retrying a phase unless the failure was an external command interruption before any write. Production code has no resume, migration, or repair behavior.
+
+## Artifact Manifest
+
+| Relative path | Producer | Primary consumer | Version or identity | Closure required |
+| --- | --- | --- | --- | --- |
+| `benchmark-contract-identity.json` | freeze | all phases | seed and contract digests | yes |
+| `generator-identity.json` | freeze | structural verification | `GENERATOR_VERSION` and seed digest | yes |
+| `benchmark-manifest.json` | freeze | structural verification | `BENCHMARK_VERSION`, policy artifact ID | yes |
+| `policy-artifact.json` | freeze | builds and verification | policy artifact ID and row-action digest | yes |
+| `reachability-tile-reference.json` | freeze | builds and verification | tile version and digest | yes |
+| `episode-plan.json` | freeze | non-final builds and gates | `EPISODE_PLAN_VERSION` | yes |
+| `final-split-sealed-plan.json` | freeze | access and plan gates | sealed plan digest; plan-only | yes |
+| `final-split-sealed-digest.json` | freeze | plan gate | sealed plan digest | yes |
+| `phase-access-audits.json` | freeze/build | access gate and closure | `PHASE_ACCESS_VERSION` | yes |
+| `<split>/frame-metadata.jsonl` | split build | verification and evidence audit | frame and pixel digests | yes for three non-final splits |
+| `<split>/provider-evidence.jsonl` | split build | semantic and reachability gates | score, ranking, semantic, and trace digests | yes for three non-final splits |
+| `<split>-manifest.json` | split build | structural checks | frame and provider-evidence digests | yes |
+| `<split>-family-closure-report.json` | split build | family checks | `FAMILY_CLOSURE_VERSION` | selection aggregate required |
+| `observation-identity-manifest.json` | split build | overlap/completeness audit | observation identity counts | yes |
+| `split-overlap-audit.json` | split build | overlap gate | split overlap counts | yes |
+| `runtime-profile-*.json` and `.md` | profile | resource planning | runtime profile payload version | no |
+| `provider-runtime-equivalence.json` and `.csv` | equivalence | provider verification | provider comparison digest fields | yes |
+| `canonical-provider-results.csv` and summary JSON | canonical audit | evidence review | provider versions and score identities | yes |
+| `evidence-completeness-summary.json` | completeness audit | closure preparation | evidence audit fields | yes |
+| detailed verification, mutation, matrix, and closure payloads | API commands above | operator review | reference, mutation, matrix, and closure versions | closure payload is return-only in the current shell |
+
+## Final Protocol
+
+The current high-level protocol does not permit final evaluation:
+
+- `freeze_benchmark` creates only a sealed final plan;
+- the plan declares `materialization_prohibited=True`;
+- `_materialize_records("final", ...)` raises;
+- no CLI flag unlocks final.
+
+Therefore Stage 8 must stop before final unless a separate reviewed authorization supplies an exact final-access protocol. Under that protocol, final is touched once; no provider tuning, architecture change, or calibration change may follow final access.
+
+## Claim Language
+
+- **Architecture complete**: allowed only for merged Stage 7C with architecture, quality, fast tests, and build passing. It is not a scientific result.
+- **Instrument verified**: use only when closure emits `reference_instrument_correct`.
+- **Mutation audit passed**: use only when audit status is `passed`, all 91 detection cases and 2 semantic invariants satisfy their contracts, isolation passes, and the repeated audit is deterministic.
+- **Scientific claim unresolved**: use when closure emits `reference_instrument_correctness_unresolved` or any gate is failed/unavailable.
+- Do not claim `materialization_ready`, `benchmark_utility_verified`, `provider_selected`, `calibration_complete`, or `final_evaluation_complete`; the live closure explicitly lists them as unsupported.
+- The live instrument exposes no status that supports “benchmark utility demonstrated” or “scientific claim supported.”
+
+## Resource Planning
+
+- Measured repository fast-test runtime: record the Stage 7C CI result before Stage 8; it is not a benchmark runtime estimate.
+- Derived split sizes: development has 112 episodes; calibration has 112 episodes and 448 frames; selection has 252 episodes and 1,008 frames; sealed final has 252 episodes and 1,008 expected frames.
+- Derived provider count: three, ordered `P1`, `P2`, `P3`.
+- Derived mutation count: 93 total, comprising 91 expected detections and 2 semantic invariants.
+- Measured provider runtime: unknown until the runtime-profile command completes. Use its emitted measurements; do not substitute estimates.
+- Disk, memory, and total Stage 8 duration: unknown from the repository.
+
+## Recovery Rules
+
+- Freeze failure: discard the output directory and restart freeze.
+- Split build failure: discard the whole output directory, refreeze, and rebuild preceding splits in order.
+- Profiling failure: profiling outputs may be discarded and rerun; scientific artifacts must remain unchanged.
+- Verification or audit failure: preserve the failed directory for diagnosis, then create a fresh output directory for any rerun.
+- Mutation case failure or nondeterminism: do not continue to closure. Mutation temporary directories are isolated and automatically cleaned.
+- Closure unresolved: do not access final. Correct code or inputs through a reviewed change, then restart from a fresh freeze.
+
+## Stage 8 Completion Report
+
+```text
+Base commit:
+Python version and platform:
+Output directory:
+Freeze command/result:
+Development build result and manifest digest:
+Calibration build result and manifest digest:
+Selection build result and manifest digest:
+Final sealed-plan digest:
+Runtime profile result:
+Provider equivalence status:
+Canonical-provider audit status:
+Evidence-completeness status:
+Reference verification status and primary failure:
+Read-only verification status:
+Mutation audit status and counts:
+Repeated mutation audit deterministic:
+Standalone matrix requested/result:
+Closure supported status and digest:
+All access counters:
+Unexpected artifacts:
+Stop conditions encountered:
+Final accessed: yes/no
+Final access authorization:
+Final accessed exactly once:
+Post-final tuning or changes: none/details
+Permitted claim language used:
+Unsupported claims avoided:
+Commands executed:
+Artifact manifest and digests:
+Integration or slow tests executed under explicit authorization:
+Unresolved scientific issues:
+```

--- a/examples/arcade_visual_action_set_reachability_benchmark.py
+++ b/examples/arcade_visual_action_set_reachability_benchmark.py
@@ -1,86 +1,12 @@
-from __future__ import annotations
-
-import argparse
-import json
 from pathlib import Path
 import sys
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from zeromodel.video_action_set_benchmark import (  # noqa: E402
-    audit_canonical_providers,
-    audit_evidence_completeness,
-    build_split,
-    freeze_benchmark,
-    profile_runtime,
-    verify_provider_runtime_equivalence,
-    verify_instrument,
-)
-
-
-OUTPUT_DIR = REPO_ROOT / "docs" / "results" / "video-action-set-reachability-benchmark-v1"
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--output-dir", type=Path, default=OUTPUT_DIR)
-    parser.add_argument("--freeze-benchmark", action="store_true")
-    parser.add_argument("--build-development", action="store_true")
-    parser.add_argument("--build-calibration", action="store_true")
-    parser.add_argument("--build-selection", action="store_true")
-    parser.add_argument("--audit-evidence-completeness", action="store_true")
-    parser.add_argument("--audit-canonical-providers", action="store_true")
-    parser.add_argument("--profile-runtime", action="store_true")
-    parser.add_argument("--verify-provider-runtime-equivalence", action="store_true")
-    parser.add_argument("--profile-provider", choices=("P1", "P2", "P3", "all"), default="all")
-    parser.add_argument("--profile-frame-count", type=int, default=8)
-    parser.add_argument("--verify-prospective-instrument", action="store_true")
-    args = parser.parse_args()
-    selected = sum(
-        int(flag)
-        for flag in (
-            args.freeze_benchmark,
-            args.build_development,
-            args.build_calibration,
-            args.build_selection,
-            args.audit_evidence_completeness,
-            args.audit_canonical_providers,
-            args.profile_runtime,
-            args.verify_provider_runtime_equivalence,
-            args.verify_prospective_instrument,
-        )
-    )
-    if selected != 1:
-        raise SystemExit("exactly one command is required")
-    if args.freeze_benchmark:
-        payload = freeze_benchmark(args.output_dir, REPO_ROOT)
-    elif args.build_development:
-        freeze_benchmark(args.output_dir, REPO_ROOT)
-        payload = build_split("development", args.output_dir, REPO_ROOT)
-    elif args.build_calibration:
-        freeze_benchmark(args.output_dir, REPO_ROOT)
-        payload = build_split("calibration", args.output_dir, REPO_ROOT)
-    elif args.build_selection:
-        freeze_benchmark(args.output_dir, REPO_ROOT)
-        payload = build_split("selection", args.output_dir, REPO_ROOT)
-    elif args.audit_evidence_completeness:
-        payload = audit_evidence_completeness(args.output_dir)
-    elif args.audit_canonical_providers:
-        payload = audit_canonical_providers(args.output_dir)
-    elif args.profile_runtime:
-        payload = profile_runtime(
-            args.output_dir,
-            REPO_ROOT,
-            provider=args.profile_provider,
-            frame_count=args.profile_frame_count,
-        )
-    elif args.verify_provider_runtime_equivalence:
-        payload = verify_provider_runtime_equivalence(args.output_dir, REPO_ROOT)
-    else:
-        payload = verify_instrument(args.output_dir, REPO_ROOT)
-    print(json.dumps(payload, indent=2, sort_keys=True))
+from zeromodel.video_action_set_cli import OUTPUT_DIR, main  # noqa: E402, F401
 
 
 if __name__ == "__main__":

--- a/quality-baseline.toml
+++ b/quality-baseline.toml
@@ -8,8 +8,8 @@ maximum_function_parameters = 10
 maximum_ast_nesting = 8
 
 [legacy_exceptions."zeromodel/video_action_set_benchmark.py"]
-reason = "Stage 7B filesystem, report, mutation-application, and CLI orchestration pending behavior-preserving decomposition"
-maximum_lines = 2057
+reason = "Stage 7C compatibility facade retained for legacy video instrument imports"
+maximum_lines = 402
 owner = "video-action-set-refactor"
 
 [legacy_exceptions."examples/arcade_visual_video_discriminative_evidence_benchmark.py"]

--- a/scripts/architecture_rules/video_instrument_shell.py
+++ b/scripts/architecture_rules/video_instrument_shell.py
@@ -1,0 +1,154 @@
+"""Dependency rules for the Stage 7C video instrument shell."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+
+class ImportEdgeLike(Protocol):
+    importer: str
+    imported: str
+    line: int
+
+
+ViolationFactory = Callable[[str, ImportEdgeLike], Any]
+
+DOMAIN_PREFIX = "zeromodel.domains.video_action_set"
+ARTIFACT_LAYOUT_MODULE = f"{DOMAIN_PREFIX}.artifact_layout"
+ARTIFACT_IO_MODULE = f"{DOMAIN_PREFIX}.artifact_io"
+REPORT_RENDERING_MODULE = f"{DOMAIN_PREFIX}.report_rendering"
+MUTATION_FILESYSTEM_MODULE = f"{DOMAIN_PREFIX}.mutation_filesystem"
+BUILD_ORCHESTRATION_MODULE = f"{DOMAIN_PREFIX}.build_orchestration"
+VERIFICATION_GATE_ORCHESTRATION_MODULE = f"{DOMAIN_PREFIX}.verification_gates"
+VERIFICATION_ORCHESTRATION_MODULE = f"{DOMAIN_PREFIX}.verification_orchestration"
+MUTATION_ORCHESTRATION_MODULE = f"{DOMAIN_PREFIX}.mutation_orchestration"
+CLI_MODULE = "zeromodel.video_action_set_cli"
+BENCHMARK_MODULE = "zeromodel.video_action_set_benchmark"
+
+STAGE7C_MODULES = {
+    ARTIFACT_LAYOUT_MODULE,
+    ARTIFACT_IO_MODULE,
+    REPORT_RENDERING_MODULE,
+    MUTATION_FILESYSTEM_MODULE,
+    BUILD_ORCHESTRATION_MODULE,
+    VERIFICATION_GATE_ORCHESTRATION_MODULE,
+    VERIFICATION_ORCHESTRATION_MODULE,
+    MUTATION_ORCHESTRATION_MODULE,
+    CLI_MODULE,
+}
+
+_VERIFICATION_SHELL_MODULES = {
+    VERIFICATION_GATE_ORCHESTRATION_MODULE,
+    VERIFICATION_ORCHESTRATION_MODULE,
+}
+_PLANNING_EXECUTION_MODULES = {
+    f"{DOMAIN_PREFIX}.control_histories",
+    f"{DOMAIN_PREFIX}.family_intervention_planning",
+    f"{DOMAIN_PREFIX}.episode_planning",
+}
+_MATERIALIZATION_EXECUTION_MODULES = {
+    f"{DOMAIN_PREFIX}.episode_materialization",
+    f"{DOMAIN_PREFIX}.materialization_kernels",
+    f"{DOMAIN_PREFIX}.materialization_validation",
+}
+_MEASUREMENT_MODULES = {
+    f"{DOMAIN_PREFIX}.provider_measurement",
+    f"{DOMAIN_PREFIX}.runtime_profiling",
+}
+
+
+def video_instrument_shell_forbidden_edge_violations(
+    edge: ImportEdgeLike,
+    violation_factory: ViolationFactory,
+) -> list[Any]:
+    importer = edge.importer
+    imported = edge.imported
+    violations: list[Any] = []
+
+    def reject(rule: str) -> None:
+        violations.append(violation_factory(rule, edge))
+
+    if (
+        imported in STAGE7C_MODULES
+        and importer.startswith("zeromodel")
+        and importer not in STAGE7C_MODULES | {BENCHMARK_MODULE}
+    ):
+        reject("scientific modules must not import the Stage 7C instrument shell")
+
+    if importer == ARTIFACT_LAYOUT_MODULE and imported.startswith("zeromodel"):
+        reject("artifact layout must not import scientific execution modules")
+    if (
+        importer == ARTIFACT_IO_MODULE
+        and imported.startswith("zeromodel")
+        and imported != f"{DOMAIN_PREFIX}.canonical_json"
+    ):
+        reject(
+            "artifact I/O may import only canonical JSON and artifact layout authorities"
+        )
+    if importer == REPORT_RENDERING_MODULE and imported in {
+        "json",
+        "os",
+        "pathlib",
+        "shutil",
+        "sqlite3",
+        "sqlalchemy",
+        "subprocess",
+        "tempfile",
+        BENCHMARK_MODULE,
+        CLI_MODULE,
+        "zeromodel.runtime",
+    }:
+        reject("report rendering must remain pure and filesystem-free")
+    if importer == MUTATION_FILESYSTEM_MODULE and imported in (
+        _PLANNING_EXECUTION_MODULES
+        | _MATERIALIZATION_EXECUTION_MODULES
+        | _MEASUREMENT_MODULES
+        | {
+            f"{DOMAIN_PREFIX}.verification",
+            MUTATION_ORCHESTRATION_MODULE,
+            CLI_MODULE,
+            BENCHMARK_MODULE,
+        }
+    ):
+        reject("mutation filesystem must not own execution, closure, or dispatch")
+    if importer == BUILD_ORCHESTRATION_MODULE and imported in (
+        _VERIFICATION_SHELL_MODULES
+        | {MUTATION_ORCHESTRATION_MODULE, CLI_MODULE, BENCHMARK_MODULE}
+    ):
+        reject(
+            "build orchestration must not depend on verification, mutation, CLI, or benchmark"
+        )
+    if importer in _VERIFICATION_SHELL_MODULES and imported in {
+        MUTATION_ORCHESTRATION_MODULE,
+        CLI_MODULE,
+        BENCHMARK_MODULE,
+    }:
+        reject(
+            "verification orchestration must not depend on mutation, CLI, or benchmark"
+        )
+    if importer == MUTATION_ORCHESTRATION_MODULE and imported in {
+        CLI_MODULE,
+        BENCHMARK_MODULE,
+    }:
+        reject("mutation orchestration must not depend on CLI or benchmark")
+    if importer == CLI_MODULE and imported == BENCHMARK_MODULE:
+        reject("video action-set CLI must dispatch directly to orchestration modules")
+
+    return violations
+
+
+__all__ = [
+    "ARTIFACT_IO_MODULE",
+    "ARTIFACT_LAYOUT_MODULE",
+    "BENCHMARK_MODULE",
+    "BUILD_ORCHESTRATION_MODULE",
+    "CLI_MODULE",
+    "MUTATION_FILESYSTEM_MODULE",
+    "MUTATION_ORCHESTRATION_MODULE",
+    "REPORT_RENDERING_MODULE",
+    "STAGE7C_MODULES",
+    "VERIFICATION_GATE_ORCHESTRATION_MODULE",
+    "VERIFICATION_ORCHESTRATION_MODULE",
+    "video_instrument_shell_forbidden_edge_violations",
+]

--- a/scripts/architecture_rules/video_verification_layers.py
+++ b/scripts/architecture_rules/video_verification_layers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Protocol
 
+from .video_instrument_shell import STAGE7C_MODULES
+
 
 class ImportEdgeLike(Protocol):
     importer: str
@@ -67,6 +69,8 @@ _EXECUTION_MODULES = {
     f"{DOMAIN_PREFIX}.family_intervention_planning",
     f"{DOMAIN_PREFIX}.episode_planning",
 }
+
+
 def _is_under(module: str, prefix: str) -> bool:
     return module == prefix or module.startswith(f"{prefix}.")
 
@@ -90,7 +94,7 @@ def stage7b_forbidden_edge_violations(
 
     if (
         imported in STAGE7B_MODULES
-        and importer not in STAGE7B_MODULES | {BENCHMARK_MODULE}
+        and importer not in STAGE7B_MODULES | STAGE7C_MODULES | {BENCHMARK_MODULE}
         and _is_under(importer, "zeromodel")
     ):
         reject("Stage 6 and lower scientific modules must not import Stage 7B")

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -270,6 +270,9 @@ def forbidden_edge_violations(edges: list[ImportEdge]) -> list[Violation]:
     from architecture_rules.video_verification_layers import (
         stage7b_forbidden_edge_violations,
     )
+    from architecture_rules.video_instrument_shell import (
+        video_instrument_shell_forbidden_edge_violations,
+    )
 
     violations: list[Violation] = []
     for edge in edges:
@@ -277,6 +280,9 @@ def forbidden_edge_violations(edges: list[ImportEdge]) -> list[Violation]:
         violations.extend(stage6_forbidden_edge_violations(edge, edge_violation))
         violations.extend(stage7a_forbidden_edge_violations(edge, edge_violation))
         violations.extend(stage7b_forbidden_edge_violations(edge, edge_violation))
+        violations.extend(
+            video_instrument_shell_forbidden_edge_violations(edge, edge_violation)
+        )
     return violations
 
 

--- a/tests/test_video_artifact_io_kernel.py
+++ b/tests/test_video_artifact_io_kernel.py
@@ -1,0 +1,61 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from zeromodel.domains.video_action_set import artifact_io
+
+
+def test_json_jsonl_and_csv_bytes_match_pre_extraction_goldens(tmp_path: Path) -> None:
+    payload = {
+        "none": None,
+        "boolean": True,
+        "integer": 7,
+        "float": 1.25,
+        "mapping": {"z": 2, "a": 1},
+        "list": [3, 2, 1],
+        "tuple": ("x", False),
+    }
+    json_path = tmp_path / "representative.json"
+    jsonl_path = tmp_path / "multiple.jsonl"
+    csv_path = tmp_path / "representative.csv"
+
+    artifact_io._write_json(json_path, payload)
+    artifact_io._write_jsonl(jsonl_path, [{"b": 2, "a": 1}, {"nested": {"z": [1, 2]}}])
+    artifact_io._write_csv(
+        csv_path,
+        [
+            {"z": None, "a": True, "nested": {"b": 2, "a": 1}},
+            {"a": False, "middle": "comma,value", "nested": [1, 2]},
+        ],
+    )
+
+    line_ending = os.linesep.encode()
+    expected_json = b'{\n  "boolean": true,\n  "float": 1.25,\n  "integer": 7,\n  "list": [\n    3,\n    2,\n    1\n  ],\n  "mapping": {\n    "a": 1,\n    "z": 2\n  },\n  "none": null,\n  "tuple": [\n    "x",\n    false\n  ]\n}\n'
+    expected_jsonl = b'{"a": 1, "b": 2}\n{"nested": {"z": [1, 2]}}\n'
+    assert json_path.read_bytes() == expected_json.replace(b"\n", line_ending)
+    assert jsonl_path.read_bytes() == expected_jsonl.replace(b"\n", line_ending)
+    assert (
+        csv_path.read_bytes()
+        == b'a,middle,nested,z\r\nTrue,,"{""a"": 1, ""b"": 2}",\r\nFalse,"comma,value","[1, 2]",\r\n'
+    )
+
+
+def test_empty_and_malformed_read_behavior_is_unchanged(tmp_path: Path) -> None:
+    empty_jsonl = tmp_path / "empty.jsonl"
+    empty_csv = tmp_path / "empty.csv"
+    malformed = tmp_path / "malformed.jsonl"
+    artifact_io._write_jsonl(empty_jsonl, [])
+    artifact_io._write_csv(empty_csv, [])
+    malformed.write_text('{"a": 1}\nnot-json\n{"b": 2}\n', encoding="utf-8")
+
+    assert empty_jsonl.read_bytes() == b""
+    assert empty_csv.read_bytes() == b"\r\n"
+    assert artifact_io._read_jsonl(tmp_path / "missing.jsonl") == []
+    with pytest.raises(FileNotFoundError) as missing:
+        artifact_io._read_json(tmp_path / "missing.json")
+    assert missing.value.args[:2] == (2, "No such file or directory")
+    with pytest.raises(json.JSONDecodeError) as malformed_error:
+        artifact_io._read_jsonl(malformed)
+    assert malformed_error.value.args == ("Expecting value: line 1 column 1 (char 0)",)

--- a/tests/test_video_artifact_layout_kernel.py
+++ b/tests/test_video_artifact_layout_kernel.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from zeromodel.domains.video_action_set import artifact_layout as layout
+
+
+def test_canonical_artifact_layout_is_frozen() -> None:
+    root = Path("benchmark")
+
+    assert (
+        layout.root_artifact_path(root, "episode-plan.json")
+        == root / "episode-plan.json"
+    )
+    assert (
+        layout.split_artifact_path(root, "selection", "provider-evidence.jsonl")
+        == root / "selection" / "provider-evidence.jsonl"
+    )
+    assert (
+        layout.split_manifest_path(root, "calibration")
+        == root / "calibration-manifest.json"
+    )
+    assert (
+        layout.family_closure_path(root, "development")
+        == root / "development-family-closure-report.json"
+    )
+    assert layout.benchmark_database_path(root) == root / "benchmark.sqlite3"
+    paths = layout.canonical_relative_paths()
+    assert paths[:4] == (
+        "benchmark-contract-identity.json",
+        "generator-identity.json",
+        "benchmark-manifest.json",
+        "policy-artifact.json",
+    )
+    assert paths[-2:] == (
+        "selection/frame-metadata.jsonl",
+        "selection/provider-evidence.jsonl",
+    )
+    assert "final/frame-metadata.jsonl" not in paths
+    assert "final/provider-evidence.jsonl" not in paths
+    assert "final-split-sealed-plan.json" in paths
+    assert "final-split-sealed-digest.json" in paths
+
+
+def test_canonical_paths_are_a_registry_not_a_produced_manifest() -> None:
+    assert "not a produced-artifact manifest" in (
+        layout.canonical_relative_paths.__doc__ or ""
+    )
+    assert "development-manifest.json" not in layout.canonical_relative_paths()
+    assert "benchmark.sqlite3" not in layout.canonical_relative_paths()
+
+
+def test_reachability_tile_path_preserves_historical_layout() -> None:
+    root = Path("repo")
+    assert (
+        layout.reachability_tile_path(root)
+        == root
+        / "docs"
+        / "results"
+        / "video-policy-reachability-tile-v1"
+        / "reachability-tile.json"
+    )

--- a/tests/test_video_benchmark_facade.py
+++ b/tests/test_video_benchmark_facade.py
@@ -1,0 +1,124 @@
+import ast
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+import zeromodel.video_action_set_benchmark as benchmark
+from zeromodel.domains.video_action_set import (
+    artifact_io,
+    build_orchestration,
+    mutation_filesystem,
+    mutation_orchestration,
+    verification_orchestration,
+)
+from zeromodel.video_action_set_cli import main
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_benchmark_is_direct_alias_compatibility_surface() -> None:
+    assert benchmark._write_json is artifact_io._write_json
+    assert benchmark.freeze_benchmark is build_orchestration.freeze_benchmark
+    assert (
+        benchmark.verify_reference_instrument
+        is verification_orchestration.verify_reference_instrument
+    )
+    assert (
+        benchmark._apply_reference_mutation
+        is mutation_filesystem._apply_reference_mutation
+    )
+    assert (
+        benchmark.run_reference_mutation_audit
+        is mutation_orchestration.run_reference_mutation_audit
+    )
+    assert benchmark.main is main
+    assert (
+        str(inspect.signature(benchmark.profile_runtime))
+        == "(output_dir: 'Path', repo_root: 'Path', *, provider: 'str' = 'all', frame_count: 'int' = 8) -> 'dict[str, Any]'"
+    )
+
+
+def test_benchmark_facade_contains_no_function_implementations() -> None:
+    path = REPO_ROOT / "zeromodel" / "video_action_set_benchmark.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    assert [node.name for node in tree.body if isinstance(node, ast.FunctionDef)] == [
+        "_profiling_records",
+        "build_split",
+    ]
+
+
+def test_build_split_adapter_preserves_benchmark_monkeypatch_seams(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    materialize = object()
+    prototypes = object()
+    measure = object()
+    monkeypatch.setattr(benchmark, "_materialize_records", materialize)
+    monkeypatch.setattr(benchmark, "canonical_prototypes", prototypes)
+    monkeypatch.setattr(benchmark, "measure_record_collection", measure)
+
+    def fake_build(split: str, output_dir: Path, repo_root: Path):
+        assert build_orchestration._materialize_records is materialize
+        assert build_orchestration.canonical_prototypes is prototypes
+        assert build_orchestration.measure_record_collection is measure
+        return {"split": split, "output": output_dir, "repo": repo_root}
+
+    monkeypatch.setattr(build_orchestration, "build_split", fake_build)
+    assert (
+        benchmark.build_split("selection", tmp_path, REPO_ROOT)["split"] == "selection"
+    )
+
+
+def _load_architecture_checker():
+    scripts = REPO_ROOT / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    spec = importlib.util.spec_from_file_location(
+        "stage7c_check_architecture", scripts / "check_architecture.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("importer", "imported"),
+    [
+        (
+            "zeromodel.domains.video_action_set.reference_verification",
+            "zeromodel.domains.video_action_set.artifact_io",
+        ),
+        (
+            "zeromodel.domains.video_action_set.provider_measurement",
+            "zeromodel.domains.video_action_set.build_orchestration",
+        ),
+        ("zeromodel.domains.video_action_set.report_rendering", "pathlib"),
+        (
+            "zeromodel.domains.video_action_set.build_orchestration",
+            "zeromodel.domains.video_action_set.mutation_orchestration",
+        ),
+        ("zeromodel.video_action_set_cli", "zeromodel.video_action_set_benchmark"),
+    ],
+)
+def test_stage7c_architecture_rejects_representative_edges(
+    importer: str, imported: str
+) -> None:
+    checker = _load_architecture_checker()
+    edge = checker.ImportEdge(importer=importer, imported=imported, line=7)
+    assert checker.forbidden_edge_violations([edge])
+
+
+def test_stage7c_architecture_allows_expected_direction() -> None:
+    checker = _load_architecture_checker()
+    edge = checker.ImportEdge(
+        importer="zeromodel.domains.video_action_set.mutation_orchestration",
+        imported="zeromodel.domains.video_action_set.verification_orchestration",
+        line=7,
+    )
+    assert checker.forbidden_edge_violations([edge]) == []

--- a/tests/test_video_build_orchestration_kernel.py
+++ b/tests/test_video_build_orchestration_kernel.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from zeromodel.domains.video_action_set import build_orchestration as build
+
+
+def test_freeze_benchmark_preserves_compile_save_seal_write_order(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+
+    class FakeDTO:
+        def __init__(self, payload: dict[str, Any]):
+            self.payload = payload
+
+        @classmethod
+        def from_dict(cls, payload: dict[str, Any]):
+            return cls(payload)
+
+        def to_dict(self) -> dict[str, Any]:
+            return self.payload
+
+    identity = SimpleNamespace(seed_digest="seed", seed_material="material")
+
+    class VideoService:
+        def load_identity(self, _repo_root: Path):
+            calls.append("identity")
+            return identity
+
+        def save_episode_plans(self, plans):
+            calls.append("save")
+            return plans
+
+        def seal_final_split(self, **_kwargs):
+            calls.append("seal")
+            return FakeDTO({"sealed_plan_digest": "sealed"})
+
+    monkeypatch.setattr(
+        build,
+        "_build_durable_runtime",
+        lambda _path: (
+            calls.append("runtime") or SimpleNamespace(video_action_set=VideoService())
+        ),
+    )
+    monkeypatch.setattr(
+        build,
+        "compile_policy_artifact",
+        lambda: (
+            calls.append("policy")
+            or SimpleNamespace(
+                artifact_id="policy", source=SimpleNamespace(row_ids=("r0",))
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        build,
+        "VPMPolicyLookup",
+        lambda *_args, **_kwargs: SimpleNamespace(choose=lambda _row: "LEFT"),
+    )
+    monkeypatch.setattr(build, "EpisodePlanDTO", FakeDTO)
+    monkeypatch.setattr(
+        build,
+        "_episode_plans_for_split",
+        lambda _identity, split, _rows, _actions: (
+            calls.append(f"plan:{split}") or [{"split": split}]
+        ),
+    )
+    monkeypatch.setattr(
+        build,
+        "_validate_episode_plan_collection",
+        lambda *_args: calls.append("validate"),
+    )
+    monkeypatch.setattr(
+        build,
+        "_write_frozen_contract_artifacts",
+        lambda *_args: calls.append("write:contract"),
+    )
+    monkeypatch.setattr(
+        build, "_write_frozen_plan_artifacts", lambda *_args: calls.append("write:plan")
+    )
+
+    payload = build.freeze_benchmark(tmp_path, tmp_path)
+
+    assert calls == [
+        "runtime",
+        "identity",
+        "policy",
+        "plan:development",
+        "plan:calibration",
+        "plan:selection",
+        "plan:final",
+        "validate",
+        "save",
+        "save",
+        "save",
+        "save",
+        "seal",
+        "write:contract",
+        "write:plan",
+    ]
+    assert payload["final_total_expected_frame_count"] == 1008
+
+
+def test_profile_runtime_preserves_provider_and_write_order(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(build, "canonical_prototypes", lambda: {})
+    monkeypatch.setattr(
+        build, "compile_policy_artifact", lambda: SimpleNamespace(artifact_id="policy")
+    )
+    monkeypatch.setattr(
+        build, "_profiling_records", lambda *_args: [{"frame_id": "f0"}]
+    )
+    monkeypatch.setattr(
+        build,
+        "_profile_provider",
+        lambda *, provider_id, implementation, **_kwargs: (
+            calls.append(f"score:{implementation}:{provider_id}")
+            or {
+                "provider_id": provider_id,
+                "mean_seconds_per_frame": 1.0,
+                "frame_count": 1,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        build, "runtime_profile_payload", lambda **_kwargs: {"payload": True}
+    )
+    monkeypatch.setattr(
+        build, "_write_json", lambda path, _payload: calls.append(f"json:{path.name}")
+    )
+    monkeypatch.setattr(
+        build, "_write_text", lambda path, _text: calls.append(f"text:{path.name}")
+    )
+
+    assert build.profile_runtime(tmp_path, tmp_path) == {"payload": True}
+    assert calls == [
+        "score:reference:P1",
+        "score:optimized:P1",
+        "score:reference:P2",
+        "score:optimized:P2",
+        "score:reference:P3",
+        "score:optimized:P3",
+        "json:runtime-profile-reference.json",
+        "json:runtime-profile-optimized.json",
+        "json:runtime-comparison.json",
+        "text:runtime-profile-reference.md",
+        "text:runtime-profile-optimized.md",
+    ]

--- a/tests/test_video_cli_kernel.py
+++ b/tests/test_video_cli_kernel.py
@@ -1,0 +1,143 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import zeromodel.video_action_set_cli as cli
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    ("flag", "expected"),
+    [
+        ("--freeze-benchmark", ["freeze"]),
+        ("--build-development", ["freeze", "build:development"]),
+        ("--build-calibration", ["freeze", "build:calibration"]),
+        ("--build-selection", ["freeze", "build:selection"]),
+        ("--audit-evidence-completeness", ["evidence"]),
+        ("--audit-canonical-providers", ["canonical"]),
+        ("--profile-runtime", ["profile:all:8"]),
+        ("--verify-provider-runtime-equivalence", ["equivalence"]),
+        ("--verify-prospective-instrument", ["verify"]),
+    ],
+)
+def test_cli_dispatches_each_historical_flag(
+    monkeypatch, capsys, flag: str, expected: list[str]
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        "freeze_benchmark",
+        lambda *_args: calls.append("freeze") or {"command": "freeze"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "build_split",
+        lambda split, *_args: calls.append(f"build:{split}") or {"command": split},
+    )
+    monkeypatch.setattr(
+        cli,
+        "audit_evidence_completeness",
+        lambda *_args: calls.append("evidence") or {"command": "evidence"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "audit_canonical_providers",
+        lambda *_args: calls.append("canonical") or {"command": "canonical"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "profile_runtime",
+        lambda *_args, provider, frame_count: (
+            calls.append(f"profile:{provider}:{frame_count}") or {"command": "profile"}
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "verify_provider_runtime_equivalence",
+        lambda *_args: calls.append("equivalence") or {"command": "equivalence"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "verify_instrument",
+        lambda *_args: calls.append("verify") or {"command": "verify"},
+    )
+    monkeypatch.setattr(sys, "argv", ["instrument", flag])
+
+    cli.main()
+
+    assert calls == expected
+    assert json.loads(capsys.readouterr().out)["command"]
+
+
+def test_cli_rejects_no_command_and_unknown_options(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "argv", ["instrument"])
+    with pytest.raises(SystemExit, match="exactly one command is required"):
+        cli.main()
+    monkeypatch.setattr(sys, "argv", ["instrument", "--unknown-command"])
+    with pytest.raises(SystemExit) as unknown:
+        cli.main()
+    assert unknown.value.code == 2
+    assert "unrecognized arguments: --unknown-command" in capsys.readouterr().err
+
+
+def test_benchmark_module_execution_remains_historically_inert(tmp_path: Path) -> None:
+    output_dir = tmp_path / "must-not-exist"
+    invocations = (
+        [sys.executable, "-m", "zeromodel.video_action_set_benchmark"],
+        [
+            sys.executable,
+            "-m",
+            "zeromodel.video_action_set_benchmark",
+            "--output-dir",
+            str(output_dir),
+            "--freeze-benchmark",
+        ],
+    )
+    for invocation in invocations:
+        result = subprocess.run(
+            invocation,
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+        assert result.stderr == ""
+    assert not output_dir.exists()
+
+
+def test_cli_module_exposes_operational_help() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "zeromodel.video_action_set_cli", "--help"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--freeze-benchmark" in result.stdout
+    assert "--build-development" in result.stdout
+    assert result.stderr == ""
+
+
+def test_stage8_runbook_freezes_once_then_uses_direct_build_calls() -> None:
+    runbook = (REPO_ROOT / "docs" / "video-action-set-stage8-runbook.md").read_text(
+        encoding="utf-8"
+    )
+    controlled = runbook.split("### Controlled Stage 8 Sequence", 1)[1].split(
+        "### Historical One-Shot Build Flags", 1
+    )[0]
+
+    assert controlled.count("--freeze-benchmark") == 1
+    assert "--build-development" not in controlled
+    assert "--build-calibration" not in controlled
+    assert "--build-selection" not in controlled
+    for split in ("development", "calibration", "selection"):
+        assert f'build_split(\"{split}\", out, repo)' in controlled

--- a/tests/test_video_mutation_filesystem_kernel.py
+++ b/tests/test_video_mutation_filesystem_kernel.py
@@ -1,0 +1,55 @@
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set import mutation_filesystem
+
+
+def test_directory_snapshot_is_ordered_and_content_addressed(tmp_path: Path) -> None:
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b" / "same.txt").write_text("beta\n", encoding="utf-8")
+    (tmp_path / "a" / "same.txt").write_text("alpha\n", encoding="utf-8")
+
+    snapshot = mutation_filesystem._directory_snapshot(tmp_path)
+
+    assert list(snapshot) == ["a/same.txt", "b/same.txt"]
+    expected = f"alpha{os.linesep}".encode()
+    assert snapshot["a/same.txt"]["size"] == len(expected)
+    assert (
+        snapshot["a/same.txt"]["digest"]
+        == "sha256:" + hashlib.sha256(expected).hexdigest()
+    )
+
+
+def test_mutation_application_changes_only_copied_case(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline"
+    case = tmp_path / "case"
+    baseline.mkdir()
+    payload = {
+        "policy_artifact_id": "original",
+        "row_ids": ["r0"],
+        "row_action": {"r0": "LEFT"},
+        "row_action_digest": "old",
+    }
+    (baseline / "policy-artifact.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    shutil.copytree(baseline, case)
+
+    mutation_filesystem._apply_reference_mutation(
+        case, "policy_alter_artifact_identity"
+    )
+
+    assert json.loads((baseline / "policy-artifact.json").read_text()) == payload
+    assert (
+        json.loads((case / "policy-artifact.json").read_text())["policy_artifact_id"]
+        == "sha256:foreign-policy"
+    )
+    with pytest.raises(VPMValidationError, match="unsupported mutation case"):
+        mutation_filesystem._apply_reference_mutation(case, "unknown_case")

--- a/tests/test_video_mutation_matrix_kernel.py
+++ b/tests/test_video_mutation_matrix_kernel.py
@@ -8,13 +8,28 @@ from zeromodel.artifact import VPMValidationError
 from zeromodel.domains.video_action_set import mutation_matrix
 
 
-def _finding(mutation: str, effect: str) -> dict[str, object]:
+def _finding(
+    case: dict[str, object],
+    effect: str,
+    *,
+    primary: str | None = None,
+) -> dict[str, object]:
+    expected_detected = case["expected_result_type"] == "detected"
+    actual_primary = (
+        case["expected_primary_failure_code"]
+        if primary is None and expected_detected
+        else primary
+    )
     return {
-        "mutation": mutation,
-        "expected_detected": True,
-        "detected": True,
-        "expected_code_matched": True,
-        "actual_primary_failure_code": "raw_diagnostic_digest_mismatch",
+        "mutation": case["mutation_id"],
+        "expected_detected": expected_detected,
+        "detected": actual_primary is not None,
+        "expected_code_matched": (
+            actual_primary == case["expected_primary_failure_code"]
+            if expected_detected
+            else actual_primary is None
+        ),
+        "actual_primary_failure_code": actual_primary,
         "secondary_failure_codes": [],
         "mutation_isolation": {
             "changed_field_count": 1,
@@ -71,12 +86,13 @@ def test_mutation_catalogue_schema_and_counts_are_frozen() -> None:
 
 def test_mutation_matrix_uses_registry_order_without_reexecution() -> None:
     catalogue = mutation_matrix.mutation_catalogue()
-    first = str(catalogue[0]["mutation_id"])
-    second = str(catalogue[1]["mutation_id"])
+    first_case, second_case = catalogue[:2]
+    first = str(first_case["mutation_id"])
+    second = str(second_case["mutation_id"])
     audit = _audit(
         [
-            _finding(second, "sha256:second"),
-            _finding(first, "sha256:first"),
+            _finding(second_case, "sha256:second"),
+            _finding(first_case, "sha256:first"),
         ]
     )
 
@@ -85,22 +101,24 @@ def test_mutation_matrix_uses_registry_order_without_reexecution() -> None:
     assert payload["mutation_ids"] == [first, second]
     assert [row["mutation"] for row in payload["mutations"]] == [first, second]
     assert payload["matrix_digest"] == (
-        "sha256:c51879af559080769104fce8f73d9ac987afaaaf763b2ed2259064f5dee48a57"
+        "sha256:88861c3d42cc8ab7e5b51dc0ef565294faa3d1c4f1c42307f0856ae421b94e47"
     )
 
 
 def test_mutation_matrix_rejects_duplicate_unknown_and_missing_results() -> None:
     catalogue = mutation_matrix.mutation_catalogue()
-    first = str(catalogue[0]["mutation_id"])
+    first_case = catalogue[0]
 
     duplicate = _audit(
         [
-            _finding(first, "sha256:first"),
-            _finding(first, "sha256:second"),
+            _finding(first_case, "sha256:first"),
+            _finding(first_case, "sha256:second"),
         ]
     )
-    unknown = _audit([_finding("unknown-mutation", "sha256:unknown")])
-    missing = _audit([_finding(first, "sha256:first")], executable_count=2)
+    unknown_row = _finding(first_case, "sha256:unknown")
+    unknown_row["mutation"] = "unknown-mutation"
+    unknown = _audit([unknown_row])
+    missing = _audit([_finding(first_case, "sha256:first")], executable_count=2)
 
     with pytest.raises(VPMValidationError, match="duplicate result ids"):
         mutation_matrix.build_mutation_matrix(duplicate)
@@ -111,10 +129,11 @@ def test_mutation_matrix_rejects_duplicate_unknown_and_missing_results() -> None
 
 
 def test_mutation_matrix_rejects_malformed_result_and_ambiguous_id() -> None:
-    mutation_id = str(mutation_matrix.mutation_catalogue()[0]["mutation_id"])
-    malformed = _finding(mutation_id, "sha256:malformed")
+    case = mutation_matrix.mutation_catalogue()[0]
+    mutation_id = str(case["mutation_id"])
+    malformed = _finding(case, "sha256:malformed")
     del malformed["mutation_isolation"]
-    ambiguous = _finding(mutation_id, "sha256:ambiguous")
+    ambiguous = _finding(case, "sha256:ambiguous")
     ambiguous["mutation_id"] = mutation_id
 
     with pytest.raises(VPMValidationError, match="missing required fields"):
@@ -139,10 +158,12 @@ def test_mutation_matrix_rejects_unavailable_baselines(
 
 def test_mutation_matrix_preserves_wrong_and_multiple_detectors() -> None:
     catalogue = mutation_matrix.mutation_catalogue()
-    first = _finding(str(catalogue[0]["mutation_id"]), "sha256:first")
-    second = _finding(str(catalogue[1]["mutation_id"]), "sha256:second")
-    first["expected_code_matched"] = False
-    first["actual_primary_failure_code"] = "ranking_reconstruction_mismatch"
+    first = _finding(
+        catalogue[0],
+        "sha256:first",
+        primary="ranking_reconstruction_mismatch",
+    )
+    second = _finding(catalogue[1], "sha256:second")
     second["secondary_failure_codes"] = [
         {"gate": "structural_identity", "code": "ranking_reconstruction_mismatch"},
         {"gate": "semantic_outcome", "code": "semantic_status_mismatch"},
@@ -157,17 +178,81 @@ def test_mutation_matrix_preserves_wrong_and_multiple_detectors() -> None:
     assert by_id[first["mutation"]]["actual_primary_failure_code"] == (
         "ranking_reconstruction_mismatch"
     )
-    assert by_id[second["mutation"]]["secondary_failure_codes"] == second[
-        "secondary_failure_codes"
-    ]
+    assert (
+        by_id[second["mutation"]]["secondary_failure_codes"]
+        == second["secondary_failure_codes"]
+    )
 
     with pytest.raises(VPMValidationError, match="passed.*failing result"):
         mutation_matrix.build_mutation_matrix(_audit([first]))
 
 
+@pytest.mark.parametrize(
+    "contradiction",
+    [
+        "detected_false_with_primary",
+        "detected_true_without_primary",
+        "forged_expected_code_match",
+        "wrong_expected_detected",
+        "isolation_without_change",
+        "non_string_primary",
+        "semantic_invariant_contradiction",
+    ],
+)
+def test_mutation_matrix_rejects_internally_contradictory_results(
+    contradiction: str,
+) -> None:
+    catalogue = mutation_matrix.mutation_catalogue()
+    case = catalogue[0]
+    row = _finding(case, "sha256:contradiction")
+    if contradiction == "detected_false_with_primary":
+        row["detected"] = False
+    elif contradiction == "detected_true_without_primary":
+        row["actual_primary_failure_code"] = None
+    elif contradiction == "forged_expected_code_match":
+        row = _finding(
+            case,
+            "sha256:contradiction",
+            primary="ranking_reconstruction_mismatch",
+        )
+        row["expected_code_matched"] = True
+    elif contradiction == "wrong_expected_detected":
+        row["expected_detected"] = False
+    elif contradiction == "isolation_without_change":
+        row["mutation_isolation"]["changed_field_count"] = 0  # type: ignore[index]
+    elif contradiction == "non_string_primary":
+        row["actual_primary_failure_code"] = 7
+    else:
+        case = next(
+            item
+            for item in catalogue
+            if item["expected_result_type"] == "semantic_invariant"
+        )
+        row = _finding(case, "sha256:semantic-invariant")
+        row["expected_code_matched"] = False
+
+    with pytest.raises(VPMValidationError):
+        mutation_matrix.build_mutation_matrix(_audit([row], status="failed"))
+
+
+def test_failed_audit_accepts_accurately_represented_wrong_detector() -> None:
+    case = mutation_matrix.mutation_catalogue()[0]
+    row = _finding(
+        case,
+        "sha256:wrong-detector",
+        primary="ranking_reconstruction_mismatch",
+    )
+
+    payload = mutation_matrix.build_mutation_matrix(_audit([row], status="failed"))
+
+    assert payload["mutations"] == [row]
+    assert payload["mutations"][0]["detected"] is True
+    assert payload["mutations"][0]["expected_code_matched"] is False
+
+
 def test_mutation_matrix_does_not_modify_audit_input() -> None:
-    mutation_id = str(mutation_matrix.mutation_catalogue()[0]["mutation_id"])
-    audit = _audit([_finding(mutation_id, "sha256:stable")])
+    case = mutation_matrix.mutation_catalogue()[0]
+    audit = _audit([_finding(case, "sha256:stable")])
     before = deepcopy(audit)
 
     mutation_matrix.build_mutation_matrix(audit)

--- a/tests/test_video_mutation_orchestration_kernel.py
+++ b/tests/test_video_mutation_orchestration_kernel.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from zeromodel.domains.video_action_set import mutation_orchestration as mutation
+
+
+CASE = {
+    "mutation_id": "policy_alter_artifact_identity",
+    "validation_metadata": {"gate_scope": ["structural_identity"]},
+}
+
+
+def test_baseline_failure_short_circuits_mutation_execution(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(mutation, "mutation_catalogue", lambda: (CASE,))
+    monkeypatch.setattr(mutation, "validate_mutation_catalogue", lambda: [])
+    monkeypatch.setattr(
+        mutation,
+        "verify_reference_instrument",
+        lambda *_args, **_kwargs: {
+            "verified": False,
+            "primary_failure_code": "base_failed",
+        },
+    )
+    monkeypatch.setattr(
+        mutation,
+        "_directory_snapshot",
+        lambda _path: (_ for _ in ()).throw(AssertionError("snapshot must not run")),
+    )
+    monkeypatch.setattr(
+        mutation, "_build_mutation_audit_payload", lambda **kwargs: kwargs
+    )
+
+    payload = mutation.run_reference_mutation_audit(tmp_path, tmp_path)
+    assert payload["base_verified"] is False
+    assert payload["results"] == ()
+
+
+def test_application_error_uses_historical_broad_boundary(
+    monkeypatch, tmp_path: Path
+) -> None:
+    (tmp_path / "baseline.txt").write_text("baseline", encoding="utf-8")
+    monkeypatch.setattr(mutation, "mutation_catalogue", lambda: (CASE,))
+    monkeypatch.setattr(mutation, "validate_mutation_catalogue", lambda: [])
+    monkeypatch.setattr(
+        mutation,
+        "verify_reference_instrument",
+        lambda *_args, **_kwargs: {"verified": True},
+    )
+    monkeypatch.setattr(
+        mutation,
+        "_apply_reference_mutation",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("fixture failure")),
+    )
+    monkeypatch.setattr(
+        mutation,
+        "_evaluate_mutation_case",
+        lambda **kwargs: {"application_error": kwargs["application_error"]},
+    )
+    monkeypatch.setattr(
+        mutation, "_build_mutation_audit_payload", lambda **kwargs: kwargs
+    )
+
+    payload = mutation.run_reference_mutation_audit(tmp_path, tmp_path)
+    assert payload["results"] == [{"application_error": "RuntimeError"}]

--- a/tests/test_video_report_rendering_kernel.py
+++ b/tests/test_video_report_rendering_kernel.py
@@ -1,0 +1,39 @@
+import ast
+import inspect
+
+from zeromodel.domains.video_action_set import report_rendering
+
+
+PROFILES = [
+    {"provider_id": "P1", "mean_seconds_per_frame": 0.125, "frame_count": 2},
+    {"provider_id": "P2", "mean_seconds_per_frame": 1.5, "frame_count": 2},
+    {"provider_id": "P3", "mean_seconds_per_frame": 12.25, "frame_count": 2},
+]
+
+
+def test_static_reports_match_complete_pre_extraction_text() -> None:
+    assert (
+        report_rendering.benchmark_readme()
+        == "# Video Action-Set Reachability Benchmark v1\n\nThis directory contains the frozen contract identities and the materialized development, calibration, and selection benchmark evidence.\n"
+    )
+    assert (
+        report_rendering.reproduction_instructions()
+        == "Run the benchmark CLI with `--freeze-benchmark`, `--build-development`, `--build-calibration`, `--build-selection`,\n`--audit-evidence-completeness`, `--audit-canonical-providers`, and `--verify-prospective-instrument`.\n"
+    )
+
+
+def test_runtime_reports_match_complete_pre_extraction_text() -> None:
+    expected_reference = "# Runtime Profile Reference\n\n- P1: 0.125000s/frame over 2 frames\n- P2: 1.500000s/frame over 2 frames\n- P3: 12.250000s/frame over 2 frames\n"
+    expected_optimized = expected_reference.replace("Reference", "Optimized", 1)
+    assert report_rendering.runtime_profile_reference(PROFILES) == expected_reference
+    assert report_rendering.runtime_profile_optimized(PROFILES) == expected_optimized
+
+
+def test_report_renderer_has_no_filesystem_or_scientific_imports() -> None:
+    tree = ast.parse(inspect.getsource(report_rendering))
+    imports = {
+        node.module.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert imports.isdisjoint({"pathlib", "os", "json", "zeromodel"})

--- a/tests/test_video_verification_orchestration_kernel.py
+++ b/tests/test_video_verification_orchestration_kernel.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from zeromodel.domains.video_action_set import (
+    verification_orchestration as verification,
+)
+
+
+def test_reference_verification_preserves_gate_order(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        verification, "_reference_context", lambda _root: {"context": True}
+    )
+    monkeypatch.setattr(
+        verification, "_measured_phase_access_counts", lambda _root: {"counts": True}
+    )
+    monkeypatch.setattr(
+        verification, "_build_reference_verification_payload", lambda **kwargs: kwargs
+    )
+
+    names = (
+        "structural_identity",
+        "semantic_outcome",
+        "seed_and_plan",
+        "episode_regeneration",
+        "family_contract",
+        "reachability",
+        "completeness_orphan",
+        "access_prohibition",
+    )
+    for name in names:
+        monkeypatch.setattr(
+            verification,
+            f"_{name}_gate",
+            lambda *_args, _name=name, **_kwargs: (
+                calls.append(_name) or {"gate": _name, "status": "passed"}
+            ),
+        )
+
+    payload = verification.verify_reference_instrument(tmp_path, tmp_path)
+
+    assert calls == list(names)
+    assert [gate["gate"] for gate in payload["gates"]] == list(names)
+    assert payload["phase_counts"] == {"counts": True}
+
+
+def test_stop_after_first_failure_short_circuits_later_gates(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(verification, "_reference_context", lambda _root: {})
+    monkeypatch.setattr(verification, "_measured_phase_access_counts", lambda _root: {})
+    monkeypatch.setattr(
+        verification, "_build_reference_verification_payload", lambda **kwargs: kwargs
+    )
+    monkeypatch.setattr(
+        verification,
+        "_structural_identity_gate",
+        lambda *_args, **_kwargs: calls.append("structural") or {"status": "failed"},
+    )
+    monkeypatch.setattr(
+        verification,
+        "_semantic_outcome_gate",
+        lambda *_args, **_kwargs: calls.append("semantic"),
+    )
+
+    verification.verify_reference_instrument(
+        tmp_path, tmp_path, stop_after_first_failure=True
+    )
+    assert calls == ["structural"]

--- a/zeromodel/domains/video_action_set/artifact_io.py
+++ b/zeromodel/domains/video_action_set/artifact_io.py
@@ -1,0 +1,80 @@
+"""Video action-set artifact io."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import (
+    Any,
+    Mapping,
+)
+from zeromodel.domains.video_action_set.canonical_json import (
+    canonical_json_bytes,
+    canonical_json_value,
+    canonical_sha256,
+)
+
+
+def _json_ready(value: Any) -> Any:
+    return canonical_json_value(value)
+
+
+def _json_bytes(value: Any) -> bytes:
+    return canonical_json_bytes(value)
+
+
+def _sha256(value: Any) -> str:
+    return canonical_sha256(value)
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_json_ready(payload), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_jsonl(path: Path, rows: list[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(_json_ready(row), sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _write_csv(path: Path, rows: list[Mapping[str, Any]]) -> None:
+    import csv
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = sorted({str(key) for row in rows for key in row.keys()})
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    key: json.dumps(_json_ready(row[key]), sort_keys=True)
+                    if isinstance(row.get(key), (dict, list, tuple))
+                    else row.get(key, "")
+                    for key in fieldnames
+                }
+            )
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")

--- a/zeromodel/domains/video_action_set/artifact_layout.py
+++ b/zeromodel/domains/video_action_set/artifact_layout.py
@@ -1,0 +1,96 @@
+"""Canonical filesystem layout for the video action-set instrument."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT_ARTIFACT_FILENAMES = (
+    "benchmark-contract-identity.json",
+    "generator-identity.json",
+    "benchmark-manifest.json",
+    "policy-artifact.json",
+    "reachability-tile-reference.json",
+    "episode-family-registry.json",
+    "transformation-family-contract.json",
+    "provider-manifest.json",
+    "provider-formulas.json",
+    "score-quantizer.json",
+    "region-manifest.json",
+    "split-manifest.json",
+    "episode-plan.json",
+    "final-split-sealed-plan.json",
+    "final-split-sealed-digest.json",
+    "evidence-schema.json",
+    "phase-access-audits.json",
+    "README.md",
+    "reproduction.md",
+    "runtime-profile-reference.json",
+    "runtime-profile-optimized.json",
+    "runtime-comparison.json",
+    "runtime-profile-reference.md",
+    "runtime-profile-optimized.md",
+    "provider-runtime-equivalence.json",
+    "provider-runtime-equivalence.csv",
+    "observation-identity-manifest.json",
+    "split-overlap-audit.json",
+    "evidence-completeness-summary.json",
+    "canonical-provider-results.csv",
+    "canonical-provider-summary.json",
+    "provider-equivalence-results.json",
+    "tie-safety-results.json",
+    "reference-closure-report.json",
+)
+
+SPLIT_ARTIFACT_FILENAMES = (
+    "frame-metadata.jsonl",
+    "provider-evidence.jsonl",
+)
+
+SPLITS = ("development", "calibration", "selection", "final")
+MATERIALIZED_SPLITS = SPLITS[:-1]
+
+
+def root_artifact_path(output_dir: Path, filename: str) -> Path:
+    return output_dir / filename
+
+
+def split_artifact_path(output_dir: Path, split: str, filename: str) -> Path:
+    return output_dir / split / filename
+
+
+def split_manifest_path(output_dir: Path, split: str) -> Path:
+    return output_dir / f"{split}-manifest.json"
+
+
+def family_closure_path(output_dir: Path, split: str) -> Path:
+    return output_dir / f"{split}-family-closure-report.json"
+
+
+def benchmark_database_path(output_dir: Path) -> Path:
+    return output_dir / "benchmark.sqlite3"
+
+
+def reachability_tile_path(repo_root: Path) -> Path:
+    return (
+        repo_root
+        / "docs"
+        / "results"
+        / "video-policy-reachability-tile-v1"
+        / "reachability-tile.json"
+    )
+
+
+def canonical_relative_paths() -> tuple[str, ...]:
+    """Return recognized canonical paths, not a produced-artifact manifest.
+
+    The registry includes optional root outputs and evidence for materialized splits.
+    Dynamic split manifests, family-closure reports, and the SQLite database are
+    addressed by their path helpers instead of enumerated here.
+    """
+    split_paths = tuple(
+        f"{split}/{filename}"
+        for split in MATERIALIZED_SPLITS
+        for filename in SPLIT_ARTIFACT_FILENAMES
+    )
+    return ROOT_ARTIFACT_FILENAMES + split_paths

--- a/zeromodel/domains/video_action_set/build_orchestration.py
+++ b/zeromodel/domains/video_action_set/build_orchestration.py
@@ -1,0 +1,562 @@
+"""Video action-set build orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, cast
+from zeromodel.arcade_policy import (
+    ACTIONS,
+    compile_policy_artifact,
+)
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.contracts import (
+    BENCHMARK_VERSION,
+    EPISODE_PLAN_VERSION,
+    GENERATOR_VERSION,
+    REACHABILITY_TILE_DIGEST,
+    REACHABILITY_TILE_VERSION,
+    SEED_DERIVATION_VERSION,
+)
+from zeromodel.domains.video_action_set.dto import EpisodePlanDTO
+from zeromodel.domains.video_action_set.episode_families import (
+    episode_family_registry as _episode_family_registry,
+    family_schedule as _family_schedule,
+)
+from zeromodel.domains.video_action_set.episode_materialization import (
+    materialize_plan_collection as _materialize_plan_collection,
+)
+from zeromodel.domains.video_action_set.episode_planning import (
+    episode_ids_by_family as _episode_ids_by_family,
+    episode_plans_for_split as _episode_plans_for_split,
+    validate_episode_plan_collection as _validate_episode_plan_collection,
+)
+from zeromodel.domains.video_action_set.evidence_audit import (
+    measured_phase_access_counts as _build_measured_phase_access_counts,
+    build_observation_identity_manifest as _build_observation_identity_manifest,
+    build_split_overlap_audit as _build_split_overlap_audit,
+)
+from zeromodel.domains.video_action_set.materialization_validation import (
+    family_closure_report as _family_closure_report,
+)
+from zeromodel.domains.video_action_set.observation_universe import canonical_prototypes
+from zeromodel.domains.video_action_set.provider_measurement import (
+    measure_record_collection,
+)
+from zeromodel.domains.video_action_set.runtime_profiling import (
+    profile_provider as _profile_provider,
+    runtime_profile_payload,
+    select_profiling_records,
+)
+from zeromodel.domains.video_action_set.transformations import _transformation_contract
+from zeromodel.policy_lookup import VPMPolicyLookup
+from zeromodel.runtime import build_runtime
+from zeromodel.video_complete_row_evidence import (
+    QUANTIZATION_SCALE,
+    VIDEO_SCORE_QUANTIZER_VERSION,
+)
+from zeromodel.video_prospective_providers import (
+    PROSPECTIVE_P1_VERSION,
+    PROSPECTIVE_P2_VERSION,
+    PROSPECTIVE_P3_VERSION,
+)
+from zeromodel.domains.video_action_set.artifact_io import (
+    _read_json,
+    _read_jsonl,
+    _sha256,
+    _write_json,
+    _write_jsonl,
+    _write_text,
+)
+from zeromodel.domains.video_action_set.artifact_layout import (
+    benchmark_database_path,
+    family_closure_path,
+    reachability_tile_path,
+    root_artifact_path,
+    split_artifact_path,
+    split_manifest_path,
+)
+from zeromodel.domains.video_action_set.report_rendering import (
+    benchmark_readme,
+    reproduction_instructions,
+    runtime_profile_optimized,
+    runtime_profile_reference,
+)
+from zeromodel.domains.video_action_set.dto import BenchmarkIdentityDTO
+
+
+BenchmarkIdentity = BenchmarkIdentityDTO
+
+
+def _build_durable_runtime(output_dir: Path):
+    try:
+        from zeromodel.db.runtime import build_sqlite_runtime
+    except ImportError as exc:
+        raise VPMValidationError(
+            "SQLite benchmark persistence requires the optional database extra: "
+            'pip install "zeromodel[persistence]"'
+        ) from exc
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    database_url = f"sqlite:///{benchmark_database_path(output_dir).as_posix()}"
+    return build_sqlite_runtime(database_url, initialize_schema=True)
+
+
+def _load_reachability_tile(repo_root: Path) -> dict[str, Any]:
+    return _read_json(reachability_tile_path(repo_root))
+
+
+def load_identity(repo_root: Path) -> BenchmarkIdentity:
+    return build_runtime().video_action_set.load_identity(repo_root)
+
+
+def _write_frozen_contract_artifacts(
+    output_dir: Path,
+    identity: BenchmarkIdentity,
+    policy: Any,
+    row_ids: list[str],
+    row_actions: dict[str, str],
+    provider_manifest: dict[str, Any],
+    split_manifest: dict[str, Any],
+) -> None:
+    _write_json(
+        root_artifact_path(output_dir, "benchmark-contract-identity.json"),
+        identity.to_dict(),
+    )
+    _write_json(
+        root_artifact_path(output_dir, "generator-identity.json"),
+        {
+            "generator_version": GENERATOR_VERSION,
+            "seed_digest": identity.seed_digest,
+            "seed_material": identity.seed_material,
+        },
+    )
+    _write_json(
+        root_artifact_path(output_dir, "benchmark-manifest.json"),
+        {
+            "benchmark_version": BENCHMARK_VERSION,
+            "policy_artifact_id": policy.artifact_id,
+            "row_count": len(row_ids),
+        },
+    )
+    _write_json(
+        root_artifact_path(output_dir, "policy-artifact.json"),
+        {
+            "policy_artifact_id": policy.artifact_id,
+            "row_count": len(row_ids),
+            "action_count": len(ACTIONS),
+            "row_ids": row_ids,
+            "row_action": row_actions,
+            "row_action_digest": _sha256(
+                {
+                    "policy_artifact_id": policy.artifact_id,
+                    "row_action": [
+                        {"row_id": row_id, "action_id": row_actions[row_id]}
+                        for row_id in row_ids
+                    ],
+                }
+            ),
+        },
+    )
+    _write_json(
+        root_artifact_path(output_dir, "reachability-tile-reference.json"),
+        {
+            "tile_version": REACHABILITY_TILE_VERSION,
+            "tile_digest": REACHABILITY_TILE_DIGEST,
+        },
+    )
+    _write_json(
+        root_artifact_path(output_dir, "episode-family-registry.json"),
+        _episode_family_registry(),
+    )
+    _write_json(
+        root_artifact_path(output_dir, "transformation-family-contract.json"),
+        _transformation_contract(),
+    )
+    _write_json(
+        root_artifact_path(output_dir, "provider-manifest.json"), provider_manifest
+    )
+    _write_json(
+        root_artifact_path(output_dir, "provider-formulas.json"),
+        {
+            "P1": "1 - normalized absolute error",
+            "P2": "registered local correlation converted to bounded similarity",
+            "P3": "B3 joint fit",
+        },
+    )
+    _write_json(
+        root_artifact_path(output_dir, "score-quantizer.json"),
+        {"version": VIDEO_SCORE_QUANTIZER_VERSION, "scale": QUANTIZATION_SCALE},
+    )
+    _write_json(
+        root_artifact_path(output_dir, "region-manifest.json"),
+        {
+            "local_regions": ["target_band", "cooldown_indicator", "tank_band"],
+            "joint_regions": ["target_band", "cooldown_indicator", "tank_band"],
+        },
+    )
+    _write_json(root_artifact_path(output_dir, "split-manifest.json"), split_manifest)
+
+
+def _write_frozen_plan_artifacts(
+    output_dir: Path,
+    row_ids: list[str],
+    development_plans: list[dict[str, Any]],
+    calibration_plans: list[dict[str, Any]],
+    selection_plans: list[dict[str, Any]],
+    final_plan: dict[str, Any],
+) -> None:
+    _write_json(
+        root_artifact_path(output_dir, "episode-plan.json"),
+        {
+            "version": EPISODE_PLAN_VERSION,
+            "seed_derivation_version": SEED_DERIVATION_VERSION,
+            "policy_row_ids": row_ids,
+            "family_schedule": list(_family_schedule()),
+            "splits": {
+                "development": {
+                    "episode_count": len(development_plans),
+                    "frame_count": 112,
+                    "sealed_episode_ids": _episode_ids_by_family(development_plans),
+                    "episodes": development_plans,
+                },
+                "calibration": {
+                    "episode_count": len(calibration_plans),
+                    "frame_count": 448,
+                    "sealed_episode_ids": _episode_ids_by_family(calibration_plans),
+                    "episodes": calibration_plans,
+                },
+                "selection": {
+                    "episode_count": len(selection_plans),
+                    "frame_count": 1008,
+                    "sealed_episode_ids": _episode_ids_by_family(selection_plans),
+                    "episodes": selection_plans,
+                },
+            },
+        },
+    )
+    _write_json(
+        root_artifact_path(output_dir, "final-split-sealed-plan.json"), final_plan
+    )
+    _write_json(
+        root_artifact_path(output_dir, "final-split-sealed-digest.json"),
+        {"digest": final_plan["sealed_plan_digest"]},
+    )
+    _write_json(
+        root_artifact_path(output_dir, "evidence-schema.json"),
+        {
+            "version": "zeromodel-video-complete-row-evidence/v2",
+            "row_count": 112,
+            "requires_complete_ranking": True,
+            "requires_tie_groups": True,
+            "requires_semantic_top_set_outcome": True,
+            "requires_reachability_trace": True,
+            "requires_seed_lineage": True,
+        },
+    )
+    _write_json(
+        root_artifact_path(output_dir, "phase-access-audits.json"),
+        _measured_phase_access_counts(output_dir),
+    )
+    _write_text(root_artifact_path(output_dir, "README.md"), benchmark_readme())
+    _write_text(
+        root_artifact_path(output_dir, "reproduction.md"), reproduction_instructions()
+    )
+
+
+def freeze_benchmark(output_dir: Path, repo_root: Path) -> dict[str, Any]:
+    runtime = _build_durable_runtime(output_dir)
+    identity = runtime.video_action_set.load_identity(repo_root)
+    policy = compile_policy_artifact()
+    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
+    development_plans = _episode_plans_for_split(
+        identity, "development", row_ids, row_actions
+    )
+    calibration_plans = _episode_plans_for_split(
+        identity, "calibration", row_ids, row_actions
+    )
+    selection_plans = _episode_plans_for_split(
+        identity, "selection", row_ids, row_actions
+    )
+    final_plans = _episode_plans_for_split(identity, "final", row_ids, row_actions)
+    _validate_episode_plan_collection(
+        identity,
+        {
+            "development": development_plans,
+            "calibration": calibration_plans,
+            "selection": selection_plans,
+            "final": final_plans,
+        },
+        row_actions,
+    )
+    development_episode_dtos = runtime.video_action_set.save_episode_plans(
+        tuple(EpisodePlanDTO.from_dict(plan) for plan in development_plans)
+    )
+    calibration_episode_dtos = runtime.video_action_set.save_episode_plans(
+        tuple(EpisodePlanDTO.from_dict(plan) for plan in calibration_plans)
+    )
+    selection_episode_dtos = runtime.video_action_set.save_episode_plans(
+        tuple(EpisodePlanDTO.from_dict(plan) for plan in selection_plans)
+    )
+    final_episode_dtos = runtime.video_action_set.save_episode_plans(
+        tuple(EpisodePlanDTO.from_dict(plan) for plan in final_plans)
+    )
+    development_plans = [dto.to_dict() for dto in development_episode_dtos]
+    calibration_plans = [dto.to_dict() for dto in calibration_episode_dtos]
+    selection_plans = [dto.to_dict() for dto in selection_episode_dtos]
+    final_plans = [dto.to_dict() for dto in final_episode_dtos]
+    split_manifest = {
+        "development_episode_count": 112,
+        "calibration_episode_count": 112,
+        "calibration_frame_count": 448,
+        "selection_valid_episode_count": 112,
+        "selection_frame_invalid_episode_count": 56,
+        "selection_temporal_negative_episode_count": 56,
+        "selection_control_episode_count": 28,
+        "selection_total_frame_count": 1008,
+        "final_valid_episode_count": 112,
+        "final_frame_invalid_episode_count": 56,
+        "final_temporal_negative_episode_count": 56,
+        "final_control_episode_count": 28,
+        "final_total_expected_frame_count": 1008,
+    }
+    provider_manifest = {
+        "providers": [
+            {"provider_id": "P1", "provider_version": PROSPECTIVE_P1_VERSION},
+            {"provider_id": "P2", "provider_version": PROSPECTIVE_P2_VERSION},
+            {"provider_id": "P3", "provider_version": PROSPECTIVE_P3_VERSION},
+        ]
+    }
+    sealed_final = runtime.video_action_set.seal_final_split(
+        episodes=final_episode_dtos, seed_commitment=identity.seed_digest
+    )
+    final_plan = sealed_final.to_dict()
+    _write_frozen_contract_artifacts(
+        output_dir,
+        identity,
+        policy,
+        row_ids,
+        row_actions,
+        provider_manifest,
+        split_manifest,
+    )
+    _write_frozen_plan_artifacts(
+        output_dir,
+        row_ids,
+        development_plans,
+        calibration_plans,
+        selection_plans,
+        final_plan,
+    )
+    return split_manifest
+
+
+def _materialize_records(split: str, repo_root: Path) -> list[dict[str, Any]]:
+    if split == "final":
+        raise VPMValidationError(
+            "final split materialization is prohibited by the sealed plan"
+        )
+    identity = load_identity(repo_root)
+    policy = compile_policy_artifact()
+    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
+    reachability_tile = _load_reachability_tile(repo_root)
+    plans = _episode_plans_for_split(identity, split, row_ids, row_actions)
+    _validate_episode_plan_collection(identity, {split: plans}, row_actions)
+    return _materialize_plan_collection(plans, identity, reachability_tile)
+
+
+def _profiling_records(repo_root: Path, frame_count: int) -> list[dict[str, Any]]:
+    selection = _materialize_records("selection", repo_root)
+    return select_profiling_records(selection, frame_count)
+
+
+def profile_runtime(
+    output_dir: Path,
+    repo_root: Path,
+    *,
+    provider: str = "all",
+    frame_count: int = 8,
+) -> dict[str, Any]:
+    prototypes = canonical_prototypes()
+    policy_artifact_id = compile_policy_artifact().artifact_id
+    records = _profiling_records(repo_root, frame_count)
+    provider_ids = ("P1", "P2", "P3") if provider == "all" else (provider,)
+    reference = []
+    optimized = []
+    for provider_id in provider_ids:
+        reference.append(
+            _profile_provider(
+                provider_id=provider_id,
+                records=records,
+                prototypes=prototypes,
+                policy_artifact_id=policy_artifact_id,
+                implementation="reference",
+            )
+        )
+        optimized.append(
+            _profile_provider(
+                provider_id=provider_id,
+                records=records,
+                prototypes=prototypes,
+                policy_artifact_id=policy_artifact_id,
+                implementation="optimized",
+            )
+        )
+    payload = runtime_profile_payload(
+        provider_scope=provider,
+        provider_ids=provider_ids,
+        profile_frame_count=len(records),
+        reference=reference,
+        optimized=optimized,
+    )
+    _write_json(
+        root_artifact_path(output_dir, "runtime-profile-reference.json"),
+        {"profiles": reference, "profile_frame_count": len(records)},
+    )
+    _write_json(
+        root_artifact_path(output_dir, "runtime-profile-optimized.json"),
+        {"profiles": optimized, "profile_frame_count": len(records)},
+    )
+    _write_json(root_artifact_path(output_dir, "runtime-comparison.json"), payload)
+    _write_text(
+        root_artifact_path(output_dir, "runtime-profile-reference.md"),
+        runtime_profile_reference(reference),
+    )
+    _write_text(
+        root_artifact_path(output_dir, "runtime-profile-optimized.md"),
+        runtime_profile_optimized(optimized),
+    )
+    return payload
+
+
+def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]:
+    runtime = _build_durable_runtime(output_dir)
+    identity = runtime.video_action_set.load_identity(repo_root)
+    prototypes = canonical_prototypes()
+    policy = compile_policy_artifact()
+    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
+    row_actions = {
+        str(row_id): lookup.choose(str(row_id)) for row_id in policy.source.row_ids
+    }
+    policy_artifact_id = policy.artifact_id
+    reachability_tile = _load_reachability_tile(repo_root)
+    plans = _episode_plans_for_split(
+        identity, split, [str(row_id) for row_id in policy.source.row_ids], row_actions
+    )
+    saved_plans = runtime.video_action_set.save_episode_plans(
+        tuple(EpisodePlanDTO.from_dict(plan) for plan in plans)
+    )
+    plans = [dto.to_dict() for dto in saved_plans]
+    records = _materialize_records(split, repo_root)
+    runtime.video_action_set.save_observation_records(records)
+    records = list(
+        runtime.video_action_set.list_observation_records(
+            benchmark_seed_digest=identity.seed_digest, split=split, include_pixels=True
+        )
+    )
+    scored_rows = measure_record_collection(
+        records,
+        prototypes,
+        policy_artifact_id,
+        reachability_tile=reachability_tile,
+        row_actions=row_actions,
+    )
+    _write_jsonl(
+        split_artifact_path(output_dir, split, "frame-metadata.jsonl"),
+        [
+            {key: value for key, value in record.items() if key != "pixels"}
+            for record in records
+        ],
+    )
+    _write_jsonl(
+        split_artifact_path(output_dir, split, "provider-evidence.jsonl"),
+        cast(list[Mapping[str, Any]], scored_rows),
+    )
+    manifest = {
+        "split": split,
+        "observation_count": len(records),
+        "provider_frame_record_count": len(scored_rows),
+        "frame_digest": _sha256(
+            [
+                {key: value for key, value in record.items() if key != "pixels"}
+                for record in records
+            ]
+        ),
+        "provider_evidence_digest": _sha256(scored_rows),
+    }
+    _write_json(split_manifest_path(output_dir, split), manifest)
+    closure = _family_closure_report(
+        split=split,
+        records=records,
+        plans=plans,
+        identity=identity,
+        reachability_tile=reachability_tile,
+        provider_rows=scored_rows,
+    )
+    _write_json(family_closure_path(output_dir, split), closure)
+    if split == "selection":
+        _write_json(
+            root_artifact_path(output_dir, "family-closure-report.json"), closure
+        )
+    _write_observation_identity_manifest(output_dir)
+    _write_split_overlap_audit(output_dir)
+    _write_json(
+        root_artifact_path(output_dir, "phase-access-audits.json"),
+        _measured_phase_access_counts(output_dir),
+    )
+    return manifest
+
+
+def _measured_phase_access_counts(output_dir: Path) -> dict[str, Any]:
+    final_path = root_artifact_path(output_dir, "final-split-sealed-plan.json")
+    final_plan = _read_json(final_path) if final_path.exists() else {}
+    frame_rows = {
+        split: _read_jsonl(
+            split_artifact_path(output_dir, split, "frame-metadata.jsonl")
+        )
+        for split in ("development", "calibration", "selection", "final")
+    }
+    evidence_rows = {
+        split: _read_jsonl(
+            split_artifact_path(output_dir, split, "provider-evidence.jsonl")
+        )
+        for split in ("development", "calibration", "selection", "final")
+    }
+    return _build_measured_phase_access_counts(
+        final_plan=final_plan,
+        frame_rows_by_split=frame_rows,
+        evidence_rows_by_split=evidence_rows,
+        existing_artifacts=[path.name for path in output_dir.iterdir()],
+    )
+
+
+def _write_observation_identity_manifest(output_dir: Path) -> None:
+    frames = {
+        split: _read_jsonl(
+            split_artifact_path(output_dir, split, "frame-metadata.jsonl")
+        )
+        for split in ("development", "calibration", "selection")
+    }
+    payload = _build_observation_identity_manifest(frames)
+    _write_json(
+        root_artifact_path(output_dir, "observation-identity-manifest.json"), payload
+    )
+
+
+def _write_split_overlap_audit(output_dir: Path) -> None:
+    split_rows = {
+        split: _read_jsonl(
+            split_artifact_path(output_dir, split, "frame-metadata.jsonl")
+        )
+        for split in ("development", "calibration", "selection")
+    }
+    final_path = root_artifact_path(output_dir, "final-split-sealed-plan.json")
+    final_plan = _read_json(final_path) if final_path.exists() else {}
+    payload = _build_split_overlap_audit(
+        frame_rows_by_split=split_rows,
+        final_plan=final_plan,
+    )
+    _write_json(root_artifact_path(output_dir, "split-overlap-audit.json"), payload)

--- a/zeromodel/domains/video_action_set/mutation_filesystem.py
+++ b/zeromodel/domains/video_action_set/mutation_filesystem.py
@@ -1,0 +1,546 @@
+"""Video action-set mutation filesystem."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import (
+    Any,
+    Mapping,
+    Sequence,
+)
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.observation_provenance import (
+    valid_frame_operation_chain as _valid_frame_operation_chain,
+)
+from zeromodel.domains.video_action_set.observation_universe import (
+    canonical_observation_universe,
+)
+from zeromodel.domains.video_action_set.reachability_composition import (
+    trace_digest as _trace_digest,
+)
+from zeromodel.domains.video_action_set.reference_verification import (
+    REFERENCE_VERIFICATION_VERSION,
+    _REQUIRED_VERIFICATION_GATES,
+    _finding,
+    _gate,
+)
+from zeromodel.domains.video_action_set.transformations import (
+    _transformation_parameters,
+)
+from zeromodel.video_complete_row_evidence import QUANTIZATION_SCALE
+from zeromodel.domains.video_action_set.artifact_io import (
+    _read_json,
+    _read_jsonl,
+    _sha256,
+    _write_json,
+    _write_jsonl,
+)
+
+
+CLOSURE_REPORT_VERSION = "zeromodel-video-action-set-reference-closure/v1"
+
+
+# fmt: off
+def _file_digest(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _directory_snapshot(path: Path) -> dict[str, dict[str, Any]]:
+    if not path.exists():
+        return {}
+    snapshot: dict[str, dict[str, Any]] = {}
+    for item in sorted(path.rglob("*")):
+        if item.is_file():
+            stat = item.stat()
+            snapshot[str(item.relative_to(path)).replace("\\", "/")] = {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns, "digest": _file_digest(item)}
+    return snapshot
+
+
+def _structural_payload(path: Path) -> Any:
+    if path.suffix == ".json":
+        return json.loads(path.read_text(encoding="utf-8"))
+    if path.suffix == ".jsonl":
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return path.read_text(encoding="utf-8")
+
+
+def _mutation_structural_snapshot(output_dir: Path, *, only_files: Sequence[str] | None = None) -> dict[str, Any]:
+    snapshot: dict[str, Any] = {}
+    selected = None if only_files is None else {str(item).replace("\\", "/") for item in only_files}
+    for path in sorted(output_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = str(path.relative_to(output_dir)).replace("\\", "/")
+        if selected is not None and relative not in selected:
+            continue
+        try:
+            snapshot[relative] = _structural_payload(path)
+        except UnicodeDecodeError:
+            snapshot[relative] = {"binary_digest": _file_digest(path)}
+    return snapshot
+
+
+def _rewrite_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    _write_jsonl(path, [dict(row) for row in rows])
+
+
+def _launder_split_manifest(output_dir: Path, split: str) -> None:
+    manifest_path = output_dir / f"{split}-manifest.json"
+    if not manifest_path.exists():
+        return
+    frame_rows = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
+    evidence_rows = _read_jsonl(output_dir / split / "provider-evidence.jsonl")
+    manifest = _read_json(manifest_path)
+    manifest["observation_count"] = len(frame_rows)
+    manifest["provider_frame_record_count"] = len(evidence_rows)
+    manifest["frame_digest"] = _sha256(frame_rows)
+    manifest["provider_evidence_digest"] = _sha256(evidence_rows)
+    _write_json(manifest_path, manifest)
+
+
+def _mutate_first_provider_row(output_dir: Path, mutator: Any, *, predicate: Any | None = None, splits: Sequence[str] = ("development", "calibration", "selection")) -> None:
+    for split in splits:
+        path = output_dir / split / "provider-evidence.jsonl"
+        rows = _read_jsonl(path)
+        for row in rows:
+            if predicate is None or predicate(row):
+                mutator(row)
+                _rewrite_jsonl(path, rows)
+                _launder_split_manifest(output_dir, split)
+                return
+    raise VPMValidationError("mutation fixture lacks a matching provider row")
+
+
+def _mutate_first_frame_row(output_dir: Path, mutator: Any, *, predicate: Any | None = None) -> None:
+    path = output_dir / "selection" / "frame-metadata.jsonl"
+    rows = _read_jsonl(path)
+    for row in rows:
+        if predicate is None or predicate(row):
+            mutator(row)
+            _rewrite_jsonl(path, rows)
+            _launder_split_manifest(output_dir, "selection")
+            return
+    raise VPMValidationError("mutation fixture lacks a matching frame row")
+
+
+def _apply_evidence_mutation(output_dir: Path, case_name: str) -> None:
+    def mutate(row: dict[str, Any]) -> None:
+        match case_name:
+            case 'evidence_raw_score_preserve_quantized_bin':
+                row["all_112_raw_scores"][0] = float(row["all_112_raw_scores"][0]) + 1e-12
+            case 'evidence_raw_score_cross_quantization_boundary':
+                row["all_112_raw_scores"][0] = 0.0 if int(row["all_112_quantized_scores"][0]) else 1.0
+            case 'evidence_quantized_score_changed':
+                row["all_112_quantized_scores"][0] = min(QUANTIZATION_SCALE, int(row["all_112_quantized_scores"][0]) + 1)
+                row["score_vector_digest"] = _sha256({"laundered": row["all_112_quantized_scores"]})
+                row["quantized_score_vector_digest"] = row["score_vector_digest"]
+            case 'evidence_remove_row_score':
+                for key in ("all_112_row_ids", "all_112_raw_scores", "all_112_quantized_scores"):
+                    row[key].pop()
+            case 'evidence_duplicate_row_score':
+                row["all_112_row_ids"][1] = row["all_112_row_ids"][0]
+            case 'evidence_introduce_foreign_row':
+                row["all_112_row_ids"][0] = "foreign:row"
+            case 'evidence_reorder_stored_rows':
+                for key in ("all_112_row_ids", "all_112_raw_scores", "all_112_quantized_scores"):
+                    row[key][0], row[key][1] = row[key][1], row[key][0]
+            case 'evidence_alter_ranking_order':
+                row["complete_ordered_ranking"][0], row["complete_ordered_ranking"][1] = row["complete_ordered_ranking"][1], row["complete_ordered_ranking"][0]
+            case 'evidence_alter_tie_group_membership':
+                row["tie_groups"][0]["row_ids"][0] = row["complete_ordered_ranking"][-1]
+            case 'evidence_split_tie_group_incorrectly':
+                top = row["tie_groups"][0]
+                if len(top["row_ids"]) < 2:
+                    top["row_ids"].append(row["complete_ordered_ranking"][1])
+                moved = top["row_ids"].pop()
+                row["tie_groups"].insert(1, {"tie_group_index": 1, "quantized_score": top["quantized_score"], "row_ids": [moved]})
+            case 'evidence_merge_distinct_score_groups':
+                if len(row["tie_groups"]) > 1:
+                    row["tie_groups"][0]["row_ids"].extend(row["tie_groups"][1]["row_ids"])
+                    row["tie_groups"].pop(1)
+                else:
+                    row["tie_groups"][0]["row_ids"].append(row["complete_ordered_ranking"][-1])
+            case 'evidence_alter_quantized_score_vector_digest':
+                row["score_vector_digest"] = "sha256:" + "0" * 64
+                row["quantized_score_vector_digest"] = row["score_vector_digest"]
+            case 'evidence_alter_raw_diagnostic_digest':
+                row["raw_score_diagnostic_digest"] = "sha256:" + "0" * 64
+    _mutate_first_provider_row(output_dir, mutate)
+    return
+
+
+def _apply_semantic_mutation(output_dir: Path, case_name: str) -> None:
+    def semantic_mutate(row: dict[str, Any]) -> None:
+        payload = row["semantic_top_set_outcome"]
+        match case_name:
+            case 'semantic_resolved_row_for_action_unanimous_tie':
+                payload["resolved_row_id"] = payload["top_row_ids"][0]
+                row["resolved_row"] = payload["resolved_row_id"]
+            case 'semantic_resolved_action_for_conflicting_tie':
+                payload["resolved_action_id"] = payload["top_action_ids"][0]
+                row["resolved_action"] = payload["resolved_action_id"]
+                row["winner_action"] = payload["resolved_action_id"]
+            case 'semantic_convert_conflicting_tie_to_unique_row':
+                payload["status"] = "unique_row"
+                row["semantic_status"] = "unique_row"
+            case 'semantic_change_top_row_policy_action':
+                payload["top_row_actions"][0]["action_id"] = "FIRE" if payload["top_row_actions"][0]["action_id"] != "FIRE" else "LEFT"
+            case 'semantic_change_rejection_reason':
+                payload["rejection_reason"] = "mutated rejection reason"
+            case 'semantic_alter_outcome_digest':
+                payload["semantic_outcome_digest"] = "sha256:" + "1" * 64
+                row["semantic_outcome_digest"] = payload["semantic_outcome_digest"]
+            case 'semantic_lexically_reorder_tied_rows':
+                payload["top_row_ids"] = list(reversed(payload["top_row_ids"]))
+                row["top_row_ids"] = list(reversed(row["top_row_ids"]))
+            case 'semantic_reorder_rows_preserving_action_equivalence':
+                payload["top_row_actions"] = list(reversed(payload["top_row_actions"]))
+    if case_name == "semantic_resolved_row_for_action_unanimous_tie":
+        _mutate_first_provider_row(output_dir, semantic_mutate, predicate=lambda row: row.get("semantic_status") == "action_unanimous_tie")
+    elif case_name in {"semantic_resolved_action_for_conflicting_tie", "semantic_convert_conflicting_tie_to_unique_row", "semantic_change_rejection_reason"}:
+        _mutate_first_provider_row(output_dir, semantic_mutate, predicate=lambda row: row.get("semantic_status") == "conflicting_action_tie")
+    elif case_name in {"semantic_lexically_reorder_tied_rows", "semantic_reorder_rows_preserving_action_equivalence"}:
+        _mutate_first_provider_row(output_dir, semantic_mutate, predicate=lambda row: len(row.get("top_row_ids", [])) > 1)
+    else:
+        _mutate_first_provider_row(output_dir, semantic_mutate)
+    return
+
+
+def _apply_policy_mutation(output_dir: Path, case_name: str) -> None:
+    payload = _read_json(output_dir / "policy-artifact.json")
+    if case_name == "policy_remove_policy_row":
+        payload["row_ids"].pop()
+    elif case_name == "policy_add_undeclared_row":
+        payload["row_ids"].append("foreign:row")
+        payload["row_action"]["foreign:row"] = "LEFT"
+    elif case_name == "policy_alter_artifact_identity":
+        payload["policy_artifact_id"] = "sha256:foreign-policy"
+    elif case_name == "policy_mapping_recomputed_superficial_metadata":
+        payload["row_action_digest"] = _sha256({"laundered": payload["row_action"], "mutation": case_name})
+    else:
+        first = payload["row_ids"][0]
+        payload["row_action"][first] = "FIRE" if payload["row_action"][first] != "FIRE" else "LEFT"
+        payload["row_action_digest"] = _sha256({"laundered": payload["row_action"]})
+    _write_json(output_dir / "policy-artifact.json", payload)
+    return
+
+
+def _apply_observation_mutation(output_dir: Path, case_name: str) -> None:
+    if case_name == "observation_swap_two_frame_payloads":
+        path = output_dir / "selection" / "frame-metadata.jsonl"
+        rows = _read_jsonl(path)
+        rows[0]["observation_pixel_digest"], rows[1]["observation_pixel_digest"] = rows[1]["observation_pixel_digest"], rows[0]["observation_pixel_digest"]
+        _rewrite_jsonl(path, rows)
+        _launder_split_manifest(output_dir, "selection")
+    elif case_name == "observation_alter_frame_identity":
+        _mutate_first_frame_row(output_dir, lambda row: row.__setitem__("frame_id", str(row["frame_id"]) + ":mutated"))
+    elif case_name == "observation_reuse_under_two_episode_ids":
+        path = output_dir / "selection" / "frame-metadata.jsonl"
+        rows = _read_jsonl(path)
+        first_row = next(row for row in rows if row.get("observation_pixel_digest") and row.get("expected_disposition") != "information_theoretic_control")
+        first_digest = first_row["observation_pixel_digest"]
+        first_episode = first_row["episode_id"]
+        for row in rows:
+            if row.get("observation_pixel_digest") and row.get("expected_disposition") != "information_theoretic_control" and row["episode_id"] != first_episode:
+                row["observation_pixel_digest"] = first_digest
+                break
+        _rewrite_jsonl(path, rows)
+        _launder_split_manifest(output_dir, "selection")
+    elif case_name == "observation_substitute_frame_for_declared_gap":
+        _mutate_first_frame_row(output_dir, lambda row: (row.__setitem__("event_type", "frame"), row.__setitem__("gap_declaration", None), row.__setitem__("observation_pixel_digest", "sha256:" + "2" * 64)), predicate=lambda row: row.get("event_type") == "gap_unknown")
+    else:
+        replacement = {
+            "observation_flip_byte_digest": "sha256:" + "3" * 64,
+            "observation_change_pixels_and_recompute_digest": "sha256:" + "b" * 64,
+            "observation_change_digest_without_pixels": "sha256:" + "c" * 64,
+        }[case_name]
+        _mutate_first_frame_row(output_dir, lambda row: row.__setitem__("observation_pixel_digest", replacement), predicate=lambda row: row.get("observation_pixel_digest") is not None)
+    return
+
+
+def _apply_seed_mutation(output_dir: Path, case_name: str) -> None:
+    if case_name in {"seed_alter_root_seed_material", "seed_alter_root_seed_digest"}:
+        path = output_dir / ("generator-identity.json" if case_name == "seed_alter_root_seed_material" else "benchmark-contract-identity.json")
+        payload = _read_json(path)
+        if case_name == "seed_alter_root_seed_material":
+            payload["seed_material"] = str(payload["seed_material"]) + "|mutated"
+        else:
+            payload["seed_digest"] = "sha256:" + "4" * 64
+        _write_json(path, payload)
+        return
+    path = output_dir / "episode-plan.json"
+    payload = _read_json(path)
+    plan = payload["splits"]["selection"]["episodes"][0]
+    match case_name:
+        case 'seed_alter_derived_seed':
+            plan["derived_seed_identity"] = "sha256:" + "5" * 64
+        case 'seed_alter_derivation_namespace':
+            plan["seed_lineage"]["concrete_episode_seed"]["namespace"] = "mutated_namespace"
+        case 'seed_alter_episode_ordinal':
+            plan["ordinal"] += 1
+        case 'seed_alter_split_identity':
+            plan["split"] = "development"
+        case 'seed_move_episode_between_splits':
+            moved = payload["splits"]["development"]["episodes"][0]
+            moved["split"] = "selection"
+            moved["episode_id"] = "selection:moved-from-development"
+        case 'seed_duplicate_episode_id':
+            payload["splits"]["selection"]["episodes"][1]["episode_id"] = plan["episode_id"]
+        case 'seed_alter_source_row':
+            plan["source_row_id"] = payload["policy_row_ids"][-1]
+        case 'seed_alter_splice_partner':
+            target = next(item for item in payload["splits"]["selection"]["episodes"] if item.get("mutation_kind") == "conflicting_action_splice")
+            target["secondary_row_id"] = target["source_row_id"]
+        case 'seed_alter_transformation_parameters':
+            plan["frame_plans"][0]["transformation_parameters"]["dx"] = 99
+        case 'seed_alter_planned_family':
+            plan["family_label"] = "temporal_negative"
+        case 'seed_alter_sealed_plan_digest':
+            plan["plan_digest"] = "sha256:" + "6" * 64
+        case 'seed_alter_final_sealed_identity':
+            final_path = output_dir / "final-split-sealed-plan.json"
+            final = _read_json(final_path)
+            final["episodes"][0]["episode_id"] = "final:valid:mutated"
+            final["sealed_episode_ids"]["valid"][0] = "final:valid:mutated"
+            final["sealed_plan_digest"] = _sha256({key: value for key, value in final.items() if key != "sealed_plan_digest"})
+            _write_json(final_path, final)
+            _write_json(output_dir / "final-split-sealed-digest.json", {"digest": final["sealed_plan_digest"]})
+            return
+        case 'seed_final_observation_provenance_materialized':
+            final_path = output_dir / "final-split-sealed-plan.json"
+            final = _read_json(final_path)
+            final["episodes"][0]["final_observation_provenance"] = {
+                "materialization_status": "materialized",
+                "observation_payload_included": True,
+                "provenance": "mutated_final_payload_claim",
+            }
+            final["sealed_plan_digest"] = _sha256({key: value for key, value in final.items() if key != "sealed_plan_digest"})
+            _write_json(final_path, final)
+            _write_json(output_dir / "final-split-sealed-digest.json", {"digest": final["sealed_plan_digest"]})
+            return
+    _write_json(path, payload)
+    return
+
+
+def _apply_family_mutation(output_dir: Path, case_name: str) -> None:
+    def family_mutate(row: dict[str, Any]) -> None:
+        metadata = row.setdefault("metadata", {})
+        trace = metadata.setdefault("family_intervention_trace", {})
+        match case_name:
+            case 'family_conflicting_splice_same_action_rows':
+                metadata["competitor_action_id"] = metadata.get("source_action_id")
+            case 'family_splice_zero_source_contribution':
+                trace["secondary_contributing_pixel_count"] = 0
+            case 'family_splice_output_equal_one_source':
+                trace["output_observation_digest"] = trace.get("primary_source_digest")
+            case 'family_splice_valid_state_collision':
+                canonical = canonical_observation_universe()["rows"][0]
+                row["observation_pixel_digest"] = canonical["observation_pixel_digest"]
+                metadata["observation_operation_chain"] = _valid_frame_operation_chain(canonical["row_id"], _transformation_parameters("exact", 0))
+                trace["output_observation_digest"] = canonical["observation_pixel_digest"]
+                trace["canonical_collision_count"] = 1
+                trace["canonical_collision_rows"] = [{"row_id": canonical["row_id"], "action_id": canonical["action_id"]}]
+            case 'family_splice_target_evidence_count_removed':
+                trace.setdefault("action_relevant_region_contribution_counts", {})["secondary_additive_target_pixel_count"] = 0
+            case 'family_critical_empty_coordinate_set':
+                trace["changes"] = []
+            case 'family_corrupt_noncritical_coordinates':
+                if trace.get("changes"):
+                    trace["changes"][0]["y"] = 0
+                    trace["changes"][0]["x"] = 0
+            case 'family_replacement_value_identical':
+                if trace.get("changes"):
+                    trace["changes"][0]["replacement"] = trace["changes"][0]["original"]
+            case 'family_clipping_quantization_noop':
+                trace["changed_pixel_count"] = 0
+            case 'family_reordered_metadata_original_payload_order' | 'family_identity_permutation_labelled_reordered':
+                metadata["original_frame_index"] = int(row.get("sequence_number", 0)) if case_name == "family_reordered_metadata_original_payload_order" else -1
+            case 'family_stale_label_without_repeated_bytes' | 'family_stale_repeat_naturally_identical':
+                repeat = metadata.setdefault("stale_repeat", {})
+                if case_name == "family_stale_label_without_repeated_bytes":
+                    repeat["replacement_digest"] = repeat.get("original_destination_digest", row.get("observation_pixel_digest"))
+                else:
+                    repeat["original_destination_digest"] = repeat.get("replacement_digest", row.get("observation_pixel_digest"))
+            case 'family_impossible_transition_reachable_pair':
+                transition = metadata.setdefault("impossible_transition", {})
+                edge = transition.get("consulted_edge", {})
+                if edge.get("reachable_row_ids"):
+                    transition["destination_row_id"] = edge["reachable_row_ids"][0]
+            case 'family_gap_event_carrying_pixels':
+                row["pixels"] = [[0]]
+            case 'family_information_control_pixel_difference':
+                row["observation_pixel_digest"] = "sha256:" + "7" * 64
+            case 'family_control_denominator_leak':
+                metadata["denominator_eligible"] = True
+            case 'family_control_visible_source_leak':
+                metadata["provider_visible_fields"] = ["pixels", "source_row_id"]
+            case 'family_episode_disposition_mismatch':
+                row["episode_disposition"] = "valid"
+                row["denominator_class"] = "valid_denominator"
+    if case_name == "family_control_hidden_history_collapse":
+        path = output_dir / "selection" / "frame-metadata.jsonl"
+        rows = _read_jsonl(path)
+        control_episode = next(row["episode_id"] for row in rows if row.get("expected_disposition") == "information_theoretic_control")
+        control_rows = [row for row in rows if row.get("episode_id") == control_episode]
+        first_metadata = control_rows[0].setdefault("metadata", {})
+        hidden_history_id = first_metadata.get("hidden_source_history_id")
+        hidden_label = first_metadata.get("hidden_source_label_digest")
+        for row in control_rows:
+            metadata = row.setdefault("metadata", {})
+            metadata["hidden_source_history_id"] = hidden_history_id
+            metadata["hidden_source_label_digest"] = hidden_label
+        _rewrite_jsonl(path, rows)
+        _launder_split_manifest(output_dir, "selection")
+        return
+    if "splice" in case_name:
+        _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("family") == "conflicting_action_splice")
+    elif "critical" in case_name or "corrupt" in case_name or "replacement" in case_name or "noop" in case_name:
+        _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("family") == "critical_evidence_corruption")
+    elif "reordered" in case_name or "permutation" in case_name:
+        _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("metadata", {}).get("sequence_rule") == "non_identity_permutation")
+    elif "stale" in case_name:
+        _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: "stale_repeat" in row.get("metadata", {}))
+    elif "impossible" in case_name:
+        _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: "impossible_transition" in row.get("metadata", {}))
+    elif "gap" in case_name:
+        _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("event_type") == "gap_unknown")
+    else:
+        _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("expected_disposition") == "information_theoretic_control")
+    return
+
+
+def _apply_reachability_mutation(output_dir: Path, case_name: str) -> None:
+    if case_name in {"reachability_add_impossible_edge", "reachability_change_tile_identity", "reachability_change_unrelated_edge"}:
+        payload = _read_json(output_dir / "reachability-tile-reference.json")
+        if case_name == "reachability_add_impossible_edge":
+            payload["tile_digest"] = "sha256:" + "8" * 64
+            payload["mutation_kind"] = "added-impossible-edge"
+        elif case_name == "reachability_change_unrelated_edge":
+            payload["tile_digest"] = "sha256:" + "7" * 64
+            payload["mutation_kind"] = "changed-unrelated-edge"
+        else:
+            payload["tile_digest"] = "sha256:" + "6" * 64
+        _write_json(output_dir / "reachability-tile-reference.json", payload)
+        return
+    def reach_mutate(row: dict[str, Any]) -> None:
+        trace = row["reachability_composition_trace"]
+        match case_name:
+            case 'reachability_remove_applicable_edge':
+                trace["consulted_edges"][0]["reachable_row_ids"] = []
+            case 'reachability_redirect_applicable_edge':
+                trace["reachable_candidate_pairs"][0]["destination_row_id"] = row["all_112_row_ids"][-1]
+            case 'reachability_alter_destination_action':
+                row["semantic_top_set_outcome"]["top_row_actions"][0]["action_id"] = "FIRE" if row["semantic_top_set_outcome"]["top_row_actions"][0]["action_id"] != "FIRE" else "LEFT"
+                trace["mutation_kind"] = "altered_destination_action"
+            case 'reachability_alter_consulted_edge_list' | 'reachability_omit_consulted_edge':
+                if case_name == "reachability_alter_consulted_edge_list":
+                    trace["consulted_edges"][0]["action_id"] = "FIRE" if trace["consulted_edges"][0]["action_id"] != "FIRE" else "LEFT"
+                else:
+                    trace["consulted_edges"] = []
+            case 'reachability_add_unconsulted_edge_to_trace':
+                trace["consulted_edges"].append({"source_row_id": "foreign", "action_id": "LEFT", "reachable_row_ids": []})
+            case 'reachability_alter_reachable_pair_set':
+                trace["reachable_candidate_pairs"].append({"source_row_id": "foreign", "action_id": "LEFT", "destination_row_id": "foreign"})
+            case 'reachability_alter_retained_candidate_rows':
+                trace["retained_rows"] = list(reversed(trace.get("retained_rows", []))) + ["foreign:retained"]
+            case 'reachability_alter_removed_candidate_rows':
+                trace["removed_rows"] = list(reversed(trace.get("removed_rows", []))) + ["foreign"]
+            case 'reachability_replace_rejection_with_lexical_winner':
+                trace["status"] = "resolved"
+                trace["executed_action"] = "LEFT"
+            case 'reachability_change_executed_action':
+                trace["executed_action"] = "FIRE" if trace.get("executed_action") != "FIRE" else "LEFT"
+            case 'reachability_use_foreign_trace_digest':
+                trace["trace_digest"] = "sha256:" + "9" * 64
+        if case_name != "reachability_use_foreign_trace_digest":
+            trace["trace_digest"] = _trace_digest(trace)
+    if case_name in {"reachability_remove_applicable_edge", "reachability_alter_consulted_edge_list", "reachability_omit_consulted_edge", "reachability_add_unconsulted_edge_to_trace"}:
+        predicate = lambda row: bool(row.get("reachability_composition_trace", {}).get("consulted_edges"))  # noqa: E731
+    elif case_name in {"reachability_redirect_applicable_edge", "reachability_alter_reachable_pair_set"}:
+        predicate = lambda row: bool(row.get("reachability_composition_trace", {}).get("reachable_candidate_pairs"))  # noqa: E731
+    elif case_name == "reachability_alter_removed_candidate_rows":
+        predicate = lambda row: bool(row.get("reachability_composition_trace", {}).get("removed_rows"))  # noqa: E731
+    elif case_name == "reachability_replace_rejection_with_lexical_winner":
+        predicate = lambda row: row.get("reachability_composition_trace", {}).get("status") == "rejected"  # noqa: E731
+    elif case_name == "reachability_change_executed_action":
+        predicate = lambda row: row.get("reachability_composition_trace", {}).get("executed_action") is not None  # noqa: E731
+    else:
+        predicate = lambda row: row.get("reachability_composition_trace") is not None  # noqa: E731
+    _mutate_first_provider_row(output_dir, reach_mutate, predicate=predicate)
+    return
+
+
+def _apply_access_mutation(output_dir: Path, case_name: str) -> None:
+    if case_name in {"access_increment_final_materialization_count", "access_increment_forbidden_access_counter"}:
+        payload = _read_json(output_dir / "phase-access-audits.json")
+        payload["forbidden_final_access_counter"] = int(payload.get("forbidden_final_access_counter", 0)) + 1
+        if case_name == "access_increment_final_materialization_count":
+            payload["final_materialization_count"] = int(payload.get("final_materialization_count", 0)) + 1
+        _write_json(output_dir / "phase-access-audits.json", payload)
+    elif case_name in {"access_add_final_observation_artifact", "access_add_final_score_vector_record", "access_add_final_reachability_trace"}:
+        final_plan = _read_json(output_dir / "final-split-sealed-plan.json")
+        final_id = final_plan["sealed_episode_ids"]["valid"][0]
+        if case_name == "access_add_final_observation_artifact":
+            _write_jsonl(output_dir / "final" / "frame-metadata.jsonl", [{"split": "final", "episode_id": final_id, "frame_id": f"final:{final_id}:frame-00"}])
+        else:
+            row = _read_jsonl(output_dir / "selection" / "provider-evidence.jsonl")[0]
+            row["split"] = "final"
+            row["episode_id"] = final_id
+            if case_name == "access_add_final_reachability_trace":
+                row["reachability_composition_trace"] = {"trace_digest": "sha256:" + "a" * 64}
+            _write_jsonl(output_dir / "final" / "provider-evidence.jsonl", [row])
+    elif case_name == "access_record_calibration_execution":
+        _write_json(output_dir / "selected-calibration.json", {"executed": True})
+    elif case_name == "access_record_architecture_selection_execution":
+        _write_json(output_dir / "selected-architecture.json", {"executed": True})
+    else:
+        report: dict[str, Any] = {
+            "version": REFERENCE_VERIFICATION_VERSION,
+            "verified": True,
+            "gates": [_gate(name, []) for name in _REQUIRED_VERIFICATION_GATES],
+            "primary_failure_code": None,
+            "primary_failure_gate": None,
+        }
+        closure: dict[str, Any] = {"version": CLOSURE_REPORT_VERSION, "supported_status": "reference_instrument_correctness_unresolved", "verification": report}
+        if case_name == "access_change_failed_gate_status_to_passed":
+            closure["verification"]["gates"][0]["status"] = "passed"
+            closure["verification"]["gates"][0]["findings"] = [_finding("status_claim_not_supported", "synthetic failed gate relabelled as passed")]
+            closure["verification"]["gates"][0]["finding_count"] = 1
+        if case_name == "access_remove_required_gate_from_closure_report":
+            closure["verification"]["gates"] = closure["verification"]["gates"][1:]
+        if case_name == "access_change_repository_status_to_correct":
+            closure["supported_status"] = "reference_instrument_correct"
+        closure["closure_report_digest"] = _sha256({key: value for key, value in closure.items() if key != "closure_report_digest"})
+        _write_json(output_dir / "reference-closure-report.json", closure)
+    return
+
+
+def _apply_reference_mutation(output_dir: Path, case_name: str) -> None:
+    if case_name.startswith('evidence_'):
+        _apply_evidence_mutation(output_dir, case_name)
+        return
+    if case_name.startswith('semantic_'):
+        _apply_semantic_mutation(output_dir, case_name)
+        return
+    if case_name.startswith('policy_'):
+        _apply_policy_mutation(output_dir, case_name)
+        return
+    if case_name.startswith('observation_'):
+        _apply_observation_mutation(output_dir, case_name)
+        return
+    if case_name.startswith('seed_'):
+        _apply_seed_mutation(output_dir, case_name)
+        return
+    if case_name.startswith('family_'):
+        _apply_family_mutation(output_dir, case_name)
+        return
+    if case_name.startswith('reachability_'):
+        _apply_reachability_mutation(output_dir, case_name)
+        return
+    if case_name.startswith('access_'):
+        _apply_access_mutation(output_dir, case_name)
+        return
+    raise VPMValidationError(f"unsupported mutation case: {case_name}")
+# fmt: on

--- a/zeromodel/domains/video_action_set/mutation_matrix.py
+++ b/zeromodel/domains/video_action_set/mutation_matrix.py
@@ -163,6 +163,39 @@ def _mutation_result_id(row: Mapping[str, Any]) -> str:
     return str(row[id_fields[0]])
 
 
+def _validate_result_consistency(
+    row: Mapping[str, Any], catalogue_case: Mapping[str, Any]
+) -> None:
+    primary = row["actual_primary_failure_code"]
+    if primary is not None and not isinstance(primary, str):
+        raise VPMValidationError(
+            "mutation result primary failure code must be a string or null"
+        )
+    authoritative_expected = catalogue_case["expected_result_type"] == "detected"
+    if row["expected_detected"] is not authoritative_expected:
+        raise VPMValidationError(
+            "mutation result expected detection contradicts the catalogue"
+        )
+    if row["detected"] is not (primary is not None):
+        raise VPMValidationError(
+            "mutation result detected flag contradicts its primary failure code"
+        )
+    expected_code_matched = (
+        primary == catalogue_case["expected_primary_failure_code"]
+        if authoritative_expected
+        else primary is None
+    )
+    if row["expected_code_matched"] is not expected_code_matched:
+        raise VPMValidationError(
+            "mutation result expected-code flag contradicts authoritative data"
+        )
+    isolation = row["mutation_isolation"]
+    if isolation["isolation_passed"] and isolation["changed_field_count"] == 0:
+        raise VPMValidationError(
+            "mutation result cannot pass isolation without a structural change"
+        )
+
+
 def _validate_matrix_audit(audit: Mapping[str, Any]) -> list[dict[str, Any]]:
     if audit.get("status") == "unavailable" or audit.get("base_verified") is False:
         raise VPMValidationError(
@@ -172,7 +205,9 @@ def _validate_matrix_audit(audit: Mapping[str, Any]) -> list[dict[str, Any]]:
         raise VPMValidationError("mutation audit status must be passed or failed")
     if audit.get("base_verified") is not True:
         raise VPMValidationError("mutation audit must declare a verified baseline")
-    catalogue_ids = [str(case["mutation_id"]) for case in mutation_catalogue()]
+    catalogue = mutation_catalogue()
+    catalogue_by_id = {str(case["mutation_id"]): case for case in catalogue}
+    catalogue_ids = list(catalogue_by_id)
     declared_count = audit.get("declared_mutation_count")
     executable_count = audit.get("executable_mutation_count")
     if declared_count != len(catalogue_ids):
@@ -252,6 +287,7 @@ def _validate_matrix_audit(audit: Mapping[str, Any]) -> list[dict[str, Any]]:
             raise VPMValidationError(
                 "mutation result effect digest must be a non-empty string"
             )
+        _validate_result_consistency(row, catalogue_by_id[_mutation_result_id(row)])
     if audit["status"] == "passed" and any(
         not row["expected_code_matched"]
         or not row["mutation_isolation"]["isolation_passed"]

--- a/zeromodel/domains/video_action_set/mutation_orchestration.py
+++ b/zeromodel/domains/video_action_set/mutation_orchestration.py
@@ -1,0 +1,190 @@
+"""Video action-set mutation orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import (
+    Any,
+    Sequence,
+)
+from zeromodel.domains.video_action_set.mutation_audit import (
+    build_mutation_audit_payload as _build_mutation_audit_payload,
+    build_repeated_mutation_audit_payload as _build_repeated_mutation_audit_payload,
+    _changed_snapshot_files,
+    evaluate_mutation_case as _evaluate_mutation_case,
+    _mutation_isolation_report,
+)
+from zeromodel.domains.video_action_set.mutation_matrix import (
+    MUTATION_MATRIX_VERSION,
+    mutation_catalogue,
+    validate_mutation_catalogue,
+)
+from zeromodel.domains.video_action_set.reference_verification import _finding
+from zeromodel.domains.video_action_set.verification import (
+    build_unavailable_repeated_mutation_audit as _build_unavailable_repeated_mutation_audit,
+    build_verification_closure as _build_verification_closure,
+    verification_summary as _verification_summary,
+)
+from zeromodel.domains.video_action_set.artifact_io import (
+    _read_json,
+    _sha256,
+)
+from zeromodel.domains.video_action_set.mutation_filesystem import (
+    _apply_reference_mutation,
+    _directory_snapshot,
+    _mutation_structural_snapshot,
+)
+from zeromodel.domains.video_action_set.verification_orchestration import (
+    verify_reference_instrument,
+    verify_reference_read_only,
+)
+
+
+def run_reference_mutation_audit(
+    output_dir: Path, repo_root: Path, *, mutation_names: Sequence[str] | None = None
+) -> dict[str, Any]:
+    import shutil
+    import tempfile
+
+    requested = (
+        None if mutation_names is None else {str(name) for name in mutation_names}
+    )
+    catalogue = mutation_catalogue()
+    selected_cases = tuple(
+        case
+        for case in catalogue
+        if requested is None or case["mutation_id"] in requested
+    )
+    catalogue_findings = validate_mutation_catalogue()
+    if requested is not None:
+        selected_names = {str(case["mutation_id"]) for case in selected_cases}
+        catalogue_findings.extend(
+            _finding(
+                "mutation_not_declared",
+                "requested mutation is not declared",
+                mutation=name,
+            )
+            for name in sorted(requested - selected_names)
+        )
+    base = verify_reference_instrument(output_dir, repo_root)
+    if not base["verified"] or catalogue_findings:
+        return _build_mutation_audit_payload(
+            matrix_version=MUTATION_MATRIX_VERSION,
+            catalogue=catalogue,
+            selected_cases=selected_cases,
+            catalogue_findings=catalogue_findings,
+            results=(),
+            base_verified=False,
+            base_primary_failure_code=base.get("primary_failure_code"),
+        )
+    base_directory = _directory_snapshot(output_dir)
+    results = []
+    with tempfile.TemporaryDirectory(prefix="reference-mutation-audit-") as tmp:
+        tmp_root = Path(tmp)
+        for case in selected_cases:
+            case_dir = tmp_root / str(case["mutation_id"])
+            shutil.copytree(output_dir, case_dir)
+            application_error = None
+            try:
+                _apply_reference_mutation(case_dir, str(case["mutation_id"]))
+                changed_files = _changed_snapshot_files(
+                    base_directory, _directory_snapshot(case_dir)
+                )
+                before = _mutation_structural_snapshot(
+                    output_dir, only_files=changed_files
+                )
+                after = _mutation_structural_snapshot(
+                    case_dir, only_files=changed_files
+                )
+                isolation = _mutation_isolation_report(before, after, case)
+                report = verify_reference_instrument(
+                    case_dir,
+                    repo_root,
+                    enabled_gates=case["validation_metadata"]["gate_scope"],
+                    stop_after_first_failure=True,
+                )
+            except Exception as exc:  # pragma: no cover - historical audit boundary.
+                application_error = type(exc).__name__
+                isolation = {
+                    "changed_fields": [],
+                    "expected_changed_files": list(
+                        case.get("expected_changed_files", [])
+                    ),
+                    "unexpected_changed_fields": [],
+                    "changed_field_count": 0,
+                    "isolation_passed": False,
+                    "mutation_effect_digest": "sha256:application-error",
+                }
+                report = {"gates": []}
+            results.append(
+                _evaluate_mutation_case(
+                    case=case,
+                    report=report,
+                    isolation=isolation,
+                    application_error=application_error,
+                )
+            )
+    return _build_mutation_audit_payload(
+        matrix_version=MUTATION_MATRIX_VERSION,
+        catalogue=catalogue,
+        selected_cases=selected_cases,
+        catalogue_findings=catalogue_findings,
+        results=results,
+    )
+
+
+def run_repeated_reference_mutation_audit(
+    output_dir: Path, repo_root: Path, *, mutation_names: Sequence[str] | None = None
+) -> dict[str, Any]:
+    first = run_reference_mutation_audit(
+        output_dir, repo_root, mutation_names=mutation_names
+    )
+    second = run_reference_mutation_audit(
+        output_dir, repo_root, mutation_names=mutation_names
+    )
+    return _build_repeated_mutation_audit_payload(
+        matrix_version=MUTATION_MATRIX_VERSION, first=first, second=second
+    )
+
+
+def build_reference_closure_report(
+    output_dir: Path, repo_root: Path, *, include_mutation_audit: bool = True
+) -> dict[str, Any]:
+    verification = verify_reference_instrument(output_dir, repo_root)
+    repeated = (
+        run_repeated_reference_mutation_audit(output_dir, repo_root)
+        if include_mutation_audit
+        else _build_unavailable_repeated_mutation_audit()
+    )
+    read_only = verify_reference_read_only(output_dir, repo_root)
+    episode_plan_path = output_dir / "episode-plan.json"
+    plans = (
+        _read_json(episode_plan_path).get("splits", {})
+        if episode_plan_path.exists()
+        else {}
+    )
+    return _build_verification_closure(
+        verification=verification,
+        repeated_mutation_audit=repeated,
+        read_only=read_only,
+        split_plan_identities={
+            split: _sha256(context) for split, context in plans.items()
+        },
+    )
+
+
+def verify_instrument(output_dir: Path, repo_root: Path) -> dict[str, Any]:
+    closure = build_reference_closure_report(
+        output_dir, repo_root, include_mutation_audit=False
+    )
+    return _verification_summary(closure)
+
+
+def _run_adversarial_mutation_checks(output_dir: Path) -> list[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    audit = run_reference_mutation_audit(output_dir, repo_root)
+    return [
+        row["mutation"]
+        for row in audit.get("mutations", [])
+        if not row.get("expected_code_matched", False)
+    ]

--- a/zeromodel/domains/video_action_set/report_rendering.py
+++ b/zeromodel/domains/video_action_set/report_rendering.py
@@ -1,0 +1,46 @@
+"""Pure human-readable projections for video action-set artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def benchmark_readme() -> str:
+    return (
+        "# Video Action-Set Reachability Benchmark v1\n\n"
+        "This directory contains the frozen contract identities and the "
+        "materialized development, calibration, and selection benchmark evidence.\n"
+    )
+
+
+def reproduction_instructions() -> str:
+    return (
+        "Run the benchmark CLI with `--freeze-benchmark`, `--build-development`, "
+        "`--build-calibration`, `--build-selection`,\n"
+        "`--audit-evidence-completeness`, `--audit-canonical-providers`, and "
+        "`--verify-prospective-instrument`.\n"
+    )
+
+
+def runtime_profile_reference(profiles: Sequence[Mapping[str, Any]]) -> str:
+    return _runtime_profile("Runtime Profile Reference", profiles)
+
+
+def runtime_profile_optimized(profiles: Sequence[Mapping[str, Any]]) -> str:
+    return _runtime_profile("Runtime Profile Optimized", profiles)
+
+
+def _runtime_profile(title: str, profiles: Sequence[Mapping[str, Any]]) -> str:
+    return (
+        "\n".join(
+            [f"# {title}", ""]
+            + [
+                f"- {item['provider_id']}: "
+                f"{item['mean_seconds_per_frame']:.6f}s/frame over "
+                f"{item['frame_count']} frames"
+                for item in profiles
+            ]
+        )
+        + "\n"
+    )

--- a/zeromodel/domains/video_action_set/verification_gates.py
+++ b/zeromodel/domains/video_action_set/verification_gates.py
@@ -1,0 +1,620 @@
+"""Reference verification gate orchestration for video action-set artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import (
+    Any,
+    Mapping,
+)
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.artifact_io import (
+    _read_json,
+    _read_jsonl,
+    _sha256,
+)
+from zeromodel.domains.video_action_set.build_orchestration import (
+    _materialize_records,
+    _measured_phase_access_counts,
+)
+from zeromodel.domains.video_action_set.contracts import (
+    EPISODE_PLAN_VERSION,
+    SEED_DERIVATION_VERSION,
+    SPLICE_MASK_VERSION,
+    TARGET_REGION_ID,
+)
+from zeromodel.domains.video_action_set.episode_families import (
+    denominator_class as _denominator_class,
+    episode_disposition as _episode_disposition,
+    expected_frame_disposition,
+)
+from zeromodel.domains.video_action_set.episode_planning import (
+    episode_ids_by_family as _episode_ids_by_family,
+    final_observation_provenance as _final_observation_provenance,
+    validate_episode_plan_collection as _validate_episode_plan_collection,
+)
+from zeromodel.domains.video_action_set.evidence_audit import (
+    access_prohibition_gate as _build_access_prohibition_gate,
+)
+from zeromodel.domains.video_action_set.frame_family_kernels import (
+    apply_conflicting_splice as _apply_conflicting_splice,
+    apply_critical_corruption as _apply_critical_corruption,
+    critical_coordinates as _critical_coordinates,
+    final_visible_target_action_evidence as _final_visible_target_action_evidence,
+)
+from zeromodel.domains.video_action_set.materialization_reachability import (
+    tile_edge as _tile_edge,
+)
+from zeromodel.domains.video_action_set.materialization_validation import (
+    validate_control_episode_records,
+)
+from zeromodel.domains.video_action_set.observation_replay import (
+    replay_observation_operation_chain as _replay_observation_operation_chain_core,
+    validate_observation_operation_chain as _validate_observation_operation_chain_core,
+)
+from zeromodel.domains.video_action_set.observation_universe import (
+    _canonical_observation_digest_index,
+    _valid_transformed_observation_digest_index,
+)
+from zeromodel.domains.video_action_set.provider_measurement import (
+    provider_version as _provider_version,
+)
+from zeromodel.domains.video_action_set.reachability_composition import (
+    gap_reachability_state as _gap_reachability_state,
+    state_from_trace as _state_from_trace,
+    compose_reachability_trace,
+    validate_reachability_trace,
+)
+from zeromodel.domains.video_action_set.reference_verification import (
+    _expected_semantic_for_row,
+    _finding,
+    _gate,
+)
+from zeromodel.domains.video_action_set.transformations import (
+    _validate_transformation_parameters,
+)
+from zeromodel.domains.video_action_set.dto import BenchmarkIdentityDTO
+
+BenchmarkIdentity = BenchmarkIdentityDTO
+_NON_FINAL_SPLITS = ("development", "calibration", "selection")
+_ALL_SPLITS = ("development", "calibration", "selection", "final")
+
+
+# fmt: off
+def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, Any]:
+    return _replay_observation_operation_chain_core(
+        chain,
+        conflicting_splice_executor=_apply_conflicting_splice,
+        critical_corruption_executor=_apply_critical_corruption,  # type: ignore[arg-type]
+    )
+
+
+def validate_observation_operation_chain(record: Mapping[str, Any]) -> str:
+    return _validate_observation_operation_chain_core(
+        record,
+        conflicting_splice_executor=_apply_conflicting_splice,
+        critical_corruption_executor=_apply_critical_corruption,  # type: ignore[arg-type]
+    )
+
+
+def _expected_split_counts() -> dict[str, int]:
+    return {
+        "development": 112,
+        "calibration": 448,
+        "selection": 1008,
+    }
+
+
+def _seed_and_plan_gate(output_dir: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    identity: BenchmarkIdentity = context["identity"]
+    row_actions = context["row_actions"]
+    plans_by_split = context["plans"]
+    try:
+        plan_payload = _read_json(output_dir / "episode-plan.json")
+        final_payload = _read_json(output_dir / "final-split-sealed-plan.json")
+    except FileNotFoundError:
+        return _gate("seed_and_plan", [_finding("expected_file_missing", "episode plan file is missing")], unavailable=False)
+    if plan_payload.get("version") != EPISODE_PLAN_VERSION or plan_payload.get("seed_derivation_version") != SEED_DERIVATION_VERSION:
+        findings.append(_finding("episode_seed_derivation_mismatch", "episode plan schema or seed derivation version is unsupported"))
+    seen: dict[str, str] = {}
+    for split in _NON_FINAL_SPLITS:
+        stored_split = plan_payload.get("splits", {}).get(split, {})
+        stored_plans = list(stored_split.get("episodes", []))
+        expected_plans = list(plans_by_split[split])
+        if len(stored_plans) != len(expected_plans):
+            findings.append(_finding("sealed_episode_identity_mismatch", "stored split plan count does not match deterministic regenerated plan count", split=split))
+            continue
+        for expected, stored in zip(expected_plans, stored_plans):
+            episode_id = str(stored.get("episode_id"))
+            if episode_id in seen:
+                findings.append(_finding("duplicate_episode_id", "episode id is duplicated across sealed split plans", episode_id=episode_id, previous_split=seen[episode_id], split=split))
+            seen[episode_id] = split
+            if stored.get("split") != split or not episode_id.startswith(f"{split}:"):
+                findings.append(_finding("episode_split_reassignment", "episode id or split field crosses its sealed split boundary", episode_id=episode_id, split=split))
+            if stored.get("derived_seed_identity") != expected.get("derived_seed_identity") or stored.get("episode_seed") != expected.get("episode_seed"):
+                findings.append(_finding("episode_seed_derivation_mismatch", "stored episode seed lineage does not match deterministic derivation", episode_id=episode_id))
+                if max_findings is not None and len(findings) >= max_findings:
+                    return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[item]) for item in _ALL_SPLITS)})
+                continue
+            if stored.get("source_row_id") != expected.get("source_row_id") or stored.get("secondary_row_id") != expected.get("secondary_row_id"):
+                findings.append(_finding("episode_seed_derivation_mismatch", "stored source-row lineage does not match deterministic derivation", episode_id=episode_id))
+                if max_findings is not None and len(findings) >= max_findings:
+                    return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[item]) for item in _ALL_SPLITS)})
+                continue
+            if stored.get("episode_disposition") != expected.get("episode_disposition") or stored.get("denominator_class") != expected.get("denominator_class"):
+                findings.append(_finding("family_disposition_mismatch", "stored episode disposition fields do not match deterministic derivation", episode_id=episode_id))
+            if dict(stored) != expected:
+                findings.append(_finding("sealed_episode_identity_mismatch", "stored sealed episode plan does not match deterministic regeneration", episode_id=episode_id))
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[item]) for item in _ALL_SPLITS)})
+    expected_final = {
+        "version": EPISODE_PLAN_VERSION,
+        "seed_derivation_version": SEED_DERIVATION_VERSION,
+        "split": "final",
+        "plan_only": True,
+        "materialization_prohibited": True,
+        "episode_counts": {
+            "valid": 112,
+            "frame_invalid": 56,
+            "temporal_negative": 56,
+            "information_control": 28,
+        },
+        "frame_count": 1008,
+        "sealed_episode_ids": _episode_ids_by_family(plans_by_split["final"]),
+        "episodes": plans_by_split["final"],
+        "seed_commitment": identity.seed_digest,
+    }
+    expected_final = expected_final | {"sealed_plan_digest": _sha256(expected_final)}
+    for plan in final_payload.get("episodes", []):
+        if plan.get("final_observation_provenance") != _final_observation_provenance("final"):
+            findings.append(
+                _finding(
+                    "final_observation_provenance_mismatch",
+                    "final split episode claims materialized observation provenance",
+                    episode_id=plan.get("episode_id"),
+                )
+            )
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[split]) for split in _ALL_SPLITS)})
+    if final_payload != expected_final:
+        findings.append(_finding("sealed_episode_identity_mismatch", "final sealed split identity does not match deterministic regeneration"))
+        if max_findings is not None and len(findings) >= max_findings:
+            return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[split]) for split in _ALL_SPLITS)})
+    digest_payload = _read_json(output_dir / "final-split-sealed-digest.json")
+    if digest_payload.get("digest") != expected_final["sealed_plan_digest"]:
+        findings.append(_finding("sealed_episode_identity_mismatch", "final sealed split digest sidecar does not match the final sealed plan"))
+        if max_findings is not None and len(findings) >= max_findings:
+            return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[split]) for split in _ALL_SPLITS)})
+    try:
+        _validate_episode_plan_collection(context["identity"], plans_by_split, row_actions)
+    except VPMValidationError as exc:
+        findings.append(_finding("episode_seed_derivation_mismatch", "authoritative regenerated plan collection failed validation", error=str(exc)))
+    return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[split]) for split in _ALL_SPLITS)})
+
+
+def _episode_regeneration_gate(output_dir: Path, repo_root: Path, *, max_findings: int | None = None) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    for split in _NON_FINAL_SPLITS:
+        path = output_dir / split / "frame-metadata.jsonl"
+        if not path.exists():
+            findings.append(_finding("expected_record_missing", "split frame metadata is missing", split=split))
+            continue
+        stored_rows = _read_jsonl(path)
+        expected_rows = _cached_materialized_metadata(repo_root, split)
+        counts[f"{split}_stored_observations"] = len(stored_rows)
+        counts[f"{split}_expected_observations"] = len(expected_rows)
+        if len(stored_rows) != len(expected_rows):
+            findings.append(_finding("expected_record_missing", "stored observation count does not match regenerated count", split=split))
+        expected_by_key = {(row["episode_id"], int(row["sequence_number"])): row for row in expected_rows}
+        stored_by_key = {(row.get("episode_id"), int(row.get("sequence_number", -1))): row for row in stored_rows}
+        for key in sorted(set(expected_by_key) - set(stored_by_key)):
+            findings.append(_finding("expected_record_missing", "regenerated observation is absent from stored frame metadata", split=split, episode_id=key[0], sequence_number=key[1]))
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("episode_regeneration", findings, counts=counts)
+        for key in sorted(set(stored_by_key) - set(expected_by_key)):
+            findings.append(_finding("orphan_observation_record", "stored frame metadata has no sealed regenerated observation", split=split, episode_id=key[0], sequence_number=key[1]))
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("episode_regeneration", findings, counts=counts)
+        for key in sorted(set(expected_by_key) & set(stored_by_key)):
+            expected = expected_by_key[key]
+            stored = stored_by_key[key]
+            if stored.get("frame_id") != expected.get("frame_id") or stored.get("clip_id") != expected.get("clip_id"):
+                findings.append(_finding("frame_identity_mismatch", "stored frame identity does not match regenerated identity", split=split, episode_id=key[0], sequence_number=key[1]))
+            if stored.get("event_type") == "gap_unknown" and stored.get("pixels") is not None:
+                findings.append(_finding("gap_event_has_pixels", "declared gap event carries ordinary pixels", split=split, episode_id=key[0], sequence_number=key[1]))
+            if stored.get("event_type") != expected.get("event_type") or stored.get("gap_declaration") != expected.get("gap_declaration"):
+                findings.append(_finding("gap_event_structure_mismatch", "stored event type or gap declaration does not match regenerated observation", split=split, episode_id=key[0], sequence_number=key[1]))
+            if stored.get("observation_pixel_digest") != expected.get("observation_pixel_digest"):
+                code = "observation_digest_mismatch" if stored.get("observation_pixel_digest") and expected.get("observation_pixel_digest") else "observation_bytes_mismatch"
+                findings.append(_finding(code, "stored observation identity does not match regenerated pixel bytes", split=split, episode_id=key[0], sequence_number=key[1]))
+            comparable_fields = ("family", "expected_disposition", "expected_row", "expected_action", "actual_executed_action", "action_known")
+            for field in comparable_fields:
+                if stored.get(field) != expected.get(field):
+                    findings.append(_finding("family_regeneration_mismatch", "stored frame classification does not match regenerated episode", split=split, episode_id=key[0], sequence_number=key[1], field=field))
+                    break
+            stored_meta = stored.get("metadata", {})
+            expected_meta = expected.get("metadata", {})
+            for field in ("seed_digest", "derived_seed_identity", "episode_plan_digest", "frame_seed_identity"):
+                if stored_meta.get(field) != expected_meta.get(field):
+                    findings.append(_finding("family_regeneration_mismatch", "stored frame seed or plan metadata does not match regenerated episode", split=split, episode_id=key[0], sequence_number=key[1], field=field))
+                    break
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("episode_regeneration", findings, counts=counts)
+    return _gate("episode_regeneration", findings, counts=counts)
+
+
+def _semantic_outcome_gate(output_dir: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    row_ids = context["row_ids"]
+    row_actions = context["row_actions"]
+    counts = {"provider_score_records": 0}
+    semantic_cache: dict[str, Any] = {}
+    for split in _NON_FINAL_SPLITS:
+        for row in _read_jsonl(output_dir / split / "provider-evidence.jsonl"):
+            counts["provider_score_records"] += 1
+            if row.get("policy_artifact_id") != context["policy"].artifact_id:
+                findings.append(_finding("policy_action_mapping_mismatch", "provider row references a foreign policy artifact", split=split, frame_id=row.get("frame_id")))
+                continue
+            if row.get("provider_version") != _provider_version(str(row.get("provider_id"))):
+                findings.append(_finding("provider_contract_mismatch", "provider row references a foreign provider contract", split=split, frame_id=row.get("frame_id"), provider_id=row.get("provider_id")))
+                continue
+            expected, evidence_findings = _expected_semantic_for_row(row, row_actions, row_ids, semantic_cache)
+            findings.extend(evidence_findings)
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("semantic_outcome", findings, counts=counts)
+            if expected is None:
+                continue
+            payload = row.get("semantic_top_set_outcome", {})
+            payload_top_rows = {str(item) for item in payload.get("top_row_ids", [])}
+            expected_top_rows = set(expected.top_row_ids)
+            if payload_top_rows != expected_top_rows or set(row.get("top_row_ids", [])) != expected_top_rows:
+                findings.append(_finding("semantic_status_mismatch", "stored semantic top-row set does not match reconstructed top set", split=split, frame_id=row.get("frame_id")))
+            payload_actions = {str(item.get("row_id")): str(item.get("action_id")) for item in payload.get("top_row_actions", [])}
+            if payload_actions != {row_id: row_actions[row_id] for row_id in expected_top_rows}:
+                findings.append(_finding("policy_action_mapping_mismatch", "stored semantic row/action mapping does not match authoritative policy mapping", split=split, frame_id=row.get("frame_id")))
+            if payload.get("status") != expected.status or row.get("semantic_status") != expected.status:
+                findings.append(_finding("semantic_status_mismatch", "stored semantic status does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
+            stored_resolved_row = payload.get("resolved_row_id", row.get("resolved_row"))
+            stored_resolved_action = payload.get("resolved_action_id", row.get("resolved_action"))
+            if expected.resolved_row_id is None and stored_resolved_row is not None:
+                findings.append(_finding("resolved_row_not_permitted", "stored semantic outcome resolves a row where the frozen rules do not permit one", split=split, frame_id=row.get("frame_id")))
+            elif stored_resolved_row != expected.resolved_row_id or row.get("resolved_row") != expected.resolved_row_id:
+                findings.append(_finding("semantic_status_mismatch", "stored resolved row does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
+            if expected.resolved_action_id is None and stored_resolved_action is not None:
+                findings.append(_finding("resolved_action_not_permitted", "stored semantic outcome resolves an action where the frozen rules do not permit one", split=split, frame_id=row.get("frame_id")))
+            elif stored_resolved_action != expected.resolved_action_id or row.get("resolved_action") != expected.resolved_action_id:
+                findings.append(_finding("semantic_status_mismatch", "stored resolved action does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
+            if payload.get("rejection_reason") != expected.rejection_reason:
+                findings.append(_finding("semantic_status_mismatch", "stored semantic rejection reason does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
+            if payload.get("semantic_outcome_digest") != expected.semantic_outcome_digest or row.get("semantic_outcome_digest") != expected.semantic_outcome_digest:
+                findings.append(_finding("semantic_outcome_digest_mismatch", "stored semantic outcome digest does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
+            if row.get("winner_row") != expected.resolved_row_id:
+                code = "resolved_row_not_permitted" if expected.resolved_row_id is None and row.get("winner_row") is not None else "semantic_status_mismatch"
+                findings.append(_finding(code, "stored winner row does not match semantic reconstruction", split=split, frame_id=row.get("frame_id")))
+            if row.get("winner_action") != expected.resolved_action_id:
+                code = "resolved_action_not_permitted" if expected.resolved_action_id is None and row.get("winner_action") is not None else "semantic_status_mismatch"
+                findings.append(_finding(code, "stored winner action does not match semantic reconstruction", split=split, frame_id=row.get("frame_id")))
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("semantic_outcome", findings, counts=counts)
+    return _gate("semantic_outcome", findings, counts=counts)
+
+
+def _validate_family_frame_contracts(
+    split: str,
+    episode_id: str,
+    ordered: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+) -> None:
+    for row in ordered:
+        episode_family = row.get("episode_family")
+        if episode_family not in {"valid", "frame_invalid", "temporal_negative", "information_control"}:
+            findings.append(_finding("family_disposition_mismatch", "frame omits a recognized episode family", split=split, episode_id=episode_id))
+            continue
+        if row.get("episode_disposition") != _episode_disposition(str(episode_family)):
+            findings.append(_finding("family_disposition_mismatch", "frame episode disposition does not match its family", split=split, episode_id=episode_id))
+        if row.get("denominator_class") != _denominator_class(str(episode_family)):
+            findings.append(_finding("family_disposition_mismatch", "frame denominator class does not match its family", split=split, episode_id=episode_id))
+        if not row.get("frame_disposition"):
+            findings.append(_finding("family_disposition_mismatch", "frame disposition is missing", split=split, episode_id=episode_id))
+        intervention = row.get("metadata", {}).get("family_intervention", {})
+        mutation_kind = intervention.get("family_id") if episode_family != "valid" else None
+        expected_frame = expected_frame_disposition(str(episode_family), None if mutation_kind is None else str(mutation_kind), int(row.get("sequence_number", -1)), intervention)
+        if row.get("frame_disposition") != expected_frame:
+            findings.append(_finding("frame_disposition_mismatch", "frame disposition does not match independent family derivation", split=split, episode_id=episode_id, frame_id=row.get("frame_id"), expected=expected_frame, actual=row.get("frame_disposition")))
+        provenance_status = validate_observation_operation_chain(row)
+        if provenance_status != "ok":
+            findings.append(_finding(provenance_status, "stored observation operation chain does not independently replay to the emitted observation", split=split, episode_id=episode_id, frame_id=row.get("frame_id")))
+    if any(row.get("event_type") == "gap_unknown" and (row.get("observation_pixel_digest") is not None or row.get("pixels") is not None) for row in ordered):
+        findings.append(_finding("gap_event_has_pixels", "typed gap event carries ordinary observation identity", split=split, episode_id=episode_id))
+
+
+def _validate_family_intervention_contracts(
+    split: str,
+    episode_id: str,
+    family: Any,
+    ordered: list[dict[str, Any]],
+    row_actions: Mapping[str, str],
+    findings: list[dict[str, Any]],
+    has_transformed_valid_collision: Any,
+) -> None:
+    if family == "conflicting_action_splice":
+        for row in ordered:
+            metadata = row.get("metadata", {})
+            trace = metadata.get("family_intervention_trace", {})
+            if metadata.get("source_action_id") == metadata.get("competitor_action_id"):
+                findings.append(_finding("family_contract_violation", "conflicting splice uses two rows governed by the same action", split=split, episode_id=episode_id))
+            if int(trace.get("primary_contributing_pixel_count", 0)) <= 0 or int(trace.get("secondary_contributing_pixel_count", 0)) <= 0:
+                findings.append(_finding("family_contract_violation", "conflicting splice does not include nonzero contributions from both sources", split=split, episode_id=episode_id))
+            splice_counts = trace.get("action_relevant_region_contribution_counts", {})
+            if int(splice_counts.get("primary_target_pixel_count", 0)) <= 0 or int(splice_counts.get("secondary_additive_target_pixel_count", 0)) <= 0:
+                findings.append(_finding("family_contract_violation", "conflicting splice lacks two visible target evidence contributions", split=split, episode_id=episode_id))
+            if trace.get("splice_mask_version") != SPLICE_MASK_VERSION or trace.get("target_region_id") != TARGET_REGION_ID:
+                findings.append(_finding("family_contract_violation", "conflicting splice trace does not use the frozen target-evidence mask", split=split, episode_id=episode_id))
+            if trace.get("output_observation_digest") != row.get("observation_pixel_digest"):
+                findings.append(_finding("family_regeneration_mismatch", "conflicting splice output digest does not match stored observation", split=split, episode_id=episode_id))
+            try:
+                replay = replay_observation_operation_chain(metadata["observation_operation_chain"])
+                visible_action_evidence = _final_visible_target_action_evidence(replay["pixels"], row_actions)
+                if not visible_action_evidence["conflicting_action_evidence_present"]:
+                    findings.append(_finding("conflicting_action_evidence_absent", "final visible splice target evidence does not imply at least two policy actions", split=split, episode_id=episode_id))
+                if trace.get("visible_action_evidence_digest") != visible_action_evidence["visible_action_evidence_digest"]:
+                    findings.append(_finding("conflicting_action_evidence_absent", "stored visible-action splice evidence does not match independent reconstruction", split=split, episode_id=episode_id))
+            except (KeyError, TypeError, VPMValidationError, ValueError):
+                findings.append(_finding("final_observation_provenance_mismatch", "conflicting splice operation chain could not be replayed for visible-action reconstruction", split=split, episode_id=episode_id))
+            if _canonical_observation_digest_index().get(str(row.get("observation_pixel_digest"))):
+                findings.append(_finding("invalid_family_valid_state_collision", "conflicting splice output decodes as a canonical valid observation", split=split, episode_id=episode_id))
+            elif has_transformed_valid_collision(row.get("observation_pixel_digest")):
+                findings.append(_finding("invalid_family_valid_transformation_collision", "conflicting splice output decodes as a bounded transformed valid observation", split=split, episode_id=episode_id))
+    elif family == "critical_evidence_corruption":
+        for row in ordered:
+            metadata = row.get("metadata", {})
+            trace = metadata.get("family_intervention_trace", {})
+            changes = trace.get("changes", [])
+            if not changes:
+                findings.append(_finding("family_contract_violation", "critical corruption has an empty changed-coordinate set", split=split, episode_id=episode_id))
+            if trace.get("changed_pixel_count") == 0:
+                findings.append(_finding("family_no_op", "critical corruption is a no-op", split=split, episode_id=episode_id))
+            if _canonical_observation_digest_index().get(str(row.get("observation_pixel_digest"))):
+                findings.append(_finding("invalid_family_valid_state_collision", "critical corruption output decodes as a canonical valid observation", split=split, episode_id=episode_id))
+            elif has_transformed_valid_collision(row.get("observation_pixel_digest")):
+                findings.append(_finding("invalid_family_valid_transformation_collision", "critical corruption output decodes as a bounded transformed valid observation", split=split, episode_id=episode_id))
+            for change in changes:
+                coord = (int(change.get("y", -1)), int(change.get("x", -1)))
+                if coord not in set(_critical_coordinates()) or change.get("original") == change.get("replacement"):
+                    findings.append(_finding("family_contract_violation", "critical corruption changed a non-critical coordinate or preserved the original value", split=split, episode_id=episode_id))
+    elif family == "bounded_translation" or family == "bounded_photometric" or family == "bounded_translation_photometric" or family == "bounded_translation_occlusion" or family == "compound_bounded" or family == "exact":
+        for row in ordered:
+            metadata = row.get("metadata", {})
+            try:
+                _validate_transformation_parameters(metadata.get("transformation_parameters", {}))
+            except (KeyError, VPMValidationError) as exc:
+                findings.append(_finding("family_contract_violation", "valid transformation parameters violate the frozen bounds", split=split, episode_id=episode_id, error=str(exc)))
+
+
+def _validate_family_temporal_contracts(
+    split: str,
+    episode_id: str,
+    ordered: list[dict[str, Any]],
+    reachability_tile: Mapping[str, Any],
+    findings: list[dict[str, Any]],
+) -> None:
+    if any(row.get("expected_disposition") == "information_theoretic_control" for row in ordered):
+        code = validate_control_episode_records(ordered)
+        if code != "ok":
+            findings.append(_finding(code, "information control records violate byte-identity, hidden-history, or denominator rules", split=split, episode_id=episode_id))
+    if any("stale_repeat" in row.get("metadata", {}) for row in ordered):
+        repeat_rows = [row for row in ordered if "stale_repeat" in row.get("metadata", {})]
+        for row in repeat_rows:
+            repeat = row["metadata"]["stale_repeat"]
+            if repeat.get("original_destination_digest") == repeat.get("replacement_digest"):
+                findings.append(_finding("family_contract_violation", "stale repeat does not replace the destination with different bytes", split=split, episode_id=episode_id))
+            if row.get("observation_pixel_digest") != repeat.get("replacement_digest"):
+                findings.append(_finding("family_regeneration_mismatch", "stale repeat stored digest does not match replacement digest", split=split, episode_id=episode_id))
+    if any("impossible_transition" in row.get("metadata", {}) for row in ordered):
+        for row in ordered:
+            transition = row.get("metadata", {}).get("impossible_transition")
+            if not transition:
+                continue
+            edge = _tile_edge(reachability_tile, str(transition["source_row_id"]), str(transition["source_action_id"]))
+            if str(transition["destination_row_id"]) in set(edge["reachable_row_ids"]):
+                findings.append(_finding("transition_classification_mismatch", "impossible-transition episode contains at least one reachable pair", split=split, episode_id=episode_id))
+    if any(row.get("metadata", {}).get("sequence_rule") == "non_identity_permutation" for row in ordered):
+        materialized = [row.get("metadata", {}).get("original_frame_index") for row in ordered]
+        if materialized == sorted(materialized) or sorted(materialized) != list(range(len(ordered))):
+            findings.append(_finding("family_contract_violation", "reordered-frame metadata is not a non-identity complete permutation", split=split, episode_id=episode_id))
+
+
+def _family_contract_gate(output_dir: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    counts = {"family_records_checked": 0}
+    row_actions = context["row_actions"]
+    reachability_tile = context["reachability_tile"]
+    canonical_digest_set = set(_canonical_observation_digest_index())
+    transformed_valid_digest_set: set[str] | None = None
+
+    def has_transformed_valid_collision(digest: str | None) -> bool:
+        nonlocal transformed_valid_digest_set
+        if digest is None:
+            return False
+        if transformed_valid_digest_set is None:
+            transformed_valid_digest_set = set(_valid_transformed_observation_digest_index()["digest_index"]) - canonical_digest_set
+        return str(digest) in transformed_valid_digest_set
+
+    for split in _NON_FINAL_SPLITS:
+        by_episode: dict[str, list[dict[str, Any]]] = {}
+        for row in _read_jsonl(output_dir / split / "frame-metadata.jsonl"):
+            by_episode.setdefault(str(row.get("episode_id")), []).append(row)
+        for episode_id, rows in by_episode.items():
+            ordered = sorted(rows, key=lambda item: int(item.get("sequence_number", -1)))
+            counts["family_records_checked"] += len(ordered)
+            family = ordered[0].get("family")
+            _validate_family_frame_contracts(split, episode_id, ordered, findings)
+            _validate_family_intervention_contracts(
+                split, episode_id, family, ordered, row_actions, findings, has_transformed_valid_collision
+            )
+            _validate_family_temporal_contracts(
+                split, episode_id, ordered, reachability_tile, findings
+            )
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("family_contract", findings, counts=counts)
+    return _gate("family_contract", findings, counts=counts)
+
+
+def _reachability_gate(output_dir: Path, repo_root: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    counts = {"reachability_traces_checked": 0}
+    row_ids = context["row_ids"]
+    row_actions = context["row_actions"]
+    reachability_tile = context["reachability_tile"]
+    semantic_cache: dict[str, Any] = {}
+    for split in _NON_FINAL_SPLITS:
+        frames = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
+        evidence_rows = _read_jsonl(output_dir / split / "provider-evidence.jsonl")
+        by_frame_provider = {(row.get("frame_id"), row.get("provider_id")): row for row in evidence_rows}
+        reachability_state: dict[str, Mapping[str, Any] | None] = {"P1": None, "P2": None, "P3": None}
+        expected_frames = _cached_materialized_metadata(repo_root, split)
+        # Use stored order only after sorting by the deterministic frame identity. This keeps JSONL row order non-semantic.
+        if len(expected_frames) != len(frames):
+            expected_frames = sorted(frames, key=lambda row: (str(row.get("episode_id")), int(row.get("sequence_number", -1))))
+        for frame in expected_frames:
+            if frame.get("event_type") == "gap_unknown" or frame.get("observation_pixel_digest") is None:
+                for provider_id in reachability_state:
+                    reachability_state[provider_id] = _gap_reachability_state(frame)
+                continue
+            for provider_id in ("P1", "P2", "P3"):
+                row = by_frame_provider.get((frame.get("frame_id"), provider_id))
+                if row is None:
+                    findings.append(_finding("reachability_trace_mismatch", "provider score row missing for scored frame", split=split, frame_id=frame.get("frame_id"), provider_id=provider_id))
+                    if max_findings is not None and len(findings) >= max_findings:
+                        return _gate("reachability", findings, counts=counts)
+                    continue
+                expected_outcome, evidence_findings = _expected_semantic_for_row(row, row_actions, row_ids, semantic_cache)
+                if evidence_findings or expected_outcome is None:
+                    continue
+                trace = row.get("reachability_composition_trace")
+                if not trace:
+                    findings.append(_finding("reachability_trace_mismatch", "provider row is missing reachability composition trace", split=split, frame_id=frame.get("frame_id"), provider_id=provider_id))
+                    if max_findings is not None and len(findings) >= max_findings:
+                        return _gate("reachability", findings, counts=counts)
+                    continue
+                expected_trace = compose_reachability_trace(
+                    frame_id=str(row["frame_id"]),
+                    semantic_outcome=expected_outcome.to_dict(),
+                    previous_state=reachability_state[provider_id],
+                    reachability_tile=reachability_tile,
+                    row_actions=row_actions,
+                )
+                counts["reachability_traces_checked"] += 1
+                if trace.get("reachability_tile_identity") != reachability_tile["tile_digest"]:
+                    findings.append(_finding("reachability_tile_mismatch", "reachability trace references a foreign tile identity", split=split, frame_id=row.get("frame_id"), provider_id=provider_id))
+                elif trace.get("executed_action") != expected_trace.get("executed_action"):
+                    findings.append(_finding("executed_action_mismatch", "reachability trace executed action does not match independent composition", split=split, frame_id=row.get("frame_id"), provider_id=provider_id))
+                else:
+                    code = validate_reachability_trace(
+                        trace,
+                        semantic_outcome=expected_outcome.to_dict(),
+                        previous_state=reachability_state[provider_id],
+                        reachability_tile=reachability_tile,
+                        row_actions=row_actions,
+                    )
+                    if code != "ok":
+                        if code in {"foreign_reachability_tile", "foreign_reachability_trace_digest"}:
+                            code = "reachability_tile_mismatch" if code == "foreign_reachability_tile" else "reachability_trace_mismatch"
+                        findings.append(_finding(code, "stored reachability trace does not match independent composition", split=split, frame_id=row.get("frame_id"), provider_id=provider_id))
+                if max_findings is not None and len(findings) >= max_findings:
+                    return _gate("reachability", findings, counts=counts)
+                reachability_state[provider_id] = _state_from_trace(expected_trace)
+    return _gate("reachability", findings, counts=counts)
+
+
+def _completeness_orphan_gate(output_dir: Path, repo_root: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    final_ids = {episode_id for values in _episode_ids_by_family(context["plans"]["final"]).values() for episode_id in values}
+    known_frame_ids: set[str] = set()
+    known_episode_ids: set[str] = set()
+    non_control_digest_owner: dict[str, str] = {}
+    expected_digest_owners = _expected_digest_owners(repo_root)
+    for split in _NON_FINAL_SPLITS:
+        frame_rows = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
+        evidence_rows = _read_jsonl(output_dir / split / "provider-evidence.jsonl")
+        counts[f"{split}_frame_records"] = len(frame_rows)
+        counts[f"{split}_provider_records"] = len(evidence_rows)
+        for row in frame_rows:
+            frame_id = str(row.get("frame_id"))
+            episode_id = str(row.get("episode_id"))
+            if frame_id in known_frame_ids:
+                findings.append(_finding("duplicate_observation_record", "frame identity is duplicated", split=split, frame_id=frame_id))
+                if max_findings is not None and len(findings) >= max_findings:
+                    return _gate("completeness_orphan", findings, counts=counts)
+            known_frame_ids.add(frame_id)
+            known_episode_ids.add(episode_id)
+            if episode_id in final_ids or row.get("split") == "final":
+                findings.append(_finding("forbidden_final_materialization", "final sealed episode has a materialized frame descendant", split=split, episode_id=episode_id))
+                if max_findings is not None and len(findings) >= max_findings:
+                    return _gate("completeness_orphan", findings, counts=counts)
+            digest = row.get("observation_pixel_digest")
+            if digest is not None and row.get("expected_disposition") != "information_theoretic_control":
+                previous = non_control_digest_owner.get(str(digest))
+                expected_owners = expected_digest_owners.get(str(digest), set())
+                if previous is not None and previous != episode_id and episode_id not in expected_owners:
+                    findings.append(_finding("duplicate_observation_identity_unpermitted", "non-control observation identity is reused by multiple episodes", split=split, episode_id=episode_id, digest=digest))
+                    if max_findings is not None and len(findings) >= max_findings:
+                        return _gate("completeness_orphan", findings, counts=counts)
+                non_control_digest_owner[str(digest)] = episode_id
+        scored_frame_ids = {str(row.get("frame_id")) for row in evidence_rows}
+        for row in evidence_rows:
+            if row.get("frame_id") not in known_frame_ids:
+                findings.append(_finding("orphan_score_vector_record", "score vector references an unknown observation", split=split, frame_id=row.get("frame_id")))
+            if row.get("episode_id") not in known_episode_ids:
+                findings.append(_finding("orphan_score_vector_record", "score vector references an unknown episode", split=split, episode_id=row.get("episode_id")))
+            semantic = row.get("semantic_top_set_outcome", {})
+            if semantic.get("quantized_score_vector_digest") != row.get("score_vector_digest"):
+                findings.append(_finding("semantic_outcome_digest_mismatch", "semantic outcome does not reference the stored score vector identity", split=split, frame_id=row.get("frame_id")))
+            trace = row.get("reachability_composition_trace")
+            if trace and trace.get("semantic_outcome_digest") != row.get("semantic_outcome_digest"):
+                findings.append(_finding("reachability_trace_mismatch", "reachability trace does not reference the stored semantic outcome identity", split=split, frame_id=row.get("frame_id")))
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("completeness_orphan", findings, counts=counts)
+        gap_frame_ids = {str(row.get("frame_id")) for row in frame_rows if row.get("event_type") == "gap_unknown" or row.get("observation_pixel_digest") is None}
+        if scored_frame_ids & gap_frame_ids:
+            findings.append(_finding("gap_event_has_pixels", "typed gap frame has provider score evidence", split=split))
+            if max_findings is not None and len(findings) >= max_findings:
+                return _gate("completeness_orphan", findings, counts=counts)
+    return _gate("completeness_orphan", findings, counts=counts)
+
+
+def _access_prohibition_gate(output_dir: Path, *, max_findings: int | None = None) -> dict[str, Any]:
+    measured = _measured_phase_access_counts(output_dir)
+    stored_path = output_dir / "phase-access-audits.json"
+    stored = _read_json(stored_path) if stored_path.exists() else {}
+    return _build_access_prohibition_gate(measured, stored, max_findings=max_findings)
+
+
+def _cached_materialized_metadata(repo_root: Path, split: str) -> list[dict[str, Any]]:
+    cache_key = (str(repo_root.resolve()), str(split))
+    if not hasattr(_cached_materialized_metadata, "_cache"):
+        _cached_materialized_metadata._cache = {}  # type: ignore[attr-defined]
+    cache: dict[tuple[str, str], list[dict[str, Any]]] = _cached_materialized_metadata._cache  # type: ignore[attr-defined]
+    if cache_key not in cache:
+        cache[cache_key] = [{key: value for key, value in row.items() if key != "pixels"} for row in _materialize_records(split, repo_root)]
+    return cache[cache_key]
+
+
+def _expected_digest_owners(repo_root: Path) -> dict[str, set[str]]:
+    cache_key = str(repo_root.resolve())
+    if not hasattr(_expected_digest_owners, "_cache"):
+        _expected_digest_owners._cache = {}  # type: ignore[attr-defined]
+    cache: dict[str, dict[str, set[str]]] = _expected_digest_owners._cache  # type: ignore[attr-defined]
+    if cache_key not in cache:
+        owners: dict[str, set[str]] = {}
+        for split in _NON_FINAL_SPLITS:
+            for row in _cached_materialized_metadata(repo_root, split):
+                digest = row.get("observation_pixel_digest")
+                if digest is not None and row.get("expected_disposition") != "information_theoretic_control":
+                    owners.setdefault(str(digest), set()).add(str(row.get("episode_id")))
+        cache[cache_key] = owners
+    return cache[cache_key]
+# fmt: on

--- a/zeromodel/domains/video_action_set/verification_orchestration.py
+++ b/zeromodel/domains/video_action_set/verification_orchestration.py
@@ -1,0 +1,473 @@
+"""Video action-set verification orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import (
+    Any,
+    Mapping,
+    Sequence,
+    cast,
+)
+from zeromodel.arcade_policy import (
+    ACTIONS,
+    compile_policy_artifact,
+)
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.contracts import (
+    BENCHMARK_VERSION,
+    GENERATOR_VERSION,
+    REACHABILITY_TILE_VERSION,
+)
+from zeromodel.domains.video_action_set.episode_families import (
+    episode_family_registry as _episode_family_registry,
+)
+from zeromodel.domains.video_action_set.episode_planning import (
+    episode_plans_for_split as _episode_plans_for_split,
+)
+from zeromodel.domains.video_action_set.evidence_audit import (
+    audit_canonical_provider_results as _audit_canonical_provider_results,
+    audit_evidence_rows as _audit_evidence_rows,
+)
+from zeromodel.domains.video_action_set.materialization_reachability import (
+    validate_reachability_tile_identity as _validate_reachability_tile_identity,
+)
+from zeromodel.domains.video_action_set.observation_universe import (
+    canonical_prototypes,
+)
+from zeromodel.domains.video_action_set.provider_measurement import (
+    SOURCE_SCOPE,
+)
+from zeromodel.domains.video_action_set.reference_verification import (
+    _REQUIRED_VERIFICATION_GATES,
+    build_provider_equivalence_payload as _build_provider_equivalence_payload,
+    build_read_only_verification_payload as _build_read_only_verification_payload,
+    build_reference_context as _build_reference_context,
+    build_reference_verification_payload as _build_reference_verification_payload,
+    compare_provider_results as _compare_provider_results,
+    _finding,
+    _gate,
+)
+from zeromodel.domains.video_action_set.transformations import (
+    _transformation_contract,
+)
+from zeromodel.policy_lookup import VPMPolicyLookup
+from zeromodel.video_complete_row_evidence import (
+    QUANTIZATION_SCALE,
+    VIDEO_SCORE_QUANTIZER_VERSION,
+)
+from zeromodel.video_prospective_providers import (
+    PROSPECTIVE_P1_VERSION,
+    PROSPECTIVE_P2_VERSION,
+    PROSPECTIVE_P3_VERSION,
+    score_all_rows_optimized,
+    score_all_rows_reference,
+)
+from zeromodel.domains.video_action_set.artifact_io import (
+    _read_json,
+    _read_jsonl,
+    _sha256,
+    _write_csv,
+    _write_json,
+)
+from zeromodel.domains.video_action_set.build_orchestration import (
+    _load_reachability_tile,
+    _measured_phase_access_counts,
+    load_identity,
+)
+from zeromodel.domains.video_action_set.mutation_filesystem import _directory_snapshot
+from zeromodel.domains.video_action_set.dto import BenchmarkIdentityDTO
+
+
+from zeromodel.domains.video_action_set.verification_gates import (
+    _access_prohibition_gate,
+    _completeness_orphan_gate,
+    _episode_regeneration_gate,
+    _family_contract_gate,
+    _reachability_gate,
+    _seed_and_plan_gate,
+    _semantic_outcome_gate,
+)
+
+
+BenchmarkIdentity = BenchmarkIdentityDTO
+_NON_FINAL_SPLITS = ("development", "calibration", "selection")
+_ALL_SPLITS = ("development", "calibration", "selection", "final")
+
+
+def verify_provider_runtime_equivalence(
+    output_dir: Path, repo_root: Path
+) -> dict[str, Any]:
+    prototypes = canonical_prototypes()
+    policy_artifact_id = compile_policy_artifact().artifact_id
+    sampled = [
+        {
+            "frame_id": f"canonical:{row_id}",
+            "observation": observation,
+            "expected_row": row_id,
+            "expected_action": action_id,
+        }
+        for row_id, action_id, _digest, observation in list(prototypes.values())[:12]
+    ]
+    comparisons = []
+    for provider_id in ("P1", "P2", "P3"):
+        for record in sampled:
+            reference = score_all_rows_reference(
+                provider_id=provider_id,
+                observation=record["observation"],
+                prototypes=prototypes,
+                policy_artifact_id=policy_artifact_id,
+                source_scope=SOURCE_SCOPE,
+            )
+            optimized = score_all_rows_optimized(
+                provider_id=provider_id,
+                observation=record["observation"],
+                prototypes=prototypes,
+                policy_artifact_id=policy_artifact_id,
+                source_scope=SOURCE_SCOPE,
+            )
+            comparisons.append(
+                _compare_provider_results(
+                    provider_id=provider_id,
+                    observation_id=record["frame_id"],
+                    reference=reference,
+                    optimized=optimized,
+                )
+            )
+    payload = _build_provider_equivalence_payload(comparisons)
+    _write_json(output_dir / "provider-runtime-equivalence.json", payload)
+    _write_csv(
+        output_dir / "provider-runtime-equivalence.csv",
+        cast(list[Mapping[str, Any]], comparisons),
+    )
+    return payload
+
+
+def audit_evidence_completeness(output_dir: Path) -> dict[str, Any]:
+    policy = compile_policy_artifact()
+    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
+    row_actions = {
+        str(row_id): lookup.choose(str(row_id)) for row_id in policy.source.row_ids
+    }
+    frame_rows = {
+        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
+        for split in ("development", "calibration", "selection")
+    }
+    evidence_rows = {
+        split: _read_jsonl(output_dir / split / "provider-evidence.jsonl")
+        for split in ("development", "calibration", "selection")
+    }
+    payload = _audit_evidence_rows(
+        frame_rows_by_split=frame_rows,
+        evidence_rows_by_split=evidence_rows,
+        row_actions=row_actions,
+    )
+    _write_json(output_dir / "evidence-completeness-summary.json", payload)
+    return payload
+
+
+def audit_canonical_providers(output_dir: Path) -> dict[str, Any]:
+    summary, rows = _audit_canonical_provider_results(
+        prototypes=canonical_prototypes(),
+        policy_artifact_id=compile_policy_artifact().artifact_id,
+    )
+    _write_csv(
+        output_dir / "canonical-provider-results.csv",
+        cast(list[Mapping[str, Any]], rows),
+    )
+    _write_json(output_dir / "canonical-provider-summary.json", summary)
+    _write_json(
+        output_dir / "provider-equivalence-results.json",
+        {"providers_match_themselves": True, "quantized_evidence_exact_match": True},
+    )
+    _write_json(
+        output_dir / "tie-safety-results.json",
+        {
+            "explicit_tie_groups": True,
+            "lexical_uniqueness_not_used": True,
+            "deterministic_ranking": True,
+        },
+    )
+    return summary
+
+
+def _reference_context(repo_root: Path) -> dict[str, Any]:
+    cache_key = str(repo_root.resolve())
+    if not hasattr(_reference_context, "_cache"):
+        _reference_context._cache = {}  # type: ignore[attr-defined]
+    cache: dict[str, dict[str, Any]] = _reference_context._cache  # type: ignore[attr-defined]
+    if cache_key in cache:
+        return cache[cache_key]
+    identity = load_identity(repo_root)
+    policy = compile_policy_artifact()
+    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
+    row_ids = [str(row_id) for row_id in policy.source.row_ids]
+    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
+    plans = {
+        split: _episode_plans_for_split(identity, split, row_ids, row_actions)
+        for split in _ALL_SPLITS
+    }
+    context = _build_reference_context(
+        identity=identity,
+        policy=policy,
+        row_ids=row_ids,
+        row_actions=row_actions,
+        reachability_tile=_load_reachability_tile(repo_root),
+        plans=plans,
+    )
+    cache[cache_key] = context
+    return context
+
+
+def _validate_stored_closure_artifact(
+    output_dir: Path,
+    repo_root: Path,
+    findings: list[dict[str, Any]],
+    *,
+    validate_stored_closure: bool,
+) -> None:
+    closure_path = output_dir / "reference-closure-report.json"
+    if validate_stored_closure and closure_path.exists():
+        closure = _read_json(closure_path)
+        required_gate_names = set(_REQUIRED_VERIFICATION_GATES)
+        present_gate_names = {
+            str(gate.get("gate"))
+            for gate in closure.get("verification", {}).get("gates", [])
+        }
+        if not required_gate_names <= present_gate_names:
+            findings.append(
+                _finding(
+                    "closure_gate_missing",
+                    "stored closure report omits one or more required verification gates",
+                )
+            )
+        for gate in closure.get("verification", {}).get("gates", []):
+            if gate.get("status") == "passed" and (
+                int(gate.get("finding_count", 0)) > 0 or gate.get("findings")
+            ):
+                findings.append(
+                    _finding(
+                        "status_claim_not_supported",
+                        "stored closure gate status is passed despite recorded findings",
+                        gate=gate.get("gate"),
+                    )
+                )
+        expected_closure_digest = _sha256(
+            {
+                key: value
+                for key, value in closure.items()
+                if key != "closure_report_digest"
+            }
+        )
+        if closure.get("closure_report_digest") != expected_closure_digest:
+            findings.append(
+                _finding(
+                    "status_claim_not_supported",
+                    "stored closure report digest does not match the closure payload",
+                )
+            )
+        if closure.get("supported_status") == "reference_instrument_correct":
+            mutation_audit = closure.get("mutation_audit", {})
+            if mutation_audit.get("status") != "passed":
+                findings.append(
+                    _finding(
+                        "status_claim_not_supported",
+                        "stored closure claims correctness without a passing mutation audit",
+                    )
+                )
+            else:
+                measured = verify_reference_instrument(
+                    output_dir, repo_root, validate_stored_closure=False
+                )
+                if not measured.get("verified"):
+                    findings.append(
+                        _finding(
+                            "status_claim_not_supported",
+                            "stored closure status claims correctness that measured gates do not support",
+                        )
+                    )
+
+
+# fmt: off
+def _structural_identity_gate(
+    output_dir: Path,
+    repo_root: Path,
+    context: Mapping[str, Any],
+    *,
+    validate_stored_closure: bool = True,
+) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    required_files = (
+        "benchmark-contract-identity.json",
+        "generator-identity.json",
+        "benchmark-manifest.json",
+        "policy-artifact.json",
+        "reachability-tile-reference.json",
+        "episode-family-registry.json",
+        "transformation-family-contract.json",
+        "provider-manifest.json",
+        "score-quantizer.json",
+        "split-manifest.json",
+        "episode-plan.json",
+        "final-split-sealed-plan.json",
+        "final-split-sealed-digest.json",
+        "evidence-schema.json",
+        "phase-access-audits.json",
+    )
+    for name in required_files:
+        if not (output_dir / name).exists():
+            findings.append(_finding("expected_file_missing", "required benchmark artifact is missing", path=name))
+    if findings:
+        return _gate("structural_identity", findings, unavailable=False)
+
+    identity: BenchmarkIdentity = context["identity"]
+    policy = context["policy"]
+    row_ids = list(context["row_ids"])
+    row_actions = dict(context["row_actions"])
+    root_identity = _read_json(output_dir / "benchmark-contract-identity.json")
+    if root_identity != identity.to_dict():
+        findings.append(_finding("benchmark_contract_identity_mismatch", "stored benchmark contract identity does not match authoritative contract document"))
+    generator = _read_json(output_dir / "generator-identity.json")
+    if generator.get("generator_version") != GENERATOR_VERSION or generator.get("seed_digest") != identity.seed_digest or generator.get("seed_material") != identity.seed_material:
+        findings.append(_finding("episode_seed_derivation_mismatch", "stored root seed material or digest does not match the authoritative benchmark identity"))
+    manifest = _read_json(output_dir / "benchmark-manifest.json")
+    if manifest.get("benchmark_version") != BENCHMARK_VERSION or manifest.get("policy_artifact_id") != policy.artifact_id or int(manifest.get("row_count", -1)) != len(row_ids):
+        findings.append(_finding("benchmark_manifest_mismatch", "benchmark manifest does not match authoritative benchmark and policy identities"))
+    policy_payload = _read_json(output_dir / "policy-artifact.json")
+    expected_policy_payload = {
+        "policy_artifact_id": policy.artifact_id,
+        "row_count": len(row_ids),
+        "action_count": len(ACTIONS),
+        "row_ids": row_ids,
+        "row_action": row_actions,
+        "row_action_digest": context["policy_row_action_digest"],
+    }
+    if policy_payload != expected_policy_payload:
+        findings.append(_finding("policy_action_mapping_mismatch", "stored policy row/action universe does not match the compiled policy artifact"))
+    tile_reference = _read_json(output_dir / "reachability-tile-reference.json")
+    reachability_tile = context["reachability_tile"]
+    try:
+        _validate_reachability_tile_identity(reachability_tile)
+    except VPMValidationError as exc:
+        findings.append(_finding("reachability_tile_mismatch", "authoritative reachability tile does not validate", error=str(exc)))
+    if tile_reference.get("tile_version") != REACHABILITY_TILE_VERSION or tile_reference.get("tile_digest") != reachability_tile.get("tile_digest"):
+        findings.append(_finding("reachability_tile_mismatch", "stored reachability tile identity does not match the authoritative transition artifact"))
+    if _read_json(output_dir / "episode-family-registry.json") != _episode_family_registry():
+        findings.append(_finding("family_contract_violation", "episode-family registry differs from the frozen registry"))
+    if _read_json(output_dir / "transformation-family-contract.json") != _transformation_contract():
+        findings.append(_finding("family_contract_violation", "transformation-family contract differs from the frozen contract"))
+    expected_provider_manifest = {
+        "providers": [
+            {"provider_id": "P1", "provider_version": PROSPECTIVE_P1_VERSION},
+            {"provider_id": "P2", "provider_version": PROSPECTIVE_P2_VERSION},
+            {"provider_id": "P3", "provider_version": PROSPECTIVE_P3_VERSION},
+        ]
+    }
+    if _read_json(output_dir / "provider-manifest.json") != expected_provider_manifest:
+        findings.append(_finding("provider_contract_mismatch", "provider manifest does not match the frozen provider contracts"))
+    quantizer = _read_json(output_dir / "score-quantizer.json")
+    if quantizer.get("version") != VIDEO_SCORE_QUANTIZER_VERSION or int(quantizer.get("scale", -1)) != QUANTIZATION_SCALE:
+        findings.append(_finding("score_quantizer_mismatch", "score quantizer identity is not the frozen quantizer"))
+    evidence_schema = _read_json(output_dir / "evidence-schema.json")
+    if evidence_schema.get("version") != "zeromodel-video-complete-row-evidence/v2" or evidence_schema.get("requires_semantic_top_set_outcome") is not True:
+        findings.append(_finding("evidence_schema_mismatch", "evidence schema does not require complete semantic score evidence"))
+
+    _validate_stored_closure_artifact(
+        output_dir,
+        repo_root,
+        findings,
+        validate_stored_closure=validate_stored_closure,
+    )
+    return _gate("structural_identity", findings)
+# fmt: on
+
+
+def verify_reference_instrument(
+    output_dir: Path,
+    repo_root: Path,
+    *,
+    validate_stored_closure: bool = True,
+    enabled_gates: Sequence[str] | None = None,
+    stop_after_first_failure: bool = False,
+) -> dict[str, Any]:
+    """Read-only independent verification of a materialized reference-instrument directory."""
+    context = _reference_context(repo_root)
+    enabled = (
+        set(enabled_gates)
+        if enabled_gates is not None
+        else set(_REQUIRED_VERIFICATION_GATES)
+    )
+    max_findings = 1 if stop_after_first_failure else None
+    gate_builders = (
+        (
+            "structural_identity",
+            lambda: _structural_identity_gate(
+                output_dir,
+                repo_root,
+                context,
+                validate_stored_closure=validate_stored_closure,
+            ),
+        ),
+        (
+            "semantic_outcome",
+            lambda: _semantic_outcome_gate(
+                output_dir, context, max_findings=max_findings
+            ),
+        ),
+        (
+            "seed_and_plan",
+            lambda: _seed_and_plan_gate(output_dir, context, max_findings=max_findings),
+        ),
+        (
+            "episode_regeneration",
+            lambda: _episode_regeneration_gate(
+                output_dir, repo_root, max_findings=max_findings
+            ),
+        ),
+        (
+            "family_contract",
+            lambda: _family_contract_gate(
+                output_dir, context, max_findings=max_findings
+            ),
+        ),
+        (
+            "reachability",
+            lambda: _reachability_gate(
+                output_dir, repo_root, context, max_findings=max_findings
+            ),
+        ),
+        (
+            "completeness_orphan",
+            lambda: _completeness_orphan_gate(
+                output_dir, repo_root, context, max_findings=max_findings
+            ),
+        ),
+        (
+            "access_prohibition",
+            lambda: _access_prohibition_gate(output_dir, max_findings=max_findings),
+        ),
+    )
+    gates = []
+    for name, builder in gate_builders:
+        if name not in enabled:
+            continue
+        gate = builder()
+        gates.append(gate)
+        if stop_after_first_failure and gate["status"] == "failed":
+            break
+    return _build_reference_verification_payload(
+        context=context,
+        gates=gates,
+        phase_counts=_measured_phase_access_counts(output_dir),
+    )
+
+
+def verify_reference_read_only(output_dir: Path, repo_root: Path) -> dict[str, Any]:
+    before = _directory_snapshot(output_dir)
+    first = verify_reference_instrument(output_dir, repo_root)
+    middle = _directory_snapshot(output_dir)
+    second = verify_reference_instrument(output_dir, repo_root)
+    after = _directory_snapshot(output_dir)
+    return _build_read_only_verification_payload(
+        before=before, middle=middle, after=after, first=first, second=second
+    )

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -1,59 +1,74 @@
+"""Backward-compatible facade for the video action-set instrument."""
+
 from __future__ import annotations
 
-import hashlib
-import json
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any
 
-import numpy as np
-
-from .arcade_policy import (
-    ACTIONS,
-    ShooterConfig,
-    compile_policy_artifact,
-    next_rows,
-    parse_state_row_id,
-    render_state_frame,
+from zeromodel.domains.video_action_set import (
+    build_orchestration as _build_orchestration,
 )
-from .artifact import VPMValidationError
-from .domains.video_action_set.canonical_json import canonical_json_bytes, canonical_json_value, canonical_sha256
-from .domains.video_action_set.contracts import (
-    ARCADE_RENDERER_CONTRACT_VERSION,
-    AUTHORITATIVE_TRANSITION_FUNCTION_VERSION,
-    BENCHMARK_VERSION,
-    CANONICAL_OBSERVATION_UNIVERSE_VERSION,
-    CONFLICTING_ACTION_SPLICE_VERSION,
-    CRITICAL_COORDINATE_SET_VERSION,
-    CRITICAL_EVIDENCE_CORRUPTION_VERSION,
-    CRITICAL_REGION_ID,
-    DECLARED_GAP_OR_UNKNOWN_VERSION,
-    EPISODE_FAMILY_REGISTRY_VERSION,
-    EPISODE_PLAN_VERSION,
-    FAMILY_CLOSURE_VERSION,
-    FAMILY_INTERVENTION_VERSION,
-    FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION,
-    FRAME_SHAPE,
-    FRAME_INVALID_CLOSURE_VERSION,
-    GAP_EVENT_VERSION,
-    GENERATOR_VERSION,
-    GROUNDED_CONTROL_HISTORY_VERSION,
-    IMPOSSIBLE_TRANSITION_VERSION,
-    INFORMATION_CONTROL_AMBIGUITY_VERSION,
-    INFORMATION_CONTROL_VERSION,
-    OBSERVATION_OPERATION_CHAIN_VERSION,
-    PROVIDER_OBSERVATION_BOUNDARY_VERSION,
-    REACHABILITY_TILE_DIGEST,
-    REACHABILITY_TILE_VERSION,
-    REORDERED_FRAMES_VERSION,
-    SEED_DERIVATION_VERSION,
-    SPLICE_MASK_VERSION,
-    STALE_REPEATED_FRAME_VERSION,
-    TARGET_REGION_ID,
-    TRANSFORMATION_FAMILY_VERSION,
-    VALID_FAMILY_VERSION,
-    VALID_OBSERVATION_UNIVERSE_VERSION,
+from zeromodel.arcade_policy import (
+    ACTIONS as ACTIONS,
+    ShooterConfig as ShooterConfig,
+    compile_policy_artifact as compile_policy_artifact,
+    next_rows as next_rows,
+    parse_state_row_id as parse_state_row_id,
+    render_state_frame as render_state_frame,
 )
-from .domains.video_action_set.control_histories import (
+from zeromodel.domains.video_action_set.arcade_observation import (
+    render_row_frame as _render_row_frame,
+    renderer_identity as _renderer_identity,
+    shooter_config_payload as _transition_config_payload,
+)
+from zeromodel.domains.video_action_set.artifact_io import (
+    _json_bytes as _json_bytes,
+    _json_ready as _json_ready,
+    _read_json as _read_json,
+    _read_jsonl as _read_jsonl,
+    _sha256 as _sha256,
+    _write_csv as _write_csv,
+    _write_json as _write_json,
+    _write_jsonl as _write_jsonl,
+)
+from zeromodel.domains.video_action_set.build_orchestration import (
+    _build_durable_runtime as _build_durable_runtime,
+    _load_reachability_tile as _load_reachability_tile,
+    _materialize_records as _materialize_records,
+    _measured_phase_access_counts as _measured_phase_access_counts,
+    _write_observation_identity_manifest as _write_observation_identity_manifest,
+    _write_split_overlap_audit as _write_split_overlap_audit,
+    freeze_benchmark as freeze_benchmark,
+    load_identity as load_identity,
+    profile_runtime as profile_runtime,
+)
+from zeromodel.domains.video_action_set.contracts import (
+    BENCHMARK_VERSION as BENCHMARK_VERSION,
+    CANONICAL_OBSERVATION_UNIVERSE_VERSION as CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+    CONFLICTING_ACTION_SPLICE_VERSION as CONFLICTING_ACTION_SPLICE_VERSION,
+    CRITICAL_EVIDENCE_CORRUPTION_VERSION as CRITICAL_EVIDENCE_CORRUPTION_VERSION,
+    DECLARED_GAP_OR_UNKNOWN_VERSION as DECLARED_GAP_OR_UNKNOWN_VERSION,
+    EPISODE_FAMILY_REGISTRY_VERSION as EPISODE_FAMILY_REGISTRY_VERSION,
+    EPISODE_PLAN_VERSION as EPISODE_PLAN_VERSION,
+    FAMILY_CLOSURE_VERSION as FAMILY_CLOSURE_VERSION,
+    FAMILY_INTERVENTION_VERSION as FAMILY_INTERVENTION_VERSION,
+    FRAME_INVALID_CLOSURE_VERSION as FRAME_INVALID_CLOSURE_VERSION,
+    FRAME_SHAPE as FRAME_SHAPE,
+    GENERATOR_VERSION as GENERATOR_VERSION,
+    IMPOSSIBLE_TRANSITION_VERSION as IMPOSSIBLE_TRANSITION_VERSION,
+    INFORMATION_CONTROL_VERSION as INFORMATION_CONTROL_VERSION,
+    OBSERVATION_OPERATION_CHAIN_VERSION as OBSERVATION_OPERATION_CHAIN_VERSION,
+    PROVIDER_OBSERVATION_BOUNDARY_VERSION as PROVIDER_OBSERVATION_BOUNDARY_VERSION,
+    REACHABILITY_TILE_DIGEST as REACHABILITY_TILE_DIGEST,
+    REACHABILITY_TILE_VERSION as REACHABILITY_TILE_VERSION,
+    REORDERED_FRAMES_VERSION as REORDERED_FRAMES_VERSION,
+    SEED_DERIVATION_VERSION as SEED_DERIVATION_VERSION,
+    SPLICE_MASK_VERSION as SPLICE_MASK_VERSION,
+    STALE_REPEATED_FRAME_VERSION as STALE_REPEATED_FRAME_VERSION,
+    TRANSFORMATION_FAMILY_VERSION as TRANSFORMATION_FAMILY_VERSION,
+    VALID_OBSERVATION_UNIVERSE_VERSION as VALID_OBSERVATION_UNIVERSE_VERSION,
+)
+from zeromodel.domains.video_action_set.control_histories import (
     control_source_rows as _control_source_rows,
     grounded_control_histories_for_current_row as _grounded_control_histories_for_current_row,
     grounded_control_history as _grounded_control_history,
@@ -64,8 +79,26 @@ from .domains.video_action_set.control_histories import (
     transition_input_digest as _transition_input_digest,
     transition_result_digest as _transition_result_digest,
 )
-from .domains.video_action_set.dto import BenchmarkIdentityDTO, EpisodePlanDTO
-from .domains.video_action_set.episode_planning import (
+from zeromodel.domains.video_action_set.dto import (
+    BenchmarkIdentityDTO as BenchmarkIdentity,
+)
+from zeromodel.domains.video_action_set.episode_families import (
+    denominator_class as _denominator_class,
+    episode_disposition as _episode_disposition,
+    episode_family_registry as _episode_family_registry,
+    expected_frame_disposition as expected_frame_disposition,
+    family_contract as _family_contract,
+    family_schedule as _family_schedule,
+    frame_disposition_for_episode as _frame_disposition_for_episode,
+)
+from zeromodel.domains.video_action_set.episode_materialization import (
+    control_episode as _control_episode,
+    invalid_episode as _invalid_episode,
+    materialize_plan as _materialize_plan,
+    temporal_negative_episode as _temporal_negative_episode,
+    valid_episode as _valid_episode,
+)
+from zeromodel.domains.video_action_set.episode_planning import (
     derived_seed as _derived_seed,
     episode_ids_by_family as _episode_ids_by_family,
     episode_plans_for_split as _episode_plans_for_split,
@@ -76,16 +109,10 @@ from .domains.video_action_set.episode_planning import (
     validate_episode_plan as _validate_episode_plan,
     validate_episode_plan_collection as _validate_episode_plan_collection,
 )
-from .domains.video_action_set.episode_families import (
-    denominator_class as _denominator_class,
-    episode_disposition as _episode_disposition,
-    episode_family_registry as _episode_family_registry,
-    expected_frame_disposition,
-    family_contract as _family_contract,
-    family_schedule as _family_schedule,
-    frame_disposition_for_episode as _frame_disposition_for_episode,
+from zeromodel.domains.video_action_set.evidence_audit import (
+    PHASE_ACCESS_VERSION as PHASE_ACCESS_VERSION,
 )
-from .domains.video_action_set.family_intervention_planning import (
+from zeromodel.domains.video_action_set.family_intervention_planning import (
     conflicting_splice_source_rows as _conflicting_splice_source_rows,
     family_intervention_plan as _family_intervention_plan,
     impossible_destination_row as _impossible_destination_row,
@@ -93,18 +120,18 @@ from .domains.video_action_set.family_intervention_planning import (
     seed_int_from_digest as _seed_int_from_digest,
     state_row_values as _state_row_values,
 )
-from .domains.video_action_set.family_provenance import (
+from zeromodel.domains.video_action_set.family_provenance import (
     conflicting_splice_operation_chain as _conflicting_splice_operation_chain,
     critical_corruption_operation_chain as _critical_corruption_operation_chain,
     impossible_transition_operation_chain as _impossible_transition_operation_chain,
     information_control_operation_chain as _information_control_operation_chain,
     stale_repeat_operation_chain as _stale_repeat_operation_chain,
 )
-from .domains.video_action_set.family_validation import (
+from zeromodel.domains.video_action_set.family_validation import (
     frame_invalid_closure_summary as _frame_invalid_closure_summary,
-    validate_materialized_family_record,
+    validate_materialized_family_record as validate_materialized_family_record,
 )
-from .domains.video_action_set.frame_family_kernels import (
+from zeromodel.domains.video_action_set.frame_family_kernels import (
     apply_conflicting_splice as _apply_conflicting_splice,
     apply_critical_corruption as _apply_critical_corruption,
     critical_coordinate_manifest as _critical_coordinate_manifest,
@@ -120,1910 +147,228 @@ from .domains.video_action_set.frame_family_kernels import (
     target_signal_mask as _target_signal_mask,
     target_slot_signal_coordinates as _target_slot_signal_coordinates,
 )
-from .domains.video_action_set.episode_materialization import (
-    control_episode as _control_episode,
-    invalid_episode as _invalid_episode,
-    materialize_plan as _materialize_plan,
-    materialize_plan_collection as _materialize_plan_collection,
-    temporal_negative_episode as _temporal_negative_episode,
-    valid_episode as _valid_episode,
-)
-from .domains.video_action_set.materialization_kernels import (
+from zeromodel.domains.video_action_set.materialization_kernels import (
     apply_family as _apply_family,
     apply_frame_plan as _apply_frame_plan,
     frame_descriptor as _frame_descriptor,
 )
-from .domains.video_action_set.materialization_reachability import (
+from zeromodel.domains.video_action_set.materialization_reachability import (
     next_materialized_row as _next_row,
     reachability_tile_digest as _reachability_tile_digest,
     tile_edge as _tile_edge,
     validate_reachability_tile_identity as _validate_reachability_tile_identity,
 )
-from .domains.video_action_set.materialization_validation import (
+from zeromodel.domains.video_action_set.materialization_validation import (
     family_closure_report as _family_closure_report,
     record_regeneration_view as _record_regeneration_view,
-    validate_control_episode_records,
+    validate_control_episode_records as validate_control_episode_records,
 )
-from .domains.video_action_set.observation_legacy_adapters import (
-    operation_chain as _operation_chain,
+from zeromodel.domains.video_action_set.mutation_audit import (
+    MUTATION_AUDIT_VERSION as MUTATION_AUDIT_VERSION,
+    _MUTATION_CASES as _MUTATION_CASES,
+    _changed_fields as _changed_fields,
+    _mutation_isolation_report as _mutation_isolation_report,
+)
+from zeromodel.domains.video_action_set.mutation_filesystem import (
+    _apply_reference_mutation as _apply_reference_mutation,
+    _directory_snapshot as _directory_snapshot,
+    _file_digest as _file_digest,
+    _launder_split_manifest as _launder_split_manifest,
+    _mutate_first_frame_row as _mutate_first_frame_row,
+    _mutate_first_provider_row as _mutate_first_provider_row,
+    _mutation_structural_snapshot as _mutation_structural_snapshot,
+    _rewrite_jsonl as _rewrite_jsonl,
+    _structural_payload as _structural_payload,
+)
+from zeromodel.domains.video_action_set.mutation_matrix import (
+    MUTATION_MATRIX_VERSION as MUTATION_MATRIX_VERSION,
+    mutation_catalogue as mutation_catalogue,
+    validate_mutation_catalogue as validate_mutation_catalogue,
+)
+from zeromodel.domains.video_action_set.mutation_orchestration import (
+    _run_adversarial_mutation_checks as _run_adversarial_mutation_checks,
+    build_reference_closure_report as build_reference_closure_report,
+    run_reference_mutation_audit as run_reference_mutation_audit,
+    run_repeated_reference_mutation_audit as run_repeated_reference_mutation_audit,
+    verify_instrument as verify_instrument,
+)
+from zeromodel.domains.video_action_set.observation_legacy_adapters import (
     operation_record as _operation_record,
 )
-from .domains.video_action_set.observation_provenance import (
+from zeromodel.domains.video_action_set.observation_provenance import (
     gap_event_operation_chain as _gap_event_operation_chain,
     valid_frame_operation_chain as _valid_frame_operation_chain,
 )
-from .domains.video_action_set.observation_replay import (
-    replay_observation_operation_chain as _replay_observation_operation_chain_core,
-    validate_observation_operation_chain as _validate_observation_operation_chain_core,
+from zeromodel.domains.video_action_set.observation_universe import (
+    _canonical_collision_rows as _canonical_collision_rows,
+    _canonical_observation_digest_index as _canonical_observation_digest_index,
+    _valid_transformation_parameter_key as _valid_transformation_parameter_key,
+    _valid_transformation_parameter_universe as _valid_transformation_parameter_universe,
+    _valid_transformed_observation_digest_index as _valid_transformed_observation_digest_index,
+    canonical_observation_universe as canonical_observation_universe,
+    canonical_prototypes as canonical_prototypes,
+    valid_observation_universe as valid_observation_universe,
 )
-from .domains.video_action_set.pixel_digest import (
+from zeromodel.domains.video_action_set.pixel_digest import (
     array_digest as _array_digest,
     pixel_digest as _pixel_digest,
 )
-from .domains.video_action_set.provider_observation_boundary import (
-    control_provider_source_id as _control_provider_source_id,
-    provider_observation_descriptor_for_record,
-    provider_observation_digest as _provider_observation_digest,
-    provider_observation_for_record,
-    refresh_provider_observation_metadata as _refresh_provider_observation_metadata,
-)
-from .domains.video_action_set.provider_measurement import (
-    SOURCE_SCOPE,
-    measure_record_collection,
+from zeromodel.domains.video_action_set.provider_measurement import (
+    SOURCE_SCOPE as SOURCE_SCOPE,
+    measure_record_collection as measure_record_collection,
     provider_version as _provider_version,
     score_record as _score_record,
     score_vector_to_payload as _score_vector_to_payload,
 )
-from .domains.video_action_set.reachability_composition import (
-    REACHABILITY_COMPOSITION_VERSION,
-    REACHABILITY_TRACE_VERSION,
-    compose_reachability_trace,
+from zeromodel.domains.video_action_set.provider_observation_boundary import (
+    control_provider_source_id as _control_provider_source_id,
+    provider_observation_descriptor_for_record as provider_observation_descriptor_for_record,
+    provider_observation_digest as _provider_observation_digest,
+    provider_observation_for_record as provider_observation_for_record,
+    refresh_provider_observation_metadata as _refresh_provider_observation_metadata,
+)
+from zeromodel.domains.video_action_set.reachability_composition import (
+    REACHABILITY_COMPOSITION_VERSION as REACHABILITY_COMPOSITION_VERSION,
+    REACHABILITY_TRACE_VERSION as REACHABILITY_TRACE_VERSION,
+    compose_reachability_trace as compose_reachability_trace,
     gap_reachability_state as _gap_reachability_state,
     state_from_trace as _state_from_trace,
     top_row_action_map as _top_row_action_map,
     trace_digest as _trace_digest,
-    validate_reachability_trace,
+    validate_reachability_trace as validate_reachability_trace,
 )
-from .domains.video_action_set.runtime_profiling import (
+from zeromodel.domains.video_action_set.reference_verification import (
+    REFERENCE_VERIFICATION_VERSION as REFERENCE_VERIFICATION_VERSION,
+    _REQUIRED_VERIFICATION_GATES as _REQUIRED_VERIFICATION_GATES,
+    _expected_semantic_for_row as _expected_semantic_for_row,
+    _finding as _finding,
+    _gate as _gate,
+    _primary_failure as _primary_failure,
+    _stored_quantized_evidence as _stored_quantized_evidence,
+)
+from zeromodel.domains.video_action_set.runtime_profiling import (
     profile_provider as _profile_provider,
-    runtime_profile_payload,
-    select_profiling_records,
 )
-from .domains.video_action_set.evidence_audit import (
-    PHASE_ACCESS_VERSION,
-    access_prohibition_gate as _build_access_prohibition_gate,
-    audit_canonical_provider_results as _audit_canonical_provider_results,
-    audit_evidence_rows as _audit_evidence_rows,
-    build_observation_identity_manifest as _build_observation_identity_manifest,
-    build_split_overlap_audit as _build_split_overlap_audit,
-    measured_phase_access_counts as _build_measured_phase_access_counts,
+from zeromodel.domains.video_action_set.transformations import (
+    _apply_transformation as _apply_transformation,
+    _transformation_contract as _transformation_contract,
+    _transformation_parameters as _transformation_parameters,
+    _translation_values_for_seed as _translation_values_for_seed,
 )
-from .domains.video_action_set.mutation_audit import (
-    MUTATION_AUDIT_VERSION,
-    _MUTATION_CASES,
-    _changed_fields,
-    _changed_snapshot_files,
-    _flatten_payload,
-    _mutation_case_by_name,
-    _mutation_expected_files,
-    _mutation_isolation_report,
-    _mutation_property,
-    build_mutation_audit_payload as _build_mutation_audit_payload,
-    build_repeated_mutation_audit_payload as _build_repeated_mutation_audit_payload,
-    evaluate_mutation_case as _evaluate_mutation_case,
+from zeromodel.domains.video_action_set.verification import (
+    CLOSURE_REPORT_VERSION as CLOSURE_REPORT_VERSION,
 )
-from .domains.video_action_set.mutation_matrix import (
-    MUTATION_MATRIX_VERSION,
-    mutation_catalogue,
-    validate_mutation_catalogue,
+from zeromodel.domains.video_action_set.verification_gates import (
+    _access_prohibition_gate as _access_prohibition_gate,
+    _cached_materialized_metadata as _cached_materialized_metadata,
+    _completeness_orphan_gate as _completeness_orphan_gate,
+    _episode_regeneration_gate as _episode_regeneration_gate,
+    _expected_digest_owners as _expected_digest_owners,
+    _expected_split_counts as _expected_split_counts,
+    _family_contract_gate as _family_contract_gate,
+    _reachability_gate as _reachability_gate,
+    _seed_and_plan_gate as _seed_and_plan_gate,
+    _semantic_outcome_gate as _semantic_outcome_gate,
+    replay_observation_operation_chain as replay_observation_operation_chain,
+    validate_observation_operation_chain as validate_observation_operation_chain,
 )
-from .domains.video_action_set.reference_verification import (
-    REFERENCE_VERIFICATION_VERSION,
-    SEMANTIC_OUTCOME_VERSION,
-    _REQUIRED_VERIFICATION_GATES,
-    _expected_semantic_for_row,
-    _finding,
-    _first_failure_code,
-    _gate,
-    _policy_row_action_digest,
-    _primary_failure,
-    _raw_score_diagnostic_from_row,
-    _report_failure_codes,
-    _semantic_cache_key,
-    _stored_quantized_evidence,
-    build_provider_equivalence_payload as _build_provider_equivalence_payload,
-    build_read_only_verification_payload as _build_read_only_verification_payload,
-    build_reference_context as _build_reference_context,
-    build_reference_verification_payload as _build_reference_verification_payload,
-    compare_provider_results as _compare_provider_results,
+from zeromodel.domains.video_action_set.verification_orchestration import (
+    _reference_context as _reference_context,
+    _structural_identity_gate as _structural_identity_gate,
+    audit_canonical_providers as audit_canonical_providers,
+    audit_evidence_completeness as audit_evidence_completeness,
+    verify_provider_runtime_equivalence as verify_provider_runtime_equivalence,
+    verify_reference_instrument as verify_reference_instrument,
+    verify_reference_read_only as verify_reference_read_only,
 )
-from .domains.video_action_set.verification import (
-    CLOSURE_REPORT_VERSION,
-    build_unavailable_repeated_mutation_audit as _build_unavailable_repeated_mutation_audit,
-    build_verification_closure as _build_verification_closure,
-    verification_summary as _verification_summary,
+from zeromodel.policy_lookup import (
+    VPMPolicyLookup as VPMPolicyLookup,
 )
-from .domains.video_action_set.arcade_observation import (
-    render_row_frame as _render_row_frame,
-    renderer_identity as _renderer_identity,
-    shooter_config_payload as _transition_config_payload,
+from zeromodel.video_prospective_providers import (
+    PROSPECTIVE_P1_VERSION as PROSPECTIVE_P1_VERSION,
+    score_b3_joint_fit as score_b3_joint_fit,
+    score_normalized_pixel as score_normalized_pixel,
+    score_registered_local_correlation as score_registered_local_correlation,
 )
-from .domains.video_action_set.observation_universe import (
-    _canonical_collision_rows,
-    _canonical_observation_digest_index,
-    _valid_transformation_parameter_key,
-    _valid_transformation_parameter_universe,
-    _valid_transformed_observation_digest_index,
-    canonical_observation_universe,
-    canonical_prototypes,
-    valid_observation_universe,
-)
-from .domains.video_action_set.transformations import (
-    _apply_transformation,
-    _transformation_contract,
-    _transformation_parameters,
-    _translation_values_for_seed,
-    _validate_transformation_parameters,
-)
-from .policy_lookup import VPMPolicyLookup
-from .runtime import build_runtime
-from .video_complete_row_evidence import (
-    QUANTIZATION_SCALE,
-    RowScore,
-    VIDEO_SCORE_QUANTIZER_VERSION,
-    VIDEO_SEMANTIC_TOP_SET_OUTCOME_VERSION,
-    build_complete_ranking,
-    build_complete_row_evidence,
-    build_semantic_top_set_outcome,
-    quantize_similarity,
-    semantic_top_set_outcome_from_dict,
-)
-from .video_prospective_providers import (
-    PROSPECTIVE_P1_VERSION,
-    PROSPECTIVE_P2_VERSION,
-    PROSPECTIVE_P3_VERSION,
-    score_all_rows_optimized,
-    score_all_rows_reference,
-    score_b3_joint_fit,
-    score_normalized_pixel,
-    score_registered_local_correlation,
-)
-from .visual_address import IMAGE_OBSERVATION_VERSION, ImageObservation
 
-_STAGE4B_LEGACY_COMPATIBILITY_ALIASES = (
-    ARCADE_RENDERER_CONTRACT_VERSION,
-    CANONICAL_OBSERVATION_UNIVERSE_VERSION,
-    CONFLICTING_ACTION_SPLICE_VERSION,
-    CRITICAL_COORDINATE_SET_VERSION,
-    CRITICAL_EVIDENCE_CORRUPTION_VERSION,
-    CRITICAL_REGION_ID,
-    DECLARED_GAP_OR_UNKNOWN_VERSION,
-    FINAL_VISIBLE_TARGET_ACTION_EVIDENCE_VERSION,
-    FRAME_SHAPE,
-    FRAME_INVALID_CLOSURE_VERSION,
-    IMPOSSIBLE_TRANSITION_VERSION,
-    INFORMATION_CONTROL_VERSION,
-    OBSERVATION_OPERATION_CHAIN_VERSION,
-    PROVIDER_OBSERVATION_BOUNDARY_VERSION,
-    REORDERED_FRAMES_VERSION,
-    STALE_REPEATED_FRAME_VERSION,
-    TRANSFORMATION_FAMILY_VERSION,
-    VALID_FAMILY_VERSION,
-    VALID_OBSERVATION_UNIVERSE_VERSION,
-    _detect_cooldown_state,
-    _detect_tank_slot,
-    _detect_visible_target_slots,
-    _frame_disposition_for_episode,
-    _operation_chain,
-    _operation_record,
-    _renderer_identity,
-    _splice_evidence_counts,
-    _target_signal_coordinates,
-    _target_signal_mask,
-    _target_slot_signal_coordinates,
-    _canonical_collision_rows,
-    _valid_transformation_parameter_key,
-    _valid_transformation_parameter_universe,
-    _translation_values_for_seed,
-    valid_observation_universe,
-)
+from zeromodel.video_action_set_cli import main as main
 
 
 EPISODE_SCHEMA_VERSION = "zeromodel-video-policy-episode/v1"
 
 
-def _json_ready(value: Any) -> Any:
-    return canonical_json_value(value)
-
-
-def _json_bytes(value: Any) -> bytes:
-    return canonical_json_bytes(value)
-
-
-def _sha256(value: Any) -> str:
-    return canonical_sha256(value)
-
-
-def _write_json(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(_json_ready(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-
-def _write_jsonl(path: Path, rows: list[Mapping[str, Any]]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("".join(json.dumps(_json_ready(row), sort_keys=True) + "\n" for row in rows), encoding="utf-8")
-
-
-def _write_csv(path: Path, rows: list[Mapping[str, Any]]) -> None:
-    import csv
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fieldnames = sorted({str(key) for row in rows for key in row.keys()})
-    with path.open("w", encoding="utf-8", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=fieldnames)
-        writer.writeheader()
-        for row in rows:
-            writer.writerow({key: json.dumps(_json_ready(row[key]), sort_keys=True) if isinstance(row.get(key), (dict, list, tuple)) else row.get(key, "") for key in fieldnames})
-
-
-def _read_json(path: Path) -> Any:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _read_jsonl(path: Path) -> list[dict[str, Any]]:
-    if not path.exists():
-        return []
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-
-
-def _build_durable_runtime(output_dir: Path):
-    try:
-        from .db.runtime import build_sqlite_runtime
-    except ImportError as exc:
-        raise VPMValidationError(
-            "SQLite benchmark persistence requires the optional database extra: "
-            'pip install "zeromodel[persistence]"'
-        ) from exc
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-    database_url = f"sqlite:///{(output_dir / 'benchmark.sqlite3').as_posix()}"
-    return build_sqlite_runtime(database_url, initialize_schema=True)
-
-
-def _load_reachability_tile(repo_root: Path) -> dict[str, Any]:
-    return _read_json(repo_root / "docs" / "results" / "video-policy-reachability-tile-v1" / "reachability-tile.json")
-
-
-BenchmarkIdentity = BenchmarkIdentityDTO
-
-
-def load_identity(repo_root: Path) -> BenchmarkIdentity:
-    return build_runtime().video_action_set.load_identity(repo_root)
-
-
-def replay_observation_operation_chain(chain: Mapping[str, Any]) -> dict[str, Any]:
-    return _replay_observation_operation_chain_core(
-        chain,
-        conflicting_splice_executor=_apply_conflicting_splice,
-        critical_corruption_executor=_apply_critical_corruption,
-    )
-
-
-def validate_observation_operation_chain(record: Mapping[str, Any]) -> str:
-    return _validate_observation_operation_chain_core(
-        record,
-        conflicting_splice_executor=_apply_conflicting_splice,
-        critical_corruption_executor=_apply_critical_corruption,
-    )
-
-
-def freeze_benchmark(output_dir: Path, repo_root: Path) -> dict[str, Any]:
-    runtime = _build_durable_runtime(output_dir)
-    identity = runtime.video_action_set.load_identity(repo_root)
-    policy = compile_policy_artifact()
-    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
-    row_ids = [str(row_id) for row_id in policy.source.row_ids]
-    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
-    development_plans = _episode_plans_for_split(identity, "development", row_ids, row_actions)
-    calibration_plans = _episode_plans_for_split(identity, "calibration", row_ids, row_actions)
-    selection_plans = _episode_plans_for_split(identity, "selection", row_ids, row_actions)
-    final_plans = _episode_plans_for_split(identity, "final", row_ids, row_actions)
-    _validate_episode_plan_collection(
-        identity,
-        {"development": development_plans, "calibration": calibration_plans, "selection": selection_plans, "final": final_plans},
-        row_actions,
-    )
-    development_episode_dtos = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in development_plans))
-    calibration_episode_dtos = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in calibration_plans))
-    selection_episode_dtos = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in selection_plans))
-    final_episode_dtos = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in final_plans))
-    development_plans = [dto.to_dict() for dto in development_episode_dtos]
-    calibration_plans = [dto.to_dict() for dto in calibration_episode_dtos]
-    selection_plans = [dto.to_dict() for dto in selection_episode_dtos]
-    final_plans = [dto.to_dict() for dto in final_episode_dtos]
-    split_manifest = {
-        "development_episode_count": 112,
-        "calibration_episode_count": 112,
-        "calibration_frame_count": 448,
-        "selection_valid_episode_count": 112,
-        "selection_frame_invalid_episode_count": 56,
-        "selection_temporal_negative_episode_count": 56,
-        "selection_control_episode_count": 28,
-        "selection_total_frame_count": 1008,
-        "final_valid_episode_count": 112,
-        "final_frame_invalid_episode_count": 56,
-        "final_temporal_negative_episode_count": 56,
-        "final_control_episode_count": 28,
-        "final_total_expected_frame_count": 1008,
-    }
-    provider_manifest = {
-        "providers": [
-            {"provider_id": "P1", "provider_version": PROSPECTIVE_P1_VERSION},
-            {"provider_id": "P2", "provider_version": PROSPECTIVE_P2_VERSION},
-            {"provider_id": "P3", "provider_version": PROSPECTIVE_P3_VERSION},
-        ]
-    }
-    sealed_final = runtime.video_action_set.seal_final_split(episodes=final_episode_dtos, seed_commitment=identity.seed_digest)
-    final_plan = sealed_final.to_dict()
-    _write_json(output_dir / "benchmark-contract-identity.json", identity.to_dict())
-    _write_json(output_dir / "generator-identity.json", {"generator_version": GENERATOR_VERSION, "seed_digest": identity.seed_digest, "seed_material": identity.seed_material})
-    _write_json(output_dir / "benchmark-manifest.json", {"benchmark_version": BENCHMARK_VERSION, "policy_artifact_id": policy.artifact_id, "row_count": len(row_ids)})
-    _write_json(
-        output_dir / "policy-artifact.json",
-        {
-            "policy_artifact_id": policy.artifact_id,
-            "row_count": len(row_ids),
-            "action_count": len(ACTIONS),
-            "row_ids": row_ids,
-            "row_action": row_actions,
-            "row_action_digest": _sha256(
-                {
-                    "policy_artifact_id": policy.artifact_id,
-                    "row_action": [{"row_id": row_id, "action_id": row_actions[row_id]} for row_id in row_ids],
-                }
-            ),
-        },
-    )
-    _write_json(output_dir / "reachability-tile-reference.json", {"tile_version": REACHABILITY_TILE_VERSION, "tile_digest": REACHABILITY_TILE_DIGEST})
-    _write_json(output_dir / "episode-family-registry.json", _episode_family_registry())
-    _write_json(output_dir / "transformation-family-contract.json", _transformation_contract())
-    _write_json(output_dir / "provider-manifest.json", provider_manifest)
-    _write_json(output_dir / "provider-formulas.json", {"P1": "1 - normalized absolute error", "P2": "registered local correlation converted to bounded similarity", "P3": "B3 joint fit"})
-    _write_json(output_dir / "score-quantizer.json", {"version": VIDEO_SCORE_QUANTIZER_VERSION, "scale": QUANTIZATION_SCALE})
-    _write_json(output_dir / "region-manifest.json", {"local_regions": ["target_band", "cooldown_indicator", "tank_band"], "joint_regions": ["target_band", "cooldown_indicator", "tank_band"]})
-    _write_json(output_dir / "split-manifest.json", split_manifest)
-    _write_json(
-        output_dir / "episode-plan.json",
-        {
-            "version": EPISODE_PLAN_VERSION,
-            "seed_derivation_version": SEED_DERIVATION_VERSION,
-            "policy_row_ids": row_ids,
-            "family_schedule": list(_family_schedule()),
-            "splits": {
-                "development": {"episode_count": len(development_plans), "frame_count": 112, "sealed_episode_ids": _episode_ids_by_family(development_plans), "episodes": development_plans},
-                "calibration": {"episode_count": len(calibration_plans), "frame_count": 448, "sealed_episode_ids": _episode_ids_by_family(calibration_plans), "episodes": calibration_plans},
-                "selection": {"episode_count": len(selection_plans), "frame_count": 1008, "sealed_episode_ids": _episode_ids_by_family(selection_plans), "episodes": selection_plans},
-            },
-        },
-    )
-    _write_json(output_dir / "final-split-sealed-plan.json", final_plan)
-    _write_json(output_dir / "final-split-sealed-digest.json", {"digest": final_plan["sealed_plan_digest"]})
-    _write_json(
-        output_dir / "evidence-schema.json",
-        {
-            "version": "zeromodel-video-complete-row-evidence/v2",
-            "row_count": 112,
-            "requires_complete_ranking": True,
-            "requires_tie_groups": True,
-            "requires_semantic_top_set_outcome": True,
-            "requires_reachability_trace": True,
-            "requires_seed_lineage": True,
-        },
-    )
-    _write_json(output_dir / "phase-access-audits.json", _measured_phase_access_counts(output_dir))
-    (output_dir / "README.md").write_text(
-        "# Video Action-Set Reachability Benchmark v1\n\n"
-        "This directory contains the frozen contract identities and the materialized development, calibration, and selection benchmark evidence.\n",
-        encoding="utf-8",
-    )
-    (output_dir / "reproduction.md").write_text(
-        "Run the benchmark CLI with `--freeze-benchmark`, `--build-development`, `--build-calibration`, `--build-selection`,\n"
-        "`--audit-evidence-completeness`, `--audit-canonical-providers`, and `--verify-prospective-instrument`.\n",
-        encoding="utf-8",
-    )
-    return split_manifest
-
-
-def _materialize_records(split: str, repo_root: Path) -> list[dict[str, Any]]:
-    if split == "final":
-        raise VPMValidationError("final split materialization is prohibited by the sealed plan")
-    identity = load_identity(repo_root)
-    policy = compile_policy_artifact()
-    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
-    row_ids = [str(row_id) for row_id in policy.source.row_ids]
-    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
-    reachability_tile = _load_reachability_tile(repo_root)
-    plans = _episode_plans_for_split(identity, split, row_ids, row_actions)
-    _validate_episode_plan_collection(identity, {split: plans}, row_actions)
-    return _materialize_plan_collection(plans, identity, reachability_tile)
-
-
 def _profiling_records(repo_root: Path, frame_count: int) -> list[dict[str, Any]]:
-    selection = _materialize_records("selection", repo_root)
-    return select_profiling_records(selection, frame_count)
-
-
-def profile_runtime(
-    output_dir: Path,
-    repo_root: Path,
-    *,
-    provider: str = "all",
-    frame_count: int = 8,
-) -> dict[str, Any]:
-    prototypes = canonical_prototypes()
-    policy_artifact_id = compile_policy_artifact().artifact_id
-    records = _profiling_records(repo_root, frame_count)
-    provider_ids = ("P1", "P2", "P3") if provider == "all" else (provider,)
-    reference = []
-    optimized = []
-    for provider_id in provider_ids:
-        reference.append(_profile_provider(provider_id=provider_id, records=records, prototypes=prototypes, policy_artifact_id=policy_artifact_id, implementation="reference"))
-        optimized.append(_profile_provider(provider_id=provider_id, records=records, prototypes=prototypes, policy_artifact_id=policy_artifact_id, implementation="optimized"))
-    payload = runtime_profile_payload(
-        provider_scope=provider,
-        provider_ids=provider_ids,
-        profile_frame_count=len(records),
-        reference=reference,
-        optimized=optimized,
-    )
-    _write_json(output_dir / "runtime-profile-reference.json", {"profiles": reference, "profile_frame_count": len(records)})
-    _write_json(output_dir / "runtime-profile-optimized.json", {"profiles": optimized, "profile_frame_count": len(records)})
-    _write_json(output_dir / "runtime-comparison.json", payload)
-    (output_dir / "runtime-profile-reference.md").write_text(
-        "\n".join(
-            ["# Runtime Profile Reference", ""]
-            + [f"- {item['provider_id']}: {item['mean_seconds_per_frame']:.6f}s/frame over {item['frame_count']} frames" for item in reference]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    (output_dir / "runtime-profile-optimized.md").write_text(
-        "\n".join(
-            ["# Runtime Profile Optimized", ""]
-            + [f"- {item['provider_id']}: {item['mean_seconds_per_frame']:.6f}s/frame over {item['frame_count']} frames" for item in optimized]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    return payload
-
-
-def verify_provider_runtime_equivalence(output_dir: Path, repo_root: Path) -> dict[str, Any]:
-    prototypes = canonical_prototypes()
-    policy_artifact_id = compile_policy_artifact().artifact_id
-    sampled = [
-        {
-            "frame_id": f"canonical:{row_id}",
-            "observation": observation,
-            "expected_row": row_id,
-            "expected_action": action_id,
-        }
-        for row_id, action_id, _digest, observation in list(prototypes.values())[:12]
-    ]
-    comparisons = []
-    for provider_id in ("P1", "P2", "P3"):
-        for record in sampled:
-            reference = score_all_rows_reference(
-                provider_id=provider_id,
-                observation=record["observation"],
-                prototypes=prototypes,
-                policy_artifact_id=policy_artifact_id,
-                source_scope=SOURCE_SCOPE,
-            )
-            optimized = score_all_rows_optimized(
-                provider_id=provider_id,
-                observation=record["observation"],
-                prototypes=prototypes,
-                policy_artifact_id=policy_artifact_id,
-                source_scope=SOURCE_SCOPE,
-            )
-            comparisons.append(
-                _compare_provider_results(
-                    provider_id=provider_id,
-                    observation_id=record["frame_id"],
-                    reference=reference,
-                    optimized=optimized,
-                )
-            )
-    payload = _build_provider_equivalence_payload(comparisons)
-    _write_json(output_dir / "provider-runtime-equivalence.json", payload)
-    _write_csv(output_dir / "provider-runtime-equivalence.csv", comparisons)
-    return payload
+    original = _build_orchestration._materialize_records
+    _build_orchestration._materialize_records = _materialize_records
+    try:
+        return _build_orchestration._profiling_records(repo_root, frame_count)
+    finally:
+        _build_orchestration._materialize_records = original
 
 
 def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]:
-    split_dir = output_dir / split
-    runtime = _build_durable_runtime(output_dir)
-    identity = runtime.video_action_set.load_identity(repo_root)
-    prototypes = canonical_prototypes()
-    policy = compile_policy_artifact()
-    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
-    row_actions = {str(row_id): lookup.choose(str(row_id)) for row_id in policy.source.row_ids}
-    policy_artifact_id = policy.artifact_id
-    reachability_tile = _load_reachability_tile(repo_root)
-    plans = _episode_plans_for_split(identity, split, [str(row_id) for row_id in policy.source.row_ids], row_actions)
-    saved_plans = runtime.video_action_set.save_episode_plans(tuple(EpisodePlanDTO.from_dict(plan) for plan in plans))
-    plans = [dto.to_dict() for dto in saved_plans]
-    records = _materialize_records(split, repo_root)
-    runtime.video_action_set.save_observation_records(records)
-    records = list(runtime.video_action_set.list_observation_records(benchmark_seed_digest=identity.seed_digest, split=split, include_pixels=True))
-    scored_rows = measure_record_collection(
-        records,
-        prototypes,
-        policy_artifact_id,
-        reachability_tile=reachability_tile,
-        row_actions=row_actions,
+    patch_names = (
+        "_materialize_records",
+        "canonical_prototypes",
+        "measure_record_collection",
     )
-    _write_jsonl(split_dir / "frame-metadata.jsonl", [{key: value for key, value in record.items() if key != "pixels"} for record in records])
-    _write_jsonl(split_dir / "provider-evidence.jsonl", scored_rows)
-    manifest = {
-        "split": split,
-        "observation_count": len(records),
-        "provider_frame_record_count": len(scored_rows),
-        "frame_digest": _sha256([{key: value for key, value in record.items() if key != "pixels"} for record in records]),
-        "provider_evidence_digest": _sha256(scored_rows),
-    }
-    _write_json(output_dir / f"{split}-manifest.json", manifest)
-    closure = _family_closure_report(split=split, records=records, plans=plans, identity=identity, reachability_tile=reachability_tile, provider_rows=scored_rows)
-    _write_json(output_dir / f"{split}-family-closure-report.json", closure)
-    if split == "selection":
-        _write_json(output_dir / "family-closure-report.json", closure)
-    _write_observation_identity_manifest(output_dir)
-    _write_split_overlap_audit(output_dir)
-    _write_json(output_dir / "phase-access-audits.json", _measured_phase_access_counts(output_dir))
-    return manifest
-
-
-def _measured_phase_access_counts(output_dir: Path) -> dict[str, Any]:
-    final_path = output_dir / "final-split-sealed-plan.json"
-    final_plan = _read_json(final_path) if final_path.exists() else {}
-    frame_rows = {
-        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        for split in ("development", "calibration", "selection", "final")
-    }
-    evidence_rows = {
-        split: _read_jsonl(output_dir / split / "provider-evidence.jsonl")
-        for split in ("development", "calibration", "selection", "final")
-    }
-    return _build_measured_phase_access_counts(
-        final_plan=final_plan,
-        frame_rows_by_split=frame_rows,
-        evidence_rows_by_split=evidence_rows,
-        existing_artifacts=[path.name for path in output_dir.iterdir()],
-    )
-
-
-def _write_observation_identity_manifest(output_dir: Path) -> None:
-    frames = {
-        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        for split in ("development", "calibration", "selection")
-    }
-    payload = _build_observation_identity_manifest(frames)
-    _write_json(output_dir / "observation-identity-manifest.json", payload)
-
-
-def _write_split_overlap_audit(output_dir: Path) -> None:
-    split_rows = {
-        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        for split in ("development", "calibration", "selection")
-    }
-    final_path = output_dir / "final-split-sealed-plan.json"
-    final_plan = _read_json(final_path) if final_path.exists() else {}
-    payload = _build_split_overlap_audit(
-        frame_rows_by_split=split_rows,
-        final_plan=final_plan,
-    )
-    _write_json(output_dir / "split-overlap-audit.json", payload)
-
-
-def audit_evidence_completeness(output_dir: Path) -> dict[str, Any]:
-    policy = compile_policy_artifact()
-    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
-    row_actions = {
-        str(row_id): lookup.choose(str(row_id)) for row_id in policy.source.row_ids
-    }
-    frame_rows = {
-        split: _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        for split in ("development", "calibration", "selection")
-    }
-    evidence_rows = {
-        split: _read_jsonl(output_dir / split / "provider-evidence.jsonl")
-        for split in ("development", "calibration", "selection")
-    }
-    payload = _audit_evidence_rows(
-        frame_rows_by_split=frame_rows,
-        evidence_rows_by_split=evidence_rows,
-        row_actions=row_actions,
-    )
-    _write_json(output_dir / "evidence-completeness-summary.json", payload)
-    return payload
-
-
-def audit_canonical_providers(output_dir: Path) -> dict[str, Any]:
-    summary, rows = _audit_canonical_provider_results(
-        prototypes=canonical_prototypes(),
-        policy_artifact_id=compile_policy_artifact().artifact_id,
-    )
-    _write_csv(output_dir / "canonical-provider-results.csv", rows)
-    _write_json(output_dir / "canonical-provider-summary.json", summary)
-    _write_json(output_dir / "provider-equivalence-results.json", {"providers_match_themselves": True, "quantized_evidence_exact_match": True})
-    _write_json(output_dir / "tie-safety-results.json", {"explicit_tie_groups": True, "lexical_uniqueness_not_used": True, "deterministic_ranking": True})
-    return summary
-
-
-_NON_FINAL_SPLITS = ("development", "calibration", "selection")
-_ALL_SPLITS = ("development", "calibration", "selection", "final")
-
-
-
-
-def _reference_context(repo_root: Path) -> dict[str, Any]:
-    cache_key = str(repo_root.resolve())
-    if not hasattr(_reference_context, "_cache"):
-        _reference_context._cache = {}  # type: ignore[attr-defined]
-    cache: dict[str, dict[str, Any]] = _reference_context._cache  # type: ignore[attr-defined]
-    if cache_key in cache:
-        return cache[cache_key]
-    identity = load_identity(repo_root)
-    policy = compile_policy_artifact()
-    lookup = VPMPolicyLookup(policy, action_metric_ids=ACTIONS)
-    row_ids = [str(row_id) for row_id in policy.source.row_ids]
-    row_actions = {row_id: lookup.choose(row_id) for row_id in row_ids}
-    plans = {split: _episode_plans_for_split(identity, split, row_ids, row_actions) for split in _ALL_SPLITS}
-    context = _build_reference_context(
-        identity=identity,
-        policy=policy,
-        row_ids=row_ids,
-        row_actions=row_actions,
-        reachability_tile=_load_reachability_tile(repo_root),
-        plans=plans,
-    )
-    cache[cache_key] = context
-    return context
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-def _structural_identity_gate(
-    output_dir: Path,
-    repo_root: Path,
-    context: Mapping[str, Any],
-    *,
-    validate_stored_closure: bool = True,
-) -> dict[str, Any]:
-    findings: list[dict[str, Any]] = []
-    required_files = (
-        "benchmark-contract-identity.json",
-        "generator-identity.json",
-        "benchmark-manifest.json",
-        "policy-artifact.json",
-        "reachability-tile-reference.json",
-        "episode-family-registry.json",
-        "transformation-family-contract.json",
-        "provider-manifest.json",
-        "score-quantizer.json",
-        "split-manifest.json",
-        "episode-plan.json",
-        "final-split-sealed-plan.json",
-        "final-split-sealed-digest.json",
-        "evidence-schema.json",
-        "phase-access-audits.json",
-    )
-    for name in required_files:
-        if not (output_dir / name).exists():
-            findings.append(_finding("expected_file_missing", "required benchmark artifact is missing", path=name))
-    if findings:
-        return _gate("structural_identity", findings, unavailable=False)
-
-    identity: BenchmarkIdentity = context["identity"]
-    policy = context["policy"]
-    row_ids = list(context["row_ids"])
-    row_actions = dict(context["row_actions"])
-    root_identity = _read_json(output_dir / "benchmark-contract-identity.json")
-    if root_identity != identity.to_dict():
-        findings.append(_finding("benchmark_contract_identity_mismatch", "stored benchmark contract identity does not match authoritative contract document"))
-    generator = _read_json(output_dir / "generator-identity.json")
-    if generator.get("generator_version") != GENERATOR_VERSION or generator.get("seed_digest") != identity.seed_digest or generator.get("seed_material") != identity.seed_material:
-        findings.append(_finding("episode_seed_derivation_mismatch", "stored root seed material or digest does not match the authoritative benchmark identity"))
-    manifest = _read_json(output_dir / "benchmark-manifest.json")
-    if manifest.get("benchmark_version") != BENCHMARK_VERSION or manifest.get("policy_artifact_id") != policy.artifact_id or int(manifest.get("row_count", -1)) != len(row_ids):
-        findings.append(_finding("benchmark_manifest_mismatch", "benchmark manifest does not match authoritative benchmark and policy identities"))
-    policy_payload = _read_json(output_dir / "policy-artifact.json")
-    expected_policy_payload = {
-        "policy_artifact_id": policy.artifact_id,
-        "row_count": len(row_ids),
-        "action_count": len(ACTIONS),
-        "row_ids": row_ids,
-        "row_action": row_actions,
-        "row_action_digest": context["policy_row_action_digest"],
-    }
-    if policy_payload != expected_policy_payload:
-        findings.append(_finding("policy_action_mapping_mismatch", "stored policy row/action universe does not match the compiled policy artifact"))
-    tile_reference = _read_json(output_dir / "reachability-tile-reference.json")
-    reachability_tile = context["reachability_tile"]
+    originals = {name: getattr(_build_orchestration, name) for name in patch_names}
     try:
-        _validate_reachability_tile_identity(reachability_tile)
-    except VPMValidationError as exc:
-        findings.append(_finding("reachability_tile_mismatch", "authoritative reachability tile does not validate", error=str(exc)))
-    if tile_reference.get("tile_version") != REACHABILITY_TILE_VERSION or tile_reference.get("tile_digest") != reachability_tile.get("tile_digest"):
-        findings.append(_finding("reachability_tile_mismatch", "stored reachability tile identity does not match the authoritative transition artifact"))
-    if _read_json(output_dir / "episode-family-registry.json") != _episode_family_registry():
-        findings.append(_finding("family_contract_violation", "episode-family registry differs from the frozen registry"))
-    if _read_json(output_dir / "transformation-family-contract.json") != _transformation_contract():
-        findings.append(_finding("family_contract_violation", "transformation-family contract differs from the frozen contract"))
-    expected_provider_manifest = {
-        "providers": [
-            {"provider_id": "P1", "provider_version": PROSPECTIVE_P1_VERSION},
-            {"provider_id": "P2", "provider_version": PROSPECTIVE_P2_VERSION},
-            {"provider_id": "P3", "provider_version": PROSPECTIVE_P3_VERSION},
-        ]
-    }
-    if _read_json(output_dir / "provider-manifest.json") != expected_provider_manifest:
-        findings.append(_finding("provider_contract_mismatch", "provider manifest does not match the frozen provider contracts"))
-    quantizer = _read_json(output_dir / "score-quantizer.json")
-    if quantizer.get("version") != VIDEO_SCORE_QUANTIZER_VERSION or int(quantizer.get("scale", -1)) != QUANTIZATION_SCALE:
-        findings.append(_finding("score_quantizer_mismatch", "score quantizer identity is not the frozen quantizer"))
-    evidence_schema = _read_json(output_dir / "evidence-schema.json")
-    if evidence_schema.get("version") != "zeromodel-video-complete-row-evidence/v2" or evidence_schema.get("requires_semantic_top_set_outcome") is not True:
-        findings.append(_finding("evidence_schema_mismatch", "evidence schema does not require complete semantic score evidence"))
-
-    closure_path = output_dir / "reference-closure-report.json"
-    if validate_stored_closure and closure_path.exists():
-        closure = _read_json(closure_path)
-        required_gate_names = set(_REQUIRED_VERIFICATION_GATES)
-        present_gate_names = {str(gate.get("gate")) for gate in closure.get("verification", {}).get("gates", [])}
-        if not required_gate_names <= present_gate_names:
-            findings.append(_finding("closure_gate_missing", "stored closure report omits one or more required verification gates"))
-        for gate in closure.get("verification", {}).get("gates", []):
-            if gate.get("status") == "passed" and (int(gate.get("finding_count", 0)) > 0 or gate.get("findings")):
-                findings.append(_finding("status_claim_not_supported", "stored closure gate status is passed despite recorded findings", gate=gate.get("gate")))
-        expected_closure_digest = _sha256({key: value for key, value in closure.items() if key != "closure_report_digest"})
-        if closure.get("closure_report_digest") != expected_closure_digest:
-            findings.append(_finding("status_claim_not_supported", "stored closure report digest does not match the closure payload"))
-        if closure.get("supported_status") == "reference_instrument_correct":
-            mutation_audit = closure.get("mutation_audit", {})
-            if mutation_audit.get("status") != "passed":
-                findings.append(_finding("status_claim_not_supported", "stored closure claims correctness without a passing mutation audit"))
-            else:
-                measured = verify_reference_instrument(output_dir, repo_root, validate_stored_closure=False)
-                if not measured.get("verified"):
-                    findings.append(_finding("status_claim_not_supported", "stored closure status claims correctness that measured gates do not support"))
-    return _gate("structural_identity", findings)
-
-
-def _expected_split_counts() -> dict[str, int]:
-    return {
-        "development": 112,
-        "calibration": 448,
-        "selection": 1008,
-    }
-
-
-def _seed_and_plan_gate(output_dir: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
-    findings: list[dict[str, Any]] = []
-    identity: BenchmarkIdentity = context["identity"]
-    row_actions = context["row_actions"]
-    plans_by_split = context["plans"]
-    try:
-        plan_payload = _read_json(output_dir / "episode-plan.json")
-        final_payload = _read_json(output_dir / "final-split-sealed-plan.json")
-    except FileNotFoundError:
-        return _gate("seed_and_plan", [_finding("expected_file_missing", "episode plan file is missing")], unavailable=False)
-    if plan_payload.get("version") != EPISODE_PLAN_VERSION or plan_payload.get("seed_derivation_version") != SEED_DERIVATION_VERSION:
-        findings.append(_finding("episode_seed_derivation_mismatch", "episode plan schema or seed derivation version is unsupported"))
-    seen: dict[str, str] = {}
-    for split in _NON_FINAL_SPLITS:
-        stored_split = plan_payload.get("splits", {}).get(split, {})
-        stored_plans = list(stored_split.get("episodes", []))
-        expected_plans = list(plans_by_split[split])
-        if len(stored_plans) != len(expected_plans):
-            findings.append(_finding("sealed_episode_identity_mismatch", "stored split plan count does not match deterministic regenerated plan count", split=split))
-            continue
-        for expected, stored in zip(expected_plans, stored_plans):
-            episode_id = str(stored.get("episode_id"))
-            if episode_id in seen:
-                findings.append(_finding("duplicate_episode_id", "episode id is duplicated across sealed split plans", episode_id=episode_id, previous_split=seen[episode_id], split=split))
-            seen[episode_id] = split
-            if stored.get("split") != split or not episode_id.startswith(f"{split}:"):
-                findings.append(_finding("episode_split_reassignment", "episode id or split field crosses its sealed split boundary", episode_id=episode_id, split=split))
-            if stored.get("derived_seed_identity") != expected.get("derived_seed_identity") or stored.get("episode_seed") != expected.get("episode_seed"):
-                findings.append(_finding("episode_seed_derivation_mismatch", "stored episode seed lineage does not match deterministic derivation", episode_id=episode_id))
-                if max_findings is not None and len(findings) >= max_findings:
-                    return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[item]) for item in _ALL_SPLITS)})
-                continue
-            if stored.get("source_row_id") != expected.get("source_row_id") or stored.get("secondary_row_id") != expected.get("secondary_row_id"):
-                findings.append(_finding("episode_seed_derivation_mismatch", "stored source-row lineage does not match deterministic derivation", episode_id=episode_id))
-                if max_findings is not None and len(findings) >= max_findings:
-                    return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[item]) for item in _ALL_SPLITS)})
-                continue
-            if stored.get("episode_disposition") != expected.get("episode_disposition") or stored.get("denominator_class") != expected.get("denominator_class"):
-                findings.append(_finding("family_disposition_mismatch", "stored episode disposition fields do not match deterministic derivation", episode_id=episode_id))
-            if dict(stored) != expected:
-                findings.append(_finding("sealed_episode_identity_mismatch", "stored sealed episode plan does not match deterministic regeneration", episode_id=episode_id))
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[item]) for item in _ALL_SPLITS)})
-    expected_final = {
-        "version": EPISODE_PLAN_VERSION,
-        "seed_derivation_version": SEED_DERIVATION_VERSION,
-        "split": "final",
-        "plan_only": True,
-        "materialization_prohibited": True,
-        "episode_counts": {
-            "valid": 112,
-            "frame_invalid": 56,
-            "temporal_negative": 56,
-            "information_control": 28,
-        },
-        "frame_count": 1008,
-        "sealed_episode_ids": _episode_ids_by_family(plans_by_split["final"]),
-        "episodes": plans_by_split["final"],
-        "seed_commitment": identity.seed_digest,
-    }
-    expected_final = expected_final | {"sealed_plan_digest": _sha256(expected_final)}
-    for plan in final_payload.get("episodes", []):
-        if plan.get("final_observation_provenance") != _final_observation_provenance("final"):
-            findings.append(
-                _finding(
-                    "final_observation_provenance_mismatch",
-                    "final split episode claims materialized observation provenance",
-                    episode_id=plan.get("episode_id"),
-                )
-            )
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[split]) for split in _ALL_SPLITS)})
-    if final_payload != expected_final:
-        findings.append(_finding("sealed_episode_identity_mismatch", "final sealed split identity does not match deterministic regeneration"))
-        if max_findings is not None and len(findings) >= max_findings:
-            return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[split]) for split in _ALL_SPLITS)})
-    digest_payload = _read_json(output_dir / "final-split-sealed-digest.json")
-    if digest_payload.get("digest") != expected_final["sealed_plan_digest"]:
-        findings.append(_finding("sealed_episode_identity_mismatch", "final sealed split digest sidecar does not match the final sealed plan"))
-        if max_findings is not None and len(findings) >= max_findings:
-            return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[split]) for split in _ALL_SPLITS)})
-    try:
-        _validate_episode_plan_collection(context["identity"], plans_by_split, row_actions)
-    except VPMValidationError as exc:
-        findings.append(_finding("episode_seed_derivation_mismatch", "authoritative regenerated plan collection failed validation", error=str(exc)))
-    return _gate("seed_and_plan", findings, counts={"sealed_episode_count": sum(len(plans_by_split[split]) for split in _ALL_SPLITS)})
-
-
-def _episode_regeneration_gate(output_dir: Path, repo_root: Path, *, max_findings: int | None = None) -> dict[str, Any]:
-    findings: list[dict[str, Any]] = []
-    counts: dict[str, int] = {}
-    for split in _NON_FINAL_SPLITS:
-        path = output_dir / split / "frame-metadata.jsonl"
-        if not path.exists():
-            findings.append(_finding("expected_record_missing", "split frame metadata is missing", split=split))
-            continue
-        stored_rows = _read_jsonl(path)
-        expected_rows = _cached_materialized_metadata(repo_root, split)
-        counts[f"{split}_stored_observations"] = len(stored_rows)
-        counts[f"{split}_expected_observations"] = len(expected_rows)
-        if len(stored_rows) != len(expected_rows):
-            findings.append(_finding("expected_record_missing", "stored observation count does not match regenerated count", split=split))
-        expected_by_key = {(row["episode_id"], int(row["sequence_number"])): row for row in expected_rows}
-        stored_by_key = {(row.get("episode_id"), int(row.get("sequence_number", -1))): row for row in stored_rows}
-        for key in sorted(set(expected_by_key) - set(stored_by_key)):
-            findings.append(_finding("expected_record_missing", "regenerated observation is absent from stored frame metadata", split=split, episode_id=key[0], sequence_number=key[1]))
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("episode_regeneration", findings, counts=counts)
-        for key in sorted(set(stored_by_key) - set(expected_by_key)):
-            findings.append(_finding("orphan_observation_record", "stored frame metadata has no sealed regenerated observation", split=split, episode_id=key[0], sequence_number=key[1]))
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("episode_regeneration", findings, counts=counts)
-        for key in sorted(set(expected_by_key) & set(stored_by_key)):
-            expected = expected_by_key[key]
-            stored = stored_by_key[key]
-            if stored.get("frame_id") != expected.get("frame_id") or stored.get("clip_id") != expected.get("clip_id"):
-                findings.append(_finding("frame_identity_mismatch", "stored frame identity does not match regenerated identity", split=split, episode_id=key[0], sequence_number=key[1]))
-            if stored.get("event_type") == "gap_unknown" and stored.get("pixels") is not None:
-                findings.append(_finding("gap_event_has_pixels", "declared gap event carries ordinary pixels", split=split, episode_id=key[0], sequence_number=key[1]))
-            if stored.get("event_type") != expected.get("event_type") or stored.get("gap_declaration") != expected.get("gap_declaration"):
-                findings.append(_finding("gap_event_structure_mismatch", "stored event type or gap declaration does not match regenerated observation", split=split, episode_id=key[0], sequence_number=key[1]))
-            if stored.get("observation_pixel_digest") != expected.get("observation_pixel_digest"):
-                code = "observation_digest_mismatch" if stored.get("observation_pixel_digest") and expected.get("observation_pixel_digest") else "observation_bytes_mismatch"
-                findings.append(_finding(code, "stored observation identity does not match regenerated pixel bytes", split=split, episode_id=key[0], sequence_number=key[1]))
-            comparable_fields = ("family", "expected_disposition", "expected_row", "expected_action", "actual_executed_action", "action_known")
-            for field in comparable_fields:
-                if stored.get(field) != expected.get(field):
-                    findings.append(_finding("family_regeneration_mismatch", "stored frame classification does not match regenerated episode", split=split, episode_id=key[0], sequence_number=key[1], field=field))
-                    break
-            stored_meta = stored.get("metadata", {})
-            expected_meta = expected.get("metadata", {})
-            for field in ("seed_digest", "derived_seed_identity", "episode_plan_digest", "frame_seed_identity"):
-                if stored_meta.get(field) != expected_meta.get(field):
-                    findings.append(_finding("family_regeneration_mismatch", "stored frame seed or plan metadata does not match regenerated episode", split=split, episode_id=key[0], sequence_number=key[1], field=field))
-                    break
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("episode_regeneration", findings, counts=counts)
-    return _gate("episode_regeneration", findings, counts=counts)
-
-
-def _semantic_outcome_gate(output_dir: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
-    findings: list[dict[str, Any]] = []
-    row_ids = context["row_ids"]
-    row_actions = context["row_actions"]
-    counts = {"provider_score_records": 0}
-    semantic_cache: dict[str, Any] = {}
-    for split in _NON_FINAL_SPLITS:
-        for row in _read_jsonl(output_dir / split / "provider-evidence.jsonl"):
-            counts["provider_score_records"] += 1
-            if row.get("policy_artifact_id") != context["policy"].artifact_id:
-                findings.append(_finding("policy_action_mapping_mismatch", "provider row references a foreign policy artifact", split=split, frame_id=row.get("frame_id")))
-                continue
-            if row.get("provider_version") != _provider_version(str(row.get("provider_id"))):
-                findings.append(_finding("provider_contract_mismatch", "provider row references a foreign provider contract", split=split, frame_id=row.get("frame_id"), provider_id=row.get("provider_id")))
-                continue
-            expected, evidence_findings = _expected_semantic_for_row(row, row_actions, row_ids, semantic_cache)
-            findings.extend(evidence_findings)
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("semantic_outcome", findings, counts=counts)
-            if expected is None:
-                continue
-            payload = row.get("semantic_top_set_outcome", {})
-            payload_top_rows = {str(item) for item in payload.get("top_row_ids", [])}
-            expected_top_rows = set(expected.top_row_ids)
-            if payload_top_rows != expected_top_rows or set(row.get("top_row_ids", [])) != expected_top_rows:
-                findings.append(_finding("semantic_status_mismatch", "stored semantic top-row set does not match reconstructed top set", split=split, frame_id=row.get("frame_id")))
-            payload_actions = {str(item.get("row_id")): str(item.get("action_id")) for item in payload.get("top_row_actions", [])}
-            if payload_actions != {row_id: row_actions[row_id] for row_id in expected_top_rows}:
-                findings.append(_finding("policy_action_mapping_mismatch", "stored semantic row/action mapping does not match authoritative policy mapping", split=split, frame_id=row.get("frame_id")))
-            if payload.get("status") != expected.status or row.get("semantic_status") != expected.status:
-                findings.append(_finding("semantic_status_mismatch", "stored semantic status does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
-            stored_resolved_row = payload.get("resolved_row_id", row.get("resolved_row"))
-            stored_resolved_action = payload.get("resolved_action_id", row.get("resolved_action"))
-            if expected.resolved_row_id is None and stored_resolved_row is not None:
-                findings.append(_finding("resolved_row_not_permitted", "stored semantic outcome resolves a row where the frozen rules do not permit one", split=split, frame_id=row.get("frame_id")))
-            elif stored_resolved_row != expected.resolved_row_id or row.get("resolved_row") != expected.resolved_row_id:
-                findings.append(_finding("semantic_status_mismatch", "stored resolved row does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
-            if expected.resolved_action_id is None and stored_resolved_action is not None:
-                findings.append(_finding("resolved_action_not_permitted", "stored semantic outcome resolves an action where the frozen rules do not permit one", split=split, frame_id=row.get("frame_id")))
-            elif stored_resolved_action != expected.resolved_action_id or row.get("resolved_action") != expected.resolved_action_id:
-                findings.append(_finding("semantic_status_mismatch", "stored resolved action does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
-            if payload.get("rejection_reason") != expected.rejection_reason:
-                findings.append(_finding("semantic_status_mismatch", "stored semantic rejection reason does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
-            if payload.get("semantic_outcome_digest") != expected.semantic_outcome_digest or row.get("semantic_outcome_digest") != expected.semantic_outcome_digest:
-                findings.append(_finding("semantic_outcome_digest_mismatch", "stored semantic outcome digest does not match independent reconstruction", split=split, frame_id=row.get("frame_id")))
-            if row.get("winner_row") != expected.resolved_row_id:
-                code = "resolved_row_not_permitted" if expected.resolved_row_id is None and row.get("winner_row") is not None else "semantic_status_mismatch"
-                findings.append(_finding(code, "stored winner row does not match semantic reconstruction", split=split, frame_id=row.get("frame_id")))
-            if row.get("winner_action") != expected.resolved_action_id:
-                code = "resolved_action_not_permitted" if expected.resolved_action_id is None and row.get("winner_action") is not None else "semantic_status_mismatch"
-                findings.append(_finding(code, "stored winner action does not match semantic reconstruction", split=split, frame_id=row.get("frame_id")))
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("semantic_outcome", findings, counts=counts)
-    return _gate("semantic_outcome", findings, counts=counts)
-
-
-def _family_contract_gate(output_dir: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
-    findings: list[dict[str, Any]] = []
-    counts = {"family_records_checked": 0}
-    row_actions = context["row_actions"]
-    reachability_tile = context["reachability_tile"]
-    canonical_digest_set = set(_canonical_observation_digest_index())
-    transformed_valid_digest_set: set[str] | None = None
-
-    def has_transformed_valid_collision(digest: str | None) -> bool:
-        nonlocal transformed_valid_digest_set
-        if digest is None:
-            return False
-        if transformed_valid_digest_set is None:
-            transformed_valid_digest_set = set(_valid_transformed_observation_digest_index()["digest_index"]) - canonical_digest_set
-        return str(digest) in transformed_valid_digest_set
-
-    for split in _NON_FINAL_SPLITS:
-        by_episode: dict[str, list[dict[str, Any]]] = {}
-        for row in _read_jsonl(output_dir / split / "frame-metadata.jsonl"):
-            by_episode.setdefault(str(row.get("episode_id")), []).append(row)
-        for episode_id, rows in by_episode.items():
-            ordered = sorted(rows, key=lambda item: int(item.get("sequence_number", -1)))
-            counts["family_records_checked"] += len(ordered)
-            family = ordered[0].get("family")
-            for row in ordered:
-                episode_family = row.get("episode_family")
-                if episode_family not in {"valid", "frame_invalid", "temporal_negative", "information_control"}:
-                    findings.append(_finding("family_disposition_mismatch", "frame omits a recognized episode family", split=split, episode_id=episode_id))
-                    continue
-                if row.get("episode_disposition") != _episode_disposition(str(episode_family)):
-                    findings.append(_finding("family_disposition_mismatch", "frame episode disposition does not match its family", split=split, episode_id=episode_id))
-                if row.get("denominator_class") != _denominator_class(str(episode_family)):
-                    findings.append(_finding("family_disposition_mismatch", "frame denominator class does not match its family", split=split, episode_id=episode_id))
-                if not row.get("frame_disposition"):
-                    findings.append(_finding("family_disposition_mismatch", "frame disposition is missing", split=split, episode_id=episode_id))
-                intervention = row.get("metadata", {}).get("family_intervention", {})
-                mutation_kind = intervention.get("family_id") if episode_family != "valid" else None
-                expected_frame = expected_frame_disposition(str(episode_family), None if mutation_kind is None else str(mutation_kind), int(row.get("sequence_number", -1)), intervention)
-                if row.get("frame_disposition") != expected_frame:
-                    findings.append(_finding("frame_disposition_mismatch", "frame disposition does not match independent family derivation", split=split, episode_id=episode_id, frame_id=row.get("frame_id"), expected=expected_frame, actual=row.get("frame_disposition")))
-                provenance_status = validate_observation_operation_chain(row)
-                if provenance_status != "ok":
-                    findings.append(_finding(provenance_status, "stored observation operation chain does not independently replay to the emitted observation", split=split, episode_id=episode_id, frame_id=row.get("frame_id")))
-            if any(row.get("event_type") == "gap_unknown" and (row.get("observation_pixel_digest") is not None or row.get("pixels") is not None) for row in ordered):
-                findings.append(_finding("gap_event_has_pixels", "typed gap event carries ordinary observation identity", split=split, episode_id=episode_id))
-            if family == "conflicting_action_splice":
-                for row in ordered:
-                    metadata = row.get("metadata", {})
-                    trace = metadata.get("family_intervention_trace", {})
-                    if metadata.get("source_action_id") == metadata.get("competitor_action_id"):
-                        findings.append(_finding("family_contract_violation", "conflicting splice uses two rows governed by the same action", split=split, episode_id=episode_id))
-                    if int(trace.get("primary_contributing_pixel_count", 0)) <= 0 or int(trace.get("secondary_contributing_pixel_count", 0)) <= 0:
-                        findings.append(_finding("family_contract_violation", "conflicting splice does not include nonzero contributions from both sources", split=split, episode_id=episode_id))
-                    splice_counts = trace.get("action_relevant_region_contribution_counts", {})
-                    if int(splice_counts.get("primary_target_pixel_count", 0)) <= 0 or int(splice_counts.get("secondary_additive_target_pixel_count", 0)) <= 0:
-                        findings.append(_finding("family_contract_violation", "conflicting splice lacks two visible target evidence contributions", split=split, episode_id=episode_id))
-                    if trace.get("splice_mask_version") != SPLICE_MASK_VERSION or trace.get("target_region_id") != TARGET_REGION_ID:
-                        findings.append(_finding("family_contract_violation", "conflicting splice trace does not use the frozen target-evidence mask", split=split, episode_id=episode_id))
-                    if trace.get("output_observation_digest") != row.get("observation_pixel_digest"):
-                        findings.append(_finding("family_regeneration_mismatch", "conflicting splice output digest does not match stored observation", split=split, episode_id=episode_id))
-                    try:
-                        replay = replay_observation_operation_chain(metadata["observation_operation_chain"])
-                        visible_action_evidence = _final_visible_target_action_evidence(replay["pixels"], row_actions)
-                        if not visible_action_evidence["conflicting_action_evidence_present"]:
-                            findings.append(_finding("conflicting_action_evidence_absent", "final visible splice target evidence does not imply at least two policy actions", split=split, episode_id=episode_id))
-                        if trace.get("visible_action_evidence_digest") != visible_action_evidence["visible_action_evidence_digest"]:
-                            findings.append(_finding("conflicting_action_evidence_absent", "stored visible-action splice evidence does not match independent reconstruction", split=split, episode_id=episode_id))
-                    except (KeyError, TypeError, VPMValidationError, ValueError):
-                        findings.append(_finding("final_observation_provenance_mismatch", "conflicting splice operation chain could not be replayed for visible-action reconstruction", split=split, episode_id=episode_id))
-                    if _canonical_observation_digest_index().get(str(row.get("observation_pixel_digest"))):
-                        findings.append(_finding("invalid_family_valid_state_collision", "conflicting splice output decodes as a canonical valid observation", split=split, episode_id=episode_id))
-                    elif has_transformed_valid_collision(row.get("observation_pixel_digest")):
-                        findings.append(_finding("invalid_family_valid_transformation_collision", "conflicting splice output decodes as a bounded transformed valid observation", split=split, episode_id=episode_id))
-            elif family == "critical_evidence_corruption":
-                for row in ordered:
-                    metadata = row.get("metadata", {})
-                    trace = metadata.get("family_intervention_trace", {})
-                    changes = trace.get("changes", [])
-                    if not changes:
-                        findings.append(_finding("family_contract_violation", "critical corruption has an empty changed-coordinate set", split=split, episode_id=episode_id))
-                    if trace.get("changed_pixel_count") == 0:
-                        findings.append(_finding("family_no_op", "critical corruption is a no-op", split=split, episode_id=episode_id))
-                    if _canonical_observation_digest_index().get(str(row.get("observation_pixel_digest"))):
-                        findings.append(_finding("invalid_family_valid_state_collision", "critical corruption output decodes as a canonical valid observation", split=split, episode_id=episode_id))
-                    elif has_transformed_valid_collision(row.get("observation_pixel_digest")):
-                        findings.append(_finding("invalid_family_valid_transformation_collision", "critical corruption output decodes as a bounded transformed valid observation", split=split, episode_id=episode_id))
-                    for change in changes:
-                        coord = (int(change.get("y", -1)), int(change.get("x", -1)))
-                        if coord not in set(_critical_coordinates()) or change.get("original") == change.get("replacement"):
-                            findings.append(_finding("family_contract_violation", "critical corruption changed a non-critical coordinate or preserved the original value", split=split, episode_id=episode_id))
-            elif family == "bounded_translation" or family == "bounded_photometric" or family == "bounded_translation_photometric" or family == "bounded_translation_occlusion" or family == "compound_bounded" or family == "exact":
-                for row in ordered:
-                    metadata = row.get("metadata", {})
-                    try:
-                        _validate_transformation_parameters(metadata.get("transformation_parameters", {}))
-                    except (KeyError, VPMValidationError) as exc:
-                        findings.append(_finding("family_contract_violation", "valid transformation parameters violate the frozen bounds", split=split, episode_id=episode_id, error=str(exc)))
-            if any(row.get("expected_disposition") == "information_theoretic_control" for row in ordered):
-                code = validate_control_episode_records(ordered)
-                if code != "ok":
-                    findings.append(_finding(code, "information control records violate byte-identity, hidden-history, or denominator rules", split=split, episode_id=episode_id))
-            if any("stale_repeat" in row.get("metadata", {}) for row in ordered):
-                repeat_rows = [row for row in ordered if "stale_repeat" in row.get("metadata", {})]
-                for row in repeat_rows:
-                    repeat = row["metadata"]["stale_repeat"]
-                    if repeat.get("original_destination_digest") == repeat.get("replacement_digest"):
-                        findings.append(_finding("family_contract_violation", "stale repeat does not replace the destination with different bytes", split=split, episode_id=episode_id))
-                    if row.get("observation_pixel_digest") != repeat.get("replacement_digest"):
-                        findings.append(_finding("family_regeneration_mismatch", "stale repeat stored digest does not match replacement digest", split=split, episode_id=episode_id))
-            if any("impossible_transition" in row.get("metadata", {}) for row in ordered):
-                for row in ordered:
-                    transition = row.get("metadata", {}).get("impossible_transition")
-                    if not transition:
-                        continue
-                    edge = _tile_edge(reachability_tile, str(transition["source_row_id"]), str(transition["source_action_id"]))
-                    if str(transition["destination_row_id"]) in set(edge["reachable_row_ids"]):
-                        findings.append(_finding("transition_classification_mismatch", "impossible-transition episode contains at least one reachable pair", split=split, episode_id=episode_id))
-            if any(row.get("metadata", {}).get("sequence_rule") == "non_identity_permutation" for row in ordered):
-                materialized = [row.get("metadata", {}).get("original_frame_index") for row in ordered]
-                if materialized == sorted(materialized) or sorted(materialized) != list(range(len(ordered))):
-                    findings.append(_finding("family_contract_violation", "reordered-frame metadata is not a non-identity complete permutation", split=split, episode_id=episode_id))
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("family_contract", findings, counts=counts)
-    return _gate("family_contract", findings, counts=counts)
-
-
-def _reachability_gate(output_dir: Path, repo_root: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
-    findings: list[dict[str, Any]] = []
-    counts = {"reachability_traces_checked": 0}
-    row_ids = context["row_ids"]
-    row_actions = context["row_actions"]
-    reachability_tile = context["reachability_tile"]
-    semantic_cache: dict[str, Any] = {}
-    for split in _NON_FINAL_SPLITS:
-        frames = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        evidence_rows = _read_jsonl(output_dir / split / "provider-evidence.jsonl")
-        by_frame_provider = {(row.get("frame_id"), row.get("provider_id")): row for row in evidence_rows}
-        reachability_state: dict[str, Mapping[str, Any] | None] = {"P1": None, "P2": None, "P3": None}
-        expected_frames = _cached_materialized_metadata(repo_root, split)
-        # Use stored order only after sorting by the deterministic frame identity. This keeps JSONL row order non-semantic.
-        if len(expected_frames) != len(frames):
-            expected_frames = sorted(frames, key=lambda row: (str(row.get("episode_id")), int(row.get("sequence_number", -1))))
-        for frame in expected_frames:
-            if frame.get("event_type") == "gap_unknown" or frame.get("observation_pixel_digest") is None:
-                for provider_id in reachability_state:
-                    reachability_state[provider_id] = _gap_reachability_state(frame)
-                continue
-            for provider_id in ("P1", "P2", "P3"):
-                row = by_frame_provider.get((frame.get("frame_id"), provider_id))
-                if row is None:
-                    findings.append(_finding("reachability_trace_mismatch", "provider score row missing for scored frame", split=split, frame_id=frame.get("frame_id"), provider_id=provider_id))
-                    if max_findings is not None and len(findings) >= max_findings:
-                        return _gate("reachability", findings, counts=counts)
-                    continue
-                expected_outcome, evidence_findings = _expected_semantic_for_row(row, row_actions, row_ids, semantic_cache)
-                if evidence_findings or expected_outcome is None:
-                    continue
-                trace = row.get("reachability_composition_trace")
-                if not trace:
-                    findings.append(_finding("reachability_trace_mismatch", "provider row is missing reachability composition trace", split=split, frame_id=frame.get("frame_id"), provider_id=provider_id))
-                    if max_findings is not None and len(findings) >= max_findings:
-                        return _gate("reachability", findings, counts=counts)
-                    continue
-                expected_trace = compose_reachability_trace(
-                    frame_id=str(row["frame_id"]),
-                    semantic_outcome=expected_outcome.to_dict(),
-                    previous_state=reachability_state[provider_id],
-                    reachability_tile=reachability_tile,
-                    row_actions=row_actions,
-                )
-                counts["reachability_traces_checked"] += 1
-                if trace.get("reachability_tile_identity") != reachability_tile["tile_digest"]:
-                    findings.append(_finding("reachability_tile_mismatch", "reachability trace references a foreign tile identity", split=split, frame_id=row.get("frame_id"), provider_id=provider_id))
-                elif trace.get("executed_action") != expected_trace.get("executed_action"):
-                    findings.append(_finding("executed_action_mismatch", "reachability trace executed action does not match independent composition", split=split, frame_id=row.get("frame_id"), provider_id=provider_id))
-                else:
-                    code = validate_reachability_trace(
-                        trace,
-                        semantic_outcome=expected_outcome.to_dict(),
-                        previous_state=reachability_state[provider_id],
-                        reachability_tile=reachability_tile,
-                        row_actions=row_actions,
-                    )
-                    if code != "ok":
-                        if code in {"foreign_reachability_tile", "foreign_reachability_trace_digest"}:
-                            code = "reachability_tile_mismatch" if code == "foreign_reachability_tile" else "reachability_trace_mismatch"
-                        findings.append(_finding(code, "stored reachability trace does not match independent composition", split=split, frame_id=row.get("frame_id"), provider_id=provider_id))
-                if max_findings is not None and len(findings) >= max_findings:
-                    return _gate("reachability", findings, counts=counts)
-                reachability_state[provider_id] = _state_from_trace(expected_trace)
-    return _gate("reachability", findings, counts=counts)
-
-
-def _completeness_orphan_gate(output_dir: Path, repo_root: Path, context: Mapping[str, Any], *, max_findings: int | None = None) -> dict[str, Any]:
-    findings: list[dict[str, Any]] = []
-    counts: dict[str, int] = {}
-    final_ids = {episode_id for values in _episode_ids_by_family(context["plans"]["final"]).values() for episode_id in values}
-    known_frame_ids: set[str] = set()
-    known_episode_ids: set[str] = set()
-    non_control_digest_owner: dict[str, str] = {}
-    expected_digest_owners = _expected_digest_owners(repo_root)
-    for split in _NON_FINAL_SPLITS:
-        frame_rows = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-        evidence_rows = _read_jsonl(output_dir / split / "provider-evidence.jsonl")
-        counts[f"{split}_frame_records"] = len(frame_rows)
-        counts[f"{split}_provider_records"] = len(evidence_rows)
-        for row in frame_rows:
-            frame_id = str(row.get("frame_id"))
-            episode_id = str(row.get("episode_id"))
-            if frame_id in known_frame_ids:
-                findings.append(_finding("duplicate_observation_record", "frame identity is duplicated", split=split, frame_id=frame_id))
-                if max_findings is not None and len(findings) >= max_findings:
-                    return _gate("completeness_orphan", findings, counts=counts)
-            known_frame_ids.add(frame_id)
-            known_episode_ids.add(episode_id)
-            if episode_id in final_ids or row.get("split") == "final":
-                findings.append(_finding("forbidden_final_materialization", "final sealed episode has a materialized frame descendant", split=split, episode_id=episode_id))
-                if max_findings is not None and len(findings) >= max_findings:
-                    return _gate("completeness_orphan", findings, counts=counts)
-            digest = row.get("observation_pixel_digest")
-            if digest is not None and row.get("expected_disposition") != "information_theoretic_control":
-                previous = non_control_digest_owner.get(str(digest))
-                expected_owners = expected_digest_owners.get(str(digest), set())
-                if previous is not None and previous != episode_id and episode_id not in expected_owners:
-                    findings.append(_finding("duplicate_observation_identity_unpermitted", "non-control observation identity is reused by multiple episodes", split=split, episode_id=episode_id, digest=digest))
-                    if max_findings is not None and len(findings) >= max_findings:
-                        return _gate("completeness_orphan", findings, counts=counts)
-                non_control_digest_owner[str(digest)] = episode_id
-        scored_frame_ids = {str(row.get("frame_id")) for row in evidence_rows}
-        for row in evidence_rows:
-            if row.get("frame_id") not in known_frame_ids:
-                findings.append(_finding("orphan_score_vector_record", "score vector references an unknown observation", split=split, frame_id=row.get("frame_id")))
-            if row.get("episode_id") not in known_episode_ids:
-                findings.append(_finding("orphan_score_vector_record", "score vector references an unknown episode", split=split, episode_id=row.get("episode_id")))
-            semantic = row.get("semantic_top_set_outcome", {})
-            if semantic.get("quantized_score_vector_digest") != row.get("score_vector_digest"):
-                findings.append(_finding("semantic_outcome_digest_mismatch", "semantic outcome does not reference the stored score vector identity", split=split, frame_id=row.get("frame_id")))
-            trace = row.get("reachability_composition_trace")
-            if trace and trace.get("semantic_outcome_digest") != row.get("semantic_outcome_digest"):
-                findings.append(_finding("reachability_trace_mismatch", "reachability trace does not reference the stored semantic outcome identity", split=split, frame_id=row.get("frame_id")))
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("completeness_orphan", findings, counts=counts)
-        gap_frame_ids = {str(row.get("frame_id")) for row in frame_rows if row.get("event_type") == "gap_unknown" or row.get("observation_pixel_digest") is None}
-        if scored_frame_ids & gap_frame_ids:
-            findings.append(_finding("gap_event_has_pixels", "typed gap frame has provider score evidence", split=split))
-            if max_findings is not None and len(findings) >= max_findings:
-                return _gate("completeness_orphan", findings, counts=counts)
-    return _gate("completeness_orphan", findings, counts=counts)
-
-
-def _access_prohibition_gate(output_dir: Path, *, max_findings: int | None = None) -> dict[str, Any]:
-    measured = _measured_phase_access_counts(output_dir)
-    stored_path = output_dir / "phase-access-audits.json"
-    stored = _read_json(stored_path) if stored_path.exists() else {}
-    return _build_access_prohibition_gate(measured, stored, max_findings=max_findings)
-
-
-def verify_reference_instrument(
-    output_dir: Path,
-    repo_root: Path,
-    *,
-    validate_stored_closure: bool = True,
-    enabled_gates: Sequence[str] | None = None,
-    stop_after_first_failure: bool = False,
-) -> dict[str, Any]:
-    """Read-only independent verification of a materialized reference-instrument directory."""
-    context = _reference_context(repo_root)
-    enabled = set(enabled_gates) if enabled_gates is not None else set(_REQUIRED_VERIFICATION_GATES)
-    max_findings = 1 if stop_after_first_failure else None
-    gate_builders = (
-        ("structural_identity", lambda: _structural_identity_gate(output_dir, repo_root, context, validate_stored_closure=validate_stored_closure)),
-        ("semantic_outcome", lambda: _semantic_outcome_gate(output_dir, context, max_findings=max_findings)),
-        ("seed_and_plan", lambda: _seed_and_plan_gate(output_dir, context, max_findings=max_findings)),
-        ("episode_regeneration", lambda: _episode_regeneration_gate(output_dir, repo_root, max_findings=max_findings)),
-        ("family_contract", lambda: _family_contract_gate(output_dir, context, max_findings=max_findings)),
-        ("reachability", lambda: _reachability_gate(output_dir, repo_root, context, max_findings=max_findings)),
-        ("completeness_orphan", lambda: _completeness_orphan_gate(output_dir, repo_root, context, max_findings=max_findings)),
-        ("access_prohibition", lambda: _access_prohibition_gate(output_dir, max_findings=max_findings)),
-    )
-    gates = []
-    for name, builder in gate_builders:
-        if name not in enabled:
-            continue
-        gate = builder()
-        gates.append(gate)
-        if stop_after_first_failure and gate["status"] == "failed":
-            break
-    return _build_reference_verification_payload(
-        context=context,
-        gates=gates,
-        phase_counts=_measured_phase_access_counts(output_dir),
-    )
-
-
-def _file_digest(path: Path) -> str:
-    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def _directory_snapshot(path: Path) -> dict[str, dict[str, Any]]:
-    if not path.exists():
-        return {}
-    snapshot: dict[str, dict[str, Any]] = {}
-    for item in sorted(path.rglob("*")):
-        if item.is_file():
-            stat = item.stat()
-            snapshot[str(item.relative_to(path)).replace("\\", "/")] = {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns, "digest": _file_digest(item)}
-    return snapshot
-
-
-def verify_reference_read_only(output_dir: Path, repo_root: Path) -> dict[str, Any]:
-    before = _directory_snapshot(output_dir)
-    first = verify_reference_instrument(output_dir, repo_root)
-    middle = _directory_snapshot(output_dir)
-    second = verify_reference_instrument(output_dir, repo_root)
-    after = _directory_snapshot(output_dir)
-    return _build_read_only_verification_payload(before=before, middle=middle, after=after, first=first, second=second)
-
-
-
-
-
-
-
-
-
-def _cached_materialized_metadata(repo_root: Path, split: str) -> list[dict[str, Any]]:
-    cache_key = (str(repo_root.resolve()), str(split))
-    if not hasattr(_cached_materialized_metadata, "_cache"):
-        _cached_materialized_metadata._cache = {}  # type: ignore[attr-defined]
-    cache: dict[tuple[str, str], list[dict[str, Any]]] = _cached_materialized_metadata._cache  # type: ignore[attr-defined]
-    if cache_key not in cache:
-        cache[cache_key] = [{key: value for key, value in row.items() if key != "pixels"} for row in _materialize_records(split, repo_root)]
-    return cache[cache_key]
-
-
-def _expected_digest_owners(repo_root: Path) -> dict[str, set[str]]:
-    cache_key = str(repo_root.resolve())
-    if not hasattr(_expected_digest_owners, "_cache"):
-        _expected_digest_owners._cache = {}  # type: ignore[attr-defined]
-    cache: dict[str, dict[str, set[str]]] = _expected_digest_owners._cache  # type: ignore[attr-defined]
-    if cache_key not in cache:
-        owners: dict[str, set[str]] = {}
-        for split in _NON_FINAL_SPLITS:
-            for row in _cached_materialized_metadata(repo_root, split):
-                digest = row.get("observation_pixel_digest")
-                if digest is not None and row.get("expected_disposition") != "information_theoretic_control":
-                    owners.setdefault(str(digest), set()).add(str(row.get("episode_id")))
-        cache[cache_key] = owners
-    return cache[cache_key]
-
-
-
-
-
-
-
-
-
-
-def _structural_payload(path: Path) -> Any:
-    if path.suffix == ".json":
-        return json.loads(path.read_text(encoding="utf-8"))
-    if path.suffix == ".jsonl":
-        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-    return path.read_text(encoding="utf-8")
-
-
-
-
-def _mutation_structural_snapshot(output_dir: Path, *, only_files: Sequence[str] | None = None) -> dict[str, Any]:
-    snapshot: dict[str, Any] = {}
-    selected = None if only_files is None else {str(item).replace("\\", "/") for item in only_files}
-    for path in sorted(output_dir.rglob("*")):
-        if not path.is_file():
-            continue
-        relative = str(path.relative_to(output_dir)).replace("\\", "/")
-        if selected is not None and relative not in selected:
-            continue
-        try:
-            snapshot[relative] = _structural_payload(path)
-        except UnicodeDecodeError:
-            snapshot[relative] = {"binary_digest": _file_digest(path)}
-    return snapshot
-
-
-
-
-
-
-
-
-def _rewrite_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
-    _write_jsonl(path, [dict(row) for row in rows])
-
-
-def _launder_split_manifest(output_dir: Path, split: str) -> None:
-    manifest_path = output_dir / f"{split}-manifest.json"
-    if not manifest_path.exists():
-        return
-    frame_rows = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
-    evidence_rows = _read_jsonl(output_dir / split / "provider-evidence.jsonl")
-    manifest = _read_json(manifest_path)
-    manifest["observation_count"] = len(frame_rows)
-    manifest["provider_frame_record_count"] = len(evidence_rows)
-    manifest["frame_digest"] = _sha256(frame_rows)
-    manifest["provider_evidence_digest"] = _sha256(evidence_rows)
-    _write_json(manifest_path, manifest)
-
-
-def _mutate_first_provider_row(output_dir: Path, mutator: Any, *, predicate: Any | None = None, splits: Sequence[str] = ("development", "calibration", "selection")) -> None:
-    for split in splits:
-        path = output_dir / split / "provider-evidence.jsonl"
-        rows = _read_jsonl(path)
-        for row in rows:
-            if predicate is None or predicate(row):
-                mutator(row)
-                _rewrite_jsonl(path, rows)
-                _launder_split_manifest(output_dir, split)
-                return
-    raise VPMValidationError("mutation fixture lacks a matching provider row")
-
-
-def _mutate_first_frame_row(output_dir: Path, mutator: Any, *, predicate: Any | None = None) -> None:
-    path = output_dir / "selection" / "frame-metadata.jsonl"
-    rows = _read_jsonl(path)
-    for row in rows:
-        if predicate is None or predicate(row):
-            mutator(row)
-            _rewrite_jsonl(path, rows)
-            _launder_split_manifest(output_dir, "selection")
-            return
-    raise VPMValidationError("mutation fixture lacks a matching frame row")
-
-
-def _apply_reference_mutation(output_dir: Path, case_name: str) -> None:
-    if case_name.startswith("evidence_"):
-        def mutate(row: dict[str, Any]) -> None:
-            if case_name == "evidence_raw_score_preserve_quantized_bin":
-                row["all_112_raw_scores"][0] = float(row["all_112_raw_scores"][0]) + 1e-12
-            elif case_name == "evidence_raw_score_cross_quantization_boundary":
-                row["all_112_raw_scores"][0] = 0.0 if int(row["all_112_quantized_scores"][0]) else 1.0
-            elif case_name == "evidence_quantized_score_changed":
-                row["all_112_quantized_scores"][0] = min(QUANTIZATION_SCALE, int(row["all_112_quantized_scores"][0]) + 1)
-                row["score_vector_digest"] = _sha256({"laundered": row["all_112_quantized_scores"]})
-                row["quantized_score_vector_digest"] = row["score_vector_digest"]
-            elif case_name == "evidence_remove_row_score":
-                for key in ("all_112_row_ids", "all_112_raw_scores", "all_112_quantized_scores"):
-                    row[key].pop()
-            elif case_name == "evidence_duplicate_row_score":
-                row["all_112_row_ids"][1] = row["all_112_row_ids"][0]
-            elif case_name == "evidence_introduce_foreign_row":
-                row["all_112_row_ids"][0] = "foreign:row"
-            elif case_name == "evidence_reorder_stored_rows":
-                for key in ("all_112_row_ids", "all_112_raw_scores", "all_112_quantized_scores"):
-                    row[key][0], row[key][1] = row[key][1], row[key][0]
-            elif case_name == "evidence_alter_ranking_order":
-                row["complete_ordered_ranking"][0], row["complete_ordered_ranking"][1] = row["complete_ordered_ranking"][1], row["complete_ordered_ranking"][0]
-            elif case_name == "evidence_alter_tie_group_membership":
-                row["tie_groups"][0]["row_ids"][0] = row["complete_ordered_ranking"][-1]
-            elif case_name == "evidence_split_tie_group_incorrectly":
-                top = row["tie_groups"][0]
-                if len(top["row_ids"]) < 2:
-                    top["row_ids"].append(row["complete_ordered_ranking"][1])
-                moved = top["row_ids"].pop()
-                row["tie_groups"].insert(1, {"tie_group_index": 1, "quantized_score": top["quantized_score"], "row_ids": [moved]})
-            elif case_name == "evidence_merge_distinct_score_groups":
-                if len(row["tie_groups"]) > 1:
-                    row["tie_groups"][0]["row_ids"].extend(row["tie_groups"][1]["row_ids"])
-                    row["tie_groups"].pop(1)
-                else:
-                    row["tie_groups"][0]["row_ids"].append(row["complete_ordered_ranking"][-1])
-            elif case_name == "evidence_alter_quantized_score_vector_digest":
-                row["score_vector_digest"] = "sha256:" + "0" * 64
-                row["quantized_score_vector_digest"] = row["score_vector_digest"]
-            elif case_name == "evidence_alter_raw_diagnostic_digest":
-                row["raw_score_diagnostic_digest"] = "sha256:" + "0" * 64
-        _mutate_first_provider_row(output_dir, mutate)
-        return
-
-    if case_name.startswith("semantic_"):
-        def semantic_mutate(row: dict[str, Any]) -> None:
-            payload = row["semantic_top_set_outcome"]
-            if case_name == "semantic_resolved_row_for_action_unanimous_tie":
-                payload["resolved_row_id"] = payload["top_row_ids"][0]
-                row["resolved_row"] = payload["resolved_row_id"]
-            elif case_name == "semantic_resolved_action_for_conflicting_tie":
-                payload["resolved_action_id"] = payload["top_action_ids"][0]
-                row["resolved_action"] = payload["resolved_action_id"]
-                row["winner_action"] = payload["resolved_action_id"]
-            elif case_name == "semantic_convert_conflicting_tie_to_unique_row":
-                payload["status"] = "unique_row"
-                row["semantic_status"] = "unique_row"
-            elif case_name == "semantic_change_top_row_policy_action":
-                payload["top_row_actions"][0]["action_id"] = "FIRE" if payload["top_row_actions"][0]["action_id"] != "FIRE" else "LEFT"
-            elif case_name == "semantic_change_rejection_reason":
-                payload["rejection_reason"] = "mutated rejection reason"
-            elif case_name == "semantic_alter_outcome_digest":
-                payload["semantic_outcome_digest"] = "sha256:" + "1" * 64
-                row["semantic_outcome_digest"] = payload["semantic_outcome_digest"]
-            elif case_name == "semantic_lexically_reorder_tied_rows":
-                payload["top_row_ids"] = list(reversed(payload["top_row_ids"]))
-                row["top_row_ids"] = list(reversed(row["top_row_ids"]))
-            elif case_name == "semantic_reorder_rows_preserving_action_equivalence":
-                payload["top_row_actions"] = list(reversed(payload["top_row_actions"]))
-        if case_name == "semantic_resolved_row_for_action_unanimous_tie":
-            _mutate_first_provider_row(output_dir, semantic_mutate, predicate=lambda row: row.get("semantic_status") == "action_unanimous_tie")
-        elif case_name in {"semantic_resolved_action_for_conflicting_tie", "semantic_convert_conflicting_tie_to_unique_row", "semantic_change_rejection_reason"}:
-            _mutate_first_provider_row(output_dir, semantic_mutate, predicate=lambda row: row.get("semantic_status") == "conflicting_action_tie")
-        elif case_name in {"semantic_lexically_reorder_tied_rows", "semantic_reorder_rows_preserving_action_equivalence"}:
-            _mutate_first_provider_row(output_dir, semantic_mutate, predicate=lambda row: len(row.get("top_row_ids", [])) > 1)
-        else:
-            _mutate_first_provider_row(output_dir, semantic_mutate)
-        return
-
-    if case_name.startswith("policy_"):
-        payload = _read_json(output_dir / "policy-artifact.json")
-        if case_name == "policy_remove_policy_row":
-            payload["row_ids"].pop()
-        elif case_name == "policy_add_undeclared_row":
-            payload["row_ids"].append("foreign:row")
-            payload["row_action"]["foreign:row"] = "LEFT"
-        elif case_name == "policy_alter_artifact_identity":
-            payload["policy_artifact_id"] = "sha256:foreign-policy"
-        elif case_name == "policy_mapping_recomputed_superficial_metadata":
-            payload["row_action_digest"] = _sha256({"laundered": payload["row_action"], "mutation": case_name})
-        else:
-            first = payload["row_ids"][0]
-            payload["row_action"][first] = "FIRE" if payload["row_action"][first] != "FIRE" else "LEFT"
-            payload["row_action_digest"] = _sha256({"laundered": payload["row_action"]})
-        _write_json(output_dir / "policy-artifact.json", payload)
-        return
-
-    if case_name.startswith("observation_"):
-        if case_name == "observation_swap_two_frame_payloads":
-            path = output_dir / "selection" / "frame-metadata.jsonl"
-            rows = _read_jsonl(path)
-            rows[0]["observation_pixel_digest"], rows[1]["observation_pixel_digest"] = rows[1]["observation_pixel_digest"], rows[0]["observation_pixel_digest"]
-            _rewrite_jsonl(path, rows)
-            _launder_split_manifest(output_dir, "selection")
-        elif case_name == "observation_alter_frame_identity":
-            _mutate_first_frame_row(output_dir, lambda row: row.__setitem__("frame_id", str(row["frame_id"]) + ":mutated"))
-        elif case_name == "observation_reuse_under_two_episode_ids":
-            path = output_dir / "selection" / "frame-metadata.jsonl"
-            rows = _read_jsonl(path)
-            first_row = next(row for row in rows if row.get("observation_pixel_digest") and row.get("expected_disposition") != "information_theoretic_control")
-            first_digest = first_row["observation_pixel_digest"]
-            first_episode = first_row["episode_id"]
-            for row in rows:
-                if row.get("observation_pixel_digest") and row.get("expected_disposition") != "information_theoretic_control" and row["episode_id"] != first_episode:
-                    row["observation_pixel_digest"] = first_digest
-                    break
-            _rewrite_jsonl(path, rows)
-            _launder_split_manifest(output_dir, "selection")
-        elif case_name == "observation_substitute_frame_for_declared_gap":
-            _mutate_first_frame_row(output_dir, lambda row: (row.__setitem__("event_type", "frame"), row.__setitem__("gap_declaration", None), row.__setitem__("observation_pixel_digest", "sha256:" + "2" * 64)), predicate=lambda row: row.get("event_type") == "gap_unknown")
-        else:
-            replacement = {
-                "observation_flip_byte_digest": "sha256:" + "3" * 64,
-                "observation_change_pixels_and_recompute_digest": "sha256:" + "b" * 64,
-                "observation_change_digest_without_pixels": "sha256:" + "c" * 64,
-            }[case_name]
-            _mutate_first_frame_row(output_dir, lambda row: row.__setitem__("observation_pixel_digest", replacement), predicate=lambda row: row.get("observation_pixel_digest") is not None)
-        return
-
-    if case_name.startswith("seed_"):
-        if case_name in {"seed_alter_root_seed_material", "seed_alter_root_seed_digest"}:
-            path = output_dir / ("generator-identity.json" if case_name == "seed_alter_root_seed_material" else "benchmark-contract-identity.json")
-            payload = _read_json(path)
-            if case_name == "seed_alter_root_seed_material":
-                payload["seed_material"] = str(payload["seed_material"]) + "|mutated"
-            else:
-                payload["seed_digest"] = "sha256:" + "4" * 64
-            _write_json(path, payload)
-            return
-        path = output_dir / "episode-plan.json"
-        payload = _read_json(path)
-        plan = payload["splits"]["selection"]["episodes"][0]
-        if case_name == "seed_alter_derived_seed":
-            plan["derived_seed_identity"] = "sha256:" + "5" * 64
-        elif case_name == "seed_alter_derivation_namespace":
-            plan["seed_lineage"]["concrete_episode_seed"]["namespace"] = "mutated_namespace"
-        elif case_name == "seed_alter_episode_ordinal":
-            plan["ordinal"] += 1
-        elif case_name == "seed_alter_split_identity":
-            plan["split"] = "development"
-        elif case_name == "seed_move_episode_between_splits":
-            moved = payload["splits"]["development"]["episodes"][0]
-            moved["split"] = "selection"
-            moved["episode_id"] = "selection:moved-from-development"
-        elif case_name == "seed_duplicate_episode_id":
-            payload["splits"]["selection"]["episodes"][1]["episode_id"] = plan["episode_id"]
-        elif case_name == "seed_alter_source_row":
-            plan["source_row_id"] = payload["policy_row_ids"][-1]
-        elif case_name == "seed_alter_splice_partner":
-            target = next(item for item in payload["splits"]["selection"]["episodes"] if item.get("mutation_kind") == "conflicting_action_splice")
-            target["secondary_row_id"] = target["source_row_id"]
-        elif case_name == "seed_alter_transformation_parameters":
-            plan["frame_plans"][0]["transformation_parameters"]["dx"] = 99
-        elif case_name == "seed_alter_planned_family":
-            plan["family_label"] = "temporal_negative"
-        elif case_name == "seed_alter_sealed_plan_digest":
-            plan["plan_digest"] = "sha256:" + "6" * 64
-        elif case_name == "seed_alter_final_sealed_identity":
-            final_path = output_dir / "final-split-sealed-plan.json"
-            final = _read_json(final_path)
-            final["episodes"][0]["episode_id"] = "final:valid:mutated"
-            final["sealed_episode_ids"]["valid"][0] = "final:valid:mutated"
-            final["sealed_plan_digest"] = _sha256({key: value for key, value in final.items() if key != "sealed_plan_digest"})
-            _write_json(final_path, final)
-            _write_json(output_dir / "final-split-sealed-digest.json", {"digest": final["sealed_plan_digest"]})
-            return
-        elif case_name == "seed_final_observation_provenance_materialized":
-            final_path = output_dir / "final-split-sealed-plan.json"
-            final = _read_json(final_path)
-            final["episodes"][0]["final_observation_provenance"] = {
-                "materialization_status": "materialized",
-                "observation_payload_included": True,
-                "provenance": "mutated_final_payload_claim",
-            }
-            final["sealed_plan_digest"] = _sha256({key: value for key, value in final.items() if key != "sealed_plan_digest"})
-            _write_json(final_path, final)
-            _write_json(output_dir / "final-split-sealed-digest.json", {"digest": final["sealed_plan_digest"]})
-            return
-        _write_json(path, payload)
-        return
-
-    if case_name.startswith("family_"):
-        def family_mutate(row: dict[str, Any]) -> None:
-            metadata = row.setdefault("metadata", {})
-            trace = metadata.setdefault("family_intervention_trace", {})
-            if case_name == "family_conflicting_splice_same_action_rows":
-                metadata["competitor_action_id"] = metadata.get("source_action_id")
-            elif case_name == "family_splice_zero_source_contribution":
-                trace["secondary_contributing_pixel_count"] = 0
-            elif case_name == "family_splice_output_equal_one_source":
-                trace["output_observation_digest"] = trace.get("primary_source_digest")
-            elif case_name == "family_splice_valid_state_collision":
-                canonical = canonical_observation_universe()["rows"][0]
-                row["observation_pixel_digest"] = canonical["observation_pixel_digest"]
-                metadata["observation_operation_chain"] = _valid_frame_operation_chain(canonical["row_id"], _transformation_parameters("exact", 0))
-                trace["output_observation_digest"] = canonical["observation_pixel_digest"]
-                trace["canonical_collision_count"] = 1
-                trace["canonical_collision_rows"] = [{"row_id": canonical["row_id"], "action_id": canonical["action_id"]}]
-            elif case_name == "family_splice_target_evidence_count_removed":
-                trace.setdefault("action_relevant_region_contribution_counts", {})["secondary_additive_target_pixel_count"] = 0
-            elif case_name == "family_critical_empty_coordinate_set":
-                trace["changes"] = []
-            elif case_name == "family_corrupt_noncritical_coordinates":
-                if trace.get("changes"):
-                    trace["changes"][0]["y"] = 0
-                    trace["changes"][0]["x"] = 0
-            elif case_name == "family_replacement_value_identical":
-                if trace.get("changes"):
-                    trace["changes"][0]["replacement"] = trace["changes"][0]["original"]
-            elif case_name == "family_clipping_quantization_noop":
-                trace["changed_pixel_count"] = 0
-            elif case_name in {"family_reordered_metadata_original_payload_order", "family_identity_permutation_labelled_reordered"}:
-                metadata["original_frame_index"] = int(row.get("sequence_number", 0)) if case_name == "family_reordered_metadata_original_payload_order" else -1
-            elif case_name in {"family_stale_label_without_repeated_bytes", "family_stale_repeat_naturally_identical"}:
-                repeat = metadata.setdefault("stale_repeat", {})
-                if case_name == "family_stale_label_without_repeated_bytes":
-                    repeat["replacement_digest"] = repeat.get("original_destination_digest", row.get("observation_pixel_digest"))
-                else:
-                    repeat["original_destination_digest"] = repeat.get("replacement_digest", row.get("observation_pixel_digest"))
-            elif case_name == "family_impossible_transition_reachable_pair":
-                transition = metadata.setdefault("impossible_transition", {})
-                edge = transition.get("consulted_edge", {})
-                if edge.get("reachable_row_ids"):
-                    transition["destination_row_id"] = edge["reachable_row_ids"][0]
-            elif case_name == "family_gap_event_carrying_pixels":
-                row["pixels"] = [[0]]
-            elif case_name == "family_information_control_pixel_difference":
-                row["observation_pixel_digest"] = "sha256:" + "7" * 64
-            elif case_name == "family_control_denominator_leak":
-                metadata["denominator_eligible"] = True
-            elif case_name == "family_control_visible_source_leak":
-                metadata["provider_visible_fields"] = ["pixels", "source_row_id"]
-            elif case_name == "family_episode_disposition_mismatch":
-                row["episode_disposition"] = "valid"
-                row["denominator_class"] = "valid_denominator"
-        if case_name == "family_control_hidden_history_collapse":
-            path = output_dir / "selection" / "frame-metadata.jsonl"
-            rows = _read_jsonl(path)
-            control_episode = next(row["episode_id"] for row in rows if row.get("expected_disposition") == "information_theoretic_control")
-            control_rows = [row for row in rows if row.get("episode_id") == control_episode]
-            first_metadata = control_rows[0].setdefault("metadata", {})
-            hidden_history_id = first_metadata.get("hidden_source_history_id")
-            hidden_label = first_metadata.get("hidden_source_label_digest")
-            for row in control_rows:
-                metadata = row.setdefault("metadata", {})
-                metadata["hidden_source_history_id"] = hidden_history_id
-                metadata["hidden_source_label_digest"] = hidden_label
-            _rewrite_jsonl(path, rows)
-            _launder_split_manifest(output_dir, "selection")
-            return
-        if "splice" in case_name:
-            _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("family") == "conflicting_action_splice")
-        elif "critical" in case_name or "corrupt" in case_name or "replacement" in case_name or "noop" in case_name:
-            _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("family") == "critical_evidence_corruption")
-        elif "reordered" in case_name or "permutation" in case_name:
-            _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("metadata", {}).get("sequence_rule") == "non_identity_permutation")
-        elif "stale" in case_name:
-            _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: "stale_repeat" in row.get("metadata", {}))
-        elif "impossible" in case_name:
-            _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: "impossible_transition" in row.get("metadata", {}))
-        elif "gap" in case_name:
-            _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("event_type") == "gap_unknown")
-        else:
-            _mutate_first_frame_row(output_dir, family_mutate, predicate=lambda row: row.get("expected_disposition") == "information_theoretic_control")
-        return
-
-    if case_name.startswith("reachability_"):
-        if case_name in {"reachability_add_impossible_edge", "reachability_change_tile_identity", "reachability_change_unrelated_edge"}:
-            payload = _read_json(output_dir / "reachability-tile-reference.json")
-            if case_name == "reachability_add_impossible_edge":
-                payload["tile_digest"] = "sha256:" + "8" * 64
-                payload["mutation_kind"] = "added-impossible-edge"
-            elif case_name == "reachability_change_unrelated_edge":
-                payload["tile_digest"] = "sha256:" + "7" * 64
-                payload["mutation_kind"] = "changed-unrelated-edge"
-            else:
-                payload["tile_digest"] = "sha256:" + "6" * 64
-            _write_json(output_dir / "reachability-tile-reference.json", payload)
-            return
-        def reach_mutate(row: dict[str, Any]) -> None:
-            trace = row["reachability_composition_trace"]
-            if case_name == "reachability_remove_applicable_edge":
-                trace["consulted_edges"][0]["reachable_row_ids"] = []
-            elif case_name == "reachability_redirect_applicable_edge":
-                trace["reachable_candidate_pairs"][0]["destination_row_id"] = row["all_112_row_ids"][-1]
-            elif case_name == "reachability_alter_destination_action":
-                row["semantic_top_set_outcome"]["top_row_actions"][0]["action_id"] = "FIRE" if row["semantic_top_set_outcome"]["top_row_actions"][0]["action_id"] != "FIRE" else "LEFT"
-                trace["mutation_kind"] = "altered_destination_action"
-            elif case_name in {"reachability_alter_consulted_edge_list", "reachability_omit_consulted_edge"}:
-                if case_name == "reachability_alter_consulted_edge_list":
-                    trace["consulted_edges"][0]["action_id"] = "FIRE" if trace["consulted_edges"][0]["action_id"] != "FIRE" else "LEFT"
-                else:
-                    trace["consulted_edges"] = []
-            elif case_name == "reachability_add_unconsulted_edge_to_trace":
-                trace["consulted_edges"].append({"source_row_id": "foreign", "action_id": "LEFT", "reachable_row_ids": []})
-            elif case_name == "reachability_alter_reachable_pair_set":
-                trace["reachable_candidate_pairs"].append({"source_row_id": "foreign", "action_id": "LEFT", "destination_row_id": "foreign"})
-            elif case_name == "reachability_alter_retained_candidate_rows":
-                trace["retained_rows"] = list(reversed(trace.get("retained_rows", []))) + ["foreign:retained"]
-            elif case_name == "reachability_alter_removed_candidate_rows":
-                trace["removed_rows"] = list(reversed(trace.get("removed_rows", []))) + ["foreign"]
-            elif case_name == "reachability_replace_rejection_with_lexical_winner":
-                trace["status"] = "resolved"
-                trace["executed_action"] = "LEFT"
-            elif case_name == "reachability_change_executed_action":
-                trace["executed_action"] = "FIRE" if trace.get("executed_action") != "FIRE" else "LEFT"
-            elif case_name == "reachability_use_foreign_trace_digest":
-                trace["trace_digest"] = "sha256:" + "9" * 64
-            if case_name != "reachability_use_foreign_trace_digest":
-                trace["trace_digest"] = _trace_digest(trace)
-        if case_name in {"reachability_remove_applicable_edge", "reachability_alter_consulted_edge_list", "reachability_omit_consulted_edge", "reachability_add_unconsulted_edge_to_trace"}:
-            predicate = lambda row: bool(row.get("reachability_composition_trace", {}).get("consulted_edges"))
-        elif case_name in {"reachability_redirect_applicable_edge", "reachability_alter_reachable_pair_set"}:
-            predicate = lambda row: bool(row.get("reachability_composition_trace", {}).get("reachable_candidate_pairs"))
-        elif case_name == "reachability_alter_removed_candidate_rows":
-            predicate = lambda row: bool(row.get("reachability_composition_trace", {}).get("removed_rows"))
-        elif case_name == "reachability_replace_rejection_with_lexical_winner":
-            predicate = lambda row: row.get("reachability_composition_trace", {}).get("status") == "rejected"
-        elif case_name == "reachability_change_executed_action":
-            predicate = lambda row: row.get("reachability_composition_trace", {}).get("executed_action") is not None
-        else:
-            predicate = lambda row: row.get("reachability_composition_trace") is not None
-        _mutate_first_provider_row(output_dir, reach_mutate, predicate=predicate)
-        return
-
-    if case_name.startswith("access_"):
-        if case_name in {"access_increment_final_materialization_count", "access_increment_forbidden_access_counter"}:
-            payload = _read_json(output_dir / "phase-access-audits.json")
-            payload["forbidden_final_access_counter"] = int(payload.get("forbidden_final_access_counter", 0)) + 1
-            if case_name == "access_increment_final_materialization_count":
-                payload["final_materialization_count"] = int(payload.get("final_materialization_count", 0)) + 1
-            _write_json(output_dir / "phase-access-audits.json", payload)
-        elif case_name in {"access_add_final_observation_artifact", "access_add_final_score_vector_record", "access_add_final_reachability_trace"}:
-            final_plan = _read_json(output_dir / "final-split-sealed-plan.json")
-            final_id = final_plan["sealed_episode_ids"]["valid"][0]
-            if case_name == "access_add_final_observation_artifact":
-                _write_jsonl(output_dir / "final" / "frame-metadata.jsonl", [{"split": "final", "episode_id": final_id, "frame_id": f"final:{final_id}:frame-00"}])
-            else:
-                row = _read_jsonl(output_dir / "selection" / "provider-evidence.jsonl")[0]
-                row["split"] = "final"
-                row["episode_id"] = final_id
-                if case_name == "access_add_final_reachability_trace":
-                    row["reachability_composition_trace"] = {"trace_digest": "sha256:" + "a" * 64}
-                _write_jsonl(output_dir / "final" / "provider-evidence.jsonl", [row])
-        elif case_name == "access_record_calibration_execution":
-            _write_json(output_dir / "selected-calibration.json", {"executed": True})
-        elif case_name == "access_record_architecture_selection_execution":
-            _write_json(output_dir / "selected-architecture.json", {"executed": True})
-        else:
-            report = {
-                "version": REFERENCE_VERIFICATION_VERSION,
-                "verified": True,
-                "gates": [_gate(name, []) for name in _REQUIRED_VERIFICATION_GATES],
-                "primary_failure_code": None,
-                "primary_failure_gate": None,
-            }
-            closure = {"version": CLOSURE_REPORT_VERSION, "supported_status": "reference_instrument_correctness_unresolved", "verification": report}
-            if case_name == "access_change_failed_gate_status_to_passed":
-                closure["verification"]["gates"][0]["status"] = "passed"
-                closure["verification"]["gates"][0]["findings"] = [_finding("status_claim_not_supported", "synthetic failed gate relabelled as passed")]
-                closure["verification"]["gates"][0]["finding_count"] = 1
-            if case_name == "access_remove_required_gate_from_closure_report":
-                closure["verification"]["gates"] = closure["verification"]["gates"][1:]
-            if case_name == "access_change_repository_status_to_correct":
-                closure["supported_status"] = "reference_instrument_correct"
-            closure["closure_report_digest"] = _sha256({key: value for key, value in closure.items() if key != "closure_report_digest"})
-            _write_json(output_dir / "reference-closure-report.json", closure)
-        return
-    raise VPMValidationError(f"unsupported mutation case: {case_name}")
-
-
-def run_reference_mutation_audit(output_dir: Path, repo_root: Path, *, mutation_names: Sequence[str] | None = None) -> dict[str, Any]:
-    import shutil
-    import tempfile
-
-    requested = None if mutation_names is None else {str(name) for name in mutation_names}
-    catalogue = mutation_catalogue()
-    selected_cases = tuple(case for case in catalogue if requested is None or case["mutation_id"] in requested)
-    catalogue_findings = validate_mutation_catalogue()
-    if requested is not None:
-        selected_names = {str(case["mutation_id"]) for case in selected_cases}
-        catalogue_findings.extend(_finding("mutation_not_declared", "requested mutation is not declared", mutation=name) for name in sorted(requested - selected_names))
-    base = verify_reference_instrument(output_dir, repo_root)
-    if not base["verified"] or catalogue_findings:
-        return _build_mutation_audit_payload(
-            matrix_version=MUTATION_MATRIX_VERSION,
-            catalogue=catalogue,
-            selected_cases=selected_cases,
-            catalogue_findings=catalogue_findings,
-            results=(),
-            base_verified=False,
-            base_primary_failure_code=base.get("primary_failure_code"),
-        )
-    base_directory = _directory_snapshot(output_dir)
-    results = []
-    with tempfile.TemporaryDirectory(prefix="reference-mutation-audit-") as tmp:
-        tmp_root = Path(tmp)
-        for case in selected_cases:
-            case_dir = tmp_root / str(case["mutation_id"])
-            shutil.copytree(output_dir, case_dir)
-            application_error = None
-            try:
-                _apply_reference_mutation(case_dir, str(case["mutation_id"]))
-                changed_files = _changed_snapshot_files(base_directory, _directory_snapshot(case_dir))
-                before = _mutation_structural_snapshot(output_dir, only_files=changed_files)
-                after = _mutation_structural_snapshot(case_dir, only_files=changed_files)
-                isolation = _mutation_isolation_report(before, after, case)
-                report = verify_reference_instrument(case_dir, repo_root, enabled_gates=case["validation_metadata"]["gate_scope"], stop_after_first_failure=True)
-            except Exception as exc:  # pragma: no cover - historical audit boundary.
-                application_error = type(exc).__name__
-                isolation = {
-                    "changed_fields": [],
-                    "expected_changed_files": list(case.get("expected_changed_files", [])),
-                    "unexpected_changed_fields": [],
-                    "changed_field_count": 0,
-                    "isolation_passed": False,
-                    "mutation_effect_digest": "sha256:application-error",
-                }
-                report = {"gates": []}
-            results.append(_evaluate_mutation_case(case=case, report=report, isolation=isolation, application_error=application_error))
-    return _build_mutation_audit_payload(
-        matrix_version=MUTATION_MATRIX_VERSION,
-        catalogue=catalogue,
-        selected_cases=selected_cases,
-        catalogue_findings=catalogue_findings,
-        results=results,
-    )
-
-
-def run_repeated_reference_mutation_audit(output_dir: Path, repo_root: Path, *, mutation_names: Sequence[str] | None = None) -> dict[str, Any]:
-    first = run_reference_mutation_audit(output_dir, repo_root, mutation_names=mutation_names)
-    second = run_reference_mutation_audit(output_dir, repo_root, mutation_names=mutation_names)
-    return _build_repeated_mutation_audit_payload(matrix_version=MUTATION_MATRIX_VERSION, first=first, second=second)
-
-
-def build_reference_closure_report(output_dir: Path, repo_root: Path, *, include_mutation_audit: bool = True) -> dict[str, Any]:
-    verification = verify_reference_instrument(output_dir, repo_root)
-    repeated = run_repeated_reference_mutation_audit(output_dir, repo_root) if include_mutation_audit else _build_unavailable_repeated_mutation_audit()
-    read_only = verify_reference_read_only(output_dir, repo_root)
-    episode_plan_path = output_dir / "episode-plan.json"
-    plans = _read_json(episode_plan_path).get("splits", {}) if episode_plan_path.exists() else {}
-    return _build_verification_closure(
-        verification=verification,
-        repeated_mutation_audit=repeated,
-        read_only=read_only,
-        split_plan_identities={split: _sha256(context) for split, context in plans.items()},
-    )
-
-
-def verify_instrument(output_dir: Path, repo_root: Path) -> dict[str, Any]:
-    closure = build_reference_closure_report(output_dir, repo_root, include_mutation_audit=False)
-    return _verification_summary(closure)
-
-
-def _run_adversarial_mutation_checks(output_dir: Path) -> list[str]:
-    repo_root = Path(__file__).resolve().parents[1]
-    audit = run_reference_mutation_audit(output_dir, repo_root)
-    return [row["mutation"] for row in audit.get("mutations", []) if not row.get("expected_code_matched", False)]
+        for name in patch_names:
+            setattr(_build_orchestration, name, globals()[name])
+        return _build_orchestration.build_split(split, output_dir, repo_root)
+    finally:
+        for name, value in originals.items():
+            setattr(_build_orchestration, name, value)
+
+
+# fmt: off
+_STAGE7C_COMPATIBILITY_ALIASES = (ACTIONS, BENCHMARK_VERSION, BenchmarkIdentity, CANONICAL_OBSERVATION_UNIVERSE_VERSION,
+    CLOSURE_REPORT_VERSION, CONFLICTING_ACTION_SPLICE_VERSION, CRITICAL_EVIDENCE_CORRUPTION_VERSION, DECLARED_GAP_OR_UNKNOWN_VERSION,
+    EPISODE_FAMILY_REGISTRY_VERSION, EPISODE_PLAN_VERSION, FAMILY_CLOSURE_VERSION, FAMILY_INTERVENTION_VERSION,
+    FRAME_INVALID_CLOSURE_VERSION, FRAME_SHAPE, GENERATOR_VERSION, IMPOSSIBLE_TRANSITION_VERSION, INFORMATION_CONTROL_VERSION,
+    MUTATION_AUDIT_VERSION, MUTATION_MATRIX_VERSION, OBSERVATION_OPERATION_CHAIN_VERSION, PHASE_ACCESS_VERSION, PROSPECTIVE_P1_VERSION,
+    PROVIDER_OBSERVATION_BOUNDARY_VERSION, REACHABILITY_COMPOSITION_VERSION, REACHABILITY_TILE_DIGEST, REACHABILITY_TILE_VERSION,
+    REACHABILITY_TRACE_VERSION, REFERENCE_VERIFICATION_VERSION, REORDERED_FRAMES_VERSION, SEED_DERIVATION_VERSION, SOURCE_SCOPE,
+    SPLICE_MASK_VERSION, STALE_REPEATED_FRAME_VERSION, ShooterConfig, TRANSFORMATION_FAMILY_VERSION, VALID_OBSERVATION_UNIVERSE_VERSION,
+    VPMPolicyLookup, _MUTATION_CASES, _REQUIRED_VERIFICATION_GATES, _access_prohibition_gate, _apply_conflicting_splice,
+    _apply_critical_corruption, _apply_family, _apply_frame_plan, _apply_reference_mutation, _apply_transformation, _array_digest,
+    _build_durable_runtime, _cached_materialized_metadata, _canonical_collision_rows, _canonical_observation_digest_index, _changed_fields,
+    _completeness_orphan_gate, _conflicting_splice_operation_chain, _conflicting_splice_source_rows, _control_episode,
+    _control_provider_source_id, _control_source_rows, _critical_coordinate_manifest, _critical_coordinates,
+    _critical_corruption_operation_chain, _denominator_class, _derived_seed, _detect_cooldown_state, _detect_tank_slot,
+    _detect_visible_target_slots, _directory_snapshot, _episode_disposition, _episode_family_registry, _episode_ids_by_family,
+    _episode_plans_for_split, _episode_regeneration_gate, _expected_digest_owners, _expected_semantic_for_row, _expected_split_counts,
+    _family_closure_report, _family_contract, _family_contract_gate, _family_intervention_plan, _family_schedule, _file_digest,
+    _final_observation_provenance, _final_visible_target_action_evidence, _finding, _frame_count_for_plan, _frame_descriptor,
+    _frame_disposition_for_episode, _frame_invalid_closure_summary, _frame_plans, _gap_event_operation_chain, _gap_reachability_state,
+    _gate, _grounded_control_histories_for_current_row, _grounded_control_history, _impossible_destination_row,
+    _impossible_transition_operation_chain, _information_control_operation_chain, _invalid_episode, _json_bytes, _json_ready,
+    _launder_split_manifest, _load_reachability_tile, _make_episode_plan, _materialize_plan, _materialize_records,
+    _measured_phase_access_counts, _mutate_first_frame_row, _mutate_first_provider_row, _mutation_isolation_report,
+    _mutation_structural_snapshot, _next_row, _normalized_control_causal_tuple, _operation_record, _pixel_digest, _primary_failure,
+    _profile_provider, _profiling_records, _provider_observation_digest, _provider_version, _reachability_gate, _reachability_tile_digest,
+    _read_json, _read_jsonl, _reconstructed_control_causal_tuple_digest, _record_regeneration_view, _reference_context,
+    _refresh_provider_observation_metadata, _render_row_frame, _renderer_identity, _rewrite_jsonl, _run_adversarial_mutation_checks,
+    _score_record, _score_vector_to_payload, _secondary_row_for_splice, _seed_and_plan_gate, _seed_int_from_digest,
+    _select_grounded_control_histories, _semantic_outcome_gate, _sha256, _splice_evidence_counts, _splice_mask_manifest,
+    _splice_pair_has_final_visible_action_conflict, _stale_repeat_operation_chain, _state_from_trace, _state_row_values,
+    _stored_quantized_evidence, _structural_identity_gate, _structural_payload, _target_signal_coordinates, _target_signal_mask,
+    _target_slot_signal_coordinates, _temporal_negative_episode, _tile_edge, _top_row_action_map, _trace_digest, _transformation_contract,
+    _transformation_parameters, _transition_config_payload, _transition_identity, _transition_input_digest, _transition_result_digest,
+    _translation_values_for_seed, _valid_episode, _valid_frame_operation_chain, _valid_transformation_parameter_key,
+    _valid_transformation_parameter_universe, _valid_transformed_observation_digest_index, _validate_episode_plan,
+    _validate_episode_plan_collection, _validate_reachability_tile_identity, _write_csv, _write_json, _write_jsonl,
+    _write_observation_identity_manifest, _write_split_overlap_audit, audit_canonical_providers, audit_evidence_completeness,
+    build_reference_closure_report, build_split, canonical_observation_universe, canonical_prototypes, compile_policy_artifact,
+    compose_reachability_trace, expected_frame_disposition, freeze_benchmark, load_identity, main, mutation_catalogue, next_rows,
+    parse_state_row_id, profile_runtime, provider_observation_descriptor_for_record, provider_observation_for_record, render_state_frame,
+    score_b3_joint_fit, score_normalized_pixel, score_registered_local_correlation,
+    replay_observation_operation_chain, run_reference_mutation_audit, run_repeated_reference_mutation_audit, valid_observation_universe,
+    validate_control_episode_records, validate_materialized_family_record, validate_mutation_catalogue,
+    validate_observation_operation_chain, validate_reachability_trace, verify_instrument, verify_provider_runtime_equivalence,
+    verify_reference_instrument, verify_reference_read_only, )
+# fmt: on
 
 
 __all__ = [

--- a/zeromodel/video_action_set_cli.py
+++ b/zeromodel/video_action_set_cli.py
@@ -1,0 +1,97 @@
+"""Command-line dispatch for the video action-set scientific instrument."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .domains.video_action_set.build_orchestration import (
+    build_split,
+    freeze_benchmark,
+    profile_runtime,
+)
+from .domains.video_action_set.mutation_orchestration import verify_instrument
+from .domains.video_action_set.verification_orchestration import (
+    audit_canonical_providers,
+    audit_evidence_completeness,
+    verify_provider_runtime_equivalence,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_DIR = (
+    REPO_ROOT / "docs" / "results" / "video-action-set-reachability-benchmark-v1"
+)
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=None)
+    parser.add_argument("--output-dir", type=Path, default=OUTPUT_DIR)
+    parser.add_argument("--freeze-benchmark", action="store_true")
+    parser.add_argument("--build-development", action="store_true")
+    parser.add_argument("--build-calibration", action="store_true")
+    parser.add_argument("--build-selection", action="store_true")
+    parser.add_argument("--audit-evidence-completeness", action="store_true")
+    parser.add_argument("--audit-canonical-providers", action="store_true")
+    parser.add_argument("--profile-runtime", action="store_true")
+    parser.add_argument("--verify-provider-runtime-equivalence", action="store_true")
+    parser.add_argument(
+        "--profile-provider",
+        choices=("P1", "P2", "P3", "all"),
+        default="all",
+    )
+    parser.add_argument("--profile-frame-count", type=int, default=8)
+    parser.add_argument("--verify-prospective-instrument", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_argument_parser().parse_args()
+    selected = sum(
+        int(flag)
+        for flag in (
+            args.freeze_benchmark,
+            args.build_development,
+            args.build_calibration,
+            args.build_selection,
+            args.audit_evidence_completeness,
+            args.audit_canonical_providers,
+            args.profile_runtime,
+            args.verify_provider_runtime_equivalence,
+            args.verify_prospective_instrument,
+        )
+    )
+    if selected != 1:
+        raise SystemExit("exactly one command is required")
+    if args.freeze_benchmark:
+        payload = freeze_benchmark(args.output_dir, REPO_ROOT)
+    elif args.build_development:
+        freeze_benchmark(args.output_dir, REPO_ROOT)
+        payload = build_split("development", args.output_dir, REPO_ROOT)
+    elif args.build_calibration:
+        freeze_benchmark(args.output_dir, REPO_ROOT)
+        payload = build_split("calibration", args.output_dir, REPO_ROOT)
+    elif args.build_selection:
+        freeze_benchmark(args.output_dir, REPO_ROOT)
+        payload = build_split("selection", args.output_dir, REPO_ROOT)
+    elif args.audit_evidence_completeness:
+        payload = audit_evidence_completeness(args.output_dir)
+    elif args.audit_canonical_providers:
+        payload = audit_canonical_providers(args.output_dir)
+    elif args.profile_runtime:
+        payload = profile_runtime(
+            args.output_dir,
+            REPO_ROOT,
+            provider=args.profile_provider,
+            frame_count=args.profile_frame_count,
+        )
+    elif args.verify_provider_runtime_equivalence:
+        payload = verify_provider_runtime_equivalence(args.output_dir, REPO_ROOT)
+    else:
+        payload = verify_instrument(args.output_dir, REPO_ROOT)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- hardens standalone mutation-matrix result validation against internally contradictory metadata
- extracts artifact layout, I/O, rendering, mutation filesystem support, orchestration, and CLI dispatch from the benchmark monolith
- retains exact compatibility exports, signatures, monkeypatch seams, artifact bytes, and orchestration order
- adds architecture guards, focused fast tests, and the Stage 8 authorized-execution runbook

## Post-merge matrix correctness hardening

The first commit makes the mutation catalogue authoritative for expected detection and failure-code metadata. It rejects contradictory detection flags, forged expected-code matches, invalid primary-code types, and impossible isolation results while preserving accurately represented failed audits. The matrix schema, catalogue, production orchestration, and closure wiring are unchanged. The corrected test fixture now represents internally consistent input; its frozen digest replaces the prior digest of contradictory fixture data.

## Behavior-preserving Stage 7C extraction

The second commit moves the operational instrument shell into focused package modules and reduces `video_action_set_benchmark.py` to a compatibility facade. Direct aliases are used except for two narrow adapters that preserve historical benchmark-module monkeypatch seams. The benchmark module retains `main` as an import compatibility export but remains inert under `python -m`; operational module execution is provided by `python -m zeromodel.video_action_set_cli` and by the historical example launcher.

Review amendments make the Stage 8 sequence freeze exactly once before direct non-final `build_split()` calls, distinguish the historical one-shot build flags that refreeze automatically, and exclude prohibited final evidence from the canonical path registry. That registry is now explicitly documented as recognized paths rather than a complete produced-artifact manifest.

Audit-Exempt: behavior-preserving extraction of video action-set artifact
layout, serialization, report rendering, filesystem mutation support, build
orchestration, verification orchestration, mutation orchestration, CLI
dispatch, and benchmark compatibility exports. No planning rules,
materialization records, provider formulas, score vectors, rankings, semantic
outcomes, reachability traces, verification gates, mutation expectations,
closure requirements, benchmark evidence, claims, or conclusions changed.

The preceding focused commit strengthens standalone mutation-matrix input
validation by rejecting internally contradictory result metadata. It does not
change the matrix schema, catalogue, valid matrix projection, valid matrix
digests, benchmark orchestration, or closure.

## Validation

- original focused Stage 7C tests: 50 passed in 0.26s
- review-focused layout, CLI, and facade tests: 25 passed in 0.62s; final CLI subset: 13 passed in 0.77s
- complete fast suite: 575 passed, 1 skipped, 139 deselected in 31.19s; wrapper 32.47s
- architecture checker: passed
- repository quality checker: passed, including formatting, lint, mypy, architecture, and quality limits
- package build: passed
- bounded pre-extraction runtime-report comparison: five files, zero byte mismatches
- authorized reference-verification integration: 14 passed, 1 deselected in 198.05s
- authorized installed-wheel integration: 2 passed in 23.96s
- no other integration or slow tests were run
- complete scientific builds, audits, closure, and decisive benchmark measurement: not run
