### PR TITLE
feat(perception): add Phase P1 deterministic representations

### DIFF
--- a/packages/perception/README.md
+++ b/packages/perception/README.md
@@ -3,30 +3,89 @@
 `zeromodel-perception` is the domain-neutral learning and inference runtime for
 ZeroModel visual evidence.
 
-The package is intended to turn arbitrary image/action observations into
-inspectable visual representations and, in later delivery stages, use those
-representations to infer likely actions for unseen images while retaining
-supporting evidence, alternatives, confidence, rejection, and provenance.
+The package turns arbitrary image/action observations into inspectable visual
+representations and, in later delivery stages, will use those representations to
+infer likely actions for unseen images while retaining evidence, alternatives,
+confidence, rejection, and provenance.
 
-## Phase P0 status
+## Phase P1 status
 
-Phase P0 registers the package and its dependency boundary only. It contains no
-scientific behavior, image encoder, learner, predictor, or evidence algorithm.
+Phase P1 implements the first deterministic representation slice:
 
-The initial production dependencies are deliberately small:
+```text
+bounded image bytes or uint8 array -> SourceVPMDTO
+bounded discrete action            -> TargetVPMDTO
+```
+
+It does not yet learn mappings, search neighbours, infer actions, estimate
+confidence, produce evidence VPMs, or persist datasets.
+
+The production dependencies remain deliberately small:
 
 - `numpy` for deterministic array operations;
-- `pillow` for bounded image decoding and PNG serialization at the package edge;
+- `pillow` for bounded image decoding and canonical PNG serialization;
 - `zeromodel` for core VPM artifact contracts;
 - `zeromodel-observation` for observation-owned DTO and provider contracts.
 
-Pillow is an input/output adapter. Future perception internals should operate on
-validated NumPy arrays and immutable ZeroModel DTOs rather than passing mutable
-Pillow objects across service boundaries.
+Pillow remains an input/output adapter. Perception internals operate on validated
+NumPy arrays and immutable DTOs rather than passing mutable Pillow objects across
+runtime boundaries.
+
+## Source representation
+
+`SourceImageEncoderSpecDTO` declares the accepted colour space and hard limits for
+width, height, decoded pixels, and input bytes. P1 accepts `L`, `RGB`, and `RGBA`
+uint8 observations.
+
+The encoder:
+
+1. rejects malformed, oversized, or incorrectly shaped inputs;
+2. performs only the declared colour-space conversion;
+3. preserves encoded pixel orientation and coordinates;
+4. emits deterministic PNG bytes;
+5. computes separate identities for the encoder contract, normalized pixels,
+   PNG bytes, and complete Source VPM.
+
+No crop, resize, augmentation, denoising, histogram correction, EXIF transpose,
+object detection, or learned embedding is performed.
+
+## Target representation
+
+`DiscreteActionSchemaDTO` owns a canonical sorted action vocabulary. Each discrete
+action is represented as a one-row grayscale PNG with one stable field per action:
+
+```text
+0   = inactive field
+255 = selected action field
+```
+
+`decode_discrete_action` validates schema identity, encoder version, dimensions,
+PNG digest, canonical one-hot values, and metadata agreement before returning an
+action. It rejects malformed or ambiguous target VPMs rather than guessing.
+
+## Example
+
+```python
+import numpy as np
+
+from zeromodel.perception import (
+    DiscreteActionSchemaDTO,
+    decode_discrete_action,
+    encode_discrete_action,
+    encode_source_array,
+)
+
+source = encode_source_array(np.zeros((8, 8, 3), dtype=np.uint8))
+schema = DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT", "FIRE"])
+target = encode_discrete_action("RIGHT", schema)
+
+assert source.width == 8
+assert decode_discrete_action(target, schema) == "RIGHT"
+```
 
 ## Ownership boundary
 
-`zeromodel-perception` will own:
+`zeromodel-perception` owns or will own:
 
 - deterministic source-image and target-action visual representations;
 - immutable image/action dataset manifests;
@@ -44,19 +103,6 @@ It does not own:
 - SQLAlchemy persistence (`zeromodel-sqlalchemy`);
 - artifact storage, signatures, or navigation;
 - game-specific concepts such as players, aliens, bullets, or controls.
-
-## Public API
-
-During P0 the public API exposes only package identity and the delivery-stage
-marker. Scientific APIs will be added only with focused tests in later vertical
-slices.
-
-```python
-from zeromodel.perception import PERCEPTION_PACKAGE_VERSION, PERCEPTION_STAGE
-
-assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-assert PERCEPTION_STAGE == "P0"
-```
 
 See `docs/architecture/perception-runtime-design.md` for the comprehensive
 architecture and staged delivery plan.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -1,12 +1,38 @@
-"""ZeroModel perception public API.
-
-Phase P0 intentionally exposes package identity only. Scientific behavior is
-introduced through later tested vertical slices.
-"""
+"""ZeroModel perception public API."""
 
 from __future__ import annotations
 
-PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P0"
+from .representation import (
+    ACTION_SCHEMA_VERSION,
+    SOURCE_ENCODER_VERSION,
+    TARGET_ENCODER_VERSION,
+    DiscreteActionSchemaDTO,
+    PerceptionRepresentationError,
+    SourceImageEncoderSpecDTO,
+    SourceVPMDTO,
+    TargetVPMDTO,
+    decode_discrete_action,
+    encode_discrete_action,
+    encode_source_array,
+    encode_source_image_bytes,
+)
 
-__all__ = ["PERCEPTION_PACKAGE_VERSION", "PERCEPTION_STAGE"]
+PERCEPTION_PACKAGE_VERSION = "1.0.13"
+PERCEPTION_STAGE = "P1"
+
+__all__ = [
+    "ACTION_SCHEMA_VERSION",
+    "PERCEPTION_PACKAGE_VERSION",
+    "PERCEPTION_STAGE",
+    "SOURCE_ENCODER_VERSION",
+    "TARGET_ENCODER_VERSION",
+    "DiscreteActionSchemaDTO",
+    "PerceptionRepresentationError",
+    "SourceImageEncoderSpecDTO",
+    "SourceVPMDTO",
+    "TargetVPMDTO",
+    "decode_discrete_action",
+    "encode_discrete_action",
+    "encode_source_array",
+    "encode_source_image_bytes",
+]

--- a/packages/perception/src/zeromodel/perception/representation.py
+++ b/packages/perception/src/zeromodel/perception/representation.py
@@ -1,0 +1,348 @@
+"""Deterministic source-image and target-action VPM representations.
+
+Stage P1 is intentionally narrow. It normalizes bounded images into canonical PNG
+bytes and encodes bounded discrete actions into canonical one-hot PNG fields.
+No learning, similarity, evidence weighting, or inference behavior belongs here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import warnings
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Final, Mapping, Sequence
+
+import numpy as np
+from PIL import Image
+
+SOURCE_ENCODER_VERSION: Final = "perception-source-vpm/1"
+ACTION_SCHEMA_VERSION: Final = "perception-action-schema/1"
+TARGET_ENCODER_VERSION: Final = "perception-target-vpm/1"
+
+_ALLOWED_COLOR_SPACES: Final = {"L": 1, "RGB": 3, "RGBA": 4}
+
+
+class PerceptionRepresentationError(ValueError):
+    """Raised when an image or action cannot be represented canonically."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def _png_bytes(image: Image.Image) -> bytes:
+    buffer = BytesIO()
+    image.save(buffer, format="PNG", optimize=False, compress_level=9)
+    return buffer.getvalue()
+
+
+@dataclass(frozen=True)
+class SourceImageEncoderSpecDTO:
+    """Explicit bounded normalization contract for source images."""
+
+    color_space: str = "RGB"
+    max_width: int = 4096
+    max_height: int = 4096
+    max_pixels: int = 16_777_216
+    max_input_bytes: int = 64 * 1024 * 1024
+    version: str = SOURCE_ENCODER_VERSION
+
+    def __post_init__(self) -> None:
+        if self.color_space not in _ALLOWED_COLOR_SPACES:
+            raise PerceptionRepresentationError(
+                f"unsupported color_space {self.color_space!r}; "
+                f"expected one of {sorted(_ALLOWED_COLOR_SPACES)}"
+            )
+        for name, value in (
+            ("max_width", self.max_width),
+            ("max_height", self.max_height),
+            ("max_pixels", self.max_pixels),
+            ("max_input_bytes", self.max_input_bytes),
+        ):
+            if value <= 0:
+                raise PerceptionRepresentationError(f"{name} must be positive")
+        if not self.version:
+            raise PerceptionRepresentationError("version must be non-empty")
+
+    def canonical_payload(self) -> Mapping[str, object]:
+        return {
+            "color_space": self.color_space,
+            "max_height": self.max_height,
+            "max_input_bytes": self.max_input_bytes,
+            "max_pixels": self.max_pixels,
+            "max_width": self.max_width,
+            "version": self.version,
+        }
+
+    @property
+    def encoder_spec_id(self) -> str:
+        return _digest(_canonical_json(self.canonical_payload()))
+
+
+@dataclass(frozen=True)
+class SourceVPMDTO:
+    """Canonical PNG representation of one bounded source image."""
+
+    source_vpm_id: str
+    encoder_spec_id: str
+    width: int
+    height: int
+    channels: int
+    color_space: str
+    dtype: str
+    pixel_digest: str
+    png_digest: str
+    png_bytes: bytes
+
+    def to_array(self) -> np.ndarray:
+        """Decode the canonical PNG back into an immutable-shape uint8 array."""
+
+        with Image.open(BytesIO(self.png_bytes)) as image:
+            decoded = np.asarray(image.convert(self.color_space), dtype=np.uint8)
+        if self.color_space == "L":
+            decoded = decoded.reshape(self.height, self.width)
+        return decoded
+
+
+@dataclass(frozen=True)
+class DiscreteActionSchemaDTO:
+    """Stable ordered vocabulary for canonical discrete action fields."""
+
+    labels: tuple[str, ...]
+    version: str = ACTION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.labels:
+            raise PerceptionRepresentationError("action schema requires at least one label")
+        if any(not isinstance(label, str) or not label for label in self.labels):
+            raise PerceptionRepresentationError("action labels must be non-empty strings")
+        if len(set(self.labels)) != len(self.labels):
+            raise PerceptionRepresentationError("action labels must be unique")
+        if tuple(sorted(self.labels)) != self.labels:
+            raise PerceptionRepresentationError(
+                "action labels must be supplied in canonical sorted order"
+            )
+        if not self.version:
+            raise PerceptionRepresentationError("version must be non-empty")
+
+    @classmethod
+    def from_labels(cls, labels: Sequence[str]) -> "DiscreteActionSchemaDTO":
+        return cls(labels=tuple(sorted(labels)))
+
+    def canonical_payload(self) -> Mapping[str, object]:
+        return {"labels": list(self.labels), "version": self.version}
+
+    @property
+    def action_schema_id(self) -> str:
+        return _digest(_canonical_json(self.canonical_payload()))
+
+    def index_of(self, label: str) -> int:
+        try:
+            return self.labels.index(label)
+        except ValueError as exc:
+            raise PerceptionRepresentationError(
+                f"action {label!r} is not present in schema"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class TargetVPMDTO:
+    """Canonical one-row grayscale PNG representing one discrete action."""
+
+    target_vpm_id: str
+    action_schema_id: str
+    action_label: str
+    encoder_version: str
+    width: int
+    height: int
+    channels: int
+    png_digest: str
+    png_bytes: bytes
+
+    def scores(self) -> tuple[int, ...]:
+        with Image.open(BytesIO(self.png_bytes)) as image:
+            values = np.asarray(image.convert("L"), dtype=np.uint8)
+        return tuple(int(value) for value in values.reshape(-1))
+
+
+def _validate_dimensions(width: int, height: int, spec: SourceImageEncoderSpecDTO) -> None:
+    if width <= 0 or height <= 0:
+        raise PerceptionRepresentationError("image dimensions must be positive")
+    if width > spec.max_width or height > spec.max_height:
+        raise PerceptionRepresentationError(
+            f"image dimensions {width}x{height} exceed "
+            f"maximum {spec.max_width}x{spec.max_height}"
+        )
+    if width * height > spec.max_pixels:
+        raise PerceptionRepresentationError(
+            f"image pixel count {width * height} exceeds maximum {spec.max_pixels}"
+        )
+
+
+def _normalize_pil_image(
+    image: Image.Image, spec: SourceImageEncoderSpecDTO
+) -> Image.Image:
+    _validate_dimensions(image.width, image.height, spec)
+    # Pillow does not apply EXIF orientation implicitly. This preserves encoded
+    # pixel coordinates instead of silently transposing the observation.
+    normalized = image.convert(spec.color_space)
+    normalized.load()
+    return normalized
+
+
+def encode_source_image_bytes(
+    payload: bytes, spec: SourceImageEncoderSpecDTO | None = None
+) -> SourceVPMDTO:
+    """Decode bounded image bytes and emit a canonical source VPM PNG."""
+
+    resolved = spec or SourceImageEncoderSpecDTO()
+    if len(payload) > resolved.max_input_bytes:
+        raise PerceptionRepresentationError(
+            f"input payload size {len(payload)} exceeds maximum "
+            f"{resolved.max_input_bytes}"
+        )
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(BytesIO(payload)) as image:
+                normalized = _normalize_pil_image(image, resolved)
+    except (Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        raise PerceptionRepresentationError("image exceeds Pillow safety limits") from exc
+    except PerceptionRepresentationError:
+        raise
+    except Exception as exc:
+        raise PerceptionRepresentationError("input is not a supported image") from exc
+    return _source_vpm_from_normalized(normalized, resolved)
+
+
+def encode_source_array(
+    values: np.ndarray, spec: SourceImageEncoderSpecDTO | None = None
+) -> SourceVPMDTO:
+    """Normalize a bounded uint8 NumPy image into a canonical source VPM PNG."""
+
+    resolved = spec or SourceImageEncoderSpecDTO()
+    array = np.asarray(values)
+    if array.dtype != np.uint8:
+        raise PerceptionRepresentationError("source arrays must use dtype uint8")
+    expected_channels = _ALLOWED_COLOR_SPACES[resolved.color_space]
+    if resolved.color_space == "L":
+        if array.ndim != 2:
+            raise PerceptionRepresentationError("L source arrays must have shape (H, W)")
+        height, width = array.shape
+    else:
+        if array.ndim != 3 or array.shape[2] != expected_channels:
+            raise PerceptionRepresentationError(
+                f"{resolved.color_space} source arrays must have shape "
+                f"(H, W, {expected_channels})"
+            )
+        height, width, _ = array.shape
+    _validate_dimensions(width, height, resolved)
+    normalized = Image.fromarray(np.ascontiguousarray(array), mode=resolved.color_space)
+    return _source_vpm_from_normalized(normalized, resolved)
+
+
+def _source_vpm_from_normalized(
+    normalized: Image.Image, spec: SourceImageEncoderSpecDTO
+) -> SourceVPMDTO:
+    array = np.asarray(normalized, dtype=np.uint8)
+    canonical_pixels = np.ascontiguousarray(array).tobytes(order="C")
+    png = _png_bytes(normalized)
+    channels = _ALLOWED_COLOR_SPACES[spec.color_space]
+    pixel_digest = _digest(
+        _canonical_json(
+            {
+                "color_space": spec.color_space,
+                "dtype": "uint8",
+                "height": normalized.height,
+                "width": normalized.width,
+            }
+        ),
+        canonical_pixels,
+    )
+    png_digest = _digest(png)
+    source_vpm_id = _digest(
+        spec.encoder_spec_id.encode("ascii"),
+        pixel_digest.encode("ascii"),
+    )
+    return SourceVPMDTO(
+        source_vpm_id=source_vpm_id,
+        encoder_spec_id=spec.encoder_spec_id,
+        width=normalized.width,
+        height=normalized.height,
+        channels=channels,
+        color_space=spec.color_space,
+        dtype="uint8",
+        pixel_digest=pixel_digest,
+        png_digest=png_digest,
+        png_bytes=png,
+    )
+
+
+def encode_discrete_action(
+    action_label: str, schema: DiscreteActionSchemaDTO
+) -> TargetVPMDTO:
+    """Encode one schema-owned action as a canonical one-hot grayscale PNG."""
+
+    index = schema.index_of(action_label)
+    values = np.zeros((1, len(schema.labels)), dtype=np.uint8)
+    values[0, index] = 255
+    png = _png_bytes(Image.fromarray(values, mode="L"))
+    png_digest = _digest(png)
+    target_vpm_id = _digest(
+        schema.action_schema_id.encode("ascii"),
+        TARGET_ENCODER_VERSION.encode("ascii"),
+        action_label.encode("utf-8"),
+        png_digest.encode("ascii"),
+    )
+    return TargetVPMDTO(
+        target_vpm_id=target_vpm_id,
+        action_schema_id=schema.action_schema_id,
+        action_label=action_label,
+        encoder_version=TARGET_ENCODER_VERSION,
+        width=len(schema.labels),
+        height=1,
+        channels=1,
+        png_digest=png_digest,
+        png_bytes=png,
+    )
+
+
+def decode_discrete_action(
+    target: TargetVPMDTO, schema: DiscreteActionSchemaDTO
+) -> str:
+    """Decode and validate a canonical one-hot target VPM."""
+
+    if target.action_schema_id != schema.action_schema_id:
+        raise PerceptionRepresentationError("target action schema identity mismatch")
+    if target.encoder_version != TARGET_ENCODER_VERSION:
+        raise PerceptionRepresentationError("unsupported target encoder version")
+    if target.width != len(schema.labels) or target.height != 1 or target.channels != 1:
+        raise PerceptionRepresentationError("target VPM shape does not match schema")
+    if _digest(target.png_bytes) != target.png_digest:
+        raise PerceptionRepresentationError("target PNG digest mismatch")
+    scores = target.scores()
+    if len(scores) != len(schema.labels):
+        raise PerceptionRepresentationError("target PNG field count does not match schema")
+    active = [index for index, value in enumerate(scores) if value == 255]
+    if len(active) != 1 or any(value not in (0, 255) for value in scores):
+        raise PerceptionRepresentationError("target VPM is not canonical one-hot data")
+    label = schema.labels[active[0]]
+    if label != target.action_label:
+        raise PerceptionRepresentationError("target action metadata disagrees with PNG")
+    return label

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
-from zeromodel.perception import PERCEPTION_PACKAGE_VERSION, PERCEPTION_STAGE
+from zeromodel.perception import (
+    PERCEPTION_PACKAGE_VERSION,
+    PERCEPTION_STAGE,
+    DiscreteActionSchemaDTO,
+    SourceImageEncoderSpecDTO,
+)
 
 
-def test_phase_zero_public_contract() -> None:
+def test_phase_one_public_contract() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P0"
+    assert PERCEPTION_STAGE == "P1"
+    assert SourceImageEncoderSpecDTO().color_space == "RGB"
+    assert DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT"]).labels == (
+        "LEFT",
+        "RIGHT",
+    )

--- a/packages/perception/tests/test_representation.py
+++ b/packages/perception/tests/test_representation.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from io import BytesIO
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from zeromodel.perception import (
+    DiscreteActionSchemaDTO,
+    PerceptionRepresentationError,
+    SourceImageEncoderSpecDTO,
+    decode_discrete_action,
+    encode_discrete_action,
+    encode_source_array,
+    encode_source_image_bytes,
+)
+
+
+def _png_payload(values: np.ndarray, mode: str) -> bytes:
+    buffer = BytesIO()
+    Image.fromarray(values, mode=mode).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_source_array_encoding_is_deterministic_and_round_trips() -> None:
+    values = np.array(
+        [
+            [[0, 1, 2], [3, 4, 5]],
+            [[6, 7, 8], [9, 10, 11]],
+        ],
+        dtype=np.uint8,
+    )
+
+    first = encode_source_array(values)
+    second = encode_source_array(values.copy())
+
+    assert first == second
+    assert first.width == 2
+    assert first.height == 2
+    assert first.channels == 3
+    assert first.color_space == "RGB"
+    np.testing.assert_array_equal(first.to_array(), values)
+
+
+def test_source_byte_and_array_paths_share_canonical_identity() -> None:
+    values = np.array(
+        [
+            [[20, 30, 40], [50, 60, 70]],
+            [[80, 90, 100], [110, 120, 130]],
+        ],
+        dtype=np.uint8,
+    )
+
+    from_array = encode_source_array(values)
+    from_png = encode_source_image_bytes(_png_payload(values, "RGB"))
+
+    assert from_png.source_vpm_id == from_array.source_vpm_id
+    assert from_png.pixel_digest == from_array.pixel_digest
+    assert from_png.png_bytes == from_array.png_bytes
+
+
+def test_source_identity_changes_with_pixels_or_encoder_contract() -> None:
+    values = np.zeros((2, 2, 3), dtype=np.uint8)
+    changed = values.copy()
+    changed[0, 0, 0] = 1
+
+    baseline = encode_source_array(values)
+    pixel_change = encode_source_array(changed)
+    contract_change = encode_source_array(
+        values,
+        SourceImageEncoderSpecDTO(max_pixels=32),
+    )
+
+    assert baseline.source_vpm_id != pixel_change.source_vpm_id
+    assert baseline.pixel_digest != pixel_change.pixel_digest
+    assert baseline.source_vpm_id != contract_change.source_vpm_id
+    assert baseline.pixel_digest == contract_change.pixel_digest
+
+
+def test_source_encoding_rejects_wrong_dtype_shape_and_bounds() -> None:
+    with pytest.raises(PerceptionRepresentationError, match="dtype uint8"):
+        encode_source_array(np.zeros((2, 2, 3), dtype=np.float32))
+
+    with pytest.raises(PerceptionRepresentationError, match="shape"):
+        encode_source_array(np.zeros((2, 2), dtype=np.uint8))
+
+    with pytest.raises(PerceptionRepresentationError, match="exceed"):
+        encode_source_array(
+            np.zeros((3, 3, 3), dtype=np.uint8),
+            SourceImageEncoderSpecDTO(max_width=2),
+        )
+
+    payload = _png_payload(np.zeros((1, 1, 3), dtype=np.uint8), "RGB")
+    with pytest.raises(PerceptionRepresentationError, match="payload size"):
+        encode_source_image_bytes(
+            payload,
+            SourceImageEncoderSpecDTO(max_input_bytes=1),
+        )
+
+
+def test_source_encoding_rejects_invalid_image_bytes() -> None:
+    with pytest.raises(PerceptionRepresentationError, match="supported image"):
+        encode_source_image_bytes(b"not an image")
+
+
+def test_action_schema_is_canonical_and_content_addressed() -> None:
+    first = DiscreteActionSchemaDTO.from_labels(["RIGHT", "FIRE", "LEFT"])
+    second = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT", "FIRE"])
+
+    assert first.labels == ("FIRE", "LEFT", "RIGHT")
+    assert first.action_schema_id == second.action_schema_id
+
+    with pytest.raises(PerceptionRepresentationError, match="unique"):
+        DiscreteActionSchemaDTO(labels=("LEFT", "LEFT"))
+
+    with pytest.raises(PerceptionRepresentationError, match="canonical sorted"):
+        DiscreteActionSchemaDTO(labels=("RIGHT", "LEFT"))
+
+
+def test_discrete_action_encoding_is_deterministic_and_round_trips() -> None:
+    schema = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT", "FIRE"])
+
+    first = encode_discrete_action("RIGHT", schema)
+    second = encode_discrete_action("RIGHT", schema)
+
+    assert first == second
+    assert first.width == 3
+    assert first.height == 1
+    assert first.channels == 1
+    assert first.scores() == (0, 0, 255)
+    assert decode_discrete_action(first, schema) == "RIGHT"
+
+
+def test_action_encoding_rejects_unknown_label() -> None:
+    schema = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
+
+    with pytest.raises(PerceptionRepresentationError, match="not present"):
+        encode_discrete_action("FIRE", schema)
+
+
+def test_action_decoding_rejects_digest_schema_and_metadata_tampering() -> None:
+    schema = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
+    target = encode_discrete_action("LEFT", schema)
+
+    with pytest.raises(PerceptionRepresentationError, match="digest mismatch"):
+        decode_discrete_action(replace(target, png_bytes=target.png_bytes + b"x"), schema)
+
+    other_schema = DiscreteActionSchemaDTO.from_labels(["FIRE", "LEFT", "RIGHT"])
+    with pytest.raises(PerceptionRepresentationError, match="schema identity mismatch"):
+        decode_discrete_action(target, other_schema)
+
+    with pytest.raises(PerceptionRepresentationError, match="metadata disagrees"):
+        decode_discrete_action(replace(target, action_label="RIGHT"), schema)


### PR DESCRIPTION
## Summary

Implements Phase P1 of `zeromodel-perception`: deterministic, content-addressed source-image and discrete-action VPM representations.

## Source representation

- adds `SourceImageEncoderSpecDTO` with explicit colour-space and safety limits;
- accepts bounded image bytes or `uint8` NumPy arrays;
- supports `L`, `RGB`, and `RGBA` normalization;
- preserves encoded pixel orientation and coordinates;
- emits deterministic PNG bytes;
- records separate encoder-spec, normalized-pixel, PNG, and Source VPM identities;
- rejects malformed, oversized, incorrectly typed, or incorrectly shaped inputs.

## Target representation

- adds canonical sorted `DiscreteActionSchemaDTO` vocabularies;
- encodes each discrete action as a one-row grayscale one-hot PNG;
- adds deterministic Target VPM identity and PNG digest;
- decodes only after validating schema identity, encoder version, dimensions, digest, one-hot values, and action metadata;
- rejects unknown actions and malformed or ambiguous target artifacts.

## Public API

Advances `PERCEPTION_STAGE` from `P0` to `P1` and exposes only the tested representation DTOs and functions.

## Tests

Adds focused deterministic tests for:

- array and image-byte equivalence;
- source round trips and content identity;
- identity changes caused by pixel or encoder-contract changes;
- malformed image, dtype, shape, dimension, and byte-limit rejection;
- canonical action-schema identity;
- target-action round trips;
- unknown action and tampering rejection.

## Scope boundary

This PR introduces no learning, nearest-neighbour search, prediction, evidence weighting, semantic annotations, persistence, or Space Invaders-specific behavior.

## Validation note

A local clone-based test run could not be executed from the current tool environment because outbound DNS access to GitHub was unavailable. Repository CI is expected to run the focused package tests. Existing unrelated failing checks from P0 are intentionally outside this PR's scope, as agreed.