### PR TITLE
feat(perception): add Phase P2 immutable dataset ledger

### DIFF
--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -2,6 +2,19 @@
 
 from __future__ import annotations
 
+from .dataset import (
+    DATASET_MANIFEST_VERSION,
+    INTERACTION_VERSION,
+    SPLIT_ASSIGNMENT_VERSION,
+    DatasetFindingDTO,
+    InMemoryPerceptionDatasetStore,
+    PerceptionDatasetError,
+    PerceptionDatasetManifestDTO,
+    PerceptionDatasetStore,
+    RecordedInteractionDTO,
+    SplitAssignmentDTO,
+    build_dataset_manifest,
+)
 from .representation import (
     ACTION_SCHEMA_VERSION,
     SOURCE_ENCODER_VERSION,
@@ -18,19 +31,30 @@ from .representation import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P1"
+PERCEPTION_STAGE = "P2"
 
 __all__ = [
     "ACTION_SCHEMA_VERSION",
+    "DATASET_MANIFEST_VERSION",
+    "INTERACTION_VERSION",
     "PERCEPTION_PACKAGE_VERSION",
     "PERCEPTION_STAGE",
     "SOURCE_ENCODER_VERSION",
+    "SPLIT_ASSIGNMENT_VERSION",
     "TARGET_ENCODER_VERSION",
+    "DatasetFindingDTO",
     "DiscreteActionSchemaDTO",
+    "InMemoryPerceptionDatasetStore",
+    "PerceptionDatasetError",
+    "PerceptionDatasetManifestDTO",
+    "PerceptionDatasetStore",
     "PerceptionRepresentationError",
+    "RecordedInteractionDTO",
     "SourceImageEncoderSpecDTO",
     "SourceVPMDTO",
+    "SplitAssignmentDTO",
     "TargetVPMDTO",
+    "build_dataset_manifest",
     "decode_discrete_action",
     "encode_discrete_action",
     "encode_source_array",

--- a/packages/perception/src/zeromodel/perception/dataset.py
+++ b/packages/perception/src/zeromodel/perception/dataset.py
@@ -1,0 +1,319 @@
+"""Immutable perception dataset ledger for Stage P2.
+
+The dataset layer records authoritative image/action pairings. It does not infer
+alignment from filenames or directory order, and it does not perform learning.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Iterable, Mapping, Protocol, Sequence
+
+from .representation import SourceVPMDTO, TargetVPMDTO
+
+DATASET_MANIFEST_VERSION: Final = "perception-dataset-manifest/1"
+INTERACTION_VERSION: Final = "perception-recorded-interaction/1"
+SPLIT_ASSIGNMENT_VERSION: Final = "perception-split-assignment/1"
+
+_ALLOWED_SPLITS: Final = ("train", "validation", "test")
+
+
+class PerceptionDatasetError(ValueError):
+    """Raised when a dataset cannot be represented without ambiguity."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+@dataclass(frozen=True)
+class RecordedInteractionDTO:
+    """One authoritative source/action pairing with optional next state."""
+
+    interaction_id: str
+    sequence_id: str
+    step_index: int
+    source_vpm_id: str
+    target_vpm_id: str
+    action_schema_id: str
+    action_label: str
+    source_pixel_digest: str
+    next_source_vpm_id: str | None = None
+    observed_at_ns: int | None = None
+    version: str = INTERACTION_VERSION
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("interaction_id", self.interaction_id),
+            ("sequence_id", self.sequence_id),
+            ("source_vpm_id", self.source_vpm_id),
+            ("target_vpm_id", self.target_vpm_id),
+            ("action_schema_id", self.action_schema_id),
+            ("action_label", self.action_label),
+            ("source_pixel_digest", self.source_pixel_digest),
+            ("version", self.version),
+        ):
+            if not value:
+                raise PerceptionDatasetError(f"{name} must be non-empty")
+        if self.step_index < 0:
+            raise PerceptionDatasetError("step_index must be non-negative")
+        if self.observed_at_ns is not None and self.observed_at_ns < 0:
+            raise PerceptionDatasetError("observed_at_ns must be non-negative")
+
+    @classmethod
+    def from_vpms(
+        cls,
+        *,
+        sequence_id: str,
+        step_index: int,
+        source: SourceVPMDTO,
+        target: TargetVPMDTO,
+        next_source: SourceVPMDTO | None = None,
+        observed_at_ns: int | None = None,
+    ) -> "RecordedInteractionDTO":
+        payload: Mapping[str, object] = {
+            "action_label": target.action_label,
+            "action_schema_id": target.action_schema_id,
+            "next_source_vpm_id": None if next_source is None else next_source.source_vpm_id,
+            "observed_at_ns": observed_at_ns,
+            "sequence_id": sequence_id,
+            "source_pixel_digest": source.pixel_digest,
+            "source_vpm_id": source.source_vpm_id,
+            "step_index": step_index,
+            "target_vpm_id": target.target_vpm_id,
+            "version": INTERACTION_VERSION,
+        }
+        return cls(interaction_id=_digest(_canonical_json(payload)), **payload)  # type: ignore[arg-type]
+
+    def canonical_payload(self) -> Mapping[str, object]:
+        return {
+            "action_label": self.action_label,
+            "action_schema_id": self.action_schema_id,
+            "interaction_id": self.interaction_id,
+            "next_source_vpm_id": self.next_source_vpm_id,
+            "observed_at_ns": self.observed_at_ns,
+            "sequence_id": self.sequence_id,
+            "source_pixel_digest": self.source_pixel_digest,
+            "source_vpm_id": self.source_vpm_id,
+            "step_index": self.step_index,
+            "target_vpm_id": self.target_vpm_id,
+            "version": self.version,
+        }
+
+
+@dataclass(frozen=True)
+class SplitAssignmentDTO:
+    interaction_id: str
+    split: str
+    version: str = SPLIT_ASSIGNMENT_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.interaction_id:
+            raise PerceptionDatasetError("interaction_id must be non-empty")
+        if self.split not in _ALLOWED_SPLITS:
+            raise PerceptionDatasetError(
+                f"split must be one of {_ALLOWED_SPLITS}, got {self.split!r}"
+            )
+
+
+@dataclass(frozen=True)
+class DatasetFindingDTO:
+    code: str
+    severity: str
+    interaction_ids: tuple[str, ...]
+    detail: str
+
+
+@dataclass(frozen=True)
+class PerceptionDatasetManifestDTO:
+    dataset_id: str
+    action_schema_id: str
+    source_encoder_spec_ids: tuple[str, ...]
+    interactions: tuple[RecordedInteractionDTO, ...]
+    split_assignments: tuple[SplitAssignmentDTO, ...]
+    findings: tuple[DatasetFindingDTO, ...]
+    version: str = DATASET_MANIFEST_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.dataset_id or not self.action_schema_id:
+            raise PerceptionDatasetError("dataset_id and action_schema_id must be non-empty")
+        ids = tuple(item.interaction_id for item in self.interactions)
+        if ids != tuple(sorted(ids)) or len(set(ids)) != len(ids):
+            raise PerceptionDatasetError(
+                "interactions must be unique and sorted by interaction_id"
+            )
+        assignment_ids = tuple(item.interaction_id for item in self.split_assignments)
+        if assignment_ids != ids:
+            raise PerceptionDatasetError(
+                "split assignments must be ordered one-to-one with interactions"
+            )
+
+    def split_for(self, interaction_id: str) -> str:
+        for assignment in self.split_assignments:
+            if assignment.interaction_id == interaction_id:
+                return assignment.split
+        raise KeyError(interaction_id)
+
+
+class PerceptionDatasetStore(Protocol):
+    def put(self, manifest: PerceptionDatasetManifestDTO) -> None: ...
+
+    def get(self, dataset_id: str) -> PerceptionDatasetManifestDTO: ...
+
+    def list_ids(self) -> tuple[str, ...]: ...
+
+
+class InMemoryPerceptionDatasetStore:
+    """Small DTO-only store used until persistence boundaries are promoted."""
+
+    def __init__(self) -> None:
+        self._manifests: dict[str, PerceptionDatasetManifestDTO] = {}
+
+    def put(self, manifest: PerceptionDatasetManifestDTO) -> None:
+        existing = self._manifests.get(manifest.dataset_id)
+        if existing is not None and existing != manifest:
+            raise PerceptionDatasetError(
+                "dataset identity already exists with different content"
+            )
+        self._manifests[manifest.dataset_id] = manifest
+
+    def get(self, dataset_id: str) -> PerceptionDatasetManifestDTO:
+        try:
+            return self._manifests[dataset_id]
+        except KeyError as exc:
+            raise KeyError(dataset_id) from exc
+
+    def list_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._manifests))
+
+
+def _split_name(interaction_id: str, *, seed: str) -> str:
+    value = int(hashlib.sha256(f"{seed}\0{interaction_id}".encode("utf-8")).hexdigest()[:16], 16)
+    bucket = value % 10_000
+    if bucket < 8_000:
+        return "train"
+    if bucket < 9_000:
+        return "validation"
+    return "test"
+
+
+def _findings(interactions: Sequence[RecordedInteractionDTO]) -> tuple[DatasetFindingDTO, ...]:
+    findings: list[DatasetFindingDTO] = []
+    by_pixel: dict[str, list[RecordedInteractionDTO]] = {}
+    by_sequence: dict[str, list[RecordedInteractionDTO]] = {}
+    for item in interactions:
+        by_pixel.setdefault(item.source_pixel_digest, []).append(item)
+        by_sequence.setdefault(item.sequence_id, []).append(item)
+
+    for pixel_digest, group in sorted(by_pixel.items()):
+        labels = {item.action_label for item in group}
+        if len(labels) > 1:
+            findings.append(
+                DatasetFindingDTO(
+                    code="conflicting_actions_for_identical_source",
+                    severity="error",
+                    interaction_ids=tuple(sorted(item.interaction_id for item in group)),
+                    detail=f"source pixel digest {pixel_digest} maps to actions {sorted(labels)}",
+                )
+            )
+
+    for sequence_id, group in sorted(by_sequence.items()):
+        ordered = sorted(group, key=lambda item: item.step_index)
+        indices = [item.step_index for item in ordered]
+        if len(indices) != len(set(indices)):
+            findings.append(
+                DatasetFindingDTO(
+                    code="duplicate_sequence_step",
+                    severity="error",
+                    interaction_ids=tuple(sorted(item.interaction_id for item in group)),
+                    detail=f"sequence {sequence_id!r} contains duplicate step indices",
+                )
+            )
+        timestamps = [item.observed_at_ns for item in ordered if item.observed_at_ns is not None]
+        if timestamps and timestamps != sorted(timestamps):
+            findings.append(
+                DatasetFindingDTO(
+                    code="non_monotonic_sequence_time",
+                    severity="error",
+                    interaction_ids=tuple(item.interaction_id for item in ordered),
+                    detail=f"sequence {sequence_id!r} timestamps are not monotonic",
+                )
+            )
+    return tuple(findings)
+
+
+def build_dataset_manifest(
+    interactions: Iterable[RecordedInteractionDTO],
+    *,
+    source_encoder_spec_ids: Iterable[str],
+    split_seed: str = "zeromodel-perception/p2",
+    reject_errors: bool = True,
+) -> PerceptionDatasetManifestDTO:
+    """Validate exact pairings and build an immutable content-addressed manifest."""
+
+    ordered = tuple(sorted(interactions, key=lambda item: item.interaction_id))
+    if not ordered:
+        raise PerceptionDatasetError("dataset requires at least one interaction")
+    ids = [item.interaction_id for item in ordered]
+    if len(ids) != len(set(ids)):
+        raise PerceptionDatasetError("duplicate interaction identity")
+    schema_ids = {item.action_schema_id for item in ordered}
+    if len(schema_ids) != 1:
+        raise PerceptionDatasetError("all interactions must use one action schema")
+    encoder_ids = tuple(sorted(set(source_encoder_spec_ids)))
+    if not encoder_ids or any(not value for value in encoder_ids):
+        raise PerceptionDatasetError("source_encoder_spec_ids must be non-empty")
+
+    findings = _findings(ordered)
+    if reject_errors and any(item.severity == "error" for item in findings):
+        codes = sorted({item.code for item in findings if item.severity == "error"})
+        raise PerceptionDatasetError(f"dataset validation failed: {codes}")
+
+    assignments = tuple(
+        SplitAssignmentDTO(item.interaction_id, _split_name(item.interaction_id, seed=split_seed))
+        for item in ordered
+    )
+    payload: Mapping[str, object] = {
+        "action_schema_id": next(iter(schema_ids)),
+        "findings": [
+            {
+                "code": item.code,
+                "detail": item.detail,
+                "interaction_ids": list(item.interaction_ids),
+                "severity": item.severity,
+            }
+            for item in findings
+        ],
+        "interactions": [item.canonical_payload() for item in ordered],
+        "source_encoder_spec_ids": list(encoder_ids),
+        "split_assignments": [
+            {"interaction_id": item.interaction_id, "split": item.split, "version": item.version}
+            for item in assignments
+        ],
+        "split_seed": split_seed,
+        "version": DATASET_MANIFEST_VERSION,
+    }
+    return PerceptionDatasetManifestDTO(
+        dataset_id=_digest(_canonical_json(payload)),
+        action_schema_id=next(iter(schema_ids)),
+        source_encoder_spec_ids=encoder_ids,
+        interactions=ordered,
+        split_assignments=assignments,
+        findings=findings,
+    )

--- a/packages/perception/tests/test_dataset.py
+++ b/packages/perception/tests/test_dataset.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    DiscreteActionSchemaDTO,
+    InMemoryPerceptionDatasetStore,
+    PerceptionDatasetError,
+    RecordedInteractionDTO,
+    SourceImageEncoderSpecDTO,
+    build_dataset_manifest,
+    encode_discrete_action,
+    encode_source_array,
+)
+
+
+def _interaction(
+    value: int,
+    action: str,
+    *,
+    sequence_id: str = "episode-1",
+    step_index: int = 0,
+    observed_at_ns: int | None = None,
+) -> tuple[RecordedInteractionDTO, str]:
+    spec = SourceImageEncoderSpecDTO(color_space="L")
+    source = encode_source_array(np.full((2, 2), value, dtype=np.uint8), spec)
+    schema = DiscreteActionSchemaDTO.from_labels(["FIRE", "LEFT", "RIGHT"])
+    target = encode_discrete_action(action, schema)
+    return (
+        RecordedInteractionDTO.from_vpms(
+            sequence_id=sequence_id,
+            step_index=step_index,
+            observed_at_ns=observed_at_ns,
+            source=source,
+            target=target,
+        ),
+        spec.encoder_spec_id,
+    )
+
+
+def test_interaction_identity_is_content_derived() -> None:
+    first, _ = _interaction(1, "LEFT", step_index=2)
+    second, _ = _interaction(1, "LEFT", step_index=2)
+    changed, _ = _interaction(1, "RIGHT", step_index=2)
+
+    assert first == second
+    assert first.interaction_id != changed.interaction_id
+
+
+def test_manifest_identity_and_splits_are_order_independent() -> None:
+    first, encoder_id = _interaction(1, "LEFT", step_index=0)
+    second, _ = _interaction(2, "RIGHT", step_index=1)
+
+    forward = build_dataset_manifest(
+        [first, second], source_encoder_spec_ids=[encoder_id]
+    )
+    reverse = build_dataset_manifest(
+        [second, first], source_encoder_spec_ids=[encoder_id]
+    )
+
+    assert forward == reverse
+    assert forward.dataset_id == reverse.dataset_id
+    assert {item.split for item in forward.split_assignments} <= {
+        "train",
+        "validation",
+        "test",
+    }
+
+
+def test_identical_pixels_with_conflicting_actions_are_rejected() -> None:
+    left, encoder_id = _interaction(7, "LEFT", step_index=0)
+    right, _ = _interaction(7, "RIGHT", step_index=1)
+
+    with pytest.raises(PerceptionDatasetError, match="conflicting_actions"):
+        build_dataset_manifest([left, right], source_encoder_spec_ids=[encoder_id])
+
+    manifest = build_dataset_manifest(
+        [left, right],
+        source_encoder_spec_ids=[encoder_id],
+        reject_errors=False,
+    )
+    assert manifest.findings[0].code == "conflicting_actions_for_identical_source"
+
+
+def test_duplicate_sequence_steps_are_rejected() -> None:
+    first, encoder_id = _interaction(1, "LEFT", step_index=0)
+    second, _ = _interaction(2, "RIGHT", step_index=0)
+
+    with pytest.raises(PerceptionDatasetError, match="duplicate_sequence_step"):
+        build_dataset_manifest([first, second], source_encoder_spec_ids=[encoder_id])
+
+
+def test_non_monotonic_timestamps_are_rejected() -> None:
+    first, encoder_id = _interaction(
+        1, "LEFT", step_index=0, observed_at_ns=20
+    )
+    second, _ = _interaction(
+        2, "RIGHT", step_index=1, observed_at_ns=10
+    )
+
+    with pytest.raises(PerceptionDatasetError, match="non_monotonic_sequence_time"):
+        build_dataset_manifest([first, second], source_encoder_spec_ids=[encoder_id])
+
+
+def test_manifest_rejects_mixed_action_schemas() -> None:
+    interaction, encoder_id = _interaction(1, "LEFT")
+    changed = replace(interaction, action_schema_id="sha256:other")
+
+    with pytest.raises(PerceptionDatasetError, match="one action schema"):
+        build_dataset_manifest(
+            [interaction, changed], source_encoder_spec_ids=[encoder_id]
+        )
+
+
+def test_in_memory_store_is_idempotent_and_rejects_identity_collision() -> None:
+    interaction, encoder_id = _interaction(1, "LEFT")
+    manifest = build_dataset_manifest(
+        [interaction], source_encoder_spec_ids=[encoder_id]
+    )
+    store = InMemoryPerceptionDatasetStore()
+
+    store.put(manifest)
+    store.put(manifest)
+
+    assert store.get(manifest.dataset_id) == manifest
+    assert store.list_ids() == (manifest.dataset_id,)
+
+    conflicting = replace(manifest, findings=(
+        replace(
+            manifest.findings[0], detail="changed"
+        ),
+    )) if manifest.findings else replace(
+        manifest,
+        source_encoder_spec_ids=("sha256:different",),
+    )
+    with pytest.raises(PerceptionDatasetError, match="different content"):
+        store.put(conflicting)
+
+
+def test_manifest_requires_interactions_and_encoder_identity() -> None:
+    with pytest.raises(PerceptionDatasetError, match="at least one interaction"):
+        build_dataset_manifest([], source_encoder_spec_ids=["sha256:x"])
+
+    interaction, _ = _interaction(1, "LEFT")
+    with pytest.raises(PerceptionDatasetError, match="source_encoder_spec_ids"):
+        build_dataset_manifest([interaction], source_encoder_spec_ids=[])

--- a/packages/perception/tests/test_dataset.py
+++ b/packages/perception/tests/test_dataset.py
@@ -94,12 +94,8 @@ def test_duplicate_sequence_steps_are_rejected() -> None:
 
 
 def test_non_monotonic_timestamps_are_rejected() -> None:
-    first, encoder_id = _interaction(
-        1, "LEFT", step_index=0, observed_at_ns=20
-    )
-    second, _ = _interaction(
-        2, "RIGHT", step_index=1, observed_at_ns=10
-    )
+    first, encoder_id = _interaction(1, "LEFT", step_index=0, observed_at_ns=20)
+    second, _ = _interaction(2, "RIGHT", step_index=1, observed_at_ns=10)
 
     with pytest.raises(PerceptionDatasetError, match="non_monotonic_sequence_time"):
         build_dataset_manifest([first, second], source_encoder_spec_ids=[encoder_id])
@@ -107,7 +103,11 @@ def test_non_monotonic_timestamps_are_rejected() -> None:
 
 def test_manifest_rejects_mixed_action_schemas() -> None:
     interaction, encoder_id = _interaction(1, "LEFT")
-    changed = replace(interaction, action_schema_id="sha256:other")
+    changed = replace(
+        interaction,
+        interaction_id="sha256:changed-interaction",
+        action_schema_id="sha256:other",
+    )
 
     with pytest.raises(PerceptionDatasetError, match="one action schema"):
         build_dataset_manifest(
@@ -128,11 +128,7 @@ def test_in_memory_store_is_idempotent_and_rejects_identity_collision() -> None:
     assert store.get(manifest.dataset_id) == manifest
     assert store.list_ids() == (manifest.dataset_id,)
 
-    conflicting = replace(manifest, findings=(
-        replace(
-            manifest.findings[0], detail="changed"
-        ),
-    )) if manifest.findings else replace(
+    conflicting = replace(
         manifest,
         source_encoder_spec_ids=("sha256:different",),
     )

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -4,15 +4,17 @@ from zeromodel.perception import (
     PERCEPTION_PACKAGE_VERSION,
     PERCEPTION_STAGE,
     DiscreteActionSchemaDTO,
+    InMemoryPerceptionDatasetStore,
     SourceImageEncoderSpecDTO,
 )
 
 
-def test_phase_one_public_contract() -> None:
+def test_phase_two_public_contract() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P1"
+    assert PERCEPTION_STAGE == "P2"
     assert SourceImageEncoderSpecDTO().color_space == "RGB"
     assert DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT"]).labels == (
         "LEFT",
         "RIGHT",
     )
+    assert InMemoryPerceptionDatasetStore().list_ids() == ()


### PR DESCRIPTION
## Summary

Implements Phase P2 of `zeromodel-perception`: immutable, content-addressed image/action dataset manifests with deterministic splits, explicit validation findings, and a DTO-only in-memory Store.

## Dataset model

- adds `RecordedInteractionDTO` for authoritative source/action pairings with optional next-state and timestamp metadata;
- derives interaction identity from sequence, step, source, action, optional next state, and observation time;
- adds `PerceptionDatasetManifestDTO`, `SplitAssignmentDTO`, and `DatasetFindingDTO`;
- derives dataset identity from the complete canonical manifest payload;
- sorts interactions and encoder identities canonically so input order cannot change identity.

## Validation

The manifest builder detects and, by default, rejects:

- duplicate interaction identities;
- mixed action schemas;
- identical normalized pixels paired with conflicting actions;
- duplicate sequence step indices;
- non-monotonic sequence timestamps;
- missing interactions or source-encoder identities.

Validation findings can be retained with `reject_errors=False` for diagnosis without silently repairing the dataset.

## Splits

- assigns `train`, `validation`, or `test` deterministically from interaction identity plus an explicit split seed;
- preserves one ordered assignment for every interaction;
- includes the seed and assignments in dataset identity.

## Store boundary

- adds `PerceptionDatasetStore` as a DTO-only protocol;
- adds `InMemoryPerceptionDatasetStore`;
- allows idempotent writes of identical manifests;
- rejects reuse of a dataset identity with different content.

## Public API

Advances `PERCEPTION_STAGE` from `P1` to `P2` and exports the tested dataset DTOs, Store protocol, in-memory Store, and manifest builder.

## Tests

Adds focused coverage for content-derived interaction identity, order-independent manifest identity, deterministic splits, conflicting actions for identical pixels, duplicate sequence steps, non-monotonic timestamps, mixed schemas, Store idempotency/collisions, and required inputs.

## Scope boundary

This stage performs no learning, nearest-neighbour search, action prediction, evidence weighting, persistence, or domain-specific interpretation. Existing unrelated repository check failures remain outside this PR's scope as agreed.