### PR TITLE
Define ZeroModel 1.0.13 package-system architecture

### DIFF
--- a/docs/architecture/package-system-1.0.13.md
+++ b/docs/architecture/package-system-1.0.13.md
@@ -1,0 +1,821 @@
+# ZeroModel 1.0.13 Package System Architecture
+
+**Status:** Proposed architecture contract  
+**Release:** `1.0.13`  
+**Repository model:** one repository, multiple independently buildable Python distributions  
+**Compatibility policy:** breaking source and import changes are permitted  
+**Release policy:** no intermediate extraction stage is publishable
+
+## 1. Decision
+
+ZeroModel 1.0.13 will replace the current single-distribution package with a
+workspace of independently installable capability packages that share the
+implicit `zeromodel` namespace.
+
+The package system will contain:
+
+1. `zeromodel` — the lightweight, complete artifact and bounded-policy core;
+2. `zeromodel-analysis` — deterministic analysis and verification over core artifacts;
+3. `zeromodel-observation` — provider-neutral observation and address contracts;
+4. `zeromodel-vision` — concrete deterministic visual-address runtime implementations;
+5. `zeromodel-video` — temporal policy and video action-set domain functionality;
+6. `zeromodel-sqlalchemy` — SQLAlchemy and SQLite persistence adapters.
+
+Research experiments, benchmark orchestration, evidence generation, and failed or
+unpromoted provider implementations will not be shipped as production packages.
+They will live under `research/` and may depend on production packages. Production
+packages must never import from `research/`.
+
+This is an architectural extraction, not a compatibility migration. The current
+root re-export surface will be removed rather than redirected through compatibility
+aliases.
+
+## 2. Why this change is required
+
+The current distribution declares a small NumPy dependency surface while the
+`zeromodel` namespace now contains several distinct systems:
+
+- deterministic VPM artifacts and identities;
+- bounded policy lookup and portable consumers;
+- spatial analysis and finite verification;
+- provider-neutral observation contracts;
+- deterministic and learned visual addressing;
+- temporal video policy;
+- the video action-set RMDTO domain;
+- SQLAlchemy persistence;
+- scientific benchmark and evidence machinery.
+
+These concerns have different dependency, stability, testing, and release needs.
+Keeping them in one distribution makes the root API misleading, makes optional
+capabilities appear foundational, and allows accidental imports to erase the
+intended domain boundaries.
+
+The existing RMDTO direction remains valid:
+
+```text
+Runtime -> Facade -> Engine -> Service -> Store protocol -> Store implementation
+```
+
+The package split raises that rule to the distribution level. The domain package
+owns DTOs, services, and protocols. The persistence package owns ORM mappings,
+sessions, and SQL Store implementations.
+
+## 3. Goals
+
+ZeroModel 1.0.13 must provide all of the following:
+
+- a small but genuinely functional `zeromodel` core distribution;
+- explicit package ownership for every production module;
+- an acyclic distribution dependency graph;
+- no SQLAlchemy, Torch, Transformers, or Pillow dependency in core;
+- provider-neutral observation contracts separated from concrete providers;
+- video domain logic separated from database implementation;
+- research code separated from supported runtime code;
+- independently buildable and independently testable wheels;
+- deterministic identity and schema behavior preserved across moves;
+- package boundaries enforced by executable architecture checks;
+- synchronized `1.0.13` versions for the initial multi-package release.
+
+## 4. Non-goals
+
+The 1.0.13 package-system work will not:
+
+- preserve `from zeromodel import ...` imports;
+- provide deprecation aliases for old module paths;
+- retain the existing monolithic wheel as a compatibility package;
+- publish intermediate extraction stages;
+- redesign scientific algorithms merely because their files move;
+- promote benchmark-only or negative-result research providers into production;
+- introduce a plugin registry before a concrete package requires one;
+- split into multiple Git repositories;
+- adopt independent package versions in the first release.
+
+## 5. Workspace layout
+
+The final repository layout is:
+
+```text
+packages/
+├── core/
+│   ├── pyproject.toml
+│   ├── README.md
+│   ├── src/zeromodel/core/
+│   └── tests/
+├── analysis/
+│   ├── pyproject.toml
+│   ├── README.md
+│   ├── src/zeromodel/analysis/
+│   └── tests/
+├── observation/
+│   ├── pyproject.toml
+│   ├── README.md
+│   ├── src/zeromodel/observation/
+│   └── tests/
+├── vision/
+│   ├── pyproject.toml
+│   ├── README.md
+│   ├── src/zeromodel/vision/
+│   └── tests/
+├── video/
+│   ├── pyproject.toml
+│   ├── README.md
+│   ├── src/zeromodel/video/
+│   └── tests/
+└── sqlalchemy/
+    ├── pyproject.toml
+    ├── README.md
+    ├── src/zeromodel/persistence/sqlalchemy/
+    └── tests/
+
+research/
+├── visual/
+├── video/
+├── benchmarks/
+└── evidence/
+
+integration_tests/
+examples/
+scripts/
+docs/
+pyproject.toml
+package-boundaries.toml
+```
+
+The repository-root `pyproject.toml` is workspace and tool configuration. It is
+not a publishable ZeroModel distribution after the split. Every published
+package builds from its own package directory.
+
+## 6. Shared namespace rule
+
+`zeromodel` becomes a PEP 420 implicit namespace.
+
+There must be no file at:
+
+```text
+zeromodel/__init__.py
+```
+
+and no package may ship:
+
+```text
+src/zeromodel/__init__.py
+```
+
+Each distribution owns one non-overlapping subtree:
+
+| Distribution | Owned import subtree |
+|---|---|
+| `zeromodel` | `zeromodel.core` |
+| `zeromodel-analysis` | `zeromodel.analysis` |
+| `zeromodel-observation` | `zeromodel.observation` |
+| `zeromodel-vision` | `zeromodel.vision` |
+| `zeromodel-video` | `zeromodel.video` |
+| `zeromodel-sqlalchemy` | `zeromodel.persistence.sqlalchemy` |
+
+No two distributions may contain the same import package or write files into the
+same owned subtree.
+
+Public imports must identify capability ownership:
+
+```python
+from zeromodel.core import ScoreTable, VPMArtifact, build_vpm
+from zeromodel.analysis import SpatialOptimizer
+from zeromodel.observation import VisualAddressProvider
+from zeromodel.vision import VisualSignReader
+from zeromodel.video import VideoPolicyReader
+from zeromodel.persistence.sqlalchemy import SqlAlchemyVideoActionSetStore
+```
+
+The following compatibility surface is intentionally removed:
+
+```python
+from zeromodel import ScoreTable
+from zeromodel import VisualSignReader
+from zeromodel import VideoPolicyReader
+```
+
+## 7. Distribution responsibilities
+
+### 7.1 `zeromodel` / `zeromodel.core`
+
+The core is the smallest complete expression of ZeroModel.
+
+A core-only installation must support this complete path:
+
+```text
+scored rows
+    -> deterministic VPM artifact
+    -> stable identity and source mapping
+    -> serialization or rendering
+    -> exact bounded row address
+    -> policy action and evidence
+```
+
+Core owns:
+
+- immutable artifact primitives;
+- `ScoreTable`, `LayoutRecipe`, `VPMArtifact`, cells, and regions;
+- deterministic canonicalization, identity, and digest mechanics;
+- `MatrixBlob` and its identity contract;
+- deterministic VPM construction;
+- basic source and explicit views required to build usable artifacts;
+- bundle round-trip support;
+- lightweight rendering that does not require a heavyweight optional stack;
+- exact bounded policy lookup and its decision DTOs;
+- dependency-free portable policy representation where it remains small and stable;
+- core exceptions, scalar types, and protocols required by the above.
+
+Candidate current modules include `artifact`, `bundle`, `matrix_blob`, `metrics`,
+`policy_lookup`, `render`, and the minimal parts of `views`. The inventory stage
+must verify each candidate and split modules when only part belongs in core.
+
+Core does not own:
+
+- spatial optimization, pattern discovery, manifolds, or experiment analysis;
+- generic observation-to-address contracts;
+- image encoders or visual-address providers;
+- temporal video systems;
+- SQLAlchemy or database sessions;
+- benchmark orchestration or evidence adjudication;
+- application-wide service locators that compose optional packages.
+
+Core runtime dependencies are limited to the Python standard library and NumPy.
+Importing `zeromodel.core` must not import any optional ZeroModel package or any
+tracked heavyweight external dependency.
+
+### 7.2 `zeromodel-analysis` / `zeromodel.analysis`
+
+Analysis owns deterministic transformations, diagnostics, and verification that
+operate on core artifacts but are not required to construct or address one.
+
+Expected responsibilities include:
+
+- artifact and field comparison;
+- fuzzy field composition;
+- hierarchy and pyramid operations;
+- PHOS packing and concentration analysis;
+- spatial optimization;
+- pattern detection and discovered views;
+- decision manifolds and inflection analysis;
+- Q-derived policy diagnostics;
+- finite policy property checking and verification artifacts;
+- policy transition evidence;
+- critic, learning, and training-progress artifact builders.
+
+Analysis may depend on core. Core must not depend on analysis.
+
+### 7.3 `zeromodel-observation` / `zeromodel.observation`
+
+Observation defines provider-neutral contracts between runtime observations and
+policy addresses.
+
+Observation owns:
+
+- immutable observation DTOs;
+- address contracts and address decisions;
+- provider protocols;
+- calibration and rejection contracts that are provider-neutral;
+- prototype and address manifests;
+- deployment binding between policy, provider, calibration, and source scope;
+- policy-reader composition that delegates an accepted address to core lookup,
+  when the composition remains provider-neutral.
+
+Observation must not import Torch, Transformers, Pillow, concrete image encoders,
+video benchmark machinery, SQLAlchemy, or ORM classes.
+
+Observation may depend on core. Core must not depend on observation.
+
+### 7.4 `zeromodel-vision` / `zeromodel.vision`
+
+Vision owns supported concrete image-to-address runtime implementations.
+
+Expected responsibilities include:
+
+- deterministic visual feature extraction;
+- deterministic visual index construction;
+- visual sign reading;
+- normalized-pixel and local deterministic providers that have been promoted to
+  supported runtime capabilities;
+- image-specific calibration implementations;
+- image preprocessing required by supported providers.
+
+Vision must depend on observation contracts rather than defining a competing
+provider seam.
+
+Learned provider adapters with heavyweight dependencies should not be forced into
+the base vision distribution. A future adapter such as
+`zeromodel-vision-huggingface` may own Torch and Transformers integrations after
+its runtime contract is stable. Until then, learned baselines remain research.
+
+Benchmark harnesses, architecture showdowns, calibration sweeps, and failed or
+unpromoted systems belong under `research/visual/`, not in the production wheel.
+
+### 7.5 `zeromodel-video` / `zeromodel.video`
+
+Video owns supported temporal policy and video action-set domain behavior.
+
+Video owns:
+
+- video frame and clip DTOs;
+- frame-source protocols and in-memory implementations;
+- temporal evidence, policy decisions, and traces;
+- video policy readers;
+- video action-set DTO aggregates;
+- Runtime, Facade, Engine, Service, and Store protocols for the video domain;
+- deterministic scientific planning and materialization mechanics that are
+  promoted runtime behavior rather than benchmark-only orchestration;
+- in-memory Store implementations;
+- package-specific CLI entry points that call supported video services.
+
+Video must not import SQLAlchemy, ORM modules, database sessions, or SQL Store
+implementations. ORM objects must never cross into this package.
+
+Experimental local-correlation, discriminative, joint-evidence, provider-showdown,
+and benchmark-only implementations remain research unless the inventory and
+review process identifies a separately supported runtime component.
+
+### 7.6 `zeromodel-sqlalchemy` / `zeromodel.persistence.sqlalchemy`
+
+The SQLAlchemy package is an adapter package.
+
+It owns:
+
+- ORM declarations;
+- SQLAlchemy session and engine construction;
+- SQLite URL and schema helpers;
+- SQL Store implementations;
+- DTO-to-ORM and ORM-to-DTO mapping;
+- transaction, ownership, ordering, and relational integrity behavior;
+- persistence integration tests.
+
+It may depend on core and video. It must implement Store protocols declared by
+the video domain. It must not move domain services or scientific computation
+into the persistence package.
+
+SQLite remains authoritative for durable identity, relationships, ordering,
+deduplication, transactionality, and retrieval. Python and NumPy remain
+authoritative for scientific derivation, rendering, transformation, replay, and
+digest computation.
+
+## 8. Dependency graph
+
+The only allowed production distribution edges are:
+
+```text
+zeromodel-analysis ---------> zeromodel
+
+zeromodel-observation ------> zeromodel
+          ^
+          |
+zeromodel-vision -----------> zeromodel
+          ^
+          |
+zeromodel-video ------------> zeromodel
+          ^
+          |
+zeromodel-sqlalchemy -------> zeromodel-video
+zeromodel-sqlalchemy -------> zeromodel
+```
+
+In table form:
+
+| Package | May depend on |
+|---|---|
+| core | standard library, NumPy |
+| analysis | core |
+| observation | core |
+| vision | core, observation |
+| video | core, observation |
+| sqlalchemy | core, video |
+
+Research may depend on any production package. Examples and integration tests may
+depend on any packages they demonstrate. Production packages may not depend on
+research, examples, integration tests, or repository scripts.
+
+Circular distribution dependencies are forbidden.
+
+## 9. Cross-package data rule
+
+Package boundaries are crossed only by deliberate public objects:
+
+- immutable DTOs;
+- protocols;
+- stable identifiers and digests;
+- standard-library scalar and collection types;
+- explicitly owned NumPy arrays or `MatrixBlob` values;
+- serialized bytes when serialization is the contract.
+
+The following may not cross package boundaries:
+
+- ORM entities;
+- SQLAlchemy sessions or queries;
+- private implementation classes;
+- mutable internal caches;
+- benchmark fixture objects;
+- filesystem-specific state unless the public protocol explicitly models it;
+- imports from a sibling package's private module.
+
+A sibling package may import only from the owning package's documented public
+surface or a documented public submodule. Imports from names beginning with an
+underscore are forbidden across distributions.
+
+## 10. Production versus research
+
+A module belongs in a published package only when all of the following are true:
+
+1. its runtime responsibility is stable and named;
+2. it is not tied to one benchmark fixture or one evidence package;
+3. its public inputs, outputs, rejection behavior, and identity behavior are defined;
+4. it has package-local tests independent of research fixtures;
+5. its dependencies are appropriate for the owning distribution;
+6. the project is willing to maintain it as a supported capability.
+
+A module belongs under `research/` when any of the following are true:
+
+- it orchestrates a benchmark or parameter sweep;
+- it compares named experimental systems;
+- it generates claim evidence or adjudication reports;
+- it is coupled to the arcade fixture;
+- it implements an unpromoted or negative-result provider;
+- it exists to reproduce a paper, report, or one-off scientific result;
+- its public contract changes with the experiment.
+
+Moving a module to research does not diminish its scientific value. It clarifies
+that the module is evidence machinery rather than supported runtime API.
+
+## 11. Package boundary manifest
+
+Stage 1.0.13A will introduce a repository-root `package-boundaries.toml` as the
+machine-readable authority for package ownership and allowed dependencies.
+
+The intended shape is:
+
+```toml
+schema_version = 1
+release_version = "1.0.13"
+
+[packages.core]
+distribution = "zeromodel"
+namespace = "zeromodel.core"
+source_root = "packages/core/src"
+depends_on = []
+
+[packages.analysis]
+distribution = "zeromodel-analysis"
+namespace = "zeromodel.analysis"
+source_root = "packages/analysis/src"
+depends_on = ["core"]
+
+[packages.observation]
+distribution = "zeromodel-observation"
+namespace = "zeromodel.observation"
+source_root = "packages/observation/src"
+depends_on = ["core"]
+
+[packages.vision]
+distribution = "zeromodel-vision"
+namespace = "zeromodel.vision"
+source_root = "packages/vision/src"
+depends_on = ["core", "observation"]
+
+[packages.video]
+distribution = "zeromodel-video"
+namespace = "zeromodel.video"
+source_root = "packages/video/src"
+depends_on = ["core", "observation"]
+
+[packages.sqlalchemy]
+distribution = "zeromodel-sqlalchemy"
+namespace = "zeromodel.persistence.sqlalchemy"
+source_root = "packages/sqlalchemy/src"
+depends_on = ["core", "video"]
+```
+
+Architecture tooling must read this manifest. Package ownership and allowed
+edges must not be duplicated as unrelated hard-coded lists across scripts.
+
+## 12. Versioning
+
+All initial distributions use the synchronized version `1.0.13`:
+
+```text
+zeromodel                 1.0.13
+zeromodel-analysis        1.0.13
+zeromodel-observation     1.0.13
+zeromodel-vision          1.0.13
+zeromodel-video           1.0.13
+zeromodel-sqlalchemy      1.0.13
+```
+
+Production package dependencies use exact synchronized pins for this release:
+
+```toml
+dependencies = [
+    "zeromodel==1.0.13",
+]
+```
+
+The release tooling must verify that:
+
+- every package version equals the release version;
+- every internal dependency references the same release version;
+- every expected distribution was built;
+- no unexpected distribution was built.
+
+Independent versioning is deferred until package boundaries and release cadence
+have proven stable.
+
+## 13. Public API policy
+
+Every package has a deliberately small `__init__.py` in its owned subtree.
+
+For example:
+
+```text
+packages/core/src/zeromodel/core/__init__.py
+packages/video/src/zeromodel/video/__init__.py
+```
+
+These files may re-export public objects owned by that package. They must not
+re-export objects from optional sibling packages merely for convenience.
+
+The namespace root has no initializer and no public exports.
+
+Public API tests must enumerate the intended exports. Adding a new export is a
+deliberate API change, not an automatic consequence of creating a module.
+
+## 14. Build and installation requirements
+
+Each package must independently pass:
+
+```text
+python -m build <package-directory>
+python -m twine check <package-directory>/dist/*
+install wheel into a clean virtual environment
+pip check
+import the package's public namespace
+run package-local tests against the installed wheel
+```
+
+Tests that claim wheel isolation must not add the repository root or a package
+`src` directory to `PYTHONPATH`.
+
+Every wheel must be inspected to confirm that it contains only its owned subtree.
+For example, the `zeromodel-video` wheel must not contain `zeromodel/core`,
+`zeromodel/vision`, or `zeromodel/persistence` files.
+
+## 15. Test layers
+
+The repository will use four explicit test layers.
+
+### 15.1 Package unit tests
+
+Located in each package's `tests/` directory. They test only the owning package
+and declared dependencies.
+
+### 15.2 Package wheel tests
+
+Build and install one wheel in a clean environment, then run import and behavior
+smoke tests against installed files.
+
+### 15.3 Integration tests
+
+Located under `integration_tests/`. They install the required package combination
+and test cross-package behavior such as:
+
+- core + analysis;
+- core + observation + vision;
+- core + observation + video;
+- core + observation + video + SQLAlchemy.
+
+### 15.4 Research tests
+
+Located with the research system or in a clearly marked research test area. They
+may use benchmark fixtures and generated evidence but do not define the production
+package contract.
+
+## 16. Import isolation requirements
+
+At minimum, CI must prove:
+
+```python
+import sys
+import zeromodel.core
+
+for forbidden in (
+    "sqlalchemy",
+    "torch",
+    "transformers",
+    "PIL",
+    "zeromodel.analysis",
+    "zeromodel.observation",
+    "zeromodel.vision",
+    "zeromodel.video",
+    "zeromodel.persistence.sqlalchemy",
+):
+    assert forbidden not in sys.modules
+```
+
+Equivalent probes must verify that:
+
+- observation does not import concrete vision or video implementations;
+- video does not import SQLAlchemy;
+- production packages do not import research;
+- package imports perform no database creation, model loading, network access, or
+  expensive computation.
+
+## 17. Architecture tooling
+
+The existing architecture checker must evolve from one hard-coded source root to
+workspace discovery driven by `package-boundaries.toml`.
+
+It must enforce:
+
+- unique module ownership;
+- allowed inter-package import edges;
+- no import cycles;
+- no production imports from tests, examples, or research;
+- no SQLAlchemy imports outside the SQLAlchemy package;
+- no tracked heavyweight dependencies in packages that do not declare them;
+- no sibling-private imports;
+- no `zeromodel/__init__.py` in any wheel source root;
+- no overlapping wheel contents.
+
+The current quality ratchet remains in force. Package extraction is not permission
+to increase line ceilings or hide legacy debt under new paths.
+
+## 18. CI requirements
+
+The Python workflow must ultimately include:
+
+1. repository quality and architecture checks;
+2. package build matrix for all six distributions;
+3. clean-wheel import and `pip check` validation;
+4. Python 3.10, 3.11, and 3.12 package test coverage;
+5. integration combinations defined in section 15.3;
+6. Lua fixture validation if the Lua consumer remains supported;
+7. distribution-content inspection;
+8. synchronized-version verification.
+
+Workflow path filters must include `packages/**`, `research/**`,
+`integration_tests/**`, `package-boundaries.toml`, and all workspace build scripts.
+
+## 19. Staged implementation strategy
+
+The package overhaul is implemented through an integration branch so `main` is
+not left in a partially extracted state.
+
+```text
+main
+  |
+  +-- integration/package-system-1.0.13
+          |
+          +-- Stage A: workspace and core
+          +-- Stage B: analysis
+          +-- Stage C: observation contracts
+          +-- Stage D: vision
+          +-- Stage E: video
+          +-- Stage F: SQLAlchemy
+          +-- Stage G: research separation
+          +-- Stage H: final integration and release readiness
+```
+
+Stage pull requests target the integration branch. The completed integration
+branch receives one final adversarial review and one final PR to `main`.
+
+No package is published and no release tag is created from an intermediate stage.
+Temporary transitional source paths are permitted only on the integration branch,
+must be explicitly recorded, and must be eliminated before Stage H completes.
+
+## 20. Stage definitions
+
+### Stage 1.0.13A — Workspace and core
+
+- introduce the workspace manifest and package-aware architecture tooling;
+- create `packages/core`;
+- move the approved core kernel using history-preserving moves;
+- remove the root re-export API;
+- update repository imports of moved core objects;
+- build and test the core wheel independently;
+- establish transitional test configuration for unextracted modules;
+- record every remaining temporary root module.
+
+### Stage 1.0.13B — Analysis
+
+- create `packages/analysis`;
+- move deterministic analysis and verification modules;
+- update imports and tests;
+- prove analysis depends inward on core only;
+- remove analysis modules from transitional root paths.
+
+### Stage 1.0.13C — Observation
+
+- create `packages/observation`;
+- move provider-neutral DTOs, protocols, manifests, and bindings;
+- eliminate duplicate provider seams;
+- prove observation has no concrete provider dependencies.
+
+### Stage 1.0.13D — Vision
+
+- create `packages/vision`;
+- move supported deterministic image-to-address runtime behavior;
+- move experimental, benchmark-only, and unpromoted visual systems to research;
+- prove no heavyweight learned stack is imported by base vision.
+
+### Stage 1.0.13E — Video
+
+- create `packages/video`;
+- move temporal policy and video action-set domain layers;
+- preserve RMDTO direction and immutable identities;
+- move in-memory Stores with the domain;
+- prove video imports no SQLAlchemy or ORM implementation.
+
+### Stage 1.0.13F — SQLAlchemy
+
+- create `packages/sqlalchemy`;
+- move ORM, session, engine, schema, and SQL Store implementations;
+- retain DTO-only Store boundaries;
+- run SQLite reconstruction, transaction, and concurrency integration tests.
+
+### Stage 1.0.13G — Research separation
+
+- move benchmark orchestration and evidence machinery under `research/`;
+- classify every experimental provider as promoted runtime or research;
+- ensure production wheels contain no benchmark fixtures or evidence packages.
+
+### Stage 1.0.13H — Final integration
+
+- eliminate all transitional root modules and path configuration;
+- build every sdist and wheel;
+- run clean-wheel package and integration matrices;
+- verify synchronized versions and internal pins;
+- update README, release notes, and installation guidance;
+- run adversarial external review;
+- merge the integration branch only after all blockers are resolved.
+
+## 21. Inventory gate
+
+No production module moves before the repository inventory is reviewed.
+
+The inventory must classify every current Python module as exactly one of:
+
+- `core`;
+- `analysis`;
+- `observation`;
+- `vision`;
+- `video`;
+- `sqlalchemy`;
+- `research`;
+- `examples`;
+- `tooling`;
+- `delete`;
+- `split`;
+- `undecided`.
+
+A `split` classification must identify the responsibilities and target packages.
+An `undecided` classification blocks the extraction stage that would otherwise
+move the module.
+
+The inventory must also record public exports, inbound and outbound imports,
+external dependencies, tests, CLI entry points, schema and digest ownership, and
+known architecture exceptions.
+
+## 22. Definition of done
+
+ZeroModel 1.0.13 package-system work is complete only when:
+
+- all six distributions build independently;
+- all distributions report version `1.0.13`;
+- the namespace root has no `__init__.py`;
+- the root `from zeromodel import ...` API no longer exists;
+- every production module has exactly one package owner;
+- no transitional root production modules remain;
+- the architecture checker reports no forbidden distribution edges;
+- core imports only the standard library and NumPy;
+- observation is provider-neutral;
+- vision contains no unpromoted benchmark systems;
+- video imports no SQLAlchemy;
+- SQLAlchemy implements video-owned Store protocols using DTO boundaries;
+- production packages import no research code;
+- every wheel contains only its owned namespace subtree;
+- package-local tests pass against installed wheels;
+- integration combinations pass on Python 3.10, 3.11, and 3.12;
+- the Lua consumer remains green if retained;
+- README and release documentation describe the new installation model;
+- an adversarial review finds no unresolved blocker;
+- the final integration PR is green and mergeable.
+
+## 23. Architectural authority
+
+When implementation convenience conflicts with this contract, the contract wins
+unless it is explicitly amended in the same reviewed change.
+
+The inventory may refine module placement, but it may not silently change:
+
+- the six-distribution model;
+- the implicit namespace rule;
+- the dependency direction;
+- the DTO-only persistence boundary;
+- the production/research separation;
+- the removal of compatibility re-exports;
+- the synchronized `1.0.13` release version.

--- a/docs/prompts/package-system-adversarial-review-claude.md
+++ b/docs/prompts/package-system-adversarial-review-claude.md
@@ -1,0 +1,457 @@
+# Claude Prompt — Adversarial Review of the ZeroModel 1.0.13 Package System
+
+You are the adversarial architecture reviewer for the ZeroModel 1.0.13
+multi-package overhaul.
+
+Your role is not to redesign the project from first principles. Your role is to
+attack the submitted work against the approved architecture contract, identify
+hidden violations, and determine whether the work is safe to advance.
+
+Do not provide generic praise. Do not produce a competing architecture unless a
+specific blocker proves that the approved contract cannot be implemented.
+
+## Repository
+
+```text
+https://github.com/ernanhughes/zeromodel
+```
+
+## Authoritative architecture
+
+Read this first and treat it as the governing contract:
+
+```text
+docs/architecture/package-system-1.0.13.md
+```
+
+Also read:
+
+```text
+docs/architecture/code-quality-policy.md
+docs/architecture/video-action-set-rmdto.md
+package-boundaries.toml                 # when present
+scripts/check_architecture.py
+scripts/check_quality.py
+.github/workflows/python.yml
+```
+
+## Review inputs
+
+You will be given some or all of:
+
+```text
+BASE_COMMIT=<sha>
+HEAD_COMMIT=<sha>
+STAGE=<inventory|1.0.13A|1.0.13B|1.0.13C|1.0.13D|1.0.13E|1.0.13F|1.0.13G|1.0.13H>
+STAGE_SPEC=<path or pasted prompt>
+DIFF=<git diff or pull-request diff>
+TEST_OUTPUT=<commands and results>
+CODEX_REPORT=<implementation summary>
+```
+
+For the inventory gate, also read:
+
+```text
+docs/architecture/package-inventory-1.0.13.md
+docs/architecture/package-module-map-1.0.13.csv
+docs/architecture/package-import-graph-1.0.13.json
+docs/architecture/package-dependency-findings-1.0.13.md
+```
+
+Review the actual repository and diff. Do not rely on the implementation summary
+when it conflicts with the code.
+
+## Approved package graph
+
+The production graph is limited to:
+
+```text
+analysis -> core
+observation -> core
+vision -> observation, core
+video -> observation, core
+sqlalchemy -> video, core
+```
+
+Research may depend on production packages. Production packages may not depend on
+research, examples, integration tests, tests, or repository scripts.
+
+The six distributions are fixed for 1.0.13:
+
+```text
+zeromodel
+zeromodel-analysis
+zeromodel-observation
+zeromodel-vision
+zeromodel-video
+zeromodel-sqlalchemy
+```
+
+The shared import namespace is implicit. No package may ship
+`zeromodel/__init__.py`.
+
+## Review posture
+
+Assume that a superficially successful split may be false.
+
+Actively search for:
+
+- source folders renamed without real dependency separation;
+- imports that work only because the repository root is on `sys.path`;
+- editable-install behavior that differs from wheel behavior;
+- optional dependencies imported eagerly;
+- duplicated modules shipped by multiple wheels;
+- sibling-private imports hidden behind public re-exports;
+- cycles moved from modules to distributions;
+- research code left in production under a new name;
+- ORM or SQLAlchemy objects crossing domain boundaries;
+- DTOs that have become persistence-aware;
+- runtime composition that imports optional packages eagerly;
+- tests that validate source checkout behavior rather than installed artifacts;
+- identity or schema behavior changed accidentally during file movement;
+- compatibility aliases that reconstruct the monolithic root API;
+- quality exceptions increased to make extraction easier;
+- transient integration-branch compromises left without a removal gate.
+
+## Mandatory review dimensions
+
+### 1. Namespace and wheel ownership
+
+Verify:
+
+- no `zeromodel/__init__.py` exists in any source root or built wheel;
+- each distribution owns exactly one non-overlapping namespace subtree;
+- wheel contents do not overlap;
+- package discovery cannot silently include sibling package files;
+- import order does not change which implementation wins;
+- uninstalling one optional distribution does not damage another distribution's
+  namespace files.
+
+Inspect built wheel archives when available. A source-tree inspection alone is
+not sufficient.
+
+### 2. Core isolation
+
+Verify that `zeromodel.core`:
+
+- provides a complete artifact-to-policy workflow;
+- imports only the standard library and NumPy at runtime;
+- does not import analysis, observation, vision, video, SQLAlchemy, research,
+  examples, or tests;
+- performs no expensive import-time work;
+- performs no database creation, network access, or model loading;
+- does not hide optional dependencies behind convenience imports.
+
+Flag a core that is small but unusable, as well as a core that remains functionally
+monolithic.
+
+### 3. Distribution dependency direction
+
+Construct the observed distribution-level graph from imports and metadata.
+Compare it with the approved graph.
+
+Check both:
+
+- direct Python imports; and
+- package metadata dependencies.
+
+A Python graph may be clean while metadata creates a forbidden transitive edge,
+or metadata may be clean while runtime imports violate it.
+
+### 4. Public API discipline
+
+Verify:
+
+- public exports belong to the package exporting them;
+- package `__init__.py` files do not re-export optional sibling capabilities;
+- the root compatibility API has not been recreated;
+- private modules are not imported across distributions;
+- symbols moved to research are no longer production exports;
+- package-local APIs are deliberate and tested.
+
+### 5. RMDTO and persistence boundaries
+
+For the video action-set domain, verify:
+
+```text
+Runtime -> Facade -> Engine -> Service -> Store protocol -> Store implementation -> ORM
+```
+
+Specifically search for:
+
+- SQLAlchemy imports in video;
+- ORM imports in DTOs, Services, Engines, Facades, or Runtime;
+- SQL Store implementations imported by domain code;
+- ORM entities returned from Stores;
+- database sessions passed through domain APIs;
+- persistence code recomputing or repairing scientific identities;
+- scientific derivation moved into SQL queries or ORM callbacks;
+- in-memory Stores depending on SQLAlchemy.
+
+### 6. Observation and provider neutrality
+
+Verify that observation contracts:
+
+- do not import concrete visual or video providers;
+- do not require Pillow, Torch, Transformers, or SQLAlchemy;
+- define one coherent provider seam rather than duplicate protocols;
+- preserve explicit rejection, calibration, provider identity, and provenance;
+- remain usable by both vision and video without a cycle.
+
+### 7. Production versus research
+
+Challenge every visual and video experimental module retained in a production
+wheel.
+
+For each suspicious module, ask:
+
+- Is the contract stable outside one benchmark?
+- Is it coupled to the arcade fixture?
+- Is it a parameter sweep, selector, adjudicator, or evidence generator?
+- Is the implementation promoted as supported runtime behavior?
+- Does it have package-local tests independent of research fixtures?
+- Does the claims evidence withhold or refute the capability?
+
+Do not demand deletion of negative-result research. Demand correct ownership.
+
+### 8. Identity, schema, and scientific behavior
+
+File movement must not silently change:
+
+- canonical byte construction;
+- artifact IDs;
+- matrix blob IDs;
+- provider, calibration, or deployment identities;
+- DTO serialization keys;
+- schema version constants;
+- persisted reconstruction behavior;
+- deterministic ordering;
+- rejection semantics;
+- benchmark denominators;
+- operation-chain provenance.
+
+Require golden or equivalence evidence for moved identity-bearing code.
+
+### 9. Build and installation validity
+
+Verify each affected package by evidence from:
+
+```text
+python -m build <package>
+python -m twine check <package>/dist/*
+clean virtual environment
+pip install <wheel>
+pip check
+public import smoke test
+package-local tests against installed wheel
+```
+
+Reject tests that accidentally import the checkout through:
+
+- current working directory;
+- root `pythonpath` configuration;
+- editable source links when the claim is wheel isolation;
+- an already installed monolithic `zeromodel` package;
+- environment leakage from previous package installations.
+
+### 10. Test architecture
+
+Verify separation between:
+
+- package unit tests;
+- clean-wheel tests;
+- cross-package integration tests;
+- research tests.
+
+Check that production behavior is not defined only by benchmark fixtures.
+
+Check Python 3.10, 3.11, and 3.12 coverage where the stage changes runtime code.
+
+### 11. CI and release tooling
+
+Verify:
+
+- workflow path filters include new package and workspace paths;
+- all affected packages build;
+- all expected wheels are checked;
+- version synchronization is enforced;
+- internal dependency pins are synchronized at `1.0.13`;
+- release scripts no longer assume one wheel or one `dist/` directory;
+- TestPyPI and final publication order cannot leave unresolved internal dependencies;
+- no intermediate integration stage is publishable accidentally.
+
+### 12. Quality ratchet
+
+Verify:
+
+- no global or file-specific quality ceiling was increased merely to permit moves;
+- moved files do not evade existing ceilings through path changes;
+- new modules remain within current standards;
+- cycles are fixed rather than exempted;
+- architecture rules are manifest-driven rather than duplicated inconsistently;
+- touched code improves or preserves current quality.
+
+### 13. Transitional debt
+
+Intermediate stages may temporarily leave unextracted root modules on the
+integration branch.
+
+Every temporary condition must have:
+
+- an explicit list;
+- an owning future stage;
+- a mechanical final gate;
+- no path into a published wheel.
+
+Flag any temporary workaround that can survive Stage 1.0.13H silently.
+
+## Inventory-gate review
+
+When `STAGE=inventory`, additionally verify:
+
+- every Python module has exactly one row in the CSV;
+- paths and module names are unique;
+- classifications use only approved values;
+- every production classification has a target distribution and namespace;
+- every `split` row has a concrete split plan;
+- every `undecided` row has a real blocking question;
+- AST edges include runtime, type-only, deferred, optional, and dynamic distinctions;
+- root public exports are mapped to defining modules and target APIs;
+- tests, examples, CLIs, identity ownership, and external dependencies are present;
+- JSON and CSV agree with the Markdown summary;
+- the proposed package graph contains no unreported forbidden edge;
+- Stage 1.0.13A blockers are complete.
+
+Attempt to find omitted modules by independently enumerating the repository.
+
+## Stage-specific scope discipline
+
+Review the submitted stage against its specification.
+
+Do not mark unrelated pre-existing debt as a stage blocker unless the stage:
+
+- worsens it;
+- depends on it;
+- claims to resolve it; or
+- makes it materially harder to resolve later.
+
+Record unrelated debt separately as non-blocking context.
+
+## Finding format
+
+Every finding must use this format:
+
+```text
+ID: PKG-<severity>-<number>
+Severity: Blocker | High | Medium | Low
+Confidence: High | Medium | Low
+Stage: <stage>
+Invariant: <contract rule violated>
+Evidence: <exact paths, lines, metadata, wheel entries, or commands>
+Consequence: <specific architectural or runtime failure>
+Required correction: <smallest structurally correct fix>
+Validation: <test or inspection that proves the correction>
+```
+
+A finding is not valid without concrete evidence and a specific consequence.
+
+Do not create multiple findings for the same root cause unless they require
+independent corrections.
+
+## Severity rules
+
+### Blocker
+
+Use when the stage must not merge or advance, including:
+
+- forbidden distribution edge;
+- namespace or wheel ownership collision;
+- core optional-dependency leak;
+- source-only tests masquerading as wheel validation;
+- ORM leakage across the domain boundary;
+- identity or schema regression;
+- missing module inventory that invalidates extraction planning;
+- compatibility shim rebuilding the monolith;
+- incomplete implementation of the stage's required vertical slice.
+
+### High
+
+Use for substantial design defects that may not fail immediately but undermine
+package independence, maintainability, or release correctness.
+
+### Medium
+
+Use for bounded correctness, test, documentation, or operability gaps that should
+be repaired in the current stage when practical.
+
+### Low
+
+Use only for specific polish or clarity improvements. Do not pad the review with
+style preferences.
+
+## Required output
+
+Return the review in this order:
+
+### 1. Verdict
+
+One of:
+
+```text
+PASS
+PASS WITH NON-BLOCKING CORRECTIONS
+FAIL — BLOCKERS PRESENT
+```
+
+State whether the stage may advance.
+
+### 2. Architecture conformance table
+
+Use:
+
+```text
+Dimension | Result | Evidence
+```
+
+Include at least:
+
+- namespace ownership;
+- dependency graph;
+- core isolation;
+- public API;
+- RMDTO boundary;
+- production/research separation;
+- identity preservation;
+- wheel validation;
+- CI/release behavior;
+- transitional debt.
+
+### 3. Findings
+
+List findings ordered by severity and then dependency impact.
+
+### 4. Missing evidence
+
+List claims made by the implementation report that were not proven by commands,
+artifacts, or repository state.
+
+### 5. Accepted strengths
+
+List only concrete architectural strengths that were easy to get wrong and are
+actually evidenced. Keep this section short.
+
+### 6. Required rerun
+
+Give the exact minimal commands and inspections required after corrections.
+
+### 7. Advance decision
+
+State exactly one:
+
+```text
+Advance to the next stage.
+Do not advance until Blockers are corrected.
+Repeat this stage after the listed corrections.
+```
+
+Do not implement fixes. Review only.

--- a/docs/prompts/package-system-inventory-codex.md
+++ b/docs/prompts/package-system-inventory-codex.md
@@ -1,0 +1,453 @@
+# Codex Prompt — ZeroModel 1.0.13 Package Inventory
+
+You are performing the mandatory inventory pass for the ZeroModel 1.0.13
+multi-package overhaul.
+
+This is an evidence-gathering and classification task. Do not move production
+modules, change public imports, or begin the package extraction.
+
+## Repository
+
+```text
+https://github.com/ernanhughes/zeromodel
+```
+
+Work from the latest reviewed branch containing:
+
+```text
+docs/architecture/package-system-1.0.13.md
+```
+
+Record the exact baseline commit SHA in every generated inventory artifact.
+
+## Authoritative documents
+
+Read these before making any classification:
+
+```text
+docs/architecture/package-system-1.0.13.md
+docs/architecture/code-quality-policy.md
+docs/architecture/video-action-set-rmdto.md
+pyproject.toml
+zeromodel/__init__.py
+scripts/check_architecture.py
+scripts/check_quality.py
+.github/workflows/python.yml
+```
+
+The package-system architecture contract is authoritative. The inventory may
+refine module placement, identify required splits, and expose contradictions. It
+must not silently replace the approved six-package model.
+
+## Approved target packages
+
+```text
+core         -> distribution zeromodel
+analysis     -> distribution zeromodel-analysis
+observation  -> distribution zeromodel-observation
+vision       -> distribution zeromodel-vision
+video        -> distribution zeromodel-video
+sqlalchemy   -> distribution zeromodel-sqlalchemy
+```
+
+Additional classifications are:
+
+```text
+research
+examples
+tooling
+delete
+split
+undecided
+```
+
+Every current Python module must receive exactly one classification. A `split`
+classification must identify each responsibility and target. An `undecided`
+classification must state the concrete missing fact that prevents a decision.
+
+## Objective
+
+Create a complete, mechanically grounded map of the current repository so the
+package extraction can be implemented without cosmetic boundaries, hidden
+cycles, duplicated APIs, or accidental optional dependencies.
+
+The inventory must answer:
+
+1. Which modules exist?
+2. What does each module own?
+3. Which modules import which other modules?
+4. Which external dependencies does each module import?
+5. Which symbols does each module expose publicly?
+6. Which tests and examples depend on each module?
+7. Which modules own persisted schemas, stable versions, digests, or identity behavior?
+8. Which modules are runtime capability versus benchmark or evidence machinery?
+9. Which modules must be split before they can move cleanly?
+10. Which current dependencies contradict the approved target graph?
+
+## Required deliverables
+
+Commit all of the following:
+
+```text
+docs/architecture/package-inventory-1.0.13.md
+docs/architecture/package-module-map-1.0.13.csv
+docs/architecture/package-import-graph-1.0.13.json
+docs/architecture/package-dependency-findings-1.0.13.md
+```
+
+If reusable analysis code is required, also add:
+
+```text
+scripts/analyze_package_inventory.py
+tests/test_analyze_package_inventory.py
+```
+
+Do not add a one-off script without tests when its output becomes architecture
+evidence.
+
+## Inventory scope
+
+Inventory all Python files under at least:
+
+```text
+zeromodel/
+scripts/
+examples/
+tests/
+```
+
+Also inspect:
+
+```text
+.github/workflows/
+docs/architecture/
+docs/research/
+docs/results/
+quality-baseline.toml
+pyproject.toml
+```
+
+Non-Python files do not require one module-map row, but their relationship to
+packaging, tests, claims, benchmark evidence, and runtime behavior must be
+reported where relevant.
+
+## Mechanical analysis requirements
+
+Use AST-based analysis for normal Python imports. Do not infer the graph only
+from text search.
+
+The analysis must resolve:
+
+- absolute imports;
+- relative imports;
+- imports from package `__init__.py` files;
+- sibling imports;
+- imports of tracked external packages;
+- imports from tests, examples, scripts, or research;
+- type-checking-only imports;
+- local imports inside functions;
+- optional imports guarded by `try/except`;
+- imports guarded by `TYPE_CHECKING`;
+- dynamic imports through `importlib` where statically discoverable.
+
+Report dynamic imports that cannot be resolved statically.
+
+Do not treat `TYPE_CHECKING` or function-local imports as irrelevant. Record the
+edge kind so reviewers can decide whether the package dependency is runtime,
+type-only, or deferred.
+
+## Module map schema
+
+`docs/architecture/package-module-map-1.0.13.csv` must contain one row per current
+Python module with these columns in this exact order:
+
+```text
+path,module,lines,classification,target_distribution,target_namespace,responsibility,public_symbols,inbound_internal_count,outbound_internal_count,external_dependencies,test_paths,example_paths,cli_entry_points,identity_or_schema_ownership,move_action,confidence,rationale,blocking_questions
+```
+
+Column rules:
+
+- `path`: repository-relative POSIX path;
+- `module`: current import name;
+- `lines`: physical line count;
+- `classification`: one approved classification;
+- `target_distribution`: exact distribution or blank when not production;
+- `target_namespace`: exact target import subtree or blank when not production;
+- `responsibility`: one concise dominant responsibility;
+- `public_symbols`: semicolon-separated deliberate or de facto public symbols;
+- `external_dependencies`: semicolon-separated top-level distributions;
+- `test_paths`: semicolon-separated direct tests;
+- `example_paths`: semicolon-separated direct examples;
+- `cli_entry_points`: declared or direct CLI surfaces;
+- `identity_or_schema_ownership`: version constants, digest behavior, DTO schema,
+  persisted schema, or `none`;
+- `move_action`: `move`, `split`, `retain-tooling`, `move-research`, `delete`, or
+  `investigate`;
+- `confidence`: `high`, `medium`, or `low`;
+- `rationale`: evidence-based classification reason;
+- `blocking_questions`: blank unless a concrete decision blocker exists.
+
+Escape CSV correctly. Do not place unescaped commas into fields.
+
+## Import graph schema
+
+`docs/architecture/package-import-graph-1.0.13.json` must be deterministic JSON
+with sorted keys and arrays. Use this top-level shape:
+
+```json
+{
+  "schema_version": 1,
+  "baseline_commit": "<sha>",
+  "generated_at_utc": "<iso-8601>",
+  "modules": {},
+  "edges": [],
+  "strongly_connected_components": [],
+  "unresolved_dynamic_imports": [],
+  "external_dependencies": {}
+}
+```
+
+Each module record must include:
+
+```json
+{
+  "path": "zeromodel/example.py",
+  "classification": "core",
+  "target_namespace": "zeromodel.core.example",
+  "lines": 100
+}
+```
+
+Each edge must include:
+
+```json
+{
+  "importer": "zeromodel.a",
+  "imported": "zeromodel.b",
+  "line": 12,
+  "kind": "runtime|type-checking|deferred|optional|dynamic",
+  "resolved": true
+}
+```
+
+Strongly connected components must include only components containing a genuine
+cycle. Include one concrete cycle path for each component.
+
+## Public API inventory
+
+The Markdown inventory must separately list:
+
+- every symbol exported by the current `zeromodel/__init__.py`;
+- the symbol's defining module;
+- its proposed target import;
+- whether it is retained, renamed, split, moved to research, or deleted;
+- tests and examples that currently use the root export;
+- any symbol whose apparent public status exists only because the root initializer
+  imports it.
+
+Do not assume that every current root export should survive. The architecture
+explicitly removes root compatibility re-exports.
+
+## External dependency inventory
+
+Report all imported third-party top-level modules and map them to the package or
+research area that currently requires them.
+
+At minimum, explicitly investigate:
+
+```text
+numpy
+sqlalchemy
+torch
+torchvision
+transformers
+PIL
+pytest
+```
+
+Distinguish runtime dependencies from test, dev, research, and optional imports.
+
+Identify imports that cause an optional capability to become an import-time
+requirement of an otherwise lightweight module.
+
+## Package-data and build inventory
+
+Inspect current packaging configuration and report:
+
+- packages discovered by setuptools;
+- non-Python package data;
+- console scripts or other entry points;
+- optional dependency groups;
+- test assumptions created by root `pythonpath` configuration;
+- imports that work only because the repository root is on `sys.path`;
+- expected wheel contents;
+- files currently shipped that should become research-only;
+- release and CI scripts that assume one distribution or one `dist/` directory.
+
+Run a current wheel build and inspect the archive contents. Record the exact
+command and the relevant observations. Do not modify release metadata in this
+inventory task.
+
+## Domain-boundary inventory
+
+For `zeromodel.domains.video_action_set`, `zeromodel.stores`, and `zeromodel.db`,
+map the current RMDTO path:
+
+```text
+Runtime -> Facade -> Engine -> Service -> Store protocol -> Store implementation -> ORM
+```
+
+Report every violation or suspicious edge, including:
+
+- domain imports of SQLAlchemy;
+- domain imports of ORM or SQL Store implementations;
+- ORM imports of services or runtimes;
+- ORM objects escaping Stores;
+- filesystem or benchmark orchestration embedded in reusable domain mechanics;
+- runtime composition that imports persistence eagerly.
+
+Do not change the architecture during this task. Record findings only.
+
+## Production-versus-research adjudication
+
+For every visual and video provider, benchmark, selector, calibration sweep, and
+evidence generator, answer:
+
+1. Is this a supported runtime implementation or experiment machinery?
+2. Is it coupled to the arcade fixture?
+3. Is its contract stable independently of a benchmark?
+4. Does a package-local test exist without research fixtures?
+5. Does the claims audit promote, withhold, or refute the capability?
+6. Should it move to production, move to research, be split, or be deleted?
+
+Negative-result and unpromoted implementations should default to `research`
+unless concrete runtime evidence supports production ownership.
+
+## Split analysis
+
+Do not force a module into one package when it contains multiple responsibilities.
+
+For every `split` classification, provide a table with:
+
+```text
+current module
+responsibility fragment
+target module
+target package
+symbols to move
+inbound callers
+identity/schema risk
+recommended split order
+```
+
+Pay special attention to:
+
+- the current root `__init__.py`;
+- application-wide runtime composition;
+- benchmark modules that also contain reusable mechanics;
+- visual dataset and benchmark contracts mixed with orchestration;
+- video action-set files mixing DTOs, scientific derivation, filesystem I/O,
+  orchestration, and CLI behavior;
+- persistence modules that contain domain validation;
+- modules above current quality ceilings.
+
+## Dependency findings document
+
+`docs/architecture/package-dependency-findings-1.0.13.md` must rank findings:
+
+```text
+Blocker
+High
+Medium
+Low
+```
+
+Each finding must include:
+
+- a short title;
+- exact paths and import edges;
+- why it conflicts with the target package graph;
+- the extraction stage affected;
+- the smallest structurally correct remedy;
+- whether it blocks Stage 1.0.13A.
+
+Do not pad the report with generic style advice.
+
+## Architecture comparison
+
+Compare the observed graph with the allowed graph:
+
+```text
+analysis -> core
+observation -> core
+vision -> observation, core
+video -> observation, core
+sqlalchemy -> video, core
+research -> any production package
+```
+
+Produce a package-level adjacency matrix for both:
+
+1. the proposed classification graph; and
+2. the allowed target graph.
+
+List every proposed forbidden edge.
+
+## Validation
+
+Run the repository's existing checks without weakening them:
+
+```text
+python scripts/check_quality.py
+python scripts/run_fast_tests.py
+python -m build
+python -m twine check dist/*
+```
+
+If the environment lacks a required tool, install the declared development or
+release dependency and rerun. Record exact commands and results.
+
+Also validate generated artifacts:
+
+- JSON parses;
+- CSV has one header and one row per inventoried Python file;
+- paths are unique;
+- modules are unique;
+- classifications use only allowed values;
+- every production classification has a target distribution and namespace;
+- every `split` row has a split plan;
+- every `undecided` row has a blocking question;
+- generated output is deterministic across two consecutive runs except for the
+  explicitly recorded generation timestamp.
+
+## Prohibited shortcuts
+
+Do not:
+
+- move or rename production modules;
+- add compatibility wrappers;
+- alter version numbers;
+- relax quality limits;
+- suppress import cycles;
+- classify by filename alone;
+- call benchmark code production merely because it is under `zeromodel/`;
+- call code research merely because its current evidence is negative when it
+  also provides a stable supported runtime contract;
+- silently omit modules that fail parsing;
+- treat tests as proof of package ownership without examining responsibility;
+- use repository-root import behavior as proof that a future wheel will work.
+
+## Final response
+
+Return:
+
+1. the baseline commit;
+2. files added or changed;
+3. module count by classification;
+4. cycle count;
+5. forbidden proposed edge count;
+6. Stage 1.0.13A blockers;
+7. validation commands and results;
+8. unresolved decisions requiring architectural adjudication.
+
+Stop after the inventory deliverables. Do not begin Stage 1.0.13A.

--- a/docs/prompts/package-system-stage-1.0.13a-codex.md
+++ b/docs/prompts/package-system-stage-1.0.13a-codex.md
@@ -1,0 +1,718 @@
+# Codex Prompt — Stage 1.0.13A: Workspace and Lightweight Core
+
+You are implementing Stage 1.0.13A of the ZeroModel multi-package overhaul.
+
+This stage establishes the package workspace, creates the independently buildable
+`zeromodel` core distribution, removes the monolithic root API, and introduces
+machine-enforced package boundaries.
+
+Do not extract analysis, observation, vision, video, or SQLAlchemy packages in
+this stage except where a small split is required to remove a forbidden dependency
+from an approved core module.
+
+## Repository
+
+```text
+https://github.com/ernanhughes/zeromodel
+```
+
+## Preconditions
+
+Do not begin until all of the following exist and have been reviewed:
+
+```text
+docs/architecture/package-system-1.0.13.md
+docs/architecture/package-inventory-1.0.13.md
+docs/architecture/package-module-map-1.0.13.csv
+docs/architecture/package-import-graph-1.0.13.json
+docs/architecture/package-dependency-findings-1.0.13.md
+```
+
+The inventory review must contain no unresolved Blocker for Stage 1.0.13A.
+
+If a module required for the complete core workflow is classified `undecided`,
+stop and report the architectural blocker. Do not guess.
+
+## Branch strategy
+
+Work on a dedicated stage branch based on:
+
+```text
+integration/package-system-1.0.13
+```
+
+The stage pull request targets that integration branch, not `main`.
+
+Record the exact base commit in the implementation report.
+
+## Authoritative rules
+
+Read and follow:
+
+```text
+docs/architecture/package-system-1.0.13.md
+docs/architecture/code-quality-policy.md
+docs/architecture/video-action-set-rmdto.md
+package inventory artifacts
+scripts/check_architecture.py
+scripts/check_quality.py
+quality-baseline.toml
+.github/workflows/python.yml
+```
+
+The architecture contract wins over implementation convenience.
+
+## Stage objective
+
+After this stage, the repository must contain an independently buildable core
+package at:
+
+```text
+packages/core/
+```
+
+with public imports under:
+
+```python
+from zeromodel.core import ...
+```
+
+A clean installation of the core wheel must support:
+
+```text
+scored rows
+    -> deterministic VPM artifact
+    -> stable identity and source mapping
+    -> bundle or lightweight rendering
+    -> exact bounded row address
+    -> policy action and evidence
+```
+
+The core wheel must require only the Python standard library and NumPy at runtime.
+
+The current root API must no longer exist:
+
+```python
+from zeromodel import ScoreTable
+from zeromodel import VisualSignReader
+from zeromodel import VideoPolicyReader
+```
+
+Do not replace it with compatibility aliases.
+
+## Required deliverables
+
+At minimum, this stage must add or update:
+
+```text
+packages/core/pyproject.toml
+packages/core/README.md
+packages/core/src/zeromodel/core/
+packages/core/tests/
+package-boundaries.toml
+requirements/dev.txt
+requirements/release.txt
+scripts/check_architecture.py
+scripts/check_quality.py
+scripts/check_distribution_contents.py
+scripts/check_workspace_versions.py
+.github/workflows/python.yml
+docs/architecture/package-transition-ledger-1.0.13.md
+```
+
+Add tests for every new reusable script.
+
+The exact moved modules are governed by the reviewed inventory, not by this prompt's
+candidate list.
+
+## 1. Establish the workspace
+
+### 1.1 Root project configuration
+
+Convert the repository-root `pyproject.toml` into workspace and tool configuration.
+It must no longer describe a publishable `zeromodel` distribution.
+
+Preserve and adapt relevant tool configuration for:
+
+- pytest;
+- Ruff;
+- mypy;
+- repository markers;
+- any existing quality tooling.
+
+Do not leave a root build configuration that can accidentally publish a second
+`zeromodel` distribution.
+
+Move repository development and release tooling dependencies into explicit files:
+
+```text
+requirements/dev.txt
+requirements/release.txt
+```
+
+Avoid undeclared environment assumptions. Keep package runtime dependencies in
+the package's own `pyproject.toml`.
+
+### 1.2 Core package metadata
+
+Create `packages/core/pyproject.toml` with:
+
+```text
+distribution name: zeromodel
+version: 1.0.13
+requires-python: >=3.10
+runtime dependency: numpy>=1.23
+```
+
+Preserve appropriate project metadata, license, classifiers, repository URLs, and
+README linkage from the current distribution.
+
+Use a single package-local version source. Recommended shape:
+
+```text
+packages/core/src/zeromodel/core/_version.py
+```
+
+with setuptools dynamic version loading. `zeromodel.core.__version__` may be
+public. There must be no `zeromodel.__version__` compatibility surface.
+
+### 1.3 Implicit namespace
+
+There must be no:
+
+```text
+zeromodel/__init__.py
+packages/core/src/zeromodel/__init__.py
+```
+
+The `zeromodel` namespace must be implicit under PEP 420.
+
+Add a test that inspects source roots and the built wheel for a forbidden namespace
+initializer.
+
+## 2. Introduce `package-boundaries.toml`
+
+Create the machine-readable package manifest described by the architecture
+contract.
+
+For Stage A, include all six final packages, even though only core is active.
+Represent package state explicitly, for example:
+
+```toml
+[packages.core]
+state = "active"
+
+[packages.analysis]
+state = "planned"
+```
+
+Do not infer package activation from whether a directory happens to exist.
+
+The manifest must also represent transitional root modules that remain on the
+integration branch. Each transitional module must have:
+
+- current path;
+- final owner package;
+- removal stage;
+- reason it remains;
+- whether it may appear in a built wheel.
+
+No transitional root module may appear in the core wheel.
+
+The manifest is the single authority for:
+
+- distributions;
+- namespaces;
+- source roots;
+- allowed dependencies;
+- package state;
+- synchronized release version;
+- transitional ownership.
+
+Architecture and version scripts must read it rather than duplicate package lists.
+
+## 3. Extract the core kernel
+
+Use the reviewed module map to move every approved core module or approved core
+fragment into:
+
+```text
+packages/core/src/zeromodel/core/
+```
+
+Use history-preserving moves where a complete file moves. Do not copy a module and
+leave the old implementation in place.
+
+Candidate responsibilities include:
+
+- artifact DTOs and validation;
+- canonical identity and digest mechanics;
+- matrix blob;
+- score-table metric helpers;
+- deterministic artifact construction;
+- minimal views required to construct usable artifacts;
+- bundle round trip;
+- lightweight rendering;
+- exact bounded policy lookup and decision evidence;
+- small dependency-free portable policy representation when approved by inventory.
+
+The inventory is authoritative about exact files and split requirements.
+
+### 3.1 Split mixed modules correctly
+
+When a current module contains both core and advanced behavior:
+
+1. move the core responsibility into a focused core module;
+2. leave the advanced behavior in its transitional current location;
+3. update the advanced code to import the public core object;
+4. do not create a compatibility wrapper at the old core path;
+5. preserve identity, schema versions, and behavior through tests.
+
+Do not force advanced behavior into core merely to avoid a split.
+
+### 3.2 Core public API
+
+Create a deliberate, small public surface in:
+
+```text
+packages/core/src/zeromodel/core/__init__.py
+```
+
+Re-export only objects owned by core.
+
+Add an explicit public API test that verifies the expected export set and fails on
+accidental additions.
+
+Do not re-export analysis, observation, vision, video, persistence, research, or
+transitional objects.
+
+## 4. Remove the monolithic root API
+
+Delete the current:
+
+```text
+zeromodel/__init__.py
+```
+
+Update repository production code, tests, examples, and executable scripts that
+import core symbols through the root namespace.
+
+Replace imports with ownership-explicit paths, such as:
+
+```python
+from zeromodel.core import ScoreTable
+from zeromodel.core.policy import VPMPolicyLookup
+```
+
+Choose the package public surface when it is deliberately exported. Use a public
+submodule when importing a specialized public object. Do not import private
+modules across future package boundaries.
+
+Prohibited:
+
+```python
+# No compatibility root export.
+from zeromodel import ScoreTable
+
+# No old-path shim.
+from zeromodel.artifact import ScoreTable
+
+# No dynamic alias registration.
+sys.modules["zeromodel.artifact"] = ...
+```
+
+Repository documentation that is executed or copied as an installation example
+must be updated in this stage. Broad narrative documentation can be completed in
+Stage H, but no live example may teach a removed import.
+
+## 5. Update all inbound core imports
+
+After moving core modules, scan the entire repository and update imports from:
+
+```text
+zeromodel/
+scripts/
+examples/
+tests/
+```
+
+Do not stop after core tests pass. Transitional advanced modules must consume the
+new core package instead of importing removed root modules.
+
+Run an AST check that proves no import of a removed core module path remains.
+
+Record any intentionally deferred import in the transition ledger. An import is
+not deferrable merely because it appears only in a slow test.
+
+## 6. Preserve deterministic behavior
+
+Moving identity-bearing code must not change:
+
+- canonical serialization;
+- artifact IDs;
+- matrix blob IDs;
+- digest domain separators;
+- schema version constants;
+- source mapping;
+- bundle payloads;
+- policy decisions;
+- Lua plan identity if retained in core;
+- error and rejection semantics.
+
+Before editing behavior, capture the existing golden values already encoded in
+tests. Do not regenerate expected identities to match accidental changes.
+
+Add or retain equivalence tests that construct representative artifacts through
+the new imports and assert the existing identities and serialized forms.
+
+If a golden value must change for a reason other than import location, stop and
+report it as out of scope.
+
+## 7. Package-aware architecture tooling
+
+Refactor `scripts/check_architecture.py` to discover active source roots from
+`package-boundaries.toml`.
+
+It must support both:
+
+- active package roots; and
+- explicitly declared transitional root modules.
+
+It must enforce at least:
+
+- unique module ownership;
+- no overlapping namespace files;
+- allowed inter-package edges;
+- no local import cycles;
+- no production imports from tests, examples, or research;
+- no tracked heavyweight dependency in core;
+- no sibling-private import across declared package owners;
+- no forbidden `zeromodel/__init__.py`;
+- no undeclared production module;
+- no transitional module in a production wheel.
+
+Do not hard-code a second package graph in the script.
+
+Add focused tests for manifest parsing, invalid edges, duplicate ownership,
+namespace initializers, transitional modules, and the current valid repository.
+
+## 8. Preserve the quality ratchet
+
+Update `scripts/check_quality.py` and `quality-baseline.toml` for moved paths.
+
+Rules:
+
+- preserve existing limits;
+- do not raise a numeric ceiling;
+- do not drop a file-specific exception merely because the file moved;
+- map a moved exception to its new path with the same or lower ceiling;
+- new core modules must satisfy the current new-code limits;
+- split files should reduce, not reproduce, oversized responsibilities;
+- no syntax, cycle, or forbidden-edge check may be exempted.
+
+Add a test that proves a path move cannot silently escape a quality ceiling.
+
+## 9. Distribution-content validation
+
+Create `scripts/check_distribution_contents.py` driven by
+`package-boundaries.toml`.
+
+For a built wheel it must verify:
+
+- distribution name and version;
+- owned namespace subtree only;
+- no `zeromodel/__init__.py`;
+- no transitional root module;
+- no sibling package subtree;
+- expected package metadata;
+- deterministic, sorted diagnostics.
+
+Add unit tests using small synthetic wheel archives. Do not test only the happy
+path.
+
+## 10. Version validation
+
+Create `scripts/check_workspace_versions.py` driven by
+`package-boundaries.toml`.
+
+In Stage A it must verify:
+
+- core reports `1.0.13`;
+- manifest reports `1.0.13`;
+- no active package has a different version;
+- planned package metadata is not required until the package becomes active;
+- internal dependency pins, when present, equal `1.0.13`.
+
+The script must naturally extend to all six packages in later stages.
+
+## 11. Testing structure
+
+Create package-local core tests under:
+
+```text
+packages/core/tests/
+```
+
+Move tests whose complete responsibility is core. Split mixed tests rather than
+copying them.
+
+Keep cross-package or transitional tests outside the core package and update their
+imports.
+
+At minimum, core tests must cover:
+
+- artifact construction;
+- validation;
+- deterministic identity;
+- matrix blob round trip and tamper rejection;
+- source/cell mapping;
+- basic views;
+- bundle round trip;
+- lightweight rendering;
+- exact policy lookup;
+- public API exports;
+- import isolation;
+- wheel namespace ownership.
+
+## 12. Clean-wheel proof
+
+Build the core distribution:
+
+```text
+python -m build packages/core --outdir build/dist/core
+python -m twine check build/dist/core/*
+```
+
+Create a genuinely clean virtual environment outside the repository tree.
+
+Install the wheel, not the source tree:
+
+```text
+python -m pip install <core-wheel>
+python -m pip check
+```
+
+From a temporary directory outside the repository, prove:
+
+```python
+import sys
+import zeromodel.core
+
+assert zeromodel.core.__version__ == "1.0.13"
+
+for forbidden in (
+    "sqlalchemy",
+    "torch",
+    "torchvision",
+    "transformers",
+    "PIL",
+    "zeromodel.analysis",
+    "zeromodel.observation",
+    "zeromodel.vision",
+    "zeromodel.video",
+    "zeromodel.persistence.sqlalchemy",
+):
+    assert forbidden not in sys.modules
+```
+
+Copy the core test directory to a temporary location outside the repository and
+run the package tests against the installed wheel. Ensure neither the repository
+root nor `packages/core/src` appears on `sys.path`.
+
+An editable install is not acceptable evidence for the clean-wheel gate.
+
+## 13. Transitional repository test configuration
+
+Advanced modules remain temporarily in their current source locations until later
+stages. Keep them testable on the integration branch without shipping them in the
+core wheel.
+
+Requirements:
+
+- transitional source visibility must be explicit in repository test tooling;
+- core wheel tests must not see transitional source paths;
+- transitional modules must be listed in the transition ledger and manifest;
+- no release workflow may package transitional root modules;
+- Stage H must have a mechanical check requiring the transitional list to be empty.
+
+Do not add runtime `sys.path` manipulation inside production code.
+
+## 14. Transition ledger
+
+Create:
+
+```text
+docs/architecture/package-transition-ledger-1.0.13.md
+```
+
+It must list every production Python module remaining outside `packages/*` after
+Stage A with:
+
+```text
+current path
+current import
+final package
+final namespace
+removal stage
+known forbidden-edge risk
+reason it remains
+```
+
+Also list removed old core module paths and prove that no shim remains.
+
+The ledger must be generated or validated against the manifest so it cannot drift
+silently.
+
+## 15. CI changes
+
+Update `.github/workflows/python.yml`.
+
+Path filters must include at least:
+
+```text
+packages/**
+zeromodel/**
+integration_tests/**
+research/**
+requirements/**
+package-boundaries.toml
+pyproject.toml
+scripts/**
+tests/**
+examples/**
+docs/architecture/**
+.github/workflows/python.yml
+```
+
+Replace root editable installation assumptions.
+
+The workflow must include:
+
+1. repository quality and architecture checks;
+2. current bounded fast-suite execution for transitional code;
+3. core package unit tests on Python 3.10, 3.11, and 3.12;
+4. core sdist and wheel build;
+5. Twine metadata validation;
+6. distribution-content validation;
+7. clean-wheel import isolation;
+8. package tests against the installed wheel;
+9. workspace version validation;
+10. the existing Lua fixture if its implementation remains supported.
+
+Failure logs may be uploaded as artifacts. Do not add self-modifying CI or commits
+from workflows.
+
+## 16. Release safety
+
+The existing release tooling assumes one distribution. Stage A must prevent it
+from publishing an incomplete multi-package workspace.
+
+Choose one explicit safe behavior:
+
+- make release preparation fail with a clear message while planned packages remain
+  inactive; or
+- add a manifest-driven completeness gate that fails until all six packages are
+  active and Stage H conditions are met.
+
+Do not make a partial core-only 1.0.13 publication possible through the normal
+release command.
+
+Document this temporary release lock in the transition ledger.
+
+## 17. Validation commands
+
+Run all relevant checks, including at least:
+
+```text
+python scripts/check_architecture.py
+python scripts/check_quality.py
+python scripts/check_workspace_versions.py
+python scripts/run_fast_tests.py
+python -m pytest -q packages/core/tests
+python -m build packages/core --outdir build/dist/core
+python -m twine check build/dist/core/*
+python scripts/check_distribution_contents.py build/dist/core/*.whl
+```
+
+Run the clean virtual-environment wheel proof described above.
+
+Run tests on Python 3.10, 3.11, and 3.12 when the environment permits. CI must
+cover the complete matrix even if the local environment provides only one version.
+
+Record exact commands, pass/fail status, and any environment limitation.
+
+## 18. Prohibited shortcuts
+
+Do not:
+
+- preserve the root API;
+- create old-path shim modules;
+- copy core code instead of moving or splitting it;
+- publish transitional modules in the core wheel;
+- add SQLAlchemy, Pillow, Torch, TorchVision, or Transformers to core;
+- import optional sibling packages from `zeromodel.core.__init__`;
+- use repository-root `PYTHONPATH` as clean-wheel evidence;
+- regenerate golden IDs to hide a regression;
+- raise quality ceilings;
+- hard-code package lists independently in multiple scripts;
+- begin extracting analysis, observation, vision, video, or SQLAlchemy wholesale;
+- delete research or advanced modules merely because their package stage has not
+  happened yet;
+- weaken existing scientific or RMDTO tests.
+
+## 19. Required implementation report
+
+Return a report with:
+
+### Baseline
+
+- base branch;
+- base commit;
+- inventory commit used.
+
+### Workspace changes
+
+- files added;
+- root configuration changes;
+- manifest summary.
+
+### Core extraction
+
+- files moved;
+- files split;
+- new target modules;
+- public export list;
+- removed old import paths.
+
+### Boundary proof
+
+- observed core external dependencies;
+- observed core internal package edges;
+- wheel content summary;
+- namespace initializer check;
+- import-isolation result.
+
+### Determinism proof
+
+- golden identities exercised;
+- schema/version constants preserved;
+- bundle and policy equivalence results.
+
+### Transitional debt
+
+- count of remaining root production modules;
+- owner stage for each category;
+- release lock status.
+
+### Validation
+
+- exact commands;
+- results;
+- environment limitations.
+
+### Deviations
+
+List every deviation from this prompt or the architecture contract. If none, say
+`None`.
+
+Stop after Stage 1.0.13A. Do not begin Stage B.


### PR DESCRIPTION
## What changed

This PR establishes the reviewed architecture and execution pack for the ZeroModel 1.0.13 multi-package overhaul.

It adds:

- `docs/architecture/package-system-1.0.13.md`
  - locks the six-distribution design;
  - defines the implicit `zeromodel` namespace;
  - fixes the dependency graph and RMDTO/persistence direction;
  - separates supported runtime packages from research machinery;
  - defines package, wheel, CI, versioning, and completion gates;
  - establishes an integration-branch implementation sequence.
- `docs/prompts/package-system-inventory-codex.md`
  - requires a mechanically generated module/import/public-API/dependency inventory before code moves.
- `docs/prompts/package-system-adversarial-review-claude.md`
  - provides a reusable evidence-based adversarial review contract for the inventory and every extraction stage.
- `docs/prompts/package-system-stage-1.0.13a-codex.md`
  - specifies the first implementation stage: workspace tooling, manifest-driven boundaries, core extraction, root API removal, clean-wheel proof, and release locking.

## Architectural decision

ZeroModel 1.0.13 will use one repository and six synchronized independently buildable distributions:

- `zeromodel`
- `zeromodel-analysis`
- `zeromodel-observation`
- `zeromodel-vision`
- `zeromodel-video`
- `zeromodel-sqlalchemy`

The root compatibility API will not be preserved. Research and benchmark machinery will be separated from production wheels.

## Why

The current distribution contains artifact, policy, analysis, observation, visual, video, persistence, and research responsibilities behind one root import surface. The new contract makes those ownership and dependency boundaries explicit before implementation begins.

## Validation

- Compared the branch with release commit `cc9590ad36fc6c6834c29f0890aa653c94f56744`.
- Diff contains four new Markdown documents only.
- No production code, packaging metadata, schemas, digests, or claims statuses are changed.
- Repository CI should run because the architecture document is under `docs/architecture/**`.

## Next step after merge

Run the Codex inventory prompt. Feed the resulting inventory artifacts to Claude using the adversarial review prompt. Resolve inventory blockers before creating `integration/package-system-1.0.13` and starting Stage 1.0.13A.