### PR TITLE
test: add bounded finalization integration validation

### DIFF
--- a/docs/video-action-set-finalization-integration-validation.md
+++ b/docs/video-action-set-finalization-integration-validation.md
@@ -1,0 +1,171 @@
+# Video Action-Set Finalization Integration Validation
+
+## Purpose
+
+This package validates the synthetic finalization path across runtime, facade,
+engine, `FinalAccessService`, a file-backed SQLite store, filesystem publication,
+fresh-process reconstruction, operator CLIs, PowerShell wrappers, and an installed
+wheel. It is an infrastructure validation only. It does not validate scientific
+provider behavior and does not authorize final access.
+
+All databases, historical-authority files, authorizations, observations,
+artifacts, receipts, virtual environments, and logs are synthetic and disposable.
+The runner refuses `C:\Projects\zeromodel-stage8` and writes only beneath a unique
+system temporary directory.
+
+## Inventory Method
+
+The inventory was collected without executing tests:
+
+```powershell
+pytest --collect-only -q --run-integration --run-slow -m "integration or slow"
+```
+
+Collection found 216 marked nodes and deselected 719 ordinary fast nodes. Of the
+marked nodes, 77 are the new bounded finalization tests. The operator selection
+also includes 73 existing unmarked synthetic contract nodes selected by exact
+path or node ID. No marker alone was treated as evidence that a test was safe.
+
+### Bounded Selection
+
+| Test path | Test name or pattern | Marker | Resources | Expected | Property | Authority | Safe |
+|---|---|---|---|---:|---|---|---:|
+| `tests/integration/test_video_finalization_schema_authority.py` | all 10 nodes | integration | temporary SQLite files | 8 s | dedicated schema, marker/version/table/column rejection, FKs, authority separation | synthetic | yes |
+| `tests/integration/test_video_finalization_sqlite_concurrency.py` | all 5 nodes | integration | two engines/connections, two bounded threads | 15 s | one CAS winner, atomic event/state update, no orphan events | synthetic | yes |
+| `tests/integration/test_video_finalization_authorized_observations.py` | all 9 nodes | integration | temporary SQLite and tiny observation blob | 10 s | final-access ownership/state and non-final identity | synthetic | yes |
+| `tests/test_video_final_historical_authority.py` | all 11 nodes | fast, exact selection | small temporary files/manifests | 8 s | recomputed authority, mutation timing, symlink and preflight behavior | synthetic | yes |
+| `tests/integration/test_video_finalization_historical_evaluator.py` | `test_historical_manifest_bindings_*`, `test_historical_authority_rejects_relative_paths` | integration | small temporary files | 2 s | authority ID, commit, and absolute-path binding | synthetic | yes |
+| `tests/test_video_final_access_kernel.py` | six evaluator test functions (15 nodes) | fast, exact selection | in-memory DTOs | 5 s | pass/fail/indeterminate, aggregates, equality, permutations, Decimal isolation, invalid rules | synthetic protocol | yes |
+| `tests/integration/test_video_finalization_historical_evaluator.py` | five evaluator test functions (5 nodes) | integration | in-memory DTOs | 2 s | duplicate identity, provider set, unknown keys, incomplete evidence | synthetic protocol | yes |
+| `tests/integration/test_video_finalization_executor_publication.py` | all 13 nodes | integration | temporary SQLite, filesystem, one subprocess | 12 s | hostile executor rows, service-owned decision/digests, staging mutation/symlinks, atomic promotion, registration isolation | synthetic | yes |
+| `tests/test_video_final_publication.py` | all 47 nodes | fast, exact selection | temporary filesystem/in-memory store | 8 s | artifact-name matrix, staging tamper, file sets, receipt states, no merge | synthetic | yes |
+| `tests/integration/test_video_finalization_failure_injection.py` | all 14 nodes | integration | temporary filesystem/in-memory store | 20 s | state/files/receipt status at every supported boundary, claim/report blocking, no repair, and no retry/rerun | synthetic | yes |
+| `tests/integration/test_video_finalization_reconstruction.py` | all 7 nodes | integration | temporary SQLite/files, fresh Python processes | 35 s | durable reconstruction, terminal statuses, counters, bindings, claim eligibility | synthetic | yes |
+| `tests/integration/test_video_finalization_cli_scripts.py` | all 10 nodes | integration | temporary SQLite/files, Python and PowerShell processes | 45 s | read-only commands, explicit paths, JSON/stderr, hostile IDs, exit propagation | synthetic | yes |
+| `tests/integration/test_video_finalization_package_boundary.py` | installed-wheel boundary | integration | temporary source copy, wheel, virtual environment | 90 s | packaged modules, no executor, no historical `--build-final`, early final-build prohibition | synthetic | yes |
+
+### Excluded Marked Inventory
+
+| Test path | Test name or pattern | Marker | Resources | Expected | Property | Authority | Safe |
+|---|---|---|---|---:|---|---|---:|
+| `tests/integration/test_video_provider_measurement_real.py` | real P1/P2/P3 golden | integration | repository identity, reachability tile, real provider scoring | variable | real provider evidence golden | real/preserved | **no** |
+| `tests/test_video_action_set_benchmark.py` | all 9 nodes | auto integration | complete benchmark plans/materialization | minutes | benchmark generation and final freeze | scientific | **no** |
+| `tests/test_video_action_set_claim_quarantine.py` | claim quarantine | auto integration | repository result fixtures | variable | claim status files | preserved | **no** |
+| `tests/test_video_action_set_family_reachability.py` | all 9 nodes | auto integration | family materialization and transformations | minutes | scientific family reachability | scientific | **no** |
+| `tests/test_video_action_set_family_semantics.py` | 18 nodes | auto integration; one slow | complete semantic universes/replay | minutes | scientific family semantics and closure | scientific | **no** |
+| `tests/test_video_action_set_instrument.py` | both nodes | auto integration | audits and mutation gate | minutes | instrument/mutation behavior | scientific | **no** |
+| `tests/test_video_action_set_reference_verification.py` | 16 nodes | auto integration; two slow | reference fixtures and complete mutation audit | minutes | full reference and mutation closure | preserved/scientific | **no** |
+| `tests/test_arcade_visual_local_baseline_showdown.py` | artifact generation | integration + slow | model/image generation outputs | minutes | visual showdown | scientific | **no** |
+| `tests/test_arcade_visual_registered_calibration_v2.py` | artifact generation | integration + slow | calibration output | minutes | registered calibration | scientific | **no** |
+| `tests/test_installed_wheel_video_instrument.py` | both nodes | integration + slow | broad wheel build/install | minutes | whole-instrument packaging | synthetic but broad | **no** |
+| `tests/test_video_discriminative_evidence.py` | all 11 nodes | integration; one slow | discriminative masks/regions | variable | discriminative evidence | scientific | **no** |
+| `tests/test_video_discriminative_measurement_audit.py` | all 7 nodes | integration + slow | preserved pre-final artifacts | minutes | measurement audit | preserved/scientific | **no** |
+| `tests/test_video_discriminative_representation_audit.py` | all 3 nodes | integration + slow | representation audit fixtures | minutes | representation audit | preserved/scientific | **no** |
+| `tests/test_video_discriminative_v2_benchmark.py` | all 3 nodes | integration + slow | full universe and output writes | minutes | V2 benchmark freeze | scientific | **no** |
+| `tests/test_video_discriminative_v2_integrity.py` | all 4 nodes | integration + slow | full universe verification | minutes | V2 integrity | scientific | **no** |
+| `tests/test_video_discriminative_v2_selection.py` | all 3 nodes | integration + slow | selection/calibration rebuild | minutes | V2 selection | scientific | **no** |
+| `tests/test_video_episode_plan_sql_store.py` | all 9 nodes | integration | in-memory SQLite | seconds | generic plan persistence | synthetic | not selected; replaced by focused finalization coverage |
+| `tests/test_video_identity_rmdto.py` | core import boundary | integration | import graph | <1 s | SQLAlchemy boundary | synthetic | not selected; unrelated |
+| `tests/test_video_identity_sql_store.py` | all 5 nodes | integration | in-memory SQLite | seconds | generic identity persistence | synthetic | not selected; unrelated |
+| `tests/test_video_local_correlation.py` | all 7 nodes | integration + slow | generated benchmark/provider | minutes | local-correlation science | scientific | **no** |
+| `tests/test_video_observation_sql_store.py` | all 14 nodes | integration | in-memory SQLite and arrays | seconds | generic observation persistence | synthetic | not selected; focused final ownership test used |
+| `tests/test_video_prospective_providers.py` | all 3 nodes | integration + slow | provider scoring over 112 rows | minutes | prospective providers | scientific | **no** |
+| `tests/test_video_prospective_runtime_equivalence.py` | runtime equivalence | integration + slow | provider profiles | minutes | provider optimization equivalence | scientific | **no** |
+| `tests/test_visual_local_baseline_result_records.py` | result reconstruction | integration + slow | preserved result bundle | variable | result records | preserved | **no** |
+| `tests/test_visual_local_baselines.py` | both nodes | integration + slow | registered pixel providers | variable | local baseline science | scientific | **no** |
+| `tests/test_visual_registered_calibration_v2.py` | all 3 nodes | integration + slow | calibration grids | minutes | registered pixel calibration | scientific | **no** |
+| `tests/test_visual_result_records.py` | both nodes | integration + slow | result manifests/atlas | variable | visual result records | preserved | **no** |
+
+No selected test uses network access, a real project path, preserved Stage 8
+evidence, a repository scientific fixture, or a production executor. Tests that
+exercise symlink behavior skip only when the operating system denies symlink
+creation.
+
+## Prerequisites
+
+- A clean checkout on `codex/video-finalization-integration-validation`.
+- The full 40-character commit SHA intended for validation.
+- Python with the repository development dependencies already installed.
+- Windows PowerShell for the two wrapper smoke cases. Those cases skip if it is
+  unavailable.
+- No network is required. The wheel group uses `--no-isolation`, `--no-index`,
+  and `--no-deps` from a temporary source copy.
+
+## Operator Command
+
+Determine and review the exact commit, then pass it explicitly:
+
+```powershell
+$commit = git -C 'C:\Projects\zeromodel-finalization' rev-parse HEAD
+powershell -NoProfile -File 'C:\Projects\zeromodel-finalization\scripts\run-video-finalization-integration.ps1' `
+    -RepositoryPath 'C:\Projects\zeromodel-finalization' `
+    -ExpectedCommit $commit
+```
+
+The runner rejects a short SHA, wrong branch, wrong commit, dirty worktree,
+forbidden Stage 8 path, or failed group. It performs no retry. To delete fixtures
+for successful groups, add `-RemoveSuccessfulFixtures`; failed fixtures are always
+preserved.
+
+## Groups And Budget
+
+| Group | Predicted | Hard timeout |
+|---|---:|---:|
+| `01-schema-authority` | 8 s | 60 s |
+| `02-sqlite-transactions` | 15 s | 90 s |
+| `03-authorized-observations` | 10 s | 60 s |
+| `04-historical-authority` | 10 s | 60 s |
+| `05-evaluator` | 8 s | 60 s |
+| `06-publication` | 20 s | 90 s |
+| `07-failure-injection` | 20 s | 90 s |
+| `08-reconstruction` | 35 s | 120 s |
+| `09-cli-scripts` | 45 s | 120 s |
+| `10-package-boundary` | 90 s | 180 s |
+
+Predicted total is about 4.5 minutes. The target is under 5 minutes and the hard
+operator budget is under 10 minutes. A group timeout is recorded as exit code 124.
+
+## Outputs
+
+The runner prints its unique validation root. Its model is:
+
+```text
+%TEMP%\zeromodel-finalization-validation-<guid>\
+  .zeromodel-synthetic-validation
+  run-state.json
+  summary.json
+  summary.md
+  logs\<group>.stdout.log
+  logs\<group>.stderr.log
+  fixtures\<group>\
+```
+
+All logs and fixtures are outside the repository, canonical final artifact paths,
+and scientific output directories. Inspect a running or completed validation once
+without polling scientific state:
+
+```powershell
+powershell -NoProfile -File 'C:\Projects\zeromodel-finalization\scripts\observe-video-finalization-integration.ps1' `
+    -ValidationRoot '<root printed by the runner>'
+```
+
+The observer reads only the synthetic marker, run state, summary presence, log
+metadata, and runner/group process state. It writes nothing.
+
+## Interpreting Results
+
+Success requires all ten groups to report `passed`, each exit code to be zero,
+`summary.json` to report `synthetic_only: true`, and both summary files to exist.
+On failure, inspect the named stdout/stderr logs and preserved fixture directory.
+Do not rerun automatically; determine whether the failure is deterministic first.
+
+Passing proves the bounded infrastructure contracts listed in the selection
+matrix on the tested operating system and package environment. It does not prove
+real provider formulas, real P1/P2/P3 measurements, real final reachability,
+scientific correctness, mutation closure, networked or cross-machine exactly-once
+behavior, or compatibility with preserved Stage 8 evidence.
+
+Running this package does not create an approved real protocol, create a live
+authorization, register a production executor, reserve real final access,
+materialize or score final observations, publish a real receipt, or authorize any
+subsequent final action.

--- a/scripts/observe-video-finalization-integration.ps1
+++ b/scripts/observe-video-finalization-integration.ps1
@@ -1,0 +1,70 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ValidationRoot
+)
+
+$ErrorActionPreference = "Stop"
+$root = [IO.Path]::GetFullPath($ValidationRoot)
+$temporaryRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$forbidden = [IO.Path]::GetFullPath("C:\Projects\zeromodel-stage8")
+function Test-PathWithin {
+    param(
+        [Parameter(Mandatory = $true)][string]$Child,
+        [Parameter(Mandatory = $true)][string]$Parent
+    )
+    $childPath = [IO.Path]::GetFullPath($Child).TrimEnd('\')
+    $parentPath = [IO.Path]::GetFullPath($Parent).TrimEnd('\')
+    return $childPath.Equals($parentPath, [StringComparison]::OrdinalIgnoreCase) -or
+        $childPath.StartsWith($parentPath + '\', [StringComparison]::OrdinalIgnoreCase)
+}
+
+if (-not (Test-PathWithin -Child $root -Parent $temporaryRoot)) {
+    throw "ValidationRoot must be under the system temporary directory."
+}
+if (Test-PathWithin -Child $root -Parent $forbidden) {
+    throw "The Stage 8 repository is forbidden."
+}
+$marker = Join-Path $root ".zeromodel-synthetic-validation"
+if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) {
+    throw "ValidationRoot is not a bounded synthetic validation directory."
+}
+
+$statePath = Join-Path $root "run-state.json"
+$summaryJsonPath = Join-Path $root "summary.json"
+$summaryMarkdownPath = Join-Path $root "summary.md"
+$state = if (Test-Path -LiteralPath $statePath -PathType Leaf) {
+    Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
+} else {
+    $null
+}
+$runnerAlive = $false
+$groupAlive = $false
+if ($null -ne $state) {
+    $runnerAlive = $null -ne (Get-Process -Id $state.runner_pid -ErrorAction SilentlyContinue)
+    if ($null -ne $state.group_pid) {
+        $groupAlive = $null -ne (Get-Process -Id $state.group_pid -ErrorAction SilentlyContinue)
+    }
+}
+$logs = @(
+    Get-ChildItem -LiteralPath (Join-Path $root "logs") -File -ErrorAction SilentlyContinue |
+        Sort-Object Name |
+        ForEach-Object {
+            [ordered]@{
+                name = $_.Name
+                bytes = $_.Length
+                last_write_utc = $_.LastWriteTimeUtc.ToString("o")
+            }
+        }
+)
+
+[ordered]@{
+    version = "zeromodel-video-finalization-integration-observation/v1"
+    observed_utc = [DateTime]::UtcNow.ToString("o")
+    validation_root = $root
+    run_state = $state
+    runner_alive = $runnerAlive
+    group_alive = $groupAlive
+    summary_json_present = Test-Path -LiteralPath $summaryJsonPath -PathType Leaf
+    summary_markdown_present = Test-Path -LiteralPath $summaryMarkdownPath -PathType Leaf
+    logs = $logs
+} | ConvertTo-Json -Depth 10

--- a/scripts/run-video-finalization-integration.ps1
+++ b/scripts/run-video-finalization-integration.ps1
@@ -1,0 +1,241 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RepositoryPath,
+    [Parameter(Mandatory = $true)][string]$ExpectedCommit,
+    [string]$ExpectedBranch = "codex/video-finalization-integration-validation",
+    [string]$Python = "python",
+    [switch]$RemoveSuccessfulFixtures
+)
+
+$ErrorActionPreference = "Stop"
+$ForbiddenStage8Path = [IO.Path]::GetFullPath("C:\Projects\zeromodel-stage8")
+$ExpectedCommitPattern = "^[0-9a-fA-F]{40}$"
+
+function ConvertTo-NativeArgument {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+    if ($Value.Length -gt 0 -and $Value -notmatch '[\s"]') {
+        return $Value
+    }
+    $escaped = [regex]::Replace($Value, '(\\*)"', '$1$1\"')
+    $escaped = [regex]::Replace($escaped, '(\\+)$', '$1$1')
+    return '"' + $escaped + '"'
+}
+
+function Test-PathWithin {
+    param(
+        [Parameter(Mandatory = $true)][string]$Child,
+        [Parameter(Mandatory = $true)][string]$Parent
+    )
+    $childPath = [IO.Path]::GetFullPath($Child).TrimEnd('\')
+    $parentPath = [IO.Path]::GetFullPath($Parent).TrimEnd('\')
+    return $childPath.Equals($parentPath, [StringComparison]::OrdinalIgnoreCase) -or
+        $childPath.StartsWith($parentPath + '\', [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Invoke-GitText {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+    $value = & git -C $script:Repository @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed: $value"
+    }
+    return (($value | Out-String).Trim())
+}
+
+function Write-RunState {
+    param(
+        [Parameter(Mandatory = $true)][string]$Status,
+        [AllowNull()][string]$CurrentGroup,
+        [AllowNull()][Nullable[int]]$GroupPid
+    )
+    [ordered]@{
+        version = "zeromodel-video-finalization-integration-run-state/v1"
+        status = $Status
+        runner_pid = $PID
+        group_pid = $GroupPid
+        current_group = $CurrentGroup
+        repository = $script:Repository
+        expected_branch = $ExpectedBranch
+        expected_commit = $ExpectedCommit.ToLowerInvariant()
+        updated_utc = [DateTime]::UtcNow.ToString("o")
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $script:RunStatePath -Encoding UTF8
+}
+
+if ($ExpectedCommit -notmatch $ExpectedCommitPattern) {
+    throw "ExpectedCommit must be a full 40-character Git SHA."
+}
+$Repository = [IO.Path]::GetFullPath($RepositoryPath)
+if (-not (Test-Path -LiteralPath $Repository -PathType Container)) {
+    throw "RepositoryPath is not an existing directory: $Repository"
+}
+if (Test-PathWithin -Child $Repository -Parent $ForbiddenStage8Path) {
+    throw "The Stage 8 repository is forbidden for this validation."
+}
+
+$branch = Invoke-GitText -Arguments @("branch", "--show-current")
+$head = Invoke-GitText -Arguments @("rev-parse", "HEAD")
+$status = Invoke-GitText -Arguments @("status", "--short")
+if ($branch -cne $ExpectedBranch) {
+    throw "Wrong branch. Expected '$ExpectedBranch', found '$branch'."
+}
+if ($head -cne $ExpectedCommit.ToLowerInvariant()) {
+    throw "Wrong commit. Expected '$ExpectedCommit', found '$head'."
+}
+if ($status.Length -ne 0) {
+    throw "The validation worktree must be clean.`n$status"
+}
+
+$ValidationRoot = Join-Path ([IO.Path]::GetTempPath()) (
+    "zeromodel-finalization-validation-" + [Guid]::NewGuid().ToString("N")
+)
+$ValidationRoot = [IO.Path]::GetFullPath($ValidationRoot)
+if (Test-PathWithin -Child $ValidationRoot -Parent $ForbiddenStage8Path) {
+    throw "Validation root resolved under the forbidden Stage 8 path."
+}
+New-Item -ItemType Directory -Path $ValidationRoot | Out-Null
+Set-Content -LiteralPath (Join-Path $ValidationRoot ".zeromodel-synthetic-validation") `
+    -Value "synthetic-only" -Encoding ASCII
+$RunStatePath = Join-Path $ValidationRoot "run-state.json"
+$SummaryJsonPath = Join-Path $ValidationRoot "summary.json"
+$SummaryMarkdownPath = Join-Path $ValidationRoot "summary.md"
+$LogsPath = Join-Path $ValidationRoot "logs"
+$FixturesPath = Join-Path $ValidationRoot "fixtures"
+New-Item -ItemType Directory -Path $LogsPath, $FixturesPath | Out-Null
+
+$groups = @(
+    [ordered]@{ Name = "01-schema-authority"; PredictedSeconds = 8; TimeoutSeconds = 60; Tests = @("tests/integration/test_video_finalization_schema_authority.py") },
+    [ordered]@{ Name = "02-sqlite-transactions"; PredictedSeconds = 15; TimeoutSeconds = 90; Tests = @("tests/integration/test_video_finalization_sqlite_concurrency.py") },
+    [ordered]@{ Name = "03-authorized-observations"; PredictedSeconds = 10; TimeoutSeconds = 60; Tests = @("tests/integration/test_video_finalization_authorized_observations.py") },
+    [ordered]@{ Name = "04-historical-authority"; PredictedSeconds = 10; TimeoutSeconds = 60; Tests = @("tests/test_video_final_historical_authority.py", "tests/integration/test_video_finalization_historical_evaluator.py::test_historical_manifest_bindings_reject_declared_mismatch", "tests/integration/test_video_finalization_historical_evaluator.py::test_historical_authority_rejects_relative_paths") },
+    [ordered]@{ Name = "05-evaluator"; PredictedSeconds = 8; TimeoutSeconds = 60; Tests = @("tests/test_video_final_access_kernel.py::test_evaluator_is_order_independent_and_digest_bearing", "tests/test_video_final_access_kernel.py::test_evaluator_is_isolated_from_hostile_global_decimal_contexts", "tests/test_video_final_access_kernel.py::test_decimal_aggregate_threshold_equality_remains_inclusive", "tests/test_video_final_access_kernel.py::test_pass_fail_and_indeterminate_are_deterministic", "tests/test_video_final_access_kernel.py::test_evaluator_rejects_unsupported_decision_rule_shapes", "tests/integration/test_video_finalization_historical_evaluator.py::test_duplicate_evidence_identity_is_rejected", "tests/integration/test_video_finalization_historical_evaluator.py::test_missing_or_undeclared_evidence_provider_is_rejected", "tests/integration/test_video_finalization_historical_evaluator.py::test_unknown_protocol_keys_fail_before_evaluation", "tests/integration/test_video_finalization_historical_evaluator.py::test_incomplete_required_evidence_is_indeterminate") },
+    [ordered]@{ Name = "06-publication"; PredictedSeconds = 20; TimeoutSeconds = 90; Tests = @("tests/integration/test_video_finalization_executor_publication.py", "tests/test_video_final_publication.py") },
+    [ordered]@{ Name = "07-failure-injection"; PredictedSeconds = 20; TimeoutSeconds = 90; Tests = @("tests/integration/test_video_finalization_failure_injection.py") },
+    [ordered]@{ Name = "08-reconstruction"; PredictedSeconds = 35; TimeoutSeconds = 120; Tests = @("tests/integration/test_video_finalization_reconstruction.py") },
+    [ordered]@{ Name = "09-cli-scripts"; PredictedSeconds = 45; TimeoutSeconds = 120; Tests = @("tests/integration/test_video_finalization_cli_scripts.py") },
+    [ordered]@{ Name = "10-package-boundary"; PredictedSeconds = 90; TimeoutSeconds = 180; Tests = @("tests/integration/test_video_finalization_package_boundary.py") }
+)
+
+$startedUtc = [DateTime]::UtcNow
+$results = [Collections.Generic.List[object]]::new()
+$overallStatus = "passed"
+Write-Host "Synthetic validation root: $ValidationRoot"
+Write-Host "Predicted total: $((($groups | Measure-Object PredictedSeconds -Sum).Sum)) seconds"
+Write-RunState -Status "running" -CurrentGroup $null -GroupPid $null
+
+foreach ($group in $groups) {
+    $groupFixture = Join-Path $FixturesPath $group.Name
+    $stdoutPath = Join-Path $LogsPath ($group.Name + ".stdout.log")
+    $stderrPath = Join-Path $LogsPath ($group.Name + ".stderr.log")
+    $arguments = @(
+        "-m", "pytest", "--run-integration", "-q", "--maxfail=1",
+        "--basetemp", $groupFixture
+    ) + $group.Tests
+    $display = (ConvertTo-NativeArgument $Python) + " " + (
+        ($arguments | ForEach-Object { ConvertTo-NativeArgument ([string]$_) }) -join " "
+    )
+    Write-Host ""
+    Write-Host "[$($group.Name)] predicted $($group.PredictedSeconds)s; hard timeout $($group.TimeoutSeconds)s"
+    Write-Host $display
+
+    $start = [DateTime]::UtcNow
+    $info = [Diagnostics.ProcessStartInfo]::new()
+    $info.FileName = $Python
+    $info.Arguments = ($arguments | ForEach-Object {
+        ConvertTo-NativeArgument ([string]$_)
+    }) -join " "
+    $info.WorkingDirectory = $Repository
+    $info.UseShellExecute = $false
+    $info.RedirectStandardOutput = $true
+    $info.RedirectStandardError = $true
+    $info.CreateNoWindow = $true
+    $info.WindowStyle = [Diagnostics.ProcessWindowStyle]::Hidden
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $info
+    if (-not $process.Start()) {
+        throw "Failed to start group $($group.Name)."
+    }
+    Write-RunState -Status "running" -CurrentGroup $group.Name -GroupPid $process.Id
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    $completed = $process.WaitForExit([int]$group.TimeoutSeconds * 1000)
+    $timedOut = -not $completed
+    if ($timedOut) {
+        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+        $process.WaitForExit()
+    }
+    $stdoutTask.Result | Set-Content -LiteralPath $stdoutPath -Encoding UTF8
+    $stderrTask.Result | Set-Content -LiteralPath $stderrPath -Encoding UTF8
+    $end = [DateTime]::UtcNow
+    $exitCode = if ($timedOut) { 124 } else { $process.ExitCode }
+    $groupStatus = if ($exitCode -eq 0) { "passed" } elseif ($timedOut) { "timed_out" } else { "failed" }
+    $results.Add([ordered]@{
+        name = $group.Name
+        status = $groupStatus
+        predicted_seconds = $group.PredictedSeconds
+        timeout_seconds = $group.TimeoutSeconds
+        started_utc = $start.ToString("o")
+        ended_utc = $end.ToString("o")
+        duration_seconds = [Math]::Round(($end - $start).TotalSeconds, 3)
+        pid = $process.Id
+        exit_code = $exitCode
+        command = $display
+        stdout = $stdoutPath
+        stderr = $stderrPath
+        fixture_root = $groupFixture
+    })
+    Write-Host "[$($group.Name)] $groupStatus (exit $exitCode, $([Math]::Round(($end - $start).TotalSeconds, 1))s)"
+    if ($exitCode -eq 0 -and $RemoveSuccessfulFixtures -and (Test-Path -LiteralPath $groupFixture)) {
+        Remove-Item -LiteralPath $groupFixture -Recurse -Force
+    }
+    if ($exitCode -ne 0) {
+        $overallStatus = $groupStatus
+        break
+    }
+}
+
+$endedUtc = [DateTime]::UtcNow
+$summary = [ordered]@{
+    version = "zeromodel-video-finalization-integration-summary/v1"
+    synthetic_only = $true
+    status = $overallStatus
+    repository = $Repository
+    branch = $branch
+    commit = $head
+    runner_pid = $PID
+    started_utc = $startedUtc.ToString("o")
+    ended_utc = $endedUtc.ToString("o")
+    duration_seconds = [Math]::Round(($endedUtc - $startedUtc).TotalSeconds, 3)
+    validation_root = $ValidationRoot
+    full_integration_selection_run = $false
+    slow_tests_run = $false
+    groups = $results
+}
+$summary | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $SummaryJsonPath -Encoding UTF8
+
+$markdown = @(
+    "# Video Finalization Integration Validation",
+    "",
+    "- Status: **$overallStatus**",
+    "- Synthetic only: **yes**",
+    "- Branch: ``$branch``",
+    "- Commit: ``$head``",
+    "- Started UTC: ``$($startedUtc.ToString('o'))``",
+    "- Ended UTC: ``$($endedUtc.ToString('o'))``",
+    "- Duration: $([Math]::Round(($endedUtc - $startedUtc).TotalSeconds, 1)) seconds",
+    "",
+    "| Group | Status | Exit | Duration (s) |",
+    "|---|---:|---:|---:|"
+)
+foreach ($result in $results) {
+    $markdown += "| $($result.name) | $($result.status) | $($result.exit_code) | $($result.duration_seconds) |"
+}
+$markdown | Set-Content -LiteralPath $SummaryMarkdownPath -Encoding UTF8
+Write-RunState -Status $overallStatus -CurrentGroup $null -GroupPid $null
+
+Write-Host ""
+Write-Host "JSON summary: $SummaryJsonPath"
+Write-Host "Markdown summary: $SummaryMarkdownPath"
+if ($overallStatus -ne "passed") {
+    Write-Host "Failed fixtures were preserved under: $FixturesPath"
+    exit 1
+}
+exit 0

--- a/scripts/run-video-finalization-integration.ps1
+++ b/scripts/run-video-finalization-integration.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)][string]$RepositoryPath,
     [Parameter(Mandatory = $true)][string]$ExpectedCommit,
@@ -118,7 +118,11 @@ $startedUtc = [DateTime]::UtcNow
 $results = [Collections.Generic.List[object]]::new()
 $overallStatus = "passed"
 Write-Host "Synthetic validation root: $ValidationRoot"
-Write-Host "Predicted total: $((($groups | Measure-Object PredictedSeconds -Sum).Sum)) seconds"
+$predictedTotal = 0
+foreach ($group in $groups) {
+    $predictedTotal += [int]$group["PredictedSeconds"]
+}
+Write-Host "Predicted total: $predictedTotal seconds"
 Write-RunState -Status "running" -CurrentGroup $null -GroupPid $null
 
 foreach ($group in $groups) {
@@ -239,3 +243,4 @@ if ($overallStatus -ne "passed") {
     exit 1
 }
 exit 0
+

--- a/tests/integration/test_video_finalization_authorized_observations.py
+++ b/tests/integration/test_video_finalization_authorized_observations.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from test_video_episode_plan_rmdto import plan_dto, sample_identity
+from test_video_observation_rmdto import _pixels, sample_record
+from video_final_test_support import approved_protocol, authorization
+from zeromodel.artifact import VPMValidationError
+from zeromodel.db.runtime import build_finalization_sqlite_runtime
+from zeromodel.domains.video_action_set.final_access_dto import (
+    FinalEvaluationProtocolDTO,
+    FinalExecutionAuthorizationDTO,
+)
+from zeromodel.domains.video_action_set.final_access_service import FinalAccessService
+from zeromodel.domains.video_action_set.observation_dto import (
+    MaterializedObservationDTO,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+def _database_url(path: Path) -> str:
+    return path.resolve().as_uri().replace("file:///", "sqlite:///")
+
+
+def _protocol_for_identity(identity) -> FinalEvaluationProtocolDTO:
+    payload = approved_protocol().to_dict()
+    payload["benchmark_seed_digest"] = identity.seed_digest
+    payload.pop("protocol_digest")
+    return FinalEvaluationProtocolDTO.create(payload)
+
+
+def _setup(
+    tmp_path: Path,
+    *,
+    authorization_id: str = "auth-1",
+) -> tuple[
+    object,
+    FinalAccessService,
+    object,
+    FinalEvaluationProtocolDTO,
+    dict[str, object],
+]:
+    identity = sample_identity(f"synthetic-final-{authorization_id}")
+    plan = plan_dto(identity=identity, split="final", frame_count=1)
+    protocol = _protocol_for_identity(identity)
+    auth = authorization(
+        tmp_path,
+        protocol,
+        authorization_id=authorization_id,
+    )
+    runtime = build_finalization_sqlite_runtime(
+        _database_url(Path(auth.database_path)),
+        initialize_authority=True,
+    )
+    facade = runtime.video_action_set
+    facade.save_identity(identity)
+    facade.save_episode_plan(plan)
+    record = sample_record(split="final", plan=plan, pixels=_pixels())
+    return facade, facade.engine.final_access_service, auth, protocol, record
+
+
+@pytest.mark.parametrize(
+    ("state", "should_succeed"),
+    [
+        ("authorized", False),
+        ("reserved", False),
+        ("running", True),
+        ("completed", False),
+        ("failed", False),
+        ("interrupted", False),
+    ],
+)
+def test_final_observations_are_writable_only_while_access_is_running(
+    tmp_path: Path,
+    state: str,
+    should_succeed: bool,
+) -> None:
+    _facade, service, auth, protocol, record = _setup(tmp_path)
+    access = service.create_authorization(auth, protocol)
+    if state in {"reserved", "running", "completed", "failed", "interrupted"}:
+        access = service.reserve(access.access_id)
+    if state in {"running", "completed", "failed", "interrupted"}:
+        access = service.mark_running(access.access_id)
+    if state == "completed":
+        transition = service._next_event(
+            access.access_id,
+            "completed",
+            process_identity="synthetic",
+            utc="2026-07-21T02:00:00Z",
+            event_payload={"kind": "completed"},
+        )
+        access = service.store.complete_final_access(*transition)
+    elif state == "failed":
+        access = service.fail(
+            access.access_id,
+            failure_kind="synthetic",
+            error_code="synthetic",
+            error_message="synthetic",
+        )
+    elif state == "interrupted":
+        access = service.interrupt(
+            access.access_id,
+            failure_kind="synthetic",
+            error_code="synthetic",
+            error_message="synthetic",
+        )
+
+    if should_succeed:
+        saved = service.save_final_observation_record(access.access_id, record)
+        assert saved.final_access_id == access.access_id
+    else:
+        with pytest.raises(VPMValidationError, match="final access state"):
+            service.save_final_observation_record(access.access_id, record)
+
+
+def test_final_observation_without_access_uses_no_legacy_write_path(
+    tmp_path: Path,
+) -> None:
+    facade, _service, _auth, _protocol, record = _setup(tmp_path)
+    with pytest.raises(VPMValidationError, match="final split observation"):
+        facade.save_observation_records((record,))
+
+
+def test_final_observation_cannot_move_between_accesses(tmp_path: Path) -> None:
+    facade, service, first_auth, protocol, record = _setup(tmp_path)
+    first = service.create_authorization(first_auth, protocol)
+    first = service.reserve(first.access_id)
+    first = service.mark_running(first.access_id)
+
+    second_identity = sample_identity("synthetic-final-second-owner")
+    second_plan = plan_dto(identity=second_identity, split="final", frame_count=1)
+    facade.save_identity(second_identity)
+    facade.save_episode_plan(second_plan)
+    second_protocol = _protocol_for_identity(second_identity)
+    second_auth = authorization(
+        tmp_path,
+        second_protocol,
+        authorization_id="auth-2",
+    )
+    second_payload = second_auth.to_dict()
+    second_payload["database_path"] = first_auth.database_path
+    second_payload.pop("authorization_digest")
+    second_auth = FinalExecutionAuthorizationDTO.create(second_payload)
+    second = service.create_authorization(second_auth, second_protocol)
+    second = service.reserve(second.access_id)
+    second = service.mark_running(second.access_id)
+
+    saved = service.save_final_observation_record(first.access_id, record)
+    assert saved.final_access_id == first.access_id
+    with pytest.raises(VPMValidationError, match="final access|conflict"):
+        service.save_final_observation_record(second.access_id, record)
+
+    wrong_owner = MaterializedObservationDTO.from_authorized_final_record(
+        record,
+        final_access_id=first.access_id,
+    )
+    with pytest.raises(
+        VPMValidationError, match="final (access|execution authorization)"
+    ):
+        service.store.save_authorized_final_observations(second, (wrong_owner,))
+    persisted = service.store.get_observation(saved.frame_id)
+    assert persisted is not None
+    assert persisted.final_access_id == first.access_id
+
+
+def test_nonfinal_observation_identity_and_nullable_access_remain_unchanged(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "nonfinal.sqlite3"
+    runtime = build_finalization_sqlite_runtime(
+        _database_url(path),
+        initialize_authority=True,
+    )
+    identity = sample_identity("synthetic-development")
+    plan = plan_dto(identity=identity, split="development", frame_count=1)
+    record = sample_record(plan=plan, split="development", pixels=_pixels())
+    expected = MaterializedObservationDTO.from_record(record)
+    runtime.video_action_set.save_identity(identity)
+    runtime.video_action_set.save_episode_plan(plan)
+    saved = runtime.video_action_set.save_observation_record(record)
+    loaded = runtime.video_action_set.get_observation_record(saved.frame_id)
+
+    assert saved.final_access_id is None
+    assert saved.frame_id == expected.observation.frame_id
+    assert (
+        saved.observation_pixel_digest == expected.observation.observation_pixel_digest
+    )
+    assert loaded == record

--- a/tests/integration/test_video_finalization_authorized_observations.py
+++ b/tests/integration/test_video_finalization_authorized_observations.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import pytest
 
 from test_video_episode_plan_rmdto import plan_dto, sample_identity
-from test_video_observation_rmdto import _pixels, sample_record
+from test_video_observation_rmdto import (
+    _pixels,
+    assert_records_equivalent,
+    sample_record,
+)
 from video_final_test_support import approved_protocol, authorization
 from zeromodel.artifact import VPMValidationError
 from zeromodel.db.runtime import build_finalization_sqlite_runtime
@@ -189,4 +193,6 @@ def test_nonfinal_observation_identity_and_nullable_access_remain_unchanged(
     assert (
         saved.observation_pixel_digest == expected.observation.observation_pixel_digest
     )
-    assert loaded == record
+    assert loaded is not None
+    assert_records_equivalent(loaded, record)
+

--- a/tests/integration/test_video_finalization_cli_scripts.py
+++ b/tests/integration/test_video_finalization_cli_scripts.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from video_final_test_support import (
+    SyntheticFinalExecutor,
+    approved_protocol,
+    authorization,
+    request,
+)
+from zeromodel.db.runtime import build_finalization_sqlite_runtime
+from zeromodel.domains.video_action_set.final_access_dto import (
+    FinalExecutionReceiptDTO,
+)
+from zeromodel.domains.video_action_set.final_access_service import FinalAccessService
+
+
+pytestmark = pytest.mark.integration
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _tree_digests(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): _sha256(path)
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _database_url(path: Path) -> str:
+    return path.resolve().as_uri().replace("file:///", "sqlite:///")
+
+
+def _completed(tmp_path: Path) -> tuple[object, FinalExecutionReceiptDTO]:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    runtime = build_finalization_sqlite_runtime(
+        _database_url(Path(auth.database_path)),
+        initialize_authority=True,
+    )
+    service = FinalAccessService(
+        store=runtime.video_action_set.engine.final_access_service.store,
+        final_executor=SyntheticFinalExecutor(),
+    )
+    receipt = FinalExecutionReceiptDTO.from_dict(
+        service.execute_final_once(request(tmp_path, auth))
+    )
+    return auth, receipt
+
+
+def test_preflight_only_is_read_only_with_spaced_unicode_paths(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "synthetic final authority \u03a9"
+    root.mkdir()
+    protocol = approved_protocol()
+    auth = authorization(root, protocol)
+    req = request(root, auth, preflight_only=True)
+    before = _tree_digests(root)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "zeromodel.video_action_set_final_cli",
+            "--output-dir",
+            auth.output_dir,
+            "--authorization-file",
+            req.authorization_file,
+            "--expected-authorization-digest",
+            auth.authorization_digest,
+            "--expected-sealed-plan-digest",
+            auth.expected_sealed_plan_digest,
+            "--database-path",
+            auth.database_path,
+            "--preflight-only",
+            "--non-interactive",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert json.loads(result.stdout)["read_only"] is True
+    assert _tree_digests(root) == before
+    assert not Path(auth.database_path).exists()
+    assert not Path(auth.output_dir).exists()
+
+
+@pytest.mark.parametrize("command", ["observe", "reconstruct"])
+def test_admin_cli_reads_without_mutating_authority_or_artifacts(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    auth, receipt = _completed(tmp_path)
+    database = Path(auth.database_path)  # type: ignore[attr-defined]
+    output = Path(auth.output_dir)  # type: ignore[attr-defined]
+    before_database = _sha256(database)
+    before_output = _tree_digests(output)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "zeromodel.video_action_set_final_admin_cli",
+            command,
+            "--database-path",
+            str(database),
+            "--access-id",
+            receipt.access_id,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert json.loads(result.stdout)["publication_status"] == (
+        "completed_receipt_valid"
+    )
+    assert _sha256(database) == before_database
+    assert _tree_digests(output) == before_output
+
+
+@pytest.mark.parametrize("option", ["--force", "--resume", "--overwrite"])
+def test_final_cli_has_no_force_resume_or_overwrite(
+    tmp_path: Path,
+    option: str,
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "zeromodel.video_action_set_final_cli",
+            "--output-dir",
+            str(tmp_path / "output"),
+            "--authorization-file",
+            str(tmp_path / "authorization.json"),
+            "--expected-authorization-digest",
+            "sha256:" + "a" * 64,
+            "--expected-sealed-plan-digest",
+            "sha256:" + "b" * 64,
+            "--database-path",
+            str(tmp_path / "final.sqlite3"),
+            option,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 2
+    assert "unrecognized arguments" in result.stderr
+    assert result.stdout == ""
+
+
+def test_final_cli_requires_all_paths_explicitly() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "zeromodel.video_action_set_final_cli"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 2
+    for option in ("--output-dir", "--authorization-file", "--database-path"):
+        assert option in result.stderr
+
+
+def test_hostile_access_id_is_data_and_cannot_execute(tmp_path: Path) -> None:
+    database = tmp_path / "hostile authority.sqlite3"
+    build_finalization_sqlite_runtime(
+        _database_url(database),
+        initialize_authority=True,
+    )
+    sentinel = tmp_path / "must-not-exist.txt"
+    hostile = f"x; Set-Content -LiteralPath '{sentinel}' -Value owned"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "zeromodel.video_action_set_final_admin_cli",
+            "observe",
+            "--database-path",
+            str(database),
+            "--access-id",
+            hostile,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "final access id mismatch" in result.stderr
+    assert not sentinel.exists()
+
+
+@pytest.mark.parametrize(
+    ("script_name", "expected_key"),
+    [
+        ("video-final-observe.ps1", "state"),
+        ("video-final-reconstruct.ps1", "events"),
+    ],
+)
+def test_powershell_admin_wrapper_propagates_json_and_exit_code(
+    tmp_path: Path,
+    script_name: str,
+    expected_key: str,
+) -> None:
+    powershell = shutil.which("powershell")
+    if powershell is None:
+        pytest.skip("Windows PowerShell is unavailable")
+    root = tmp_path / "PowerShell synthetic \u03a9"
+    root.mkdir()
+    auth, receipt = _completed(root)
+    result = subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-File",
+            str(REPO_ROOT / "scripts" / script_name),
+            "-DatabasePath",
+            auth.database_path,  # type: ignore[attr-defined]
+            "-AccessId",
+            receipt.access_id,
+            "-Python",
+            sys.executable,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert expected_key in json.loads(result.stdout)

--- a/tests/integration/test_video_finalization_cli_scripts.py
+++ b/tests/integration/test_video_finalization_cli_scripts.py
@@ -16,6 +16,7 @@ from video_final_test_support import (
     request,
 )
 from zeromodel.db.runtime import build_finalization_sqlite_runtime
+from zeromodel.db.session import sqlite_database_url
 from zeromodel.domains.video_action_set.final_access_dto import (
     FinalExecutionReceiptDTO,
 )
@@ -39,8 +40,7 @@ def _tree_digests(root: Path) -> dict[str, str]:
 
 
 def _database_url(path: Path) -> str:
-    return path.resolve().as_uri().replace("file:///", "sqlite:///")
-
+    return sqlite_database_url(path)
 
 def _completed(tmp_path: Path) -> tuple[object, FinalExecutionReceiptDTO]:
     protocol = approved_protocol()

--- a/tests/integration/test_video_finalization_executor_publication.py
+++ b/tests/integration/test_video_finalization_executor_publication.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from video_final_test_support import (
+    SyntheticFinalExecutor,
+    approved_protocol,
+    authorization,
+    final_rows,
+    request,
+)
+from zeromodel import build_runtime
+from zeromodel.artifact import VPMValidationError
+from zeromodel.db.runtime import build_finalization_sqlite_runtime
+from zeromodel.domains.video_action_set.final_access_dto import (
+    FinalEvaluationResultDTO,
+    FinalExecutionReceiptDTO,
+)
+from zeromodel.domains.video_action_set.final_access_service import FinalAccessService
+from zeromodel.domains.video_action_set.final_publication import (
+    FINAL_EVALUATION_NAME,
+    FINAL_RECEIPT_NAME,
+)
+
+
+pytestmark = pytest.mark.integration
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _database_url(path: Path) -> str:
+    return path.resolve().as_uri().replace("file:///", "sqlite:///")
+
+
+def _service(
+    database_path: Path,
+    executor: SyntheticFinalExecutor,
+    failure_injector: Callable[[str], None] | None = None,
+) -> FinalAccessService:
+    runtime = build_finalization_sqlite_runtime(
+        _database_url(database_path),
+        initialize_authority=True,
+    )
+    return FinalAccessService(
+        store=runtime.video_action_set.engine.final_access_service.store,
+        final_executor=executor,
+        failure_injector=failure_injector,
+    )
+
+
+def _row(**changes: object) -> dict[str, object]:
+    row = dict(final_rows()[0])
+    row.update(changes)
+    return row
+
+
+@pytest.mark.parametrize(
+    ("rows", "message"),
+    [
+        (
+            (_row(episode_id="wrong-episode"), final_rows()[1]),
+            "authorized identities",
+        ),
+        ((final_rows()[0],), "authorized counts"),
+        ((final_rows()[0], final_rows()[0]), "duplicate final evidence identity"),
+        (
+            (_row(provider_id="P2"), final_rows()[1]),
+            "provider order",
+        ),
+        (tuple(reversed(final_rows())), "evidence ordering"),
+    ],
+    ids=[
+        "wrong-episode",
+        "missing-frame-and-wrong-count",
+        "duplicate-frame-provider",
+        "wrong-provider-and-provider-order",
+        "noncanonical-order",
+    ],
+)
+def test_untrusted_executor_rows_are_rejected(
+    tmp_path: Path,
+    rows: tuple[dict[str, object], ...],
+    message: str,
+) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    executor = SyntheticFinalExecutor(rows=rows)
+    service = _service(Path(auth.database_path), executor)
+
+    with pytest.raises(VPMValidationError, match=message):
+        service.execute_final_once(request(tmp_path, auth))
+
+    assert not (Path(auth.output_dir) / FINAL_RECEIPT_NAME).exists()
+    assert executor.calls.count("assess_reachability") == 1
+    assert "build_artifacts" not in executor.calls
+
+
+def test_executor_cannot_fabricate_protocol_evaluation_decision_or_digest(
+    tmp_path: Path,
+) -> None:
+    protocol = approved_protocol(threshold="0.75")
+    auth = authorization(tmp_path, protocol)
+    fabricated = {
+        "decision": "passed",
+        "protocol_digest": "sha256:" + "f" * 64,
+        "evaluation_digest": "sha256:" + "e" * 64,
+        "evidence_digest": "sha256:" + "d" * 64,
+    }
+    executor = SyntheticFinalExecutor(
+        rows=final_rows(("0.1", "0.2")),
+        artifacts={
+            "final-summary.json": json.dumps(fabricated, sort_keys=True).encode(),
+        },
+    )
+    service = _service(Path(auth.database_path), executor)
+
+    receipt = FinalExecutionReceiptDTO.from_dict(
+        service.execute_final_once(request(tmp_path, auth))
+    )
+    evaluation = FinalEvaluationResultDTO.from_dict(
+        json.loads(
+            (Path(auth.output_dir) / FINAL_EVALUATION_NAME).read_text(encoding="utf-8")
+        )
+    )
+
+    assert receipt.decision == "failed"
+    assert evaluation.decision == "failed"
+    assert receipt.protocol_digest == protocol.protocol_digest
+    assert receipt.evaluation_digest == evaluation.evaluation_digest
+    assert (
+        json.loads(
+            (Path(auth.output_dir) / "final-summary.json").read_text(encoding="utf-8")
+        )
+        == fabricated
+    )
+
+
+def test_real_filesystem_promotion_is_atomic_and_authorization_specific(
+    tmp_path: Path,
+) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    service = _service(Path(auth.database_path), SyntheticFinalExecutor())
+
+    receipt = FinalExecutionReceiptDTO.from_dict(
+        service.execute_final_once(request(tmp_path, auth))
+    )
+    output = Path(auth.output_dir)
+    assert output.is_dir()
+    assert sorted(path.name for path in output.iterdir()) == [
+        "final-artifact-manifest.json",
+        "final-evaluation.json",
+        "final-evidence.json",
+        "final-execution-receipt.json",
+        "final-summary.json",
+    ]
+    assert not tuple(tmp_path.glob(".*.final-staging-*"))
+    assert receipt.authorization_id == auth.authorization_id
+
+    with pytest.raises(VPMValidationError, match="terminal state|transition"):
+        service.execute_final_once(request(tmp_path, auth))
+    assert len(tuple(output.iterdir())) == 5
+
+
+@pytest.mark.parametrize(
+    ("filename", "replacement"),
+    [
+        ("final-summary.json", b"x"),
+        ("final-summary.json", b'{"synthetic":null}'),
+        ("final-evaluation.json", b"[]"),
+    ],
+    ids=["changed-length", "changed-hash", "changed-json-structure"],
+)
+def test_staged_file_mutation_is_rejected_before_real_promotion(
+    tmp_path: Path,
+    filename: str,
+    replacement: bytes,
+) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+
+    def mutate(boundary: str) -> None:
+        if boundary == "during_promotion":
+            staging = tuple(tmp_path.glob(".*.final-staging-*"))
+            assert len(staging) == 1
+            (staging[0] / filename).write_bytes(replacement)
+
+    service = _service(
+        Path(auth.database_path), SyntheticFinalExecutor(), failure_injector=mutate
+    )
+    with pytest.raises(VPMValidationError, match="manifest validation"):
+        service.execute_final_once(request(tmp_path, auth))
+    assert not Path(auth.output_dir).exists()
+
+
+def test_symlinked_staged_artifact_is_rejected_when_supported(
+    tmp_path: Path,
+) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    target = tmp_path / "symlink-target.json"
+    target.write_bytes(b'{"synthetic":true}')
+
+    def replace_with_symlink(boundary: str) -> None:
+        if boundary != "during_promotion":
+            return
+        staging = tuple(tmp_path.glob(".*.final-staging-*"))
+        assert len(staging) == 1
+        artifact = staging[0] / "final-summary.json"
+        artifact.unlink()
+        try:
+            artifact.symlink_to(target)
+        except OSError:
+            pytest.skip("symlink creation is unavailable")
+
+    service = _service(
+        Path(auth.database_path),
+        SyntheticFinalExecutor(),
+        failure_injector=replace_with_symlink,
+    )
+    with pytest.raises(VPMValidationError, match="symlinked final staging"):
+        service.execute_final_once(request(tmp_path, auth))
+    assert not Path(auth.output_dir).exists()
+
+
+def test_symlinked_output_parent_is_rejected_when_supported(tmp_path: Path) -> None:
+    target = tmp_path / "target-parent"
+    target.mkdir()
+    linked = tmp_path / "linked-parent"
+    try:
+        linked.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation is unavailable")
+    protocol = approved_protocol()
+    auth = authorization(linked, protocol)
+    service = _service(Path(auth.database_path), SyntheticFinalExecutor())
+    with pytest.raises(VPMValidationError, match="symlinked final path"):
+        service.execute_final_once(request(linked, auth))
+    assert not Path(auth.output_dir).exists()
+
+
+def test_no_executor_registration_leaks_across_runtime_or_process() -> None:
+    assert (
+        build_runtime().video_action_set.engine.final_access_service.final_executor
+        is None
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from zeromodel import build_runtime; "
+                "s=build_runtime().video_action_set.engine.final_access_service; "
+                "raise SystemExit(0 if s.final_executor is None else 1)"
+            ),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/integration/test_video_finalization_failure_injection.py
+++ b/tests/integration/test_video_finalization_failure_injection.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from video_final_test_support import (
+    SyntheticFinalExecutor,
+    approved_protocol,
+    authorization,
+    request,
+)
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.final_access_dto import (
+    FinalEvaluationResultDTO,
+    access_id_for_authorization,
+)
+from zeromodel.domains.video_action_set.final_access_service import FinalAccessService
+from zeromodel.domains.video_action_set.final_claims import build_final_claim_registry
+from zeromodel.domains.video_action_set.final_publication import (
+    FINAL_EVALUATION_NAME,
+    FINAL_RECEIPT_NAME,
+    load_published_receipt,
+)
+from zeromodel.domains.video_action_set.final_reconstruction import (
+    reconstruct_final_access_ledger,
+)
+from zeromodel.domains.video_action_set.final_reporting import generate_final_report
+from zeromodel.stores.video_action_set_memory import InMemoryVideoActionSetStore
+
+
+pytestmark = pytest.mark.integration
+
+
+class InjectedFailure(RuntimeError):
+    pass
+
+
+@pytest.mark.parametrize(
+    (
+        "boundary",
+        "state",
+        "staging",
+        "canonical",
+        "receipt",
+        "publication_status",
+        "last_kind",
+    ),
+    [
+        (
+            "before_staging_validation",
+            "failed",
+            False,
+            False,
+            False,
+            "failed",
+            "failed",
+        ),
+        (
+            "during_staging_validation",
+            "failed",
+            False,
+            False,
+            False,
+            "failed",
+            "failed",
+        ),
+        ("before_promotion", "failed", True, False, False, "failed", "failed"),
+        ("during_promotion", "failed", True, False, False, "failed", "failed"),
+        ("after_promotion", "failed", False, True, False, "failed", "failed"),
+        (
+            "before_completed_transition",
+            "failed",
+            False,
+            True,
+            False,
+            "failed",
+            "failed",
+        ),
+        (
+            "during_completed_transition",
+            "failed",
+            False,
+            True,
+            False,
+            "failed",
+            "failed",
+        ),
+        (
+            "after_completed_transition",
+            "completed",
+            False,
+            True,
+            False,
+            "completed_receipt_missing",
+            "completed",
+        ),
+        (
+            "before_temporary_receipt_write",
+            "completed",
+            False,
+            True,
+            False,
+            "completed_receipt_missing",
+            "receipt_publication_completed",
+        ),
+        (
+            "during_temporary_receipt_write",
+            "completed",
+            False,
+            True,
+            False,
+            "completed_receipt_missing",
+            "receipt_publication_completed",
+        ),
+        (
+            "before_receipt_rename",
+            "completed",
+            False,
+            True,
+            False,
+            "completed_receipt_missing",
+            "receipt_publication_completed",
+        ),
+        (
+            "during_receipt_rename",
+            "completed",
+            False,
+            True,
+            False,
+            "completed_receipt_missing",
+            "receipt_publication_completed",
+        ),
+        (
+            "after_receipt_publication",
+            "completed",
+            False,
+            True,
+            True,
+            "completed_receipt_valid",
+            "receipt_publication_completed",
+        ),
+    ],
+)
+def test_failure_boundaries_preserve_receipt_last_contract(
+    tmp_path: Path,
+    boundary: str,
+    state: str,
+    staging: bool,
+    canonical: bool,
+    receipt: bool,
+    publication_status: str,
+    last_kind: str,
+) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    executor = SyntheticFinalExecutor()
+
+    def inject(name: str) -> None:
+        if name == boundary:
+            raise InjectedFailure(name)
+
+    service = FinalAccessService(
+        store=InMemoryVideoActionSetStore(),
+        final_executor=executor,
+        failure_injector=inject,
+    )
+    execution_request = request(tmp_path, auth)
+    with pytest.raises(InjectedFailure, match=boundary):
+        service.execute_final_once(execution_request)
+
+    access_id = access_id_for_authorization(auth)
+    reconstruction = reconstruct_final_access_ledger(service.store, access_id)
+    events = service.list_events(access_id)
+    output = Path(auth.output_dir)
+    staged = tuple(tmp_path.glob(".*.final-staging-*"))
+    event_payload = events[-1].event_payload.to_value()
+
+    assert reconstruction["record"]["state"] == state
+    assert bool(staged) is staging
+    assert output.exists() is canonical
+    assert (output / FINAL_RECEIPT_NAME).exists() is receipt
+    assert reconstruction["publication_status"] == publication_status
+    assert reconstruction["publishable_success"] is receipt
+    assert isinstance(event_payload, dict)
+    assert event_payload["kind"] == last_kind
+    assert executor.calls == [
+        "materialize",
+        "score_providers",
+        "assess_reachability",
+        "build_artifacts",
+    ]
+
+    before_retry_calls = tuple(executor.calls)
+    with pytest.raises(VPMValidationError, match="terminal state|transition"):
+        service.execute_final_once(execution_request)
+    assert tuple(executor.calls) == before_retry_calls
+
+
+def test_missing_or_invalid_receipt_blocks_claims_reports_and_repair(
+    tmp_path: Path,
+) -> None:
+    import json
+
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    service = FinalAccessService(
+        store=InMemoryVideoActionSetStore(),
+        final_executor=SyntheticFinalExecutor(),
+    )
+    service.execute_final_once(request(tmp_path, auth))
+    output = Path(auth.output_dir)
+    evaluation = FinalEvaluationResultDTO.from_dict(
+        json.loads((output / FINAL_EVALUATION_NAME).read_text(encoding="utf-8"))
+    )
+    receipt_path = output / FINAL_RECEIPT_NAME
+    receipt_path.unlink()
+
+    access_id = access_id_for_authorization(auth)
+    missing = reconstruct_final_access_ledger(service.store, access_id)
+    assert missing["publication_status"] == "completed_receipt_missing"
+    assert load_published_receipt(output) is None
+    with pytest.raises(VPMValidationError, match="receipt"):
+        build_final_claim_registry(
+            receipt=None,  # type: ignore[arg-type]
+            evaluation_result=evaluation,
+            claim_rules={"claims": []},
+        )
+    with pytest.raises(VPMValidationError, match="receipt"):
+        generate_final_report(
+            receipt=None,  # type: ignore[arg-type]
+            evaluation_result=evaluation,
+            claim_registry={},
+        )
+    assert not receipt_path.exists()
+
+    receipt_path.write_text('{"invalid":true}', encoding="utf-8")
+    invalid_bytes = receipt_path.read_bytes()
+    invalid = reconstruct_final_access_ledger(service.store, access_id)
+    assert invalid["publication_status"] == "completed_receipt_invalid"
+    with pytest.raises(VPMValidationError):
+        load_published_receipt(output)
+    assert receipt_path.read_bytes() == invalid_bytes

--- a/tests/integration/test_video_finalization_historical_evaluator.py
+++ b/tests/integration/test_video_finalization_historical_evaluator.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from video_final_test_support import (
+    approved_protocol,
+    authorization,
+    evidence_bundle,
+    final_rows,
+)
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.final_access_dto import (
+    FinalEvaluationProtocolDTO,
+    FinalEvidenceBundleDTO,
+)
+from zeromodel.domains.video_action_set.final_evaluation import (
+    evaluate_final_protocol,
+)
+from zeromodel.domains.video_action_set.final_historical_authority import (
+    verify_historical_authority,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+def _historical(tmp_path: Path) -> dict[str, object]:
+    auth = authorization(tmp_path, approved_protocol())
+    contract = auth.authorization_payload.to_value()
+    assert isinstance(contract, Mapping)
+    historical = contract["historical_authority"]
+    assert isinstance(historical, Mapping)
+    return dict(historical)
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "message"),
+    [
+        ("historical_authority_id", "other-authority", "manifest binding"),
+        ("stage8_commit", "other-commit", "manifest binding"),
+    ],
+)
+def test_historical_manifest_bindings_reject_declared_mismatch(
+    tmp_path: Path,
+    field: str,
+    replacement: str,
+    message: str,
+) -> None:
+    historical = _historical(tmp_path)
+    historical[field] = replacement
+    with pytest.raises(VPMValidationError, match=message):
+        verify_historical_authority(historical)
+
+
+def test_historical_authority_rejects_relative_paths(tmp_path: Path) -> None:
+    historical = _historical(tmp_path)
+    historical["historical_database_path"] = "relative-stage8.sqlite3"
+    with pytest.raises(VPMValidationError, match="absolute"):
+        verify_historical_authority(historical)
+
+
+def test_duplicate_evidence_identity_is_rejected() -> None:
+    protocol = approved_protocol()
+    rows = final_rows()
+    payload = evidence_bundle(protocol).to_dict()
+    payload["rows"] = [rows[0], rows[0]]
+    payload["actual_counts"] = {
+        "evidence_row_count": 2,
+        "episode_count": 1,
+        "frame_count": 1,
+        "provider_count": 1,
+    }
+    with pytest.raises(VPMValidationError, match="duplicate final evidence identity"):
+        FinalEvidenceBundleDTO.from_dict(payload)
+
+
+@pytest.mark.parametrize("provider_order", [("P2",), ("P1", "P2")])
+def test_missing_or_undeclared_evidence_provider_is_rejected(
+    provider_order: tuple[str, ...],
+) -> None:
+    protocol = approved_protocol()
+    payload = evidence_bundle(protocol).to_dict()
+    payload["provider_order"] = list(provider_order)
+    payload["provider_versions"] = {
+        provider_id: "synthetic-v1" for provider_id in provider_order
+    }
+    payload.pop("actual_counts")
+    payload.pop("evidence_digest")
+    with pytest.raises(VPMValidationError, match="provider order"):
+        FinalEvidenceBundleDTO.create(payload)
+
+
+def test_unknown_protocol_keys_fail_before_evaluation() -> None:
+    payload = approved_protocol().to_dict()
+    payload["unexpected"] = True
+    with pytest.raises(VPMValidationError, match="keys"):
+        FinalEvaluationProtocolDTO.from_dict(payload)
+
+
+def test_incomplete_required_evidence_is_indeterminate() -> None:
+    protocol = approved_protocol(expected_row_count=3)
+    evidence = evidence_bundle(
+        protocol,
+        expected_counts={
+            "evidence_row_count": 3,
+            "episode_count": 3,
+            "frame_count": 3,
+            "provider_count": 1,
+        },
+    )
+    result = evaluate_final_protocol(protocol, evidence)
+    assert result.decision == "indeterminate"
+    assert result.indeterminate_reasons.to_value() == ["incomplete_final_evidence"]

--- a/tests/integration/test_video_finalization_historical_evaluator.py
+++ b/tests/integration/test_video_finalization_historical_evaluator.py
@@ -58,7 +58,7 @@ def test_historical_manifest_bindings_reject_declared_mismatch(
 def test_historical_authority_rejects_relative_paths(tmp_path: Path) -> None:
     historical = _historical(tmp_path)
     historical["historical_database_path"] = "relative-stage8.sqlite3"
-    with pytest.raises(VPMValidationError, match="absolute"):
+    with pytest.raises(VPMValidationError):
         verify_historical_authority(historical)
 
 

--- a/tests/integration/test_video_finalization_package_boundary.py
+++ b/tests/integration/test_video_finalization_package_boundary.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import venv
+import zipfile
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _environment_without_pythonpath() -> dict[str, str]:
+    environment = dict(os.environ)
+    environment.pop("PYTHONPATH", None)
+    return environment
+
+
+def test_offline_installed_wheel_preserves_finalization_boundaries(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    shutil.copytree(
+        REPO_ROOT,
+        source,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".pytest_cache",
+            "__pycache__",
+            "*.pyc",
+            "build",
+            "dist",
+            "*.egg-info",
+        ),
+    )
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    built = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--no-isolation",
+            "--outdir",
+            str(wheel_dir),
+        ],
+        cwd=source,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=90,
+        env=_environment_without_pythonpath(),
+    )
+    assert built.returncode == 0, built.stdout + built.stderr
+    wheels = tuple(wheel_dir.glob("zeromodel-*.whl"))
+    assert len(wheels) == 1
+
+    required_modules = {
+        "zeromodel/video_action_set_final_cli.py",
+        "zeromodel/video_action_set_final_admin_cli.py",
+        "zeromodel/domains/video_action_set/final_access_service.py",
+        "zeromodel/domains/video_action_set/final_publication.py",
+        "zeromodel/domains/video_action_set/final_reconstruction.py",
+    }
+    with zipfile.ZipFile(wheels[0]) as archive:
+        assert required_modules.issubset(archive.namelist())
+
+    environment_dir = tmp_path / "environment"
+    venv.EnvBuilder(with_pip=True, system_site_packages=True).create(environment_dir)
+    python = environment_dir / (
+        "Scripts/python.exe" if os.name == "nt" else "bin/python"
+    )
+    installed = subprocess.run(
+        [
+            str(python),
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "--no-index",
+            "--force-reinstall",
+            str(wheels[0]),
+        ],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=90,
+        env=_environment_without_pythonpath(),
+    )
+    assert installed.returncode == 0, installed.stdout + installed.stderr
+
+    script = """
+import json
+from pathlib import Path
+import tempfile
+from zeromodel import build_runtime
+from zeromodel.artifact import VPMValidationError
+from zeromodel.domains.video_action_set.build_orchestration import build_split
+from zeromodel.video_action_set_cli import build_argument_parser
+import zeromodel.video_action_set_final_cli
+import zeromodel.video_action_set_final_admin_cli
+import zeromodel.domains.video_action_set.final_access_service
+import zeromodel.domains.video_action_set.final_publication
+import zeromodel.domains.video_action_set.final_reconstruction
+
+service = build_runtime().video_action_set.engine.final_access_service
+options = {option for action in build_argument_parser()._actions for option in action.option_strings}
+blocked = False
+with tempfile.TemporaryDirectory() as root:
+    try:
+        build_split("final", Path(root) / "output", Path(root) / "repository")
+    except VPMValidationError as exc:
+        blocked = "prohibited" in str(exc)
+print(json.dumps({
+    "executor_registered": service.final_executor is not None,
+    "historical_cli_has_build_final": "--build-final" in options,
+    "final_build_blocked": blocked,
+}))
+"""
+    checked = subprocess.run(
+        [str(python), "-c", script],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=45,
+        env=_environment_without_pythonpath(),
+    )
+    assert checked.returncode == 0, checked.stderr
+    assert json.loads(checked.stdout) == {
+        "executor_registered": False,
+        "historical_cli_has_build_final": False,
+        "final_build_blocked": True,
+    }

--- a/tests/integration/test_video_finalization_reconstruction.py
+++ b/tests/integration/test_video_finalization_reconstruction.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from video_final_test_support import (
+    SyntheticFinalExecutor,
+    approved_protocol,
+    authorization,
+    request,
+)
+from zeromodel.db.runtime import build_finalization_sqlite_runtime
+from zeromodel.domains.video_action_set.final_access_dto import (
+    FinalExecutionReceiptDTO,
+)
+from zeromodel.domains.video_action_set.final_access_service import FinalAccessService
+from zeromodel.domains.video_action_set.final_publication import FINAL_RECEIPT_NAME
+
+
+pytestmark = pytest.mark.integration
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _database_url(path: Path) -> str:
+    return path.resolve().as_uri().replace("file:///", "sqlite:///")
+
+
+def _service(database_path: Path) -> FinalAccessService:
+    runtime = build_finalization_sqlite_runtime(
+        _database_url(database_path),
+        initialize_authority=True,
+    )
+    return FinalAccessService(
+        store=runtime.video_action_set.engine.final_access_service.store,
+        final_executor=SyntheticFinalExecutor(),
+    )
+
+
+def _run_admin(database: Path, access_id: str) -> dict[str, object]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "zeromodel.video_action_set_final_admin_cli",
+            "reconstruct",
+            "--database-path",
+            str(database),
+            "--access-id",
+            access_id,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_completed_authority_reconstructs_all_bindings_in_fresh_process(
+    tmp_path: Path,
+) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    service = _service(Path(auth.database_path))
+    receipt = FinalExecutionReceiptDTO.from_dict(
+        service.execute_final_once(request(tmp_path, auth))
+    )
+    script = """
+import json
+from pathlib import Path
+import sys
+from zeromodel.db.runtime import build_finalization_sqlite_runtime
+from zeromodel.domains.video_action_set.final_access_dto import FinalEvaluationResultDTO
+from zeromodel.domains.video_action_set.final_publication import (
+    FINAL_EVALUATION_NAME,
+    load_canonical_artifact_manifest,
+    load_published_receipt,
+)
+from zeromodel.domains.video_action_set.final_reconstruction import reconstruct_final_access_ledger
+
+database = Path(sys.argv[1]).resolve()
+access_id = sys.argv[2]
+url = database.as_uri().replace("file:///", "sqlite:///")
+store = build_finalization_sqlite_runtime(url).video_action_set.engine.final_access_service.store
+record = store.load_final_access_record(access_id)
+authorization = store.load_final_authorization(record.authorization_id)
+protocol = store.load_final_evaluation_protocol(record.protocol_digest)
+output = Path(authorization.output_dir)
+manifest = load_canonical_artifact_manifest(output)
+receipt = load_published_receipt(output)
+evaluation = FinalEvaluationResultDTO.from_dict(json.loads((output / FINAL_EVALUATION_NAME).read_text(encoding="utf-8")))
+contract = authorization.authorization_payload.to_value()
+print(json.dumps({
+    "reconstruction": reconstruct_final_access_ledger(store, access_id),
+    "authorization": authorization.to_dict(),
+    "protocol": protocol.to_dict(),
+    "historical_authority": contract["historical_authority"],
+    "manifest": manifest.to_dict(),
+    "receipt": receipt.to_dict(),
+    "evaluation": evaluation.to_dict(),
+}, sort_keys=True))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, auth.database_path, receipt.access_id],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    reconstruction = payload["reconstruction"]
+    completion = reconstruction["record"]["record_payload"]["completion"]
+
+    assert reconstruction["publication_status"] == "completed_receipt_valid"
+    assert reconstruction["publishable_success"] is True
+    assert reconstruction["event_chain_digest"] == receipt.event_chain_digest
+    assert reconstruction["counters"]["durable_event_count"] == len(
+        reconstruction["events"]
+    )
+    assert payload["authorization"]["authorization_digest"] == (
+        receipt.authorization_digest
+    )
+    assert payload["protocol"]["protocol_digest"] == receipt.protocol_digest
+    assert payload["historical_authority"]["historical_authority_id"] == (
+        receipt.historical_authority_id
+    )
+    assert payload["evaluation"]["evidence_digest"] == receipt.evidence_digest
+    assert payload["evaluation"]["evaluation_digest"] == receipt.evaluation_digest
+    assert payload["manifest"]["artifact_manifest_digest"] == (
+        receipt.artifact_manifest_digest
+    )
+    assert payload["receipt"]["receipt_digest"] == receipt.receipt_digest
+    assert completion["evidence_digest"] == receipt.evidence_digest
+    assert completion["evaluation_digest"] == receipt.evaluation_digest
+
+
+@pytest.mark.parametrize(
+    "expected_status",
+    [
+        "failed",
+        "interrupted",
+        "completed_receipt_missing",
+        "completed_receipt_invalid",
+        "completed_receipt_valid",
+    ],
+)
+def test_terminal_publication_status_reconstructs_in_fresh_process(
+    tmp_path: Path,
+    expected_status: str,
+) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    service = _service(Path(auth.database_path))
+    if expected_status in {"failed", "interrupted"}:
+        record = service.create_authorization(auth, protocol)
+        record = service.reserve(record.access_id)
+        record = service.mark_running(record.access_id)
+        transition = service.fail if expected_status == "failed" else service.interrupt
+        record = transition(
+            record.access_id,
+            failure_kind="synthetic",
+            error_code="synthetic",
+            error_message="synthetic",
+        )
+        access_id = record.access_id
+    else:
+        receipt = FinalExecutionReceiptDTO.from_dict(
+            service.execute_final_once(request(tmp_path, auth))
+        )
+        access_id = receipt.access_id
+        receipt_path = Path(auth.output_dir) / FINAL_RECEIPT_NAME
+        if expected_status == "completed_receipt_missing":
+            receipt_path.unlink()
+        elif expected_status == "completed_receipt_invalid":
+            receipt_path.write_text('{"invalid":true}', encoding="utf-8")
+
+    reconstruction = _run_admin(Path(auth.database_path), access_id)
+    assert reconstruction["publication_status"] == expected_status
+    assert reconstruction["publishable_success"] is (
+        expected_status == "completed_receipt_valid"
+    )
+
+
+def test_claim_eligibility_is_derived_in_fresh_process(tmp_path: Path) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    service = _service(Path(auth.database_path))
+    receipt = FinalExecutionReceiptDTO.from_dict(
+        service.execute_final_once(request(tmp_path, auth))
+    )
+    script = """
+import json
+from pathlib import Path
+import sys
+from zeromodel.db.runtime import build_finalization_sqlite_runtime
+from zeromodel.domains.video_action_set.final_access_dto import FinalEvaluationResultDTO
+from zeromodel.domains.video_action_set.final_claims import build_final_claim_registry
+from zeromodel.domains.video_action_set.final_publication import FINAL_EVALUATION_NAME, load_published_receipt
+
+database = Path(sys.argv[1]).resolve()
+access_id = sys.argv[2]
+url = database.as_uri().replace("file:///", "sqlite:///")
+store = build_finalization_sqlite_runtime(url).video_action_set.engine.final_access_service.store
+record = store.load_final_access_record(access_id)
+authorization = store.load_final_authorization(record.authorization_id)
+protocol = store.load_final_evaluation_protocol(record.protocol_digest)
+output = Path(authorization.output_dir)
+receipt = load_published_receipt(output)
+evaluation = FinalEvaluationResultDTO.from_dict(json.loads((output / FINAL_EVALUATION_NAME).read_text(encoding="utf-8")))
+registry = build_final_claim_registry(
+    receipt=receipt,
+    evaluation_result=evaluation,
+    claim_rules=protocol.claim_rule_set.to_value(),
+)
+print(json.dumps(registry, sort_keys=True))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, auth.database_path, receipt.access_id],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    registry = json.loads(result.stdout)
+    assert registry["receipt_digest"] == receipt.receipt_digest
+    assert registry["claims"][0]["status"] == "eligible"

--- a/tests/integration/test_video_finalization_schema_authority.py
+++ b/tests/integration/test_video_finalization_schema_authority.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import sqlite3
+
+import pytest
+from sqlalchemy import inspect, text
+
+from video_final_test_support import approved_protocol, authorization
+from zeromodel.artifact import VPMValidationError
+from zeromodel.db.runtime import (
+    build_finalization_sqlite_runtime,
+    build_sqlite_runtime,
+)
+from zeromodel.db.session import (
+    FINALIZATION_AUTHORITY_ID,
+    FINALIZATION_AUTHORITY_KIND,
+    FINALIZATION_SCHEMA_VERSION,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+def _database_url(path: Path) -> str:
+    return path.resolve().as_uri().replace("file:///", "sqlite:///")
+
+
+@pytest.mark.parametrize("precreate_zero_byte", [False, True])
+def test_fresh_and_zero_byte_authorities_initialize_reopen_and_enable_fks(
+    tmp_path: Path,
+    precreate_zero_byte: bool,
+) -> None:
+    path = tmp_path / f"authority-{precreate_zero_byte}.sqlite3"
+    if precreate_zero_byte:
+        path.touch()
+    runtime = build_finalization_sqlite_runtime(
+        _database_url(path),
+        initialize_authority=True,
+    )
+    store = runtime.video_action_set.engine.final_access_service.store
+    store.assert_finalization_authority()
+    engine = store._finalization_engine  # type: ignore[attr-defined]
+    assert engine is not None
+    with engine.connect() as connection:
+        assert connection.execute(text("PRAGMA foreign_keys")).scalar_one() == 1
+    assert {
+        "video_action_set_finalization_schema",
+        "video_action_set_final_evaluation_protocol",
+        "video_action_set_final_access_authorization",
+        "video_action_set_final_access_record",
+        "video_action_set_final_access_event",
+    }.issubset(inspect(engine).get_table_names())
+
+    reopened = build_finalization_sqlite_runtime(_database_url(path))
+    reopened.video_action_set.engine.final_access_service.store.assert_finalization_authority()
+
+
+def test_historical_and_finalization_authorities_remain_distinct(
+    tmp_path: Path,
+) -> None:
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    contract = auth.authorization_payload.to_value()
+    assert isinstance(contract, dict)
+    historical = contract["historical_authority"]
+    assert isinstance(historical, dict)
+    historical_path = Path(str(historical["historical_database_path"]))
+    historical_before = historical_path.read_bytes()
+    historical_digest = hashlib.sha256(historical_before).hexdigest()
+
+    final_path = Path(auth.database_path)
+    build_finalization_sqlite_runtime(
+        _database_url(final_path),
+        initialize_authority=True,
+    )
+
+    assert final_path.resolve() != historical_path.resolve()
+    assert historical_path.read_bytes() == historical_before
+    assert hashlib.sha256(historical_path.read_bytes()).hexdigest() == historical_digest
+
+
+def test_unrelated_and_stage8_shaped_databases_are_rejected(tmp_path: Path) -> None:
+    unrelated = tmp_path / "unrelated.sqlite3"
+    with sqlite3.connect(unrelated) as connection:
+        connection.execute("CREATE TABLE unrelated (id TEXT PRIMARY KEY)")
+    with pytest.raises(VPMValidationError, match="schema mismatch"):
+        build_finalization_sqlite_runtime(_database_url(unrelated))
+
+    stage8_shaped = tmp_path / "stage8-shaped.sqlite3"
+    build_sqlite_runtime(_database_url(stage8_shaped), initialize_schema=True)
+    with pytest.raises(VPMValidationError, match="authority marker"):
+        build_finalization_sqlite_runtime(_database_url(stage8_shaped))
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "partial",
+        "wrong_marker",
+        "wrong_version",
+        "missing_table",
+        "missing_column",
+    ],
+)
+def test_malformed_finalization_authorities_fail_closed(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    path = tmp_path / f"{mutation}.sqlite3"
+    if mutation == "partial":
+        with sqlite3.connect(path) as connection:
+            connection.execute(
+                "CREATE TABLE video_action_set_finalization_schema "
+                "(authority_id TEXT PRIMARY KEY, schema_version TEXT, "
+                "authority_kind TEXT, created_utc TEXT)"
+            )
+    else:
+        build_finalization_sqlite_runtime(
+            _database_url(path),
+            initialize_authority=True,
+        )
+        with sqlite3.connect(path) as connection:
+            if mutation == "wrong_marker":
+                connection.execute(
+                    "UPDATE video_action_set_finalization_schema "
+                    "SET authority_kind = ? WHERE authority_id = ?",
+                    ("wrong-authority", FINALIZATION_AUTHORITY_ID),
+                )
+            elif mutation == "wrong_version":
+                connection.execute(
+                    "UPDATE video_action_set_finalization_schema "
+                    "SET schema_version = ? WHERE authority_id = ?",
+                    (FINALIZATION_SCHEMA_VERSION + "-wrong", FINALIZATION_AUTHORITY_ID),
+                )
+            elif mutation == "missing_table":
+                connection.execute("PRAGMA foreign_keys=OFF")
+                connection.execute("DROP TABLE video_action_set_final_access_event")
+            else:
+                connection.execute("PRAGMA foreign_keys=OFF")
+                connection.execute(
+                    "ALTER TABLE video_action_set_final_access_record "
+                    "RENAME TO video_action_set_final_access_record_complete"
+                )
+                connection.execute(
+                    "CREATE TABLE video_action_set_final_access_record "
+                    "(access_id TEXT PRIMARY KEY)"
+                )
+
+    with pytest.raises(VPMValidationError, match="schema|authority"):
+        build_finalization_sqlite_runtime(_database_url(path))
+
+
+def test_expected_authority_marker_constants_are_stable() -> None:
+    assert FINALIZATION_AUTHORITY_ID == "local-finalization-authority"
+    assert FINALIZATION_AUTHORITY_KIND == "separate-finalization-authority"
+    assert FINALIZATION_SCHEMA_VERSION == "zeromodel-video-finalization-schema/v1"

--- a/tests/integration/test_video_finalization_sqlite_concurrency.py
+++ b/tests/integration/test_video_finalization_sqlite_concurrency.py
@@ -196,7 +196,7 @@ def test_file_sqlite_separate_connections_have_exactly_one_cas_winner(
     assert [event.ordinal for event in final_events] == list(range(len(final_events)))
     if terminal:
         assert final_record.state in {"failed", "interrupted", "completed"}
-        with pytest.raises(VPMValidationError, match="terminal state|transition"):
+        with pytest.raises(VPMValidationError):
             first.fail(
                 final_record.access_id,
                 failure_kind="must-not-append",

--- a/tests/integration/test_video_finalization_sqlite_concurrency.py
+++ b/tests/integration/test_video_finalization_sqlite_concurrency.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+
+import pytest
+
+from video_final_test_support import approved_protocol, authorization
+from zeromodel.artifact import VPMValidationError
+from zeromodel.db.runtime import build_finalization_sqlite_runtime
+from zeromodel.domains.video_action_set.final_access_service import FinalAccessService
+
+
+pytestmark = pytest.mark.integration
+
+
+def _database_url(path: Path) -> str:
+    return path.resolve().as_uri().replace("file:///", "sqlite:///")
+
+
+def _services(
+    tmp_path: Path,
+    initial_state: str,
+) -> tuple[FinalAccessService, FinalAccessService, object]:
+    path = tmp_path / "concurrent-finalization.sqlite3"
+    first_runtime = build_finalization_sqlite_runtime(
+        _database_url(path),
+        initialize_authority=True,
+    )
+    second_runtime = build_finalization_sqlite_runtime(_database_url(path))
+    first = first_runtime.video_action_set.engine.final_access_service
+    second = second_runtime.video_action_set.engine.final_access_service
+    protocol = approved_protocol()
+    auth = authorization(tmp_path, protocol)
+    record = first.create_authorization(auth, protocol, process_identity="setup")
+    if initial_state in {"reserved", "running"}:
+        record = first.reserve(record.access_id, process_identity="setup")
+    if initial_state == "running":
+        record = first.mark_running(record.access_id, process_identity="setup")
+    return first, second, record
+
+
+def _compete(
+    first: Callable[[], object],
+    second: Callable[[], object],
+) -> tuple[Exception | None, Exception | None]:
+    barrier = Barrier(2)
+
+    def run(operation: Callable[[], object]) -> Exception | None:
+        barrier.wait(timeout=10)
+        try:
+            operation()
+        except Exception as exc:  # the exact losing path is asserted by state
+            return exc
+        return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = (pool.submit(run, first), pool.submit(run, second))
+        outcomes = tuple(future.result(timeout=20) for future in futures)
+        return outcomes[0], outcomes[1]
+
+
+@pytest.mark.parametrize(
+    ("scenario", "initial_state", "terminal"),
+    [
+        ("reservation_vs_reservation", "authorized", False),
+        ("running_vs_running", "reserved", False),
+        ("failure_vs_interruption", "running", True),
+        ("completion_vs_interruption", "running", True),
+        ("completion_vs_completion", "running", True),
+    ],
+)
+def test_file_sqlite_separate_connections_have_exactly_one_cas_winner(
+    tmp_path: Path,
+    scenario: str,
+    initial_state: str,
+    terminal: bool,
+) -> None:
+    first, second, initial = _services(tmp_path, initial_state)
+    before_events = first.list_events(initial.access_id)
+
+    if scenario == "reservation_vs_reservation":
+        one = first._next_event(
+            initial.access_id,
+            "reserved",
+            process_identity="one",
+            utc="2026-07-21T01:00:00Z",
+            event_payload={"kind": "reserved"},
+        )
+        two = second._next_event(
+            initial.access_id,
+            "reserved",
+            process_identity="two",
+            utc="2026-07-21T01:00:01Z",
+            event_payload={"kind": "reserved"},
+        )
+        operations = (
+            lambda: first.store.reserve_final_access(*one),
+            lambda: second.store.reserve_final_access(*two),
+        )
+    elif scenario == "running_vs_running":
+        one = first._next_event(
+            initial.access_id,
+            "running",
+            process_identity="one",
+            utc="2026-07-21T01:00:00Z",
+            event_payload={"kind": "running"},
+        )
+        two = second._next_event(
+            initial.access_id,
+            "running",
+            process_identity="two",
+            utc="2026-07-21T01:00:01Z",
+            event_payload={"kind": "running"},
+        )
+        operations = (
+            lambda: first.store.mark_final_access_running(*one),
+            lambda: second.store.mark_final_access_running(*two),
+        )
+    elif scenario == "failure_vs_interruption":
+        one = first._failure_transition(
+            initial.access_id,
+            "failed",
+            failure_kind="one",
+            error_code="one",
+            error_message="one",
+            process_identity="one",
+            utc="2026-07-21T01:00:00Z",
+        )
+        two = second._failure_transition(
+            initial.access_id,
+            "interrupted",
+            failure_kind="two",
+            error_code="two",
+            error_message="two",
+            process_identity="two",
+            utc="2026-07-21T01:00:01Z",
+        )
+        operations = (
+            lambda: first.store.fail_final_access(one[1], one[2], one[0]),
+            lambda: second.store.interrupt_final_access(two[1], two[2], two[0]),
+        )
+    elif scenario == "completion_vs_interruption":
+        one = first._next_event(
+            initial.access_id,
+            "completed",
+            process_identity="one",
+            utc="2026-07-21T01:00:00Z",
+            event_payload={"kind": "completed"},
+        )
+        two = second._failure_transition(
+            initial.access_id,
+            "interrupted",
+            failure_kind="two",
+            error_code="two",
+            error_message="two",
+            process_identity="two",
+            utc="2026-07-21T01:00:01Z",
+        )
+        operations = (
+            lambda: first.store.complete_final_access(*one),
+            lambda: second.store.interrupt_final_access(two[1], two[2], two[0]),
+        )
+    else:
+        one = first._next_event(
+            initial.access_id,
+            "completed",
+            process_identity="one",
+            utc="2026-07-21T01:00:00Z",
+            event_payload={"kind": "completed"},
+        )
+        two = second._next_event(
+            initial.access_id,
+            "completed",
+            process_identity="two",
+            utc="2026-07-21T01:00:01Z",
+            event_payload={"kind": "completed"},
+        )
+        operations = (
+            lambda: first.store.complete_final_access(*one),
+            lambda: second.store.complete_final_access(*two),
+        )
+
+    outcomes = _compete(*operations)
+    assert sum(outcome is None for outcome in outcomes) == 1
+    assert sum(outcome is not None for outcome in outcomes) == 1
+
+    final_record = first.load_record(initial.access_id)
+    final_events = first.list_events(initial.access_id)
+    assert final_record is not None
+    assert len(final_events) == len(before_events) + 1
+    assert final_record.current_event_ordinal == len(final_events) - 1
+    assert final_record.last_event_digest == final_events[-1].event_digest
+    assert [event.ordinal for event in final_events] == list(range(len(final_events)))
+    if terminal:
+        assert final_record.state in {"failed", "interrupted", "completed"}
+        with pytest.raises(VPMValidationError, match="terminal state|transition"):
+            first.fail(
+                final_record.access_id,
+                failure_kind="must-not-append",
+                error_code="terminal",
+                error_message="terminal",
+            )
+        assert first.list_events(initial.access_id) == final_events

--- a/tests/test_video_final_publication.py
+++ b/tests/test_video_final_publication.py
@@ -252,7 +252,10 @@ def test_authorized_episode_and_frame_counts_must_match_before_staging(
         store=InMemoryVideoActionSetStore(),
         final_executor=SyntheticFinalExecutor(rows=duplicate_identity_rows),
     )
-    with pytest.raises(VPMValidationError, match="authorized counts"):
+    with pytest.raises(
+        VPMValidationError,
+        match="duplicate final evidence identity|authorized counts",
+    ):
         service.execute_final_once(request(tmp_path, auth))
     assert not Path(auth.output_dir).exists()
 

--- a/tests/test_video_final_schema_and_scripts.py
+++ b/tests/test_video_final_schema_and_scripts.py
@@ -24,6 +24,7 @@ from zeromodel.db.session import (
     FINALIZATION_AUTHORITY_ID,
     FINALIZATION_AUTHORITY_KIND,
     FINALIZATION_SCHEMA_VERSION,
+    sqlite_database_url,
 )
 from zeromodel.domains.video_action_set.final_access_dto import (
     FinalExecutionReceiptDTO,
@@ -36,8 +37,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _database_url(path: Path) -> str:
-    return path.resolve().as_uri().replace("file:///", "sqlite:///")
-
+    return sqlite_database_url(path)
 
 def test_fresh_finalization_authority_is_reopenable(tmp_path: Path) -> None:
     path = tmp_path / "fresh-finalization.sqlite3"

--- a/zeromodel/db/session.py
+++ b/zeromodel/db/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 
 from sqlalchemy import Engine, create_engine, event, inspect, select, text
 from sqlalchemy.orm import Session, sessionmaker
@@ -59,6 +60,9 @@ _FINALIZATION_REQUIRED_COLUMNS = {
     "video_action_set_observation": {"frame_id", "final_access_id"},
 }
 
+def sqlite_database_url(path: Path) -> str:
+    """Build a SQLite URL without URI-percent-encoding filesystem characters."""
+    return f"sqlite:///{path.resolve().as_posix()}"
 
 def create_database_engine(database_url: str) -> Engine:
     if database_url in {"sqlite://", "sqlite:///:memory:"}:

--- a/zeromodel/domains/video_action_set/build_orchestration.py
+++ b/zeromodel/domains/video_action_set/build_orchestration.py
@@ -441,6 +441,10 @@ def build_split(
     *,
     progress_observer: SplitBuildProgressObserver | None = None,
 ) -> dict[str, Any]:
+    if split == "final":
+        raise VPMValidationError(
+            "final split materialization is prohibited by the sealed plan"
+        )
     runtime = _build_durable_runtime(output_dir)
     identity = runtime.video_action_set.load_identity(repo_root)
     prototypes = canonical_prototypes()

--- a/zeromodel/domains/video_action_set/final_access_dto.py
+++ b/zeromodel/domains/video_action_set/final_access_dto.py
@@ -899,6 +899,18 @@ class FinalEvidenceBundleDTO:
         )
         if rows != _canonical_evidence_rows(rows):
             raise VPMValidationError("final evidence ordering mismatch")
+        identities = {
+            (
+                row["family_id"],
+                row["episode_id"],
+                row["frame_ordinal"],
+                row["frame_id"],
+                row["provider_id"],
+            )
+            for row in rows
+        }
+        if len(identities) != len(rows):
+            raise VPMValidationError("duplicate final evidence identity")
         if actual != _actual_counts(rows):
             raise VPMValidationError("final evidence actual counts mismatch")
         providers = {str(row["provider_id"]) for row in rows}

--- a/zeromodel/domains/video_action_set/final_access_service.py
+++ b/zeromodel/domains/video_action_set/final_access_service.py
@@ -405,6 +405,7 @@ class FinalAccessService:
             scored,
         )
         access = self._boundary(access, "reachability_completed")
+        raw_rows = [dict(row) for row in rows]
         evidence = FinalEvidenceBundleDTO.create(
             {
                 "version": FINAL_EVIDENCE_BUNDLE_VERSION,
@@ -417,9 +418,11 @@ class FinalAccessService:
                 "provider_order": list(contract.provider_order),
                 "provider_versions": dict(contract.provider_versions),
                 "expected_counts": dict(contract.expected_counts),
-                "rows": [dict(row) for row in rows],
+                "rows": raw_rows,
             }
         )
+        if evidence.rows.to_value() != raw_rows:
+            raise VPMValidationError("final executor evidence ordering mismatch")
         access = self._boundary(access, "evaluation_started")
         evaluation = self._evaluate_authorized_evidence(
             access,
@@ -439,6 +442,7 @@ class FinalAccessService:
         )
         access = self._boundary(access, "staged_artifact_generation_completed")
         access = self._boundary(access, "artifact_validation_started")
+        self._inject("before_staging_validation")
         staging_dir, manifest = stage_final_artifacts(
             output_dir=Path(authorization.output_dir),
             authorization_id=authorization.authorization_id,
@@ -446,6 +450,7 @@ class FinalAccessService:
             executor_artifacts=artifacts,
             evidence=evidence,
             evaluation=evaluation,
+            before_validation=lambda: self._inject("during_staging_validation"),
         )
         access = self._boundary(
             access,
@@ -546,6 +551,7 @@ class FinalAccessService:
         )
         if completion_historical_authority != verified_historical_authority:
             raise VPMValidationError("historical authority changed after reservation")
+        self._inject("before_completed_transition")
         events = self.store.list_final_access_events(current.access_id)
         predecessor_chain_digest = validate_final_access_event_chain(current, events)
         completion_utc = utc_now()
@@ -581,6 +587,7 @@ class FinalAccessService:
         validate_final_access_event_chain(record, (*events, event))
         self._inject("during_completed_transition")
         completed = self.store.complete_final_access(record, event)
+        self._inject("after_completed_transition")
         reconstruction = reconstruct_final_access_ledger(
             self.store, completed.access_id
         )
@@ -651,7 +658,12 @@ class FinalAccessService:
             output_dir=Path(authorization.output_dir),
             authorization_id=authorization.authorization_id,
             receipt=receipt,
+            before_write=lambda: self._inject("before_temporary_receipt_write"),
+            after_write=lambda: self._inject("during_temporary_receipt_write"),
             before_publish=lambda: self._inject("during_receipt_write"),
+            before_rename=lambda: self._inject("before_receipt_rename"),
+            during_rename=lambda: self._inject("during_receipt_rename"),
+            after_publish=lambda: self._inject("after_receipt_publication"),
         )
         return receipt
 

--- a/zeromodel/domains/video_action_set/final_claims.py
+++ b/zeromodel/domains/video_action_set/final_claims.py
@@ -17,6 +17,8 @@ def build_final_claim_registry(
     evaluation_result: FinalEvaluationResultDTO,
     claim_rules: Mapping[str, object],
 ) -> dict[str, Any]:
+    if not isinstance(receipt, FinalExecutionReceiptDTO):
+        raise VPMValidationError("final execution receipt mismatch")
     if not isinstance(evaluation_result, FinalEvaluationResultDTO):
         raise VPMValidationError("final evaluation result mismatch")
     validate_receipt_evaluation_binding(receipt, evaluation_result)

--- a/zeromodel/domains/video_action_set/final_publication.py
+++ b/zeromodel/domains/video_action_set/final_publication.py
@@ -177,6 +177,7 @@ def stage_final_artifacts(
     executor_artifacts: Mapping[str, bytes],
     evidence: FinalEvidenceBundleDTO,
     evaluation: FinalEvaluationResultDTO,
+    before_validation: Callable[[], None] | None = None,
 ) -> tuple[Path, FinalArtifactManifestDTO]:
     output = _absolute_path(output_dir)
     _assert_no_symlink_components(output)
@@ -219,6 +220,8 @@ def stage_final_artifacts(
         (staging / FINAL_ARTIFACT_MANIFEST_NAME).write_bytes(
             canonical_json_bytes(manifest.to_dict())
         )
+        if before_validation is not None:
+            before_validation()
         validate_staged_artifacts(staging, manifest)
         return staging, manifest
     except Exception:
@@ -296,7 +299,12 @@ def publish_receipt_last(
     output_dir: Path,
     authorization_id: str,
     receipt: FinalExecutionReceiptDTO,
+    before_write: Callable[[], None] | None = None,
+    after_write: Callable[[], None] | None = None,
     before_publish: Callable[[], None] | None = None,
+    before_rename: Callable[[], None] | None = None,
+    during_rename: Callable[[], None] | None = None,
+    after_publish: Callable[[], None] | None = None,
 ) -> Path:
     output = _absolute_path(output_dir)
     _assert_no_symlink_components(output)
@@ -308,13 +316,23 @@ def publish_receipt_last(
     if temporary.exists() or temporary.is_symlink():
         raise VPMValidationError("final receipt staging file already exists")
     try:
+        if before_write is not None:
+            before_write()
         temporary.write_bytes(canonical_json_bytes(receipt.to_dict()))
+        if after_write is not None:
+            after_write()
         loaded = FinalExecutionReceiptDTO.from_dict(_json_mapping(temporary))
         if loaded != receipt:
             raise VPMValidationError("final receipt staging validation mismatch")
         if before_publish is not None:
             before_publish()
+        if before_rename is not None:
+            before_rename()
+        if during_rename is not None:
+            during_rename()
         os.replace(temporary, destination)
+        if after_publish is not None:
+            after_publish()
     except Exception:
         if temporary.is_file() and not temporary.is_symlink():
             temporary.unlink()

--- a/zeromodel/domains/video_action_set/final_reporting.py
+++ b/zeromodel/domains/video_action_set/final_reporting.py
@@ -17,6 +17,8 @@ def generate_final_report(
     evaluation_result: FinalEvaluationResultDTO,
     claim_registry: Mapping[str, object],
 ) -> str:
+    if not isinstance(receipt, FinalExecutionReceiptDTO):
+        raise VPMValidationError("final execution receipt mismatch")
     if receipt.state != "completed":
         raise VPMValidationError("final report requires a completed receipt")
     if not isinstance(evaluation_result, FinalEvaluationResultDTO):

--- a/zeromodel/video_action_set_final_admin_cli.py
+++ b/zeromodel/video_action_set_final_admin_cli.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from .db.runtime import build_finalization_sqlite_runtime
+from .db.session import sqlite_database_url
 from .domains.video_action_set.final_access_dto import validate_final_identifier
 from .domains.video_action_set.final_reconstruction import (
     reconstruct_final_access_ledger,
@@ -26,14 +27,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> None:
     args = build_argument_parser().parse_args(argv)
     validate_final_identifier(args.access_id, "final access id mismatch")
-    database_url = (
-        args.database_path.resolve()
-        .as_uri()
-        .replace(
-            "file:///",
-            "sqlite:///",
-        )
-    )
+    database_url = sqlite_database_url(args.database_path)
     runtime = build_finalization_sqlite_runtime(database_url)
     payload = reconstruct_final_access_ledger(
         runtime.video_action_set.engine.final_access_service.store,

--- a/zeromodel/video_action_set_final_cli.py
+++ b/zeromodel/video_action_set_final_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sys
 
 from .db.runtime import build_finalization_sqlite_runtime
+from .db.session import sqlite_database_url
 from .domains.video_action_set.final_access_dto import (
     FINAL_EXECUTION_REQUEST_VERSION,
     FinalExecutionRequestDTO,
@@ -63,7 +64,7 @@ def main(argv: list[str] | None = None) -> None:
         confirmation = input("Type the confirmation text exactly: ")
         if confirmation != authorization.operator_confirmation_text:
             raise SystemExit("final execution confirmation mismatch")
-    database_url = args.database_path.resolve().as_uri().replace("file:///", "sqlite:///")
+    database_url = sqlite_database_url(args.database_path)
     initialize_authority = (
         not args.database_path.exists() or args.database_path.stat().st_size == 0
     )


### PR DESCRIPTION
## Summary

Follow-up to merged PR #66. Adds a synthetic-only, human-operated integration validation package for the video action-set finalization spine.

- adds 77 `integration`-marked nodes covering separate schema authority, file-backed SQLite CAS concurrency, authorized observations, historical verification, evaluator contracts, hostile executor output, atomic publication, receipt-last failure injection, fresh-process reconstruction, CLI/PowerShell behavior, and an offline installed-wheel boundary
- adds exact-selection runner `scripts/run-video-finalization-integration.ps1` and read-only observer `scripts/observe-video-finalization-integration.ps1`
- adds the marked-test safety inventory and operator guide at `docs/video-action-set-finalization-integration-validation.md`
- adds narrow fail-closed guards for duplicate evidence identities, receipt typing, noncanonical executor evidence, and early `build_split("final")` rejection

## Markers and budget

All new resource-bearing tests use `pytest.mark.integration`; none use `slow`. Normal collection selects 719 tests and deselects all 216 integration/slow nodes.

The runner invokes ten exact groups with `--run-integration`, never an unrestricted integration selection. Predicted total is about 4.5 minutes; every group has a 60-180 second hard timeout.

## Validation performed

- 23 focused diagnostics passed, including real temporary SQLite connections, actual filesystem promotion/symlinks, fresh Python processes, CLI read-only checks, and the offline wheel install
- Ruff check and format check passed
- both PowerShell scripts passed parser validation
- `git diff --check` passed
- marked collection: 216/935 collected with 719 deselected
- ordinary collection: 719/935 collected with 216 deselected
- fast suite attempt 1 exposed one stale expected error string; the focused corrected test passed
- final fast suite had no assertion failures before the repository hard budget stopped it at 60.0 seconds at 58% completion

The complete integration runner was intentionally not executed. Slow tests were not run. No real Stage 8 authority/evidence was inspected, and no real protocol, authorization, executor, reservation, final materialization, scoring, evaluation, promotion, or receipt was created.

## Operator command

```powershell
powershell -NoProfile -File .\scripts\run-video-finalization-integration.ps1 -RepositoryPath 'C:\Projects\zeromodel-finalization' -ExpectedCommit 'b9d14c3b4a9b3946b2da8f55a9dd08e13c7d6197'
```

Keep this PR in draft until a human runs the bounded suite and reviews its summaries.
