### PR TITLE
fix: harden video action-set runtime execution

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,5 +31,6 @@ jobs:
         run: >
           python -m pytest -q
           --run-integration
+          --run-slow
           -m "integration or slow"
           --durations=50

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,13 @@ update a script under `scripts/` and leave execution to the operator.
 - Scientific rendering, transformation, mutation, replay, and digest computation stay in Python/NumPy.
 - Final split materialization is prohibited in every Store.
 - Batch observation writes must be atomic.
+- Progress observer exceptions intentionally propagate during split builds.
+  Before such a failure, SQLite episode plans plus observations, matrix blobs,
+  and observation operation chains may already be durable; split JSONL,
+  split-manifest, and family-closure artifacts are not completion markers until
+  all required files for the split exist. Same-directory retry is allowed only
+  for unchanged code and inputs before current-split filesystem completion
+  artifacts exist; otherwise require a fresh output directory.
 
 ## Working Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ python -m build
 
 ## Test Execution Policy
 
-ZeroModel has two test tiers.
+ZeroModel has four execution tiers.
 
 ### Fast tests
 
@@ -77,21 +77,36 @@ During implementation:
 3. Do not repeatedly rerun an unchanged command.
 4. Do not add exhaustive, end-to-end, materialization, or complete mutation work to the fast tier.
 
-### Integration tests
+### Integration and slow tests
 
-Integration tests require explicit human authorization.
+Integration tests and slow tests require explicit human authorization for the
+exact command being run.
 
 Do not run any of these unless the user explicitly requests it:
 
 ```powershell
-pytest --run-integration
-pytest --run-slow
-pytest -m integration
+python -m pytest -q --run-integration -m integration
+python -m pytest -q --run-slow -m slow
 ```
+
+Tests marked with both tiers require both opt-in flags.
 
 Integration tests include complete benchmark materialization, exhaustive observation universes, complete mutation audits, installed-wheel tests, historical regeneration, and long-running cross-product validation.
 
 When integration coverage is relevant, report the exact suggested command but do not execute it.
+
+### Scientific/manual checks
+
+Scientific and manual checks include development, calibration, selection, or
+final split builds, runtime profiling, provider-equivalence audits, canonical
+provider audits, evidence-completeness checks over preserved outputs, reference
+closure, and mutation audits.
+
+Coding agents must not execute integration tests, slow tests, scientific builds,
+benchmarks, or mutation audits unless the user explicitly authorizes that exact
+execution. Agents should implement the code and provide operator commands or
+scripts for long-running validation. For multi-step long validation, create or
+update a script under `scripts/` and leave execution to the operator.
 
 ## Video Action-Set RMDTO Policy
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For development:
 
 ```bash
 python -m pip install -e .[dev]
-pytest
+python scripts/run_fast_tests.py
 python -m build
 python -m twine check dist/*
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -35,7 +35,7 @@ From a clean checkout:
 ```bash
 python -m pip install --upgrade pip
 python -m pip install -e .[dev]
-pytest -q
+python scripts/run_fast_tests.py
 python -m build
 python -m twine check dist/*
 python examples/arcade_shooter_policy.py

--- a/docs/video-action-set-stage8-runbook.md
+++ b/docs/video-action-set-stage8-runbook.md
@@ -22,15 +22,41 @@ $env:ZEROMODEL_OUT = $Out
 
 ## Command Inventory
 
-These pytest commands require fresh, explicit human authorization. They are listed for
-operator planning only and are not authorized by this runbook:
+### Test Execution Tiers
+
+Fast unit tests are the default developer check:
 
 ```powershell
-python -m pytest -q --run-integration
-python -m pytest -q --run-slow
+python scripts/run_fast_tests.py
+```
+
+Integration tests require fresh, explicit human authorization:
+
+```powershell
+python -m pytest -q --run-integration -m integration
+```
+
+Slow tests require fresh, explicit human authorization:
+
+```powershell
+python -m pytest -q --run-slow -m slow
+```
+
+Tests marked with both tiers require both opt-in flags.
+
+Scientific/manual checks require fresh, explicit human authorization and should
+be scripted by coding agents rather than executed opportunistically:
+
+```powershell
 python -m pytest -q --run-integration tests/test_video_action_set_reference_verification.py -m "not slow"
 python -m pytest -q --run-integration tests/test_installed_wheel_video_instrument.py
 ```
+
+Coding agents must not execute integration tests, slow tests, scientific builds,
+benchmarks, or mutation audits unless the user explicitly authorizes that exact
+execution. Agents should implement the code and provide operator commands for
+long-running validation. For multi-step long validation, agents should create or
+update a script under `scripts/` and leave execution to the operator.
 
 ### Controlled Stage 8 Sequence
 

--- a/docs/video-action-set-stage8-runbook.md
+++ b/docs/video-action-set-stage8-runbook.md
@@ -202,6 +202,31 @@ Therefore Stage 8 must stop before final unless a separate reviewed authorizatio
 
 ## Recovery Rules
 
+- Progress observer failure during `build_split()`: the observer is called from
+  provider measurement after a frame or typed gap is processed, and observer
+  exceptions intentionally propagate. At that point the split may already have
+  identical SQLite episode plans for the split and SQLite observations,
+  matrix blobs, and observation operation chains for materialized records.
+  Provider scoring may also have produced provider descriptors and evidence
+  rows in memory for the current process, but `frame-metadata.jsonl`,
+  `provider-evidence.jsonl`, `<split>-manifest.json`,
+  `<split>-family-closure-report.json`, the selection
+  `family-closure-report.json`, `observation-identity-manifest.json`,
+  `split-overlap-audit.json`, and refreshed `phase-access-audits.json` are
+  written only after measurement returns.
+- Same-directory retry after progress observer failure is supported only for
+  the same split, unchanged code and inputs, and only when none of that split's
+  filesystem completion artifacts exist. The durable stores return existing
+  identical episode plans, observations, matrix blobs, and operation chains and
+  raise on conflicts. If any current split JSONL, split manifest, or family
+  closure artifact exists, use a fresh output directory.
+- No partially completed split may be treated as valid. Progress output is an
+  operator liveness signal, not a scientific completion marker. A split is
+  complete only when both split JSONL files, `<split>-manifest.json`, and
+  `<split>-family-closure-report.json` exist for that split; selection also
+  publishes `family-closure-report.json`. Stage 8 completion still requires the
+  later verification, audit, mutation, and closure gates listed in the execution
+  order.
 - Freeze failure: discard the output directory and restart freeze.
 - Split build failure: discard the whole output directory, refreeze, and rebuild preceding splits in order.
 - Profiling failure: profiling outputs may be discarded and rerun; scientific artifacts must remain unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,6 @@ testpaths = ["tests"]
 pythonpath = ["."]
 addopts = "--strict-markers"
 markers = [
-    "integration: end-to-end, exhaustive, materialization, or long-running tests excluded from normal development",
-    "slow: deprecated compatibility alias for integration",
+    "integration: end-to-end, persistence, materialization, or cross-component tests excluded from normal development",
+    "slow: tests normally too expensive for the fast suite, including exhaustive sweeps, profiling, full builds, and mutation audits",
 ]

--- a/scripts/publish-pypi.ps1
+++ b/scripts/publish-pypi.ps1
@@ -81,8 +81,8 @@ Remove-Item -Recurse -Force dist, build -ErrorAction SilentlyContinue
 Get-ChildItem -Directory -Filter "*.egg-info" | Remove-Item -Recurse -Force
 
 if (-not $SkipTests) {
-    Step "Running tests"
-    & $Python -m pytest -q
+    Step "Running fast tests"
+    & $Python scripts/run_fast_tests.py
 }
 
 if (-not $SkipDemo) {

--- a/scripts/run_fast_tests.py
+++ b/scripts/run_fast_tests.py
@@ -11,9 +11,7 @@ FORBIDDEN_INTEGRATION_FLAGS = {"--run-integration", "--run-slow"}
 
 def main() -> int:
     forbidden = [
-        argument
-        for argument in sys.argv[1:]
-        if argument in FORBIDDEN_INTEGRATION_FLAGS
+        argument for argument in sys.argv[1:] if argument in FORBIDDEN_INTEGRATION_FLAGS
     ]
     if forbidden:
         print(
@@ -22,7 +20,7 @@ def main() -> int:
             file=sys.stderr,
         )
         print(
-            "Run integration tests explicitly with pytest instead.",
+            "Run integration or slow tests explicitly with pytest instead.",
             file=sys.stderr,
         )
         return 2
@@ -58,8 +56,7 @@ def main() -> int:
 
     elapsed = time.monotonic() - started
     print(
-        f"\nFast-suite runtime: {elapsed:.2f}s "
-        f"(budget: {FAST_SUITE_BUDGET_SECONDS}s)"
+        f"\nFast-suite runtime: {elapsed:.2f}s (budget: {FAST_SUITE_BUDGET_SECONDS}s)"
     )
     return completed.returncode
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ import pytest
 import zeromodel.video_action_set_benchmark as benchmark
 
 
-INTEGRATION_MARKERS = {"integration", "slow"}
 INTEGRATION_TEST_PREFIXES = ("test_video_action_set_",)
 INTEGRATION_TEST_FILES = {
     "test_arcade_visual_local_baseline_showdown.py",
@@ -89,24 +88,24 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--run-integration",
         action="store_true",
         default=False,
-        help="Run tests marked as integration or slow.",
+        help="Run tests marked as integration.",
     )
     group.addoption(
         "--run-slow",
         action="store_true",
         default=False,
-        help="Deprecated compatibility alias for --run-integration.",
+        help="Run tests marked as slow.",
     )
 
 
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
-        "integration: end-to-end, exhaustive, materialization, or long-running test excluded from normal development",
+        "integration: end-to-end, persistence, materialization, or cross-component tests excluded from normal development",
     )
     config.addinivalue_line(
         "markers",
-        "slow: deprecated compatibility alias for integration",
+        "slow: tests normally too expensive for the fast suite, including exhaustive sweeps, profiling, full builds, and mutation audits",
     )
 
 
@@ -114,9 +113,8 @@ def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
-    run_integration = bool(
-        config.getoption("--run-integration") or config.getoption("--run-slow")
-    )
+    run_integration = bool(config.getoption("--run-integration"))
+    run_slow = bool(config.getoption("--run-slow"))
 
     for item in items:
         filename = item.path.name
@@ -127,14 +125,16 @@ def pytest_collection_modifyitems(
         ):
             item.add_marker(pytest.mark.integration)
 
-    if run_integration:
+    if run_integration and run_slow:
         return
 
     selected: list[pytest.Item] = []
     deselected: list[pytest.Item] = []
 
     for item in items:
-        if any(marker in item.keywords for marker in INTEGRATION_MARKERS):
+        is_integration = "integration" in item.keywords
+        is_slow = "slow" in item.keywords
+        if (is_integration and not run_integration) or (is_slow and not run_slow):
             deselected.append(item)
         else:
             selected.append(item)

--- a/tests/test_test_tier_commands_kernel.py
+++ b/tests/test_test_tier_commands_kernel.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_fast_runner_blocks_opt_in_test_tiers() -> None:
+    runner = (REPO_ROOT / "scripts" / "run_fast_tests.py").read_text(encoding="utf-8")
+
+    assert 'FORBIDDEN_INTEGRATION_FLAGS = {"--run-integration", "--run-slow"}' in runner
+    assert "Run integration or slow tests explicitly with pytest instead." in runner
+
+
+def test_runbook_documents_exact_test_tier_commands_and_agent_boundary() -> None:
+    runbook = (REPO_ROOT / "docs" / "video-action-set-stage8-runbook.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "python scripts/run_fast_tests.py" in runbook
+    assert "python -m pytest -q --run-integration -m integration" in runbook
+    assert "python -m pytest -q --run-slow -m slow" in runbook
+    assert "Tests marked with both tiers require both opt-in flags." in runbook
+    assert (
+        "Coding agents must not execute integration tests, slow tests, "
+        "scientific builds,"
+    ) in runbook
+    assert "create or\nupdate a script under `scripts/`" in runbook
+
+
+def test_pytest_markers_keep_slow_distinct_from_integration() -> None:
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    conftest = (REPO_ROOT / "tests" / "conftest.py").read_text(encoding="utf-8")
+
+    assert "slow: tests normally too expensive for the fast suite" in pyproject
+    assert "deprecated compatibility alias" not in pyproject
+    assert 'run_integration = bool(config.getoption("--run-integration"))' in conftest
+    assert 'run_slow = bool(config.getoption("--run-slow"))' in conftest
+    assert (
+        "if (is_integration and not run_integration) or (is_slow and not run_slow):"
+        in conftest
+    )

--- a/tests/test_test_tier_commands_kernel.py
+++ b/tests/test_test_tier_commands_kernel.py
@@ -41,3 +41,14 @@ def test_pytest_markers_keep_slow_distinct_from_integration() -> None:
         "if (is_integration and not run_integration) or (is_slow and not run_slow):"
         in conftest
     )
+
+
+def test_integration_workflow_supplies_both_opt_in_flags_for_combined_marker() -> None:
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "integration.yml"
+    ).read_text(encoding="utf-8")
+    command = workflow.split("python -m pytest -q", 1)[1].split("--durations=50", 1)[0]
+
+    assert '--run-integration' in command
+    assert '--run-slow' in command
+    assert '-m "integration or slow"' in command

--- a/tests/test_video_benchmark_facade.py
+++ b/tests/test_video_benchmark_facade.py
@@ -57,11 +57,19 @@ def test_build_split_adapter_preserves_benchmark_monkeypatch_seams(
     materialize = object()
     prototypes = object()
     measure = object()
+    observer = object()
     monkeypatch.setattr(benchmark, "_materialize_records", materialize)
     monkeypatch.setattr(benchmark, "canonical_prototypes", prototypes)
     monkeypatch.setattr(benchmark, "measure_record_collection", measure)
 
-    def fake_build(split: str, output_dir: Path, repo_root: Path):
+    def fake_build(
+        split: str,
+        output_dir: Path,
+        repo_root: Path,
+        *,
+        progress_observer=None,
+    ):
+        assert progress_observer is observer
         assert build_orchestration._materialize_records is materialize
         assert build_orchestration.canonical_prototypes is prototypes
         assert build_orchestration.measure_record_collection is measure
@@ -69,7 +77,13 @@ def test_build_split_adapter_preserves_benchmark_monkeypatch_seams(
 
     monkeypatch.setattr(build_orchestration, "build_split", fake_build)
     assert (
-        benchmark.build_split("selection", tmp_path, REPO_ROOT)["split"] == "selection"
+        benchmark.build_split(
+            "selection",
+            tmp_path,
+            REPO_ROOT,
+            progress_observer=observer,
+        )["split"]
+        == "selection"
     )
 
 

--- a/tests/test_video_cli_kernel.py
+++ b/tests/test_video_cli_kernel.py
@@ -37,7 +37,9 @@ def test_cli_dispatches_each_historical_flag(
     monkeypatch.setattr(
         cli,
         "build_split",
-        lambda split, *_args: calls.append(f"build:{split}") or {"command": split},
+        lambda split, *_args, **_kwargs: (
+            calls.append(f"build:{split}") or {"command": split}
+        ),
     )
     monkeypatch.setattr(
         cli,
@@ -140,4 +142,4 @@ def test_stage8_runbook_freezes_once_then_uses_direct_build_calls() -> None:
     assert "--build-calibration" not in controlled
     assert "--build-selection" not in controlled
     for split in ("development", "calibration", "selection"):
-        assert f'build_split(\"{split}\", out, repo)' in controlled
+        assert f'build_split("{split}", out, repo)' in controlled

--- a/tests/test_video_cli_kernel.py
+++ b/tests/test_video_cli_kernel.py
@@ -87,6 +87,64 @@ def test_cli_rejects_no_command_and_unknown_options(monkeypatch, capsys) -> None
     assert "unrecognized arguments: --unknown-command" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "flag",
+    ["--build-development", "--build-calibration", "--build-selection"],
+)
+def test_cli_accepts_progress_for_split_builds_only(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    flag: str,
+) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        "freeze_benchmark",
+        lambda *_args: calls.append("freeze") or {"command": "freeze"},
+    )
+
+    def fake_build_split(split: str, *_args, progress_observer=None) -> dict[str, str]:
+        assert progress_observer is not None
+        calls.append(f"build:{split}")
+        return {"command": split}
+
+    monkeypatch.setattr(cli, "build_split", fake_build_split)
+    monkeypatch.setattr(sys, "argv", ["instrument", flag, "--progress"])
+
+    cli.main()
+
+    assert calls == ["freeze", f"build:{flag.removeprefix('--build-')}"]
+    assert json.loads(capsys.readouterr().out)["command"]
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--freeze-benchmark",
+        "--profile-runtime",
+        "--audit-evidence-completeness",
+        "--audit-canonical-providers",
+    ],
+)
+def test_cli_rejects_progress_for_non_build_operations(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["instrument", flag, "--progress"])
+
+    with pytest.raises(SystemExit, match="--progress is only valid"):
+        cli.main()
+
+
+def test_cli_rejects_progress_without_explicit_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["instrument", "--progress"])
+
+    with pytest.raises(SystemExit, match="--progress is only valid"):
+        cli.main()
+
+
 def test_benchmark_module_execution_remains_historically_inert(tmp_path: Path) -> None:
     output_dir = tmp_path / "must-not-exist"
     invocations = (

--- a/tests/test_video_joint_candidate_cache_kernel.py
+++ b/tests/test_video_joint_candidate_cache_kernel.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import zeromodel.video_discriminative_joint_evidence as joint
+import zeromodel.video_prospective_providers as providers
+from zeromodel import (
+    ImageObservation,
+    JointEvidenceRegionSpec,
+    build_joint_candidate_masks,
+    build_pairwise_discriminative_masks,
+)
+from zeromodel.video_complete_row_evidence import build_semantic_top_set_outcome
+from zeromodel.video_prospective_providers import (
+    PROSPECTIVE_P3_VERSION,
+    clear_prospective_provider_caches,
+    score_all_rows_optimized,
+    score_all_rows_reference,
+)
+from zeromodel.visual_registration import RegistrationConfig
+
+
+POLICY_ARTIFACT_ID = "sha256:policy"
+SOURCE_SCOPE = "cache-kernel"
+ACTIONS = ("LEFT", "RIGHT", "STAY", "FIRE")
+
+
+@pytest.fixture(autouse=True)
+def reset_candidate_caches():
+    joint._reset_base_candidate_cache()
+    clear_prospective_provider_caches()
+    yield
+    joint._reset_base_candidate_cache()
+    clear_prospective_provider_caches()
+
+
+def _tiny_observation(index: int, *, source_id: str) -> ImageObservation:
+    pixels = np.array(
+        [
+            [index % 256, (index * 3 + 7) % 256],
+            [(index * 5 + 11) % 256, (index * 7 + 13) % 256],
+        ],
+        dtype=np.uint8,
+    )
+    return ImageObservation(pixels, source_id=source_id)
+
+
+def _region() -> tuple[JointEvidenceRegionSpec, ...]:
+    return (
+        JointEvidenceRegionSpec(
+            region_id="full",
+            top=0,
+            left=0,
+            height=2,
+            width=2,
+            weight=1.0,
+            critical=True,
+            registration_config=RegistrationConfig(
+                max_dx=0,
+                max_dy=0,
+                minimum_overlap_fraction=1.0,
+            ),
+        ),
+    )
+
+
+def _joint_inputs(
+    row_count: int = 3,
+) -> tuple[
+    dict[str, tuple[str, str, str, ImageObservation]],
+    dict[str, tuple[ImageObservation, ImageObservation]],
+    tuple[JointEvidenceRegionSpec, ...],
+]:
+    prototypes: dict[str, tuple[str, str, str, ImageObservation]] = {}
+    development: dict[str, tuple[ImageObservation, ImageObservation]] = {}
+    for index in range(row_count):
+        row_id = f"row-{index:03d}"
+        observation = _tiny_observation(index, source_id=f"prototype-{row_id}")
+        prototypes[row_id] = (
+            row_id,
+            ACTIONS[index % len(ACTIONS)],
+            observation.raw_digest,
+            observation,
+        )
+        development[row_id] = (observation, observation)
+    return prototypes, development, _region()
+
+
+def _masks(
+    prototypes: dict[str, tuple[str, str, str, ImageObservation]],
+    development: dict[str, tuple[ImageObservation, ImageObservation]],
+):
+    candidate_masks = build_joint_candidate_masks(
+        prototypes=prototypes,
+        development_observations=development,
+        intensity_tolerance=8,
+        stability_tolerance=12,
+        amendment_commit_sha="ad2093590cde95ad1dc984f0573f452693002717",
+        operational_contract_digest="sha256:test",
+        source_scope=SOURCE_SCOPE,
+    )
+    pairwise_masks = build_pairwise_discriminative_masks(
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        intensity_tolerance=8,
+        amendment_commit_sha="ad2093590cde95ad1dc984f0573f452693002717",
+        operational_contract_digest="sha256:test",
+        source_scope=SOURCE_SCOPE,
+    )
+    return candidate_masks, pairwise_masks
+
+
+def _candidate_snapshot(observation_index: int, *, row_count: int = 3) -> bytes:
+    prototypes, development, regions = _joint_inputs(row_count)
+    candidate_masks, pairwise_masks = _masks(prototypes, development)
+    observation = _tiny_observation(
+        observation_index, source_id=f"observation-{observation_index}"
+    )
+    candidates = joint.build_joint_row_candidates(
+        observation=observation,
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=regions,
+        architecture_id="B3",
+    )
+    ranked = joint.rank_joint_row_candidates(candidates)
+    return joint._json_bytes([candidate.to_dict() for candidate in ranked])
+
+
+def _provider_fixture() -> tuple[
+    dict[str, tuple[str, str, str, ImageObservation]],
+    ImageObservation,
+    dict[str, str],
+]:
+    prototypes, _development, _regions = _joint_inputs(112)
+    observation = _tiny_observation(37, source_id="score-vector-observation")
+    row_actions = {
+        row_id: action_id for row_id, action_id, _digest, _obs in prototypes.values()
+    }
+    return prototypes, observation, row_actions
+
+
+def _score_vector_snapshot(vector: Any, row_actions: dict[str, str]) -> dict[str, Any]:
+    semantic = build_semantic_top_set_outcome(
+        evidence=vector.evidence,
+        row_action=row_actions,
+    )
+    return {
+        "raw_score_vectors": list(vector.raw_scores),
+        "quantized_score_vectors": list(vector.quantized_scores),
+        "rankings": list(vector.evidence.ranking.ranked_row_ids),
+        "tie_groups": [group.to_dict() for group in vector.evidence.ranking.tie_groups],
+        "winners": {
+            "row": semantic.resolved_row_id,
+            "action": semantic.resolved_action_id,
+        },
+        "semantic_outcomes": semantic.to_dict(),
+        "evidence_digests": {
+            "score_vector": vector.evidence.score_vector_digest,
+            "quantized": vector.evidence.quantized_score_vector_digest,
+            "raw": vector.evidence.raw_score_diagnostic_digest,
+            "ranking": vector.evidence.ranking.ranking_digest,
+        },
+    }
+
+
+def test_base_candidate_cache_starts_clean_for_each_test() -> None:
+    assert joint._base_candidate_cache_info()["size"] == 0
+    _candidate_snapshot(0)
+    assert joint._base_candidate_cache_info()["size"] == 1
+
+
+def test_base_candidate_cache_capacity_and_eviction_are_deterministic() -> None:
+    capacity = joint._base_candidate_cache_info()["capacity"]
+    inserted_keys = []
+
+    for index in range(capacity + 3):
+        _candidate_snapshot(index)
+        info = joint._base_candidate_cache_info()
+        assert info["size"] <= capacity
+        inserted_keys.append(info["keys"][-1])
+
+    info = joint._base_candidate_cache_info()
+    assert info["size"] == capacity
+    assert info["keys"] == inserted_keys[-capacity:]
+
+
+def test_base_candidate_cache_hits_move_to_mru_and_info_is_snapshot() -> None:
+    capacity = joint._base_candidate_cache_info()["capacity"]
+    for index in range(capacity):
+        _candidate_snapshot(index)
+
+    original_info = joint._base_candidate_cache_info()
+    original_oldest = original_info["keys"][0]
+    original_second = original_info["keys"][1]
+    original_info["keys"].clear()
+
+    assert joint._base_candidate_cache_info()["size"] == capacity
+
+    _candidate_snapshot(0)
+    after_hit = joint._base_candidate_cache_info()
+
+    assert after_hit["hits"] == 1
+    assert after_hit["keys"][-1] == original_oldest
+
+    _candidate_snapshot(capacity)
+    after_insert = joint._base_candidate_cache_info()
+
+    assert after_insert["size"] == capacity
+    assert original_oldest in after_insert["keys"]
+    assert original_second not in after_insert["keys"]
+
+
+def test_base_candidate_cache_identity_includes_region_specs() -> None:
+    prototypes, development, regions = _joint_inputs()
+    candidate_masks, pairwise_masks = _masks(prototypes, development)
+    observation = _tiny_observation(0, source_id="observation-0")
+
+    joint.build_joint_row_candidates(
+        observation=observation,
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=regions,
+        architecture_id="B3",
+    )
+    alternate_regions = (
+        JointEvidenceRegionSpec(
+            region_id="full",
+            top=0,
+            left=0,
+            height=2,
+            width=2,
+            weight=2.0,
+            critical=True,
+            registration_config=RegistrationConfig(
+                max_dx=0,
+                max_dy=0,
+                minimum_overlap_fraction=1.0,
+            ),
+        ),
+    )
+
+    joint.build_joint_row_candidates(
+        observation=observation,
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=alternate_regions,
+        architecture_id="B3",
+    )
+    info = joint._base_candidate_cache_info()
+
+    assert info["size"] == 2
+    assert info["misses"] == 2
+
+
+def test_rescoring_after_eviction_is_byte_identical() -> None:
+    first = _candidate_snapshot(0)
+    first_key = joint._base_candidate_cache_info()["keys"][0]
+    capacity = joint._base_candidate_cache_info()["capacity"]
+
+    for index in range(1, capacity + 2):
+        _candidate_snapshot(index)
+
+    info = joint._base_candidate_cache_info()
+    assert info["size"] == capacity
+    assert first_key not in info["keys"]
+    after_eviction = _candidate_snapshot(0)
+
+    assert after_eviction == first
+
+
+def test_cached_uncached_and_reference_optimized_provider_vectors_are_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(providers, "_joint_regions", _region)
+    prototypes, observation, row_actions = _provider_fixture()
+
+    uncached_vector = score_all_rows_reference(
+        provider_id="P3",
+        observation=observation,
+        prototypes=prototypes,
+        policy_artifact_id=POLICY_ARTIFACT_ID,
+        source_scope=SOURCE_SCOPE,
+    )
+    uncached = _score_vector_snapshot(uncached_vector, row_actions)
+
+    cached_vector = score_all_rows_reference(
+        provider_id="P3",
+        observation=observation,
+        prototypes=prototypes,
+        policy_artifact_id=POLICY_ARTIFACT_ID,
+        source_scope=SOURCE_SCOPE,
+    )
+    cached = _score_vector_snapshot(cached_vector, row_actions)
+
+    assert cached == uncached
+    optimized = score_all_rows_optimized(
+        provider_id="P3",
+        observation=observation,
+        prototypes=prototypes,
+        policy_artifact_id=POLICY_ARTIFACT_ID,
+        source_scope=SOURCE_SCOPE,
+    )
+
+    assert _score_vector_snapshot(optimized, row_actions) == uncached
+    assert joint._base_candidate_cache_info()["hits"] >= 2
+    assert optimized.provider_id == "P3"
+    assert optimized.provider_version == PROSPECTIVE_P3_VERSION

--- a/tests/test_video_joint_candidate_cache_kernel.py
+++ b/tests/test_video_joint_candidate_cache_kernel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import MappingProxyType
 from typing import Any
 
 import numpy as np
@@ -14,6 +15,7 @@ from zeromodel import (
     build_pairwise_discriminative_masks,
 )
 from zeromodel.video_complete_row_evidence import build_semantic_top_set_outcome
+from zeromodel.video_complete_row_evidence import build_complete_row_evidence
 from zeromodel.video_prospective_providers import (
     PROSPECTIVE_P3_VERSION,
     clear_prospective_provider_caches,
@@ -26,6 +28,7 @@ from zeromodel.visual_registration import RegistrationConfig
 POLICY_ARTIFACT_ID = "sha256:policy"
 SOURCE_SCOPE = "cache-kernel"
 ACTIONS = ("LEFT", "RIGHT", "STAY", "FIRE")
+ARCHITECTURES = ("A3", "B3", "C3", "D3")
 
 
 @pytest.fixture(autouse=True)
@@ -113,7 +116,12 @@ def _masks(
     return candidate_masks, pairwise_masks
 
 
-def _candidate_snapshot(observation_index: int, *, row_count: int = 3) -> bytes:
+def _candidate_snapshot(
+    observation_index: int,
+    *,
+    row_count: int = 3,
+    architecture_id: str = "B3",
+) -> bytes:
     prototypes, development, regions = _joint_inputs(row_count)
     candidate_masks, pairwise_masks = _masks(prototypes, development)
     observation = _tiny_observation(
@@ -125,7 +133,7 @@ def _candidate_snapshot(observation_index: int, *, row_count: int = 3) -> bytes:
         candidate_masks=candidate_masks,
         pairwise_masks=pairwise_masks,
         regions=regions,
-        architecture_id="B3",
+        architecture_id=architecture_id,
     )
     ranked = joint.rank_joint_row_candidates(candidates)
     return joint._json_bytes([candidate.to_dict() for candidate in ranked])
@@ -164,6 +172,80 @@ def _score_vector_snapshot(vector: Any, row_actions: dict[str, str]) -> dict[str
             "quantized": vector.evidence.quantized_score_vector_digest,
             "raw": vector.evidence.raw_score_diagnostic_digest,
             "ranking": vector.evidence.ranking.ranking_digest,
+        },
+    }
+
+
+def _base_snapshot(base: Any) -> dict[str, Any]:
+    return {
+        key: (
+            [item.to_dict() for item in value]
+            if key in {"region_evidence", "pairwise_evidence"}
+            else value
+        )
+        for key, value in base.items()
+    }
+
+
+def _architecture_snapshot(
+    *,
+    architecture_id: str,
+    prototypes: dict[str, tuple[str, str, str, ImageObservation]],
+    candidate_masks: Any,
+    pairwise_masks: Any,
+    regions: tuple[JointEvidenceRegionSpec, ...],
+    observation: ImageObservation,
+    row_actions: dict[str, str],
+) -> dict[str, Any]:
+    candidates = joint.rank_joint_row_candidates(
+        joint.build_joint_row_candidates(
+            observation=observation,
+            prototypes=prototypes,
+            candidate_masks=candidate_masks,
+            pairwise_masks=pairwise_masks,
+            regions=regions,
+            architecture_id=architecture_id,
+        )
+    )
+    evidence = build_complete_row_evidence(
+        row_scores=[
+            (candidate.row_id, float(candidate.candidate_strength))
+            for candidate in candidates
+        ],
+        policy_artifact_id=POLICY_ARTIFACT_ID,
+        provider_id="P3",
+        provider_version=PROSPECTIVE_P3_VERSION,
+        policy_row_ids=tuple(sorted(prototypes)),
+    )
+    semantic = build_semantic_top_set_outcome(
+        evidence=evidence,
+        row_action=row_actions,
+    )
+    return {
+        "candidate_strength": {
+            candidate.row_id: float(candidate.candidate_strength)
+            for candidate in candidates
+        },
+        "complete_candidate_serialization": [
+            candidate.to_dict() for candidate in candidates
+        ],
+        "raw_score_vector": [item.raw_score for item in evidence.row_scores],
+        "quantized_score_vector": [
+            item.quantized_score for item in evidence.row_scores
+        ],
+        "ranking": list(evidence.ranking.ranked_row_ids),
+        "tie_groups": [group.to_dict() for group in evidence.ranking.tie_groups],
+        "winner": {
+            "row": semantic.resolved_row_id,
+            "action": semantic.resolved_action_id,
+        },
+        "semantic_outcome": semantic.to_dict(),
+        "evidence_digests": {
+            "score_vector": evidence.score_vector_digest,
+            "quantized": evidence.quantized_score_vector_digest,
+            "raw": evidence.raw_score_diagnostic_digest,
+            "ranking": evidence.ranking.ranking_digest,
+            "semantic": semantic.semantic_outcome_digest,
         },
     }
 
@@ -259,6 +341,75 @@ def test_base_candidate_cache_identity_includes_region_specs() -> None:
     assert info["misses"] == 2
 
 
+def test_base_candidate_cache_identity_includes_prototype_metadata() -> None:
+    prototypes, development, regions = _joint_inputs()
+    candidate_masks, pairwise_masks = _masks(prototypes, development)
+    observation = _tiny_observation(0, source_id="observation-0")
+
+    first = joint.build_joint_row_candidates(
+        observation=observation,
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=regions,
+        architecture_id="B3",
+    )
+    renamed_prototypes = {
+        row_id: (f"renamed-{prototype_observation_id}", action_id, digest, prototype)
+        for row_id, (
+            prototype_observation_id,
+            action_id,
+            digest,
+            prototype,
+        ) in prototypes.items()
+    }
+    second = joint.build_joint_row_candidates(
+        observation=observation,
+        prototypes=renamed_prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=regions,
+        architecture_id="B3",
+    )
+
+    info = joint._base_candidate_cache_info()
+    assert info["size"] == 2
+    assert info["misses"] == 2
+    assert {candidate.prototype_observation_id for candidate in first} == set(
+        prototypes
+    )
+    assert {
+        candidate.prototype_observation_id for candidate in second
+    } == {f"renamed-{row_id}" for row_id in prototypes}
+
+
+def test_base_candidate_cache_values_are_immutable_and_materialization_is_pure() -> None:
+    prototypes, development, regions = _joint_inputs()
+    candidate_masks, pairwise_masks = _masks(prototypes, development)
+    observation = _tiny_observation(0, source_id="observation-0")
+    candidates = joint.build_joint_row_candidates(
+        observation=observation,
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=regions,
+        architecture_id="B3",
+    )
+    key = joint._base_candidate_cache_info()["keys"][0]
+    cached = joint._BASE_CANDIDATE_CACHE.get(key)
+
+    assert cached is not None
+    assert isinstance(cached[0], MappingProxyType)
+    with pytest.raises(TypeError):
+        cached[0]["row_id"] = "mutated"
+
+    before = tuple(_base_snapshot(base) for base in cached)
+    materialized = joint._materialize_candidate(cached[0], "B3")
+
+    assert tuple(_base_snapshot(base) for base in cached) == before
+    assert materialized.to_dict() == candidates[0].to_dict()
+
+
 def test_rescoring_after_eviction_is_byte_identical() -> None:
     first = _candidate_snapshot(0)
     first_key = joint._base_candidate_cache_info()["keys"][0]
@@ -312,3 +463,54 @@ def test_cached_uncached_and_reference_optimized_provider_vectors_are_identical(
     assert joint._base_candidate_cache_info()["hits"] >= 2
     assert optimized.provider_id == "P3"
     assert optimized.provider_version == PROSPECTIVE_P3_VERSION
+
+
+@pytest.mark.parametrize("architecture_id", ARCHITECTURES)
+def test_architecture_candidate_and_score_parity_across_cache_states(
+    architecture_id: str,
+) -> None:
+    prototypes, development, regions = _joint_inputs(112)
+    candidate_masks, pairwise_masks = _masks(prototypes, development)
+    observation = _tiny_observation(37, source_id="architecture-parity-observation")
+    row_actions = {
+        row_id: action_id for row_id, action_id, _digest, _obs in prototypes.values()
+    }
+
+    uncached = _architecture_snapshot(
+        architecture_id=architecture_id,
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=regions,
+        observation=observation,
+        row_actions=row_actions,
+    )
+    cached = _architecture_snapshot(
+        architecture_id=architecture_id,
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=regions,
+        observation=observation,
+        row_actions=row_actions,
+    )
+    original_key = joint._base_candidate_cache_info()["keys"][-1]
+    assert cached == uncached
+    assert joint._base_candidate_cache_info()["hits"] >= 1
+
+    capacity = joint._base_candidate_cache_info()["capacity"]
+    for index in range(capacity + 1):
+        _candidate_snapshot(index, row_count=3, architecture_id="B3")
+
+    assert original_key not in joint._base_candidate_cache_info()["keys"]
+    rescored = _architecture_snapshot(
+        architecture_id=architecture_id,
+        prototypes=prototypes,
+        candidate_masks=candidate_masks,
+        pairwise_masks=pairwise_masks,
+        regions=regions,
+        observation=observation,
+        row_actions=row_actions,
+    )
+
+    assert rescored == uncached

--- a/tests/test_video_split_progress_kernel.py
+++ b/tests/test_video_split_progress_kernel.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import sys
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 import zeromodel.video_action_set_cli as cli
+from zeromodel.domains.video_action_set import build_orchestration as build
 from zeromodel.domains.video_action_set import provider_measurement as measurement
 from zeromodel.domains.video_action_set.artifact_io import _sha256
 from zeromodel.domains.video_action_set.provider_measurement import SplitBuildProgress
+from zeromodel.video_prospective_providers import PROSPECTIVE_PROVIDER_IDS
 
 
 def _records() -> list[dict[str, Any]]:
@@ -35,7 +39,7 @@ def _provider_rows(record: dict[str, Any]) -> list[dict[str, Any]]:
             "score_vector_digest": f"sha256:{provider_id.lower()}",
             "semantic_outcome_digest": f"sha256:semantic-{provider_id.lower()}",
         }
-        for provider_id in ("P1", "P2", "P3")
+        for provider_id in PROSPECTIVE_PROVIDER_IDS
     ]
 
 
@@ -83,10 +87,59 @@ def test_progress_observer_receives_monotonic_counts_and_gap_semantics(
     assert {event.total_frame_count for event in events} == {3}
     assert [event.scoreable_frame_count_processed for event in events] == [1, 1, 2]
     assert [event.typed_gap_count_processed for event in events] == [0, 1, 1]
-    assert [event.provider_scoring_calls_completed for event in events] == [3, 3, 6]
+    assert [
+        event.provider_scoring_calls_completed
+        for event in events
+    ] == [
+        event.scoreable_frame_count_processed * len(PROSPECTIVE_PROVIDER_IDS)
+        for event in events
+    ]
     assert [event.percentage_complete for event in events] == pytest.approx(
         [100.0 / 3.0, 200.0 / 3.0, 100.0]
     )
+
+
+def test_empty_record_collection_emits_single_final_progress_event() -> None:
+    events: list[SplitBuildProgress] = []
+
+    rows = measurement.measure_record_collection(
+        [],
+        prototypes={},
+        policy_artifact_id="policy",
+        reachability_tile={},
+        row_actions={},
+        split="selection",
+        progress_observer=events.append,
+    )
+
+    assert rows == []
+    assert len(events) == 1
+    event = events[0]
+    assert event.processed_frame_count == 0
+    assert event.total_frame_count == 0
+    assert event.scoreable_frame_count_processed == 0
+    assert event.typed_gap_count_processed == 0
+    assert event.provider_scoring_calls_completed == 0
+    assert event.percentage_complete == 100.0
+
+
+def test_empty_record_collection_without_observer_emits_no_progress_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rows = measurement.measure_record_collection(
+        [],
+        prototypes={},
+        policy_artifact_id="policy",
+        reachability_tile={},
+        row_actions={},
+        split="selection",
+        progress_observer=None,
+    )
+
+    captured = capsys.readouterr()
+    assert rows == []
+    assert captured.out == ""
+    assert captured.err == ""
 
 
 def test_progress_observer_does_not_alter_evidence_or_scientific_digests(
@@ -140,7 +193,7 @@ def test_cli_progress_goes_to_stderr_not_scientific_stdout(
                 total_frame_count=1,
                 scoreable_frame_count_processed=1,
                 typed_gap_count_processed=0,
-                provider_scoring_calls_completed=3,
+                provider_scoring_calls_completed=len(PROSPECTIVE_PROVIDER_IDS),
                 elapsed_seconds=0.25,
                 percentage_complete=100.0,
             )
@@ -160,3 +213,129 @@ def test_cli_progress_goes_to_stderr_not_scientific_stdout(
     assert json.loads(captured.out) == {"command": "development"}
     assert "development: 1/1 frames" in captured.err
     assert "provider_calls=3" in captured.err
+
+
+def test_build_split_observer_failure_leaves_no_split_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+
+    class FakeDTO:
+        def __init__(self, payload: dict[str, Any]):
+            self.payload = payload
+
+        @classmethod
+        def from_dict(cls, payload: dict[str, Any]):
+            return cls(payload)
+
+        def to_dict(self) -> dict[str, Any]:
+            return self.payload
+
+    class VideoService:
+        def load_identity(self, _repo_root: Path):
+            calls.append("identity")
+            return SimpleNamespace(seed_digest="seed")
+
+        def save_episode_plans(self, plans):
+            calls.append("save-plans")
+            return plans
+
+        def save_observation_records(self, records):
+            calls.append("save-observations")
+            return records
+
+        def list_observation_records(self, **_kwargs):
+            calls.append("list-observations")
+            return (
+                {
+                    "split": "development",
+                    "frame_id": "frame-0",
+                    "pixels": [[0]],
+                    "metadata": {},
+                },
+            )
+
+    monkeypatch.setattr(
+        build,
+        "_build_durable_runtime",
+        lambda _path: SimpleNamespace(video_action_set=VideoService()),
+    )
+    monkeypatch.setattr(build, "canonical_prototypes", lambda: {})
+    monkeypatch.setattr(
+        build,
+        "compile_policy_artifact",
+        lambda: SimpleNamespace(
+            artifact_id="policy",
+            source=SimpleNamespace(row_ids=("row-0",)),
+        ),
+    )
+    monkeypatch.setattr(
+        build,
+        "VPMPolicyLookup",
+        lambda *_args, **_kwargs: SimpleNamespace(choose=lambda _row: "LEFT"),
+    )
+    monkeypatch.setattr(build, "_load_reachability_tile", lambda _repo_root: {})
+    monkeypatch.setattr(
+        build,
+        "_episode_plans_for_split",
+        lambda _identity, split, _rows, _actions: [
+            {"split": split, "episode_id": "episode-0"}
+        ],
+    )
+    monkeypatch.setattr(build, "EpisodePlanDTO", FakeDTO)
+    monkeypatch.setattr(
+        build,
+        "_materialize_records",
+        lambda *_args: [{"pixels": [[0]]}],
+    )
+
+    def fail_during_measurement(*_args, progress_observer=None, **_kwargs):
+        calls.append("measure")
+        progress_observer(
+            SplitBuildProgress(
+                split="development",
+                processed_frame_count=1,
+                total_frame_count=1,
+                scoreable_frame_count_processed=1,
+                typed_gap_count_processed=0,
+                provider_scoring_calls_completed=len(PROSPECTIVE_PROVIDER_IDS),
+                elapsed_seconds=0.01,
+                percentage_complete=100.0,
+            )
+        )
+
+    monkeypatch.setattr(build, "measure_record_collection", fail_during_measurement)
+    monkeypatch.setattr(
+        build,
+        "_write_jsonl",
+        lambda *_args, **_kwargs: calls.append("write-jsonl"),
+    )
+    monkeypatch.setattr(
+        build,
+        "_write_json",
+        lambda *_args, **_kwargs: calls.append("write-json"),
+    )
+
+    def failing_observer(_event: SplitBuildProgress) -> None:
+        raise RuntimeError("progress monitor failed")
+
+    with pytest.raises(RuntimeError, match="progress monitor failed"):
+        build.build_split(
+            "development",
+            tmp_path,
+            tmp_path,
+            progress_observer=failing_observer,
+        )
+
+    assert calls == [
+        "identity",
+        "save-plans",
+        "save-observations",
+        "list-observations",
+        "measure",
+    ]
+    assert not (tmp_path / "development" / "frame-metadata.jsonl").exists()
+    assert not (tmp_path / "development" / "provider-evidence.jsonl").exists()
+    assert not (tmp_path / "development-manifest.json").exists()
+    assert not (tmp_path / "development-family-closure-report.json").exists()

--- a/tests/test_video_split_progress_kernel.py
+++ b/tests/test_video_split_progress_kernel.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import pytest
+
+import zeromodel.video_action_set_cli as cli
+from zeromodel.domains.video_action_set import provider_measurement as measurement
+from zeromodel.domains.video_action_set.artifact_io import _sha256
+from zeromodel.domains.video_action_set.provider_measurement import SplitBuildProgress
+
+
+def _records() -> list[dict[str, Any]]:
+    return [
+        {"split": "selection", "frame_id": "frame-00", "pixels": [[0]], "metadata": {}},
+        {
+            "split": "selection",
+            "frame_id": "frame-gap",
+            "event_type": "gap_unknown",
+            "gap_declaration": "declared_gap",
+            "pixels": None,
+            "metadata": {},
+        },
+        {"split": "selection", "frame_id": "frame-01", "pixels": [[1]], "metadata": {}},
+    ]
+
+
+def _provider_rows(record: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "frame_id": record["frame_id"],
+            "provider_id": provider_id,
+            "score_vector_digest": f"sha256:{provider_id.lower()}",
+            "semantic_outcome_digest": f"sha256:semantic-{provider_id.lower()}",
+        }
+        for provider_id in ("P1", "P2", "P3")
+    ]
+
+
+def _measure(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    progress_observer=None,
+) -> list[dict[str, Any]]:
+    monkeypatch.setattr(
+        measurement,
+        "score_record",
+        lambda record, *_args, **_kwargs: _provider_rows(record),
+    )
+    return measurement.measure_record_collection(
+        _records(),
+        prototypes={},
+        policy_artifact_id="policy",
+        reachability_tile={},
+        row_actions={},
+        split="selection",
+        progress_observer=progress_observer,
+    )
+
+
+def test_measurement_without_observer_produces_no_progress_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rows = _measure(monkeypatch)
+
+    captured = capsys.readouterr()
+    assert rows == _provider_rows(_records()[0]) + _provider_rows(_records()[2])
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_progress_observer_receives_monotonic_counts_and_gap_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[SplitBuildProgress] = []
+
+    _measure(monkeypatch, progress_observer=events.append)
+
+    assert [event.processed_frame_count for event in events] == [1, 2, 3]
+    assert {event.total_frame_count for event in events} == {3}
+    assert [event.scoreable_frame_count_processed for event in events] == [1, 1, 2]
+    assert [event.typed_gap_count_processed for event in events] == [0, 1, 1]
+    assert [event.provider_scoring_calls_completed for event in events] == [3, 3, 6]
+    assert [event.percentage_complete for event in events] == pytest.approx(
+        [100.0 / 3.0, 200.0 / 3.0, 100.0]
+    )
+
+
+def test_progress_observer_does_not_alter_evidence_or_scientific_digests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    without_progress = _measure(monkeypatch)
+    without_digest = _sha256(without_progress)
+    monkeypatch.undo()
+
+    events: list[SplitBuildProgress] = []
+    with_progress = _measure(monkeypatch, progress_observer=events.append)
+
+    assert with_progress == without_progress
+    assert _sha256(with_progress) == without_digest
+    assert events
+    forbidden_progress_keys = {
+        "processed_frame_count",
+        "total_frame_count",
+        "elapsed_seconds",
+        "percentage_complete",
+    }
+    assert all(forbidden_progress_keys.isdisjoint(row.keys()) for row in with_progress)
+
+
+def test_progress_observer_exceptions_propagate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def failing_observer(_event: SplitBuildProgress) -> None:
+        raise RuntimeError("progress monitor failed")
+
+    with pytest.raises(RuntimeError, match="progress monitor failed"):
+        _measure(monkeypatch, progress_observer=failing_observer)
+
+
+def test_cli_progress_goes_to_stderr_not_scientific_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "freeze_benchmark",
+        lambda *_args: {"command": "freeze"},
+    )
+
+    def fake_build_split(*_args: Any, progress_observer=None) -> dict[str, str]:
+        assert progress_observer is not None
+        progress_observer(
+            SplitBuildProgress(
+                split="development",
+                processed_frame_count=1,
+                total_frame_count=1,
+                scoreable_frame_count_processed=1,
+                typed_gap_count_processed=0,
+                provider_scoring_calls_completed=3,
+                elapsed_seconds=0.25,
+                percentage_complete=100.0,
+            )
+        )
+        return {"command": "development"}
+
+    monkeypatch.setattr(cli, "build_split", fake_build_split)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["instrument", "--build-development", "--progress"],
+    )
+
+    cli.main()
+    captured = capsys.readouterr()
+
+    assert json.loads(captured.out) == {"command": "development"}
+    assert "development: 1/1 frames" in captured.err
+    assert "provider_calls=3" in captured.err

--- a/zeromodel/domains/video_action_set/build_orchestration.py
+++ b/zeromodel/domains/video_action_set/build_orchestration.py
@@ -40,6 +40,7 @@ from zeromodel.domains.video_action_set.materialization_validation import (
 )
 from zeromodel.domains.video_action_set.observation_universe import canonical_prototypes
 from zeromodel.domains.video_action_set.provider_measurement import (
+    SplitBuildProgressObserver,
     measure_record_collection,
 )
 from zeromodel.domains.video_action_set.runtime_profiling import (
@@ -432,7 +433,13 @@ def profile_runtime(
     return payload
 
 
-def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]:
+def build_split(
+    split: str,
+    output_dir: Path,
+    repo_root: Path,
+    *,
+    progress_observer: SplitBuildProgressObserver | None = None,
+) -> dict[str, Any]:
     runtime = _build_durable_runtime(output_dir)
     identity = runtime.video_action_set.load_identity(repo_root)
     prototypes = canonical_prototypes()
@@ -463,6 +470,8 @@ def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]
         policy_artifact_id,
         reachability_tile=reachability_tile,
         row_actions=row_actions,
+        split=split,
+        progress_observer=progress_observer,
     )
     _write_jsonl(
         split_artifact_path(output_dir, split, "frame-metadata.jsonl"),

--- a/zeromodel/domains/video_action_set/build_orchestration.py
+++ b/zeromodel/domains/video_action_set/build_orchestration.py
@@ -56,9 +56,8 @@ from zeromodel.video_complete_row_evidence import (
     VIDEO_SCORE_QUANTIZER_VERSION,
 )
 from zeromodel.video_prospective_providers import (
-    PROSPECTIVE_P1_VERSION,
-    PROSPECTIVE_P2_VERSION,
-    PROSPECTIVE_P3_VERSION,
+    PROSPECTIVE_PROVIDER_IDS,
+    PROSPECTIVE_PROVIDER_VERSIONS,
 )
 from zeromodel.domains.video_action_set.artifact_io import (
     _read_json,
@@ -324,9 +323,11 @@ def freeze_benchmark(output_dir: Path, repo_root: Path) -> dict[str, Any]:
     }
     provider_manifest = {
         "providers": [
-            {"provider_id": "P1", "provider_version": PROSPECTIVE_P1_VERSION},
-            {"provider_id": "P2", "provider_version": PROSPECTIVE_P2_VERSION},
-            {"provider_id": "P3", "provider_version": PROSPECTIVE_P3_VERSION},
+            {
+                "provider_id": provider_id,
+                "provider_version": PROSPECTIVE_PROVIDER_VERSIONS[provider_id],
+            }
+            for provider_id in PROSPECTIVE_PROVIDER_IDS
         ]
     }
     sealed_final = runtime.video_action_set.seal_final_split(
@@ -384,7 +385,7 @@ def profile_runtime(
     prototypes = canonical_prototypes()
     policy_artifact_id = compile_policy_artifact().artifact_id
     records = _profiling_records(repo_root, frame_count)
-    provider_ids = ("P1", "P2", "P3") if provider == "all" else (provider,)
+    provider_ids = PROSPECTIVE_PROVIDER_IDS if provider == "all" else (provider,)
     reference = []
     optimized = []
     for provider_id in provider_ids:

--- a/zeromodel/domains/video_action_set/evidence_audit.py
+++ b/zeromodel/domains/video_action_set/evidence_audit.py
@@ -10,6 +10,7 @@ from ...video_complete_row_evidence import (
     semantic_top_set_outcome_from_dict,
 )
 from ...video_prospective_providers import (
+    PROSPECTIVE_PROVIDER_IDS,
     score_b3_joint_fit,
     score_normalized_pixel,
     score_registered_local_correlation,
@@ -250,7 +251,7 @@ def audit_canonical_provider_results(
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     rows: list[dict[str, Any]] = []
     summary: dict[str, Any] = {}
-    for provider_id in ("P1", "P2", "P3"):
+    for provider_id in PROSPECTIVE_PROVIDER_IDS:
         provider_rows = _score_canonical_provider(
             provider_id=provider_id,
             prototypes=prototypes,

--- a/zeromodel/domains/video_action_set/provider_measurement.py
+++ b/zeromodel/domains/video_action_set/provider_measurement.py
@@ -6,9 +6,8 @@ from typing import Any, Callable, Mapping, Sequence
 
 from ...artifact import VPMValidationError
 from ...video_prospective_providers import (
-    PROSPECTIVE_P1_VERSION,
-    PROSPECTIVE_P2_VERSION,
-    PROSPECTIVE_P3_VERSION,
+    PROSPECTIVE_PROVIDER_IDS,
+    PROSPECTIVE_PROVIDER_VERSIONS,
     score_b3_joint_fit,
     score_normalized_pixel,
     score_registered_local_correlation,
@@ -27,7 +26,7 @@ from .reachability_composition import (
 
 
 SOURCE_SCOPE = "zeromodel-video-action-set-reachability-benchmark-v1"
-PROVIDER_SCORE_CALLS_PER_SCOREABLE_FRAME = 3
+PROVIDER_SCORE_CALLS_PER_SCOREABLE_FRAME = len(PROSPECTIVE_PROVIDER_IDS)
 
 
 @dataclass(frozen=True)
@@ -46,11 +45,7 @@ SplitBuildProgressObserver = Callable[[SplitBuildProgress], None]
 
 
 def provider_version(provider_id: str) -> str:
-    return {
-        "P1": PROSPECTIVE_P1_VERSION,
-        "P2": PROSPECTIVE_P2_VERSION,
-        "P3": PROSPECTIVE_P3_VERSION,
-    }[provider_id]
+    return PROSPECTIVE_PROVIDER_VERSIONS[provider_id]
 
 
 def score_vector_to_payload(vector: Any) -> dict[str, Any]:
@@ -73,24 +68,37 @@ def _score_all_providers(
     prototypes: Mapping[str, tuple[str, str, str, ImageObservation]],
     policy_artifact_id: str,
 ) -> tuple[Any, Any, Any]:
-    p1 = score_normalized_pixel(
-        observation=observation,
-        prototypes=prototypes,
-        policy_artifact_id=policy_artifact_id,
-    )
-    p2 = score_registered_local_correlation(
-        observation=observation,
-        prototypes=prototypes,
-        policy_artifact_id=policy_artifact_id,
-        source_scope=SOURCE_SCOPE,
-    )
-    p3 = score_b3_joint_fit(
-        observation=observation,
-        prototypes=prototypes,
-        policy_artifact_id=policy_artifact_id,
-        source_scope=SOURCE_SCOPE,
-    )
-    return p1, p2, p3
+    results = []
+    for provider_id in PROSPECTIVE_PROVIDER_IDS:
+        if provider_id == "P1":
+            results.append(
+                score_normalized_pixel(
+                    observation=observation,
+                    prototypes=prototypes,
+                    policy_artifact_id=policy_artifact_id,
+                )
+            )
+        elif provider_id == "P2":
+            results.append(
+                score_registered_local_correlation(
+                    observation=observation,
+                    prototypes=prototypes,
+                    policy_artifact_id=policy_artifact_id,
+                    source_scope=SOURCE_SCOPE,
+                )
+            )
+        elif provider_id == "P3":
+            results.append(
+                score_b3_joint_fit(
+                    observation=observation,
+                    prototypes=prototypes,
+                    policy_artifact_id=policy_artifact_id,
+                    source_scope=SOURCE_SCOPE,
+                )
+            )
+        else:
+            raise VPMValidationError(f"unsupported provider_id: {provider_id}")
+    return tuple(results)
 
 
 def _reachability_trace_for_result(
@@ -233,9 +241,7 @@ def measure_record_collection(
     progress_observer: SplitBuildProgressObserver | None = None,
 ) -> list[dict[str, Any]]:
     reachability_state: dict[str, Mapping[str, Any] | None] = {
-        "P1": None,
-        "P2": None,
-        "P3": None,
+        provider_id: None for provider_id in PROSPECTIVE_PROVIDER_IDS
     }
     scored_rows: list[dict[str, Any]] = []
     split_name = (
@@ -275,6 +281,10 @@ def measure_record_collection(
             )
         )
 
+    if total_frame_count == 0:
+        emit_progress()
+        return scored_rows
+
     for record in records:
         if record.get("event_type") == "gap_unknown" or record.get("pixels") is None:
             for provider_id in reachability_state:
@@ -302,6 +312,8 @@ def measure_record_collection(
 
 __all__ = [
     "SOURCE_SCOPE",
+    "PROSPECTIVE_PROVIDER_IDS",
+    "PROVIDER_SCORE_CALLS_PER_SCOREABLE_FRAME",
     "SplitBuildProgress",
     "SplitBuildProgressObserver",
     "measure_record_collection",

--- a/zeromodel/domains/video_action_set/provider_measurement.py
+++ b/zeromodel/domains/video_action_set/provider_measurement.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from dataclasses import dataclass
+import time
+from typing import Any, Callable, Mapping, Sequence
 
 from ...artifact import VPMValidationError
 from ...video_prospective_providers import (
@@ -25,6 +27,22 @@ from .reachability_composition import (
 
 
 SOURCE_SCOPE = "zeromodel-video-action-set-reachability-benchmark-v1"
+PROVIDER_SCORE_CALLS_PER_SCOREABLE_FRAME = 3
+
+
+@dataclass(frozen=True)
+class SplitBuildProgress:
+    split: str
+    processed_frame_count: int
+    total_frame_count: int
+    scoreable_frame_count_processed: int
+    typed_gap_count_processed: int
+    provider_scoring_calls_completed: int
+    elapsed_seconds: float
+    percentage_complete: float
+
+
+SplitBuildProgressObserver = Callable[[SplitBuildProgress], None]
 
 
 def provider_version(provider_id: str) -> str:
@@ -211,6 +229,8 @@ def measure_record_collection(
     *,
     reachability_tile: Mapping[str, Any],
     row_actions: Mapping[str, str],
+    split: str | None = None,
+    progress_observer: SplitBuildProgressObserver | None = None,
 ) -> list[dict[str, Any]]:
     reachability_state: dict[str, Mapping[str, Any] | None] = {
         "P1": None,
@@ -218,10 +238,50 @@ def measure_record_collection(
         "P3": None,
     }
     scored_rows: list[dict[str, Any]] = []
+    split_name = (
+        str(split)
+        if split is not None
+        else str(records[0].get("split", ""))
+        if records
+        else ""
+    )
+    total_frame_count = len(records)
+    processed_frame_count = 0
+    scoreable_frame_count_processed = 0
+    typed_gap_count_processed = 0
+    provider_scoring_calls_completed = 0
+    started = time.monotonic()
+
+    def emit_progress() -> None:
+        if progress_observer is None:
+            return
+        percentage_complete = (
+            100.0
+            if total_frame_count == 0
+            else 100.0 * processed_frame_count / total_frame_count
+        )
+        # Progress observers are operator control-plane callbacks. Let their
+        # exceptions propagate so broken monitoring cannot silently disappear.
+        progress_observer(
+            SplitBuildProgress(
+                split=split_name,
+                processed_frame_count=processed_frame_count,
+                total_frame_count=total_frame_count,
+                scoreable_frame_count_processed=scoreable_frame_count_processed,
+                typed_gap_count_processed=typed_gap_count_processed,
+                provider_scoring_calls_completed=provider_scoring_calls_completed,
+                elapsed_seconds=time.monotonic() - started,
+                percentage_complete=percentage_complete,
+            )
+        )
+
     for record in records:
         if record.get("event_type") == "gap_unknown" or record.get("pixels") is None:
             for provider_id in reachability_state:
                 reachability_state[provider_id] = gap_reachability_state(record)
+            processed_frame_count += 1
+            typed_gap_count_processed += 1
+            emit_progress()
             continue
         scored_rows.extend(
             score_record(
@@ -233,11 +293,17 @@ def measure_record_collection(
                 row_actions=row_actions,
             )
         )
+        processed_frame_count += 1
+        scoreable_frame_count_processed += 1
+        provider_scoring_calls_completed += PROVIDER_SCORE_CALLS_PER_SCOREABLE_FRAME
+        emit_progress()
     return scored_rows
 
 
 __all__ = [
     "SOURCE_SCOPE",
+    "SplitBuildProgress",
+    "SplitBuildProgressObserver",
     "measure_record_collection",
     "provider_version",
     "score_record",

--- a/zeromodel/domains/video_action_set/reference_verification.py
+++ b/zeromodel/domains/video_action_set/reference_verification.py
@@ -15,6 +15,7 @@ from ...video_prospective_providers import (
     PROSPECTIVE_P1_VERSION,
     PROSPECTIVE_P2_VERSION,
     PROSPECTIVE_P3_VERSION,
+    PROSPECTIVE_PROVIDER_IDS,
 )
 from .canonical_json import canonical_json_value, canonical_sha256
 from .contracts import EPISODE_PLAN_VERSION
@@ -511,10 +512,9 @@ def compare_provider_results(
 def build_provider_equivalence_payload(
     comparisons: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
-    provider_order = ("P1", "P2", "P3")
     summary: dict[str, Any] = {}
     mismatches: list[str] = []
-    for provider_id in provider_order:
+    for provider_id in PROSPECTIVE_PROVIDER_IDS:
         rows = [row for row in comparisons if row.get("provider_id") == provider_id]
         provider_summary = {
             "quantized_mismatch_count": sum(

--- a/zeromodel/domains/video_action_set/verification_gates.py
+++ b/zeromodel/domains/video_action_set/verification_gates.py
@@ -74,6 +74,7 @@ from zeromodel.domains.video_action_set.transformations import (
     _validate_transformation_parameters,
 )
 from zeromodel.domains.video_action_set.dto import BenchmarkIdentityDTO
+from zeromodel.video_prospective_providers import PROSPECTIVE_PROVIDER_IDS
 
 BenchmarkIdentity = BenchmarkIdentityDTO
 _NON_FINAL_SPLITS = ("development", "calibration", "selection")
@@ -473,7 +474,9 @@ def _reachability_gate(output_dir: Path, repo_root: Path, context: Mapping[str, 
         frames = _read_jsonl(output_dir / split / "frame-metadata.jsonl")
         evidence_rows = _read_jsonl(output_dir / split / "provider-evidence.jsonl")
         by_frame_provider = {(row.get("frame_id"), row.get("provider_id")): row for row in evidence_rows}
-        reachability_state: dict[str, Mapping[str, Any] | None] = {"P1": None, "P2": None, "P3": None}
+        reachability_state: dict[str, Mapping[str, Any] | None] = {
+            provider_id: None for provider_id in PROSPECTIVE_PROVIDER_IDS
+        }
         expected_frames = _cached_materialized_metadata(repo_root, split)
         # Use stored order only after sorting by the deterministic frame identity. This keeps JSONL row order non-semantic.
         if len(expected_frames) != len(frames):
@@ -483,7 +486,7 @@ def _reachability_gate(output_dir: Path, repo_root: Path, context: Mapping[str, 
                 for provider_id in reachability_state:
                     reachability_state[provider_id] = _gap_reachability_state(frame)
                 continue
-            for provider_id in ("P1", "P2", "P3"):
+            for provider_id in PROSPECTIVE_PROVIDER_IDS:
                 row = by_frame_provider.get((frame.get("frame_id"), provider_id))
                 if row is None:
                     findings.append(_finding("reachability_trace_mismatch", "provider score row missing for scored frame", split=split, frame_id=frame.get("frame_id"), provider_id=provider_id))

--- a/zeromodel/domains/video_action_set/verification_orchestration.py
+++ b/zeromodel/domains/video_action_set/verification_orchestration.py
@@ -57,9 +57,8 @@ from zeromodel.video_complete_row_evidence import (
     VIDEO_SCORE_QUANTIZER_VERSION,
 )
 from zeromodel.video_prospective_providers import (
-    PROSPECTIVE_P1_VERSION,
-    PROSPECTIVE_P2_VERSION,
-    PROSPECTIVE_P3_VERSION,
+    PROSPECTIVE_PROVIDER_IDS,
+    PROSPECTIVE_PROVIDER_VERSIONS,
     score_all_rows_optimized,
     score_all_rows_reference,
 )
@@ -110,7 +109,7 @@ def verify_provider_runtime_equivalence(
         for row_id, action_id, _digest, observation in list(prototypes.values())[:12]
     ]
     comparisons = []
-    for provider_id in ("P1", "P2", "P3"):
+    for provider_id in PROSPECTIVE_PROVIDER_IDS:
         for record in sampled:
             reference = score_all_rows_reference(
                 provider_id=provider_id,
@@ -358,9 +357,11 @@ def _structural_identity_gate(
         findings.append(_finding("family_contract_violation", "transformation-family contract differs from the frozen contract"))
     expected_provider_manifest = {
         "providers": [
-            {"provider_id": "P1", "provider_version": PROSPECTIVE_P1_VERSION},
-            {"provider_id": "P2", "provider_version": PROSPECTIVE_P2_VERSION},
-            {"provider_id": "P3", "provider_version": PROSPECTIVE_P3_VERSION},
+            {
+                "provider_id": provider_id,
+                "provider_version": PROSPECTIVE_PROVIDER_VERSIONS[provider_id],
+            }
+            for provider_id in PROSPECTIVE_PROVIDER_IDS
         ]
     }
     if _read_json(output_dir / "provider-manifest.json") != expected_provider_manifest:

--- a/zeromodel/video_action_set_benchmark.py
+++ b/zeromodel/video_action_set_benchmark.py
@@ -215,6 +215,7 @@ from zeromodel.domains.video_action_set.pixel_digest import (
 )
 from zeromodel.domains.video_action_set.provider_measurement import (
     SOURCE_SCOPE as SOURCE_SCOPE,
+    SplitBuildProgressObserver as SplitBuildProgressObserver,
     measure_record_collection as measure_record_collection,
     provider_version as _provider_version,
     score_record as _score_record,
@@ -306,7 +307,13 @@ def _profiling_records(repo_root: Path, frame_count: int) -> list[dict[str, Any]
         _build_orchestration._materialize_records = original
 
 
-def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]:
+def build_split(
+    split: str,
+    output_dir: Path,
+    repo_root: Path,
+    *,
+    progress_observer: SplitBuildProgressObserver | None = None,
+) -> dict[str, Any]:
     patch_names = (
         "_materialize_records",
         "canonical_prototypes",
@@ -316,7 +323,12 @@ def build_split(split: str, output_dir: Path, repo_root: Path) -> dict[str, Any]
     try:
         for name in patch_names:
             setattr(_build_orchestration, name, globals()[name])
-        return _build_orchestration.build_split(split, output_dir, repo_root)
+        return _build_orchestration.build_split(
+            split,
+            output_dir,
+            repo_root,
+            progress_observer=progress_observer,
+        )
     finally:
         for name, value in originals.items():
             setattr(_build_orchestration, name, value)

--- a/zeromodel/video_action_set_cli.py
+++ b/zeromodel/video_action_set_cli.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sys
 
 from .domains.video_action_set.build_orchestration import (
     build_split,
     freeze_benchmark,
     profile_runtime,
 )
+from .domains.video_action_set.provider_measurement import SplitBuildProgress
 from .domains.video_action_set.mutation_orchestration import verify_instrument
 from .domains.video_action_set.verification_orchestration import (
     audit_canonical_providers,
@@ -23,6 +25,35 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_DIR = (
     REPO_ROOT / "docs" / "results" / "video-action-set-reachability-benchmark-v1"
 )
+_PROGRESS_FRAME_CADENCE = 25
+
+
+def _stderr_progress_observer():
+    last_reported = 0
+
+    def observe(event: SplitBuildProgress) -> None:
+        nonlocal last_reported
+        is_final = event.processed_frame_count == event.total_frame_count
+        if (
+            not is_final
+            and event.processed_frame_count - last_reported < _PROGRESS_FRAME_CADENCE
+        ):
+            return
+        last_reported = event.processed_frame_count
+        print(
+            (
+                f"{event.split}: {event.processed_frame_count}/"
+                f"{event.total_frame_count} frames "
+                f"({event.percentage_complete:.1f}%), "
+                f"scoreable={event.scoreable_frame_count_processed}, "
+                f"typed_gaps={event.typed_gap_count_processed}, "
+                f"provider_calls={event.provider_scoring_calls_completed}, "
+                f"elapsed={event.elapsed_seconds:.1f}s"
+            ),
+            file=sys.stderr,
+        )
+
+    return observe
 
 
 def build_argument_parser() -> argparse.ArgumentParser:
@@ -32,6 +63,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--build-development", action="store_true")
     parser.add_argument("--build-calibration", action="store_true")
     parser.add_argument("--build-selection", action="store_true")
+    parser.add_argument("--progress", action="store_true")
     parser.add_argument("--audit-evidence-completeness", action="store_true")
     parser.add_argument("--audit-canonical-providers", action="store_true")
     parser.add_argument("--profile-runtime", action="store_true")
@@ -48,6 +80,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_argument_parser().parse_args()
+    progress_observer = _stderr_progress_observer() if args.progress else None
     selected = sum(
         int(flag)
         for flag in (
@@ -68,13 +101,28 @@ def main() -> None:
         payload = freeze_benchmark(args.output_dir, REPO_ROOT)
     elif args.build_development:
         freeze_benchmark(args.output_dir, REPO_ROOT)
-        payload = build_split("development", args.output_dir, REPO_ROOT)
+        payload = build_split(
+            "development",
+            args.output_dir,
+            REPO_ROOT,
+            progress_observer=progress_observer,
+        )
     elif args.build_calibration:
         freeze_benchmark(args.output_dir, REPO_ROOT)
-        payload = build_split("calibration", args.output_dir, REPO_ROOT)
+        payload = build_split(
+            "calibration",
+            args.output_dir,
+            REPO_ROOT,
+            progress_observer=progress_observer,
+        )
     elif args.build_selection:
         freeze_benchmark(args.output_dir, REPO_ROOT)
-        payload = build_split("selection", args.output_dir, REPO_ROOT)
+        payload = build_split(
+            "selection",
+            args.output_dir,
+            REPO_ROOT,
+            progress_observer=progress_observer,
+        )
     elif args.audit_evidence_completeness:
         payload = audit_evidence_completeness(args.output_dir)
     elif args.audit_canonical_providers:

--- a/zeromodel/video_action_set_cli.py
+++ b/zeromodel/video_action_set_cli.py
@@ -80,7 +80,14 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_argument_parser().parse_args()
-    progress_observer = _stderr_progress_observer() if args.progress else None
+    split_build_selected = sum(
+        int(flag)
+        for flag in (
+            args.build_development,
+            args.build_calibration,
+            args.build_selection,
+        )
+    )
     selected = sum(
         int(flag)
         for flag in (
@@ -95,6 +102,12 @@ def main() -> None:
             args.verify_prospective_instrument,
         )
     )
+    if args.progress and (selected != 1 or split_build_selected != 1):
+        raise SystemExit(
+            "--progress is only valid with exactly one split-build command "
+            "(--build-development, --build-calibration, or --build-selection)"
+        )
+    progress_observer = _stderr_progress_observer() if args.progress else None
     if selected != 1:
         raise SystemExit("exactly one command is required")
     if args.freeze_benchmark:

--- a/zeromodel/video_discriminative_joint_evidence.py
+++ b/zeromodel/video_discriminative_joint_evidence.py
@@ -37,7 +37,7 @@ VIDEO_JOINT_CALIBRATION_VERSION = "zeromodel-video-joint-calibration/v1"
 _ARCHITECTURES = {"A3", "B3", "C3", "D3"}
 _BASE_CANDIDATE_CACHE_CAPACITY = 8
 _BaseCandidateCacheKey = Tuple[str, str, str, str, str]
-_BaseCandidateCacheValue = Tuple[Dict[str, Any], ...]
+_BaseCandidateCacheValue = Tuple[Mapping[str, Any], ...]
 
 
 class _BoundedBaseCandidateCache:
@@ -798,6 +798,27 @@ def _candidate_pair_key(row_a: str, row_b: str) -> Tuple[str, str]:
     return (row_a, row_b) if row_a < row_b else (row_b, row_a)
 
 
+def _prototype_cache_digest(
+    prototypes: Mapping[str, Tuple[str, str, str, ImageObservation]],
+) -> str:
+    return _digest(
+        [
+            {
+                "row_id": row_id,
+                "action_id": action_id,
+                "prototype_observation_id": prototype_observation_id,
+                "prototype_raw_digest": prototype_raw_digest,
+            }
+            for row_id, (
+                prototype_observation_id,
+                action_id,
+                prototype_raw_digest,
+                _prototype_observation,
+            ) in sorted(prototypes.items())
+        ]
+    )
+
+
 def _build_candidate_base(
     *,
     observation: ImageObservation,
@@ -1076,7 +1097,7 @@ def build_joint_row_candidates(
         raise VPMValidationError("unsupported joint architecture_id")
     cache_key = (
         observation.raw_digest,
-        _digest({row_id: value[2] for row_id, value in sorted(prototypes.items())}),
+        _prototype_cache_digest(prototypes),
         _digest({row_id: mask.payload_digest for row_id, mask in sorted(candidate_masks.items())}),
         _digest({f"{row_a}|{row_b}": mask.payload_digest for (row_a, row_b), mask in sorted(pairwise_masks.items())}),
         _digest([region.digest for region in regions]),
@@ -1090,7 +1111,7 @@ def build_joint_row_candidates(
             pairwise_masks=pairwise_masks,
             regions=regions,
         )
-        bases = _BASE_CANDIDATE_CACHE.put(cache_key, bases)
+        bases = _BASE_CANDIDATE_CACHE.put(cache_key, _freeze(bases))
     return tuple(_materialize_candidate(base, architecture_id) for base in bases)
 
 

--- a/zeromodel/video_discriminative_joint_evidence.py
+++ b/zeromodel/video_discriminative_joint_evidence.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass, field
 import hashlib
 import json
+from threading import RLock
 from types import MappingProxyType
-from typing import Any, Dict, Iterable, Mapping, Optional, Protocol, Sequence, Tuple
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -33,7 +35,70 @@ VIDEO_JOINT_PAIRWISE_MASK_SPEC_VERSION = "zeromodel-video-pairwise-mask-spec/v1"
 VIDEO_JOINT_PAIRWISE_MASK_PAYLOAD_VERSION = "zeromodel-video-pairwise-mask-payload/v1"
 VIDEO_JOINT_CALIBRATION_VERSION = "zeromodel-video-joint-calibration/v1"
 _ARCHITECTURES = {"A3", "B3", "C3", "D3"}
-_BASE_CANDIDATE_CACHE: Dict[Tuple[str, str, str, str], Tuple[Dict[str, Any], ...]] = {}
+_BASE_CANDIDATE_CACHE_CAPACITY = 8
+_BaseCandidateCacheKey = Tuple[str, str, str, str, str]
+_BaseCandidateCacheValue = Tuple[Dict[str, Any], ...]
+
+
+class _BoundedBaseCandidateCache:
+    """Deterministic LRU for the small window of repeated P3 observation scoring."""
+
+    def __init__(self, capacity: int) -> None:
+        if capacity < 1:
+            raise VPMValidationError("base candidate cache capacity must be positive")
+        self._capacity = int(capacity)
+        self._data: OrderedDict[_BaseCandidateCacheKey, _BaseCandidateCacheValue] = OrderedDict()
+        self._hits = 0
+        self._misses = 0
+        self._lock = RLock()
+
+    def get(self, key: _BaseCandidateCacheKey) -> _BaseCandidateCacheValue | None:
+        with self._lock:
+            cached = self._data.pop(key, None)
+            if cached is None:
+                self._misses += 1
+                return None
+            self._hits += 1
+            self._data[key] = cached
+            return cached
+
+    def put(self, key: _BaseCandidateCacheKey, value: _BaseCandidateCacheValue) -> _BaseCandidateCacheValue:
+        with self._lock:
+            self._data.pop(key, None)
+            self._data[key] = value
+            while len(self._data) > self._capacity:
+                self._data.popitem(last=False)
+            return value
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+            self._hits = 0
+            self._misses = 0
+
+    def info(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "capacity": self._capacity,
+                "size": len(self._data),
+                "hits": self._hits,
+                "misses": self._misses,
+                "keys": list(self._data.keys()),
+            }
+
+
+# Eight entries preserve direct A3/B3/C3/D3 architecture sweeps and
+# reference/optimized rescoring of the current observation without retaining a
+# long split's mostly unique frame observations indefinitely.
+_BASE_CANDIDATE_CACHE = _BoundedBaseCandidateCache(_BASE_CANDIDATE_CACHE_CAPACITY)
+
+
+def _reset_base_candidate_cache() -> None:
+    _BASE_CANDIDATE_CACHE.clear()
+
+
+def _base_candidate_cache_info() -> Dict[str, Any]:
+    return _BASE_CANDIDATE_CACHE.info()
 
 
 def _freeze(value: Any) -> Any:
@@ -1014,6 +1079,7 @@ def build_joint_row_candidates(
         _digest({row_id: value[2] for row_id, value in sorted(prototypes.items())}),
         _digest({row_id: mask.payload_digest for row_id, mask in sorted(candidate_masks.items())}),
         _digest({f"{row_a}|{row_b}": mask.payload_digest for (row_a, row_b), mask in sorted(pairwise_masks.items())}),
+        _digest([region.digest for region in regions]),
     )
     bases = _BASE_CANDIDATE_CACHE.get(cache_key)
     if bases is None:
@@ -1024,7 +1090,7 @@ def build_joint_row_candidates(
             pairwise_masks=pairwise_masks,
             regions=regions,
         )
-        _BASE_CANDIDATE_CACHE[cache_key] = bases
+        bases = _BASE_CANDIDATE_CACHE.put(cache_key, bases)
     return tuple(_materialize_candidate(base, architecture_id) for base in bases)
 
 

--- a/zeromodel/video_prospective_providers.py
+++ b/zeromodel/video_prospective_providers.py
@@ -7,7 +7,6 @@ from typing import Any, Generic, Mapping, Sequence, TypeVar
 
 import numpy as np
 
-from .arcade_policy import ACTIONS
 from .artifact import VPMValidationError
 from .content_identity import PrototypeUniverseIdentity, UnresolvedArtifactIdentity, prototype_universe_identity, sha256_digest
 from .video_complete_row_evidence import CompleteRowEvidence, SemanticTopSetOutcome, build_complete_row_evidence, build_semantic_top_set_outcome
@@ -35,6 +34,12 @@ from .visual_registration import RegistrationConfig
 PROSPECTIVE_P1_VERSION = "zeromodel-video-prospective-normalized-pixel/v1"
 PROSPECTIVE_P2_VERSION = "zeromodel-video-prospective-local-correlation/v1"
 PROSPECTIVE_P3_VERSION = "zeromodel-video-prospective-b3-joint-fit/v1"
+PROSPECTIVE_PROVIDER_IDS = ("P1", "P2", "P3")
+PROSPECTIVE_PROVIDER_VERSIONS = {
+    "P1": PROSPECTIVE_P1_VERSION,
+    "P2": PROSPECTIVE_P2_VERSION,
+    "P3": PROSPECTIVE_P3_VERSION,
+}
 _DEFAULT_CACHE_CAPACITY = 8
 
 
@@ -515,6 +520,8 @@ __all__ = [
     "PROSPECTIVE_P1_VERSION",
     "PROSPECTIVE_P2_VERSION",
     "PROSPECTIVE_P3_VERSION",
+    "PROSPECTIVE_PROVIDER_IDS",
+    "PROSPECTIVE_PROVIDER_VERSIONS",
     "ProviderScoreVector",
     "ProspectiveProviderResult",
     "clear_prospective_provider_caches",


### PR DESCRIPTION
## Problem

This draft hardens the video action-set runtime after an independent review of the previous branch head.

The original hardening covered:

* bounded P3 candidate caching;
* optional split progress reporting;
* explicit fast/integration/slow/manual execution boundaries.

The follow-up review found one merge blocker and several bounded hardening gaps in those changes.

## Independent-review findings addressed

1. The integration workflow used `-m "integration or slow"` but only passed `--run-integration`, silently dropping slow-marked tests under the new independent tier semantics.
2. The B3 base-candidate cache key bound prototype pixels indirectly but did not independently bind prototype metadata.
3. Empty record collections computed 100% complete but emitted no final progress event.
4. `--progress` was accepted for non-build operations where it had no effect.
5. Progress provider-call accounting duplicated the provider set as a hard-coded `3`.
6. Observer exception recovery was under-documented.
7. Cached base-candidate values remained structurally mutable by alias.
8. Fast parity coverage needed to cover A3/B3/C3/D3 cache states and score/evidence fields.

## Corrections made

* Updated `.github/workflows/integration.yml` so the combined integration/slow job passes both `--run-integration` and `--run-slow`.
* Added `PROSPECTIVE_PROVIDER_IDS = ("P1", "P2", "P3")` plus a provider-version map, and reused that order for provider scoring, provider manifests, profiling, verification/audit provider loops, reachability-state initialization, and progress accounting.
* Changed provider-call accounting to `scoreable_frame_count_processed * len(PROSPECTIVE_PROVIDER_IDS)` behavior.
* Added a final empty-progress event with zero counts and `percentage_complete = 100.0` when an observer is present; no event/output is produced when the observer is absent.
* Rejected `--progress` unless exactly one of `--build-development`, `--build-calibration`, or `--build-selection` is selected.
* Extended the B3 base-candidate cache key so the prototype component binds, in deterministic row order, `row_id`, `action_id`, `prototype_observation_id`, and prototype raw digest, while continuing to bind observation identity, candidate-mask digests, pairwise-mask digests, and ordered region digests.
* Froze cached base-candidate rows with immutable mappings/tuples at the cache boundary; `_materialize_candidate()` continues to read mappings without a serialization-contract change.
* Updated the Stage 8 runbook and AGENTS guidance with the observer-failure protocol, durable state, same-directory retry boundary, and completion artifacts.
* Added focused fast tests for the workflow flags, prototype metadata cache miss, cache-value immutability/materialization purity, empty progress, invalid progress combinations, provider-call accounting, observer failure before split file publication, and A3/B3/C3/D3 cached/uncached/evicted/rescored parity.

## Scientific compatibility

No benchmark identity, provider formula, provider version, provider order, scoring semantics, evidence schema, artifact schema, or final-access boundary changed.

Existing Stage 8 evidence was not modified and remains evidence for commit:

```text
ade210f67d07e1565025c729110c323c827db03e
```

That historical evidence validates the base scientific commit, not this hardening commit.

## Validation

* `git diff --check`: passed; only normal Windows line-ending warnings were emitted.
* `python -m ruff check <changed Python files>`: passed.
* `python -m pytest -q tests\test_video_joint_candidate_cache_kernel.py tests\test_video_split_progress_kernel.py tests\test_video_cli_kernel.py tests\test_test_tier_commands_kernel.py`: 45 passed in 8.16s on the final focused diff.
* `python scripts\run_fast_tests.py`: 607 passed, 1 skipped, 139 deselected in 39.89s; fast-suite runtime 41.00s.

## Not run

* integration tests
* slow tests
* development, calibration, or selection split builds
* runtime profiling
* provider equivalence
* canonical-provider audit
* evidence-completeness audit
* reference verification
* read-only verification
* mutation audit
* closure
* final materialization or final evaluation

## Remaining risks

* Full scientific rerun was intentionally not performed; compatibility is based on static review plus fast cache/progress/evidence parity tests.
* Same-directory retry after observer failure is supported only for unchanged code and inputs before current-split filesystem completion artifacts exist. If split JSONL, split manifest, or family-closure artifacts exist, operators must use a fresh output directory.
* Cache capacity and runtime impact were not profiled in this review-fix pass.
