### PR TITLE
feat(perception): add Phase P3 baseline inference

### DIFF
--- a/packages/perception/README.md
+++ b/packages/perception/README.md
@@ -3,65 +3,88 @@
 `zeromodel-perception` is the domain-neutral learning and inference runtime for
 ZeroModel visual evidence.
 
-The package turns arbitrary image/action observations into inspectable visual
-representations and, in later delivery stages, will use those representations to
-infer likely actions for unseen images while retaining evidence, alternatives,
-confidence, rejection, and provenance.
+## Phase P3 status
 
-## Phase P1 status
+P3 is the first complete prediction slice:
 
-Phase P1 implements the first deterministic representation slice:
+```text
+immutable image/action dataset
+        +
+unknown SourceVPMDTO
+        ↓
+ranked actions
++ confidence
++ nearest supporting observations
++ explicit rejection
+```
+
+The baseline deliberately uses the entire normalized VPM. Field relevance,
+evidence weighting, sparse translation, semantic annotation, and temporal models
+belong to later stages.
+
+## Representation
+
+P1 provides deterministic source-image and target-action artifacts:
 
 ```text
 bounded image bytes or uint8 array -> SourceVPMDTO
 bounded discrete action            -> TargetVPMDTO
 ```
 
-It does not yet learn mappings, search neighbours, infer actions, estimate
-confidence, produce evidence VPMs, or persist datasets.
+`SourceImageEncoderSpecDTO` declares colour space and hard width, height, pixel,
+and input-byte limits. P1 accepts `L`, `RGB`, and `RGBA` uint8 observations and
+performs no implicit crop, resize, augmentation, denoising, EXIF transpose,
+object detection, or learned embedding.
 
-The production dependencies remain deliberately small:
+`DiscreteActionSchemaDTO` owns a canonical sorted action vocabulary. Each action
+is encoded as a deterministic one-row one-hot grayscale PNG.
 
-- `numpy` for deterministic array operations;
-- `pillow` for bounded image decoding and canonical PNG serialization;
-- `zeromodel` for core VPM artifact contracts;
-- `zeromodel-observation` for observation-owned DTO and provider contracts.
+## Dataset ledger
 
-Pillow remains an input/output adapter. Perception internals operate on validated
-NumPy arrays and immutable DTOs rather than passing mutable Pillow objects across
-runtime boundaries.
+P2 records authoritative pairings in `RecordedInteractionDTO` and builds immutable
+`PerceptionDatasetManifestDTO` values. It detects conflicting actions for identical
+pixels, duplicate sequence steps, non-monotonic timestamps, mixed schemas, and
+missing identities. Dataset splits are deterministic from interaction identity and
+an explicit seed.
 
-## Source representation
+## Baseline model
 
-`SourceImageEncoderSpecDTO` declares the accepted colour space and hard limits for
-width, height, decoded pixels, and input bytes. P1 accepts `L`, `RGB`, and `RGBA`
-uint8 observations.
+`fit_baseline_nearest_neighbor` accepts:
 
-The encoder:
+- a P2 dataset manifest;
+- an explicit mapping of `source_vpm_id` to `SourceVPMDTO`;
+- a bounded `BaselineInferenceConfigDTO`;
+- a declared training split.
 
-1. rejects malformed, oversized, or incorrectly shaped inputs;
-2. performs only the declared colour-space conversion;
-3. preserves encoded pixel orientation and coordinates;
-4. emits deterministic PNG bytes;
-5. computes separate identities for the encoder contract, normalized pixels,
-   PNG bytes, and complete Source VPM.
+The fitter validates every source reference, requires one source shape and encoder
+contract, and materializes a self-contained immutable
+`BaselineNearestNeighborModelDTO`.
 
-No crop, resize, augmentation, denoising, histogram correction, EXIF transpose,
-object detection, or learned embedding is performed.
-
-## Target representation
-
-`DiscreteActionSchemaDTO` owns a canonical sorted action vocabulary. Each discrete
-action is represented as a one-row grayscale PNG with one stable field per action:
+The model uses normalized mean absolute pixel distance:
 
 ```text
-0   = inactive field
-255 = selected action field
+0.0 = pixel-identical
+1.0 = maximum possible uint8 difference
 ```
 
-`decode_discrete_action` validates schema identity, encoder version, dimensions,
-PNG digest, canonical one-hot values, and metadata agreement before returning an
-action. It rejects malformed or ambiguous target VPMs rather than guessing.
+The nearest observations vote with inverse-distance weights. Predictions preserve:
+
+- ranked `ActionCandidateDTO` values;
+- `NeighborEvidenceDTO` records with exact interaction identities;
+- winning weight share as confidence;
+- nearest distance;
+- top-two action margin;
+- deterministic prediction identity.
+
+Prediction statuses are:
+
+```text
+accepted
+rejected_out_of_distribution
+rejected_ambiguous
+```
+
+A rejected prediction still retains its candidates and neighbour evidence.
 
 ## Example
 
@@ -69,40 +92,68 @@ action. It rejects malformed or ambiguous target VPMs rather than guessing.
 import numpy as np
 
 from zeromodel.perception import (
+    BaselineInferenceConfigDTO,
     DiscreteActionSchemaDTO,
-    decode_discrete_action,
+    RecordedInteractionDTO,
+    SourceImageEncoderSpecDTO,
+    build_dataset_manifest,
     encode_discrete_action,
     encode_source_array,
+    fit_baseline_nearest_neighbor,
+    predict_baseline_action,
 )
 
-source = encode_source_array(np.zeros((8, 8, 3), dtype=np.uint8))
-schema = DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT", "FIRE"])
-target = encode_discrete_action("RIGHT", schema)
+spec = SourceImageEncoderSpecDTO(color_space="L")
+schema = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
 
-assert source.width == 8
-assert decode_discrete_action(target, schema) == "RIGHT"
+left = encode_source_array(np.zeros((4, 4), dtype=np.uint8), spec)
+right = encode_source_array(np.full((4, 4), 255, dtype=np.uint8), spec)
+
+interactions = [
+    RecordedInteractionDTO.from_vpms(
+        sequence_id="example",
+        step_index=0,
+        source=left,
+        target=encode_discrete_action("LEFT", schema),
+    ),
+    RecordedInteractionDTO.from_vpms(
+        sequence_id="example",
+        step_index=1,
+        source=right,
+        target=encode_discrete_action("RIGHT", schema),
+    ),
+]
+manifest = build_dataset_manifest(
+    interactions,
+    source_encoder_spec_ids=[spec.encoder_spec_id],
+)
+model = fit_baseline_nearest_neighbor(
+    manifest,
+    {left.source_vpm_id: left, right.source_vpm_id: right},
+    training_split="all",
+    config=BaselineInferenceConfigDTO(neighbor_count=2),
+)
+unknown = encode_source_array(np.full((4, 4), 10, dtype=np.uint8), spec)
+prediction = predict_baseline_action(model, unknown)
+
+assert prediction.selected_action == "LEFT"
 ```
 
-## Ownership boundary
+## Dependencies and ownership
 
-`zeromodel-perception` owns or will own:
+The production dependencies remain deliberately small:
 
-- deterministic source-image and target-action visual representations;
-- immutable image/action dataset manifests;
-- similarity and sparse-translation inference for unseen observations;
-- evidence VPMs and prediction evidence;
-- expected-versus-observed evidence conformance;
-- unexplained evidence discovery;
-- temporal observation/action/next-observation learning.
+- `numpy` for deterministic array operations and distance calculation;
+- `pillow` for bounded image decoding and canonical PNG serialization;
+- `zeromodel` for core VPM artifact contracts;
+- `zeromodel-observation` for observation-owned contracts.
 
-It does not own:
+Pillow remains an input/output adapter. Perception internals operate on validated
+NumPy arrays and immutable DTOs.
 
-- the conservative artifact kernel (`zeromodel.core`);
-- closed-world deterministic visual codebook addressing (`zeromodel.vision`);
-- video capture or arcade-domain semantics (`zeromodel.video`);
-- SQLAlchemy persistence (`zeromodel-sqlalchemy`);
-- artifact storage, signatures, or navigation;
-- game-specific concepts such as players, aliens, bullets, or controls.
+The package does not own the conservative core artifact kernel, closed-world
+`zeromodel.vision` addressing, video capture, arcade semantics, SQLAlchemy
+persistence, artifact signatures, or game-specific concepts.
 
 See `docs/architecture/perception-runtime-design.md` for the comprehensive
 architecture and staged delivery plan.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -15,6 +15,21 @@ from .dataset import (
     SplitAssignmentDTO,
     build_dataset_manifest,
 )
+from .inference import (
+    BASELINE_MODEL_VERSION,
+    CONFIDENCE_SEMANTICS,
+    DISTANCE_SEMANTICS,
+    PREDICTION_VERSION,
+    ActionCandidateDTO,
+    BaselineInferenceConfigDTO,
+    BaselineNearestNeighborModelDTO,
+    BaselinePredictionDTO,
+    BaselineTrainingExampleDTO,
+    NeighborEvidenceDTO,
+    PerceptionInferenceError,
+    fit_baseline_nearest_neighbor,
+    predict_baseline_action,
+)
 from .representation import (
     ACTION_SCHEMA_VERSION,
     SOURCE_ENCODER_VERSION,
@@ -31,23 +46,34 @@ from .representation import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P2"
+PERCEPTION_STAGE = "P3"
 
 __all__ = [
     "ACTION_SCHEMA_VERSION",
+    "BASELINE_MODEL_VERSION",
+    "CONFIDENCE_SEMANTICS",
     "DATASET_MANIFEST_VERSION",
+    "DISTANCE_SEMANTICS",
     "INTERACTION_VERSION",
     "PERCEPTION_PACKAGE_VERSION",
     "PERCEPTION_STAGE",
+    "PREDICTION_VERSION",
     "SOURCE_ENCODER_VERSION",
     "SPLIT_ASSIGNMENT_VERSION",
     "TARGET_ENCODER_VERSION",
+    "ActionCandidateDTO",
+    "BaselineInferenceConfigDTO",
+    "BaselineNearestNeighborModelDTO",
+    "BaselinePredictionDTO",
+    "BaselineTrainingExampleDTO",
     "DatasetFindingDTO",
     "DiscreteActionSchemaDTO",
     "InMemoryPerceptionDatasetStore",
+    "NeighborEvidenceDTO",
     "PerceptionDatasetError",
     "PerceptionDatasetManifestDTO",
     "PerceptionDatasetStore",
+    "PerceptionInferenceError",
     "PerceptionRepresentationError",
     "RecordedInteractionDTO",
     "SourceImageEncoderSpecDTO",
@@ -59,4 +85,6 @@ __all__ = [
     "encode_discrete_action",
     "encode_source_array",
     "encode_source_image_bytes",
+    "fit_baseline_nearest_neighbor",
+    "predict_baseline_action",
 ]

--- a/packages/perception/src/zeromodel/perception/inference.py
+++ b/packages/perception/src/zeromodel/perception/inference.py
@@ -1,0 +1,389 @@
+"""Deterministic whole-VPM nearest-neighbour inference for Stage P3.
+
+P3 is the first complete prediction slice. It uses whole-image normalized mean
+absolute distance only. Field weighting, sparse translation, semantic evidence,
+and temporal models belong to later stages.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping, Sequence
+
+import numpy as np
+
+from .dataset import PerceptionDatasetManifestDTO, RecordedInteractionDTO
+from .representation import SourceVPMDTO
+
+BASELINE_MODEL_VERSION: Final = "perception-nearest-neighbour-model/1"
+PREDICTION_VERSION: Final = "perception-nearest-neighbour-prediction/1"
+DISTANCE_SEMANTICS: Final = "normalized_mean_absolute_pixel_distance"
+CONFIDENCE_SEMANTICS: Final = "winning_inverse_distance_weight_share"
+
+
+class PerceptionInferenceError(ValueError):
+    """Raised when a model or prediction request violates the P3 contract."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+@dataclass(frozen=True)
+class BaselineInferenceConfigDTO:
+    """Bounded deterministic inference and rejection contract."""
+
+    neighbor_count: int = 3
+    maximum_distance: float = 0.35
+    minimum_margin: float = 0.05
+    epsilon: float = 1e-12
+
+    def __post_init__(self) -> None:
+        if self.neighbor_count <= 0:
+            raise PerceptionInferenceError("neighbor_count must be positive")
+        if not 0.0 <= self.maximum_distance <= 1.0:
+            raise PerceptionInferenceError("maximum_distance must be in [0, 1]")
+        if not 0.0 <= self.minimum_margin <= 1.0:
+            raise PerceptionInferenceError("minimum_margin must be in [0, 1]")
+        if self.epsilon <= 0.0:
+            raise PerceptionInferenceError("epsilon must be positive")
+
+    def canonical_payload(self) -> Mapping[str, object]:
+        return {
+            "epsilon": self.epsilon,
+            "maximum_distance": self.maximum_distance,
+            "minimum_margin": self.minimum_margin,
+            "neighbor_count": self.neighbor_count,
+        }
+
+
+@dataclass(frozen=True)
+class BaselineTrainingExampleDTO:
+    interaction_id: str
+    source_vpm_id: str
+    source_pixel_digest: str
+    action_label: str
+    width: int
+    height: int
+    channels: int
+    pixels: bytes
+
+    def __post_init__(self) -> None:
+        if not self.interaction_id or not self.source_vpm_id or not self.action_label:
+            raise PerceptionInferenceError("training example identities must be non-empty")
+        expected = self.width * self.height * self.channels
+        if expected <= 0 or len(self.pixels) != expected:
+            raise PerceptionInferenceError("training example pixel payload has invalid size")
+
+
+@dataclass(frozen=True)
+class BaselineNearestNeighborModelDTO:
+    model_id: str
+    dataset_id: str
+    action_schema_id: str
+    source_encoder_spec_id: str
+    width: int
+    height: int
+    channels: int
+    action_labels: tuple[str, ...]
+    examples: tuple[BaselineTrainingExampleDTO, ...]
+    config: BaselineInferenceConfigDTO
+    version: str = BASELINE_MODEL_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.model_id or not self.dataset_id or not self.action_schema_id:
+            raise PerceptionInferenceError("model identities must be non-empty")
+        if not self.examples:
+            raise PerceptionInferenceError("model requires at least one training example")
+        ids = tuple(item.interaction_id for item in self.examples)
+        if ids != tuple(sorted(ids)) or len(ids) != len(set(ids)):
+            raise PerceptionInferenceError("model examples must be unique and sorted")
+        if self.action_labels != tuple(sorted(set(self.action_labels))):
+            raise PerceptionInferenceError("action_labels must be unique and sorted")
+
+
+@dataclass(frozen=True)
+class NeighborEvidenceDTO:
+    interaction_id: str
+    source_vpm_id: str
+    action_label: str
+    distance: float
+    weight: float
+    rank: int
+
+
+@dataclass(frozen=True)
+class ActionCandidateDTO:
+    action_label: str
+    score: float
+    support_count: int
+    nearest_distance: float
+
+
+@dataclass(frozen=True)
+class BaselinePredictionDTO:
+    prediction_id: str
+    model_id: str
+    source_vpm_id: str
+    selected_action: str | None
+    status: str
+    confidence: float
+    confidence_semantics: str
+    distance_semantics: str
+    nearest_distance: float
+    margin: float
+    candidates: tuple[ActionCandidateDTO, ...]
+    neighbors: tuple[NeighborEvidenceDTO, ...]
+    version: str = PREDICTION_VERSION
+
+
+_ALLOWED_STATUSES: Final = {
+    "accepted",
+    "rejected_out_of_distribution",
+    "rejected_ambiguous",
+}
+
+
+def _source_pixels(source: SourceVPMDTO) -> bytes:
+    array = source.to_array()
+    return np.ascontiguousarray(array, dtype=np.uint8).reshape(-1).tobytes()
+
+
+def _interaction_by_id(
+    manifest: PerceptionDatasetManifestDTO,
+) -> dict[str, RecordedInteractionDTO]:
+    return {item.interaction_id: item for item in manifest.interactions}
+
+
+def fit_baseline_nearest_neighbor(
+    manifest: PerceptionDatasetManifestDTO,
+    source_vpms: Mapping[str, SourceVPMDTO],
+    *,
+    config: BaselineInferenceConfigDTO | None = None,
+    training_split: str = "train",
+) -> BaselineNearestNeighborModelDTO:
+    """Materialize an immutable whole-image nearest-neighbour model."""
+
+    resolved = config or BaselineInferenceConfigDTO()
+    if training_split not in {"train", "validation", "test", "all"}:
+        raise PerceptionInferenceError("training_split must be train, validation, test, or all")
+
+    interactions = _interaction_by_id(manifest)
+    selected_ids = tuple(
+        assignment.interaction_id
+        for assignment in manifest.split_assignments
+        if training_split == "all" or assignment.split == training_split
+    )
+    if not selected_ids:
+        raise PerceptionInferenceError(f"dataset contains no {training_split!r} examples")
+
+    examples: list[BaselineTrainingExampleDTO] = []
+    shape: tuple[int, int, int] | None = None
+    encoder_spec_id: str | None = None
+    for interaction_id in sorted(selected_ids):
+        interaction = interactions[interaction_id]
+        try:
+            source = source_vpms[interaction.source_vpm_id]
+        except KeyError as exc:
+            raise PerceptionInferenceError(
+                f"missing SourceVPMDTO for {interaction.source_vpm_id}"
+            ) from exc
+        if source.pixel_digest != interaction.source_pixel_digest:
+            raise PerceptionInferenceError("source pixel identity disagrees with interaction")
+        current_shape = (source.width, source.height, source.channels)
+        if shape is None:
+            shape = current_shape
+            encoder_spec_id = source.encoder_spec_id
+        elif current_shape != shape:
+            raise PerceptionInferenceError("baseline model requires one source VPM shape")
+        elif source.encoder_spec_id != encoder_spec_id:
+            raise PerceptionInferenceError("baseline model requires one source encoder spec")
+        examples.append(
+            BaselineTrainingExampleDTO(
+                interaction_id=interaction.interaction_id,
+                source_vpm_id=source.source_vpm_id,
+                source_pixel_digest=source.pixel_digest,
+                action_label=interaction.action_label,
+                width=source.width,
+                height=source.height,
+                channels=source.channels,
+                pixels=_source_pixels(source),
+            )
+        )
+
+    assert shape is not None and encoder_spec_id is not None
+    ordered_examples = tuple(sorted(examples, key=lambda item: item.interaction_id))
+    labels = tuple(sorted({item.action_label for item in ordered_examples}))
+    payload: Mapping[str, object] = {
+        "action_labels": list(labels),
+        "action_schema_id": manifest.action_schema_id,
+        "config": resolved.canonical_payload(),
+        "dataset_id": manifest.dataset_id,
+        "examples": [
+            {
+                "action_label": item.action_label,
+                "interaction_id": item.interaction_id,
+                "source_pixel_digest": item.source_pixel_digest,
+                "source_vpm_id": item.source_vpm_id,
+            }
+            for item in ordered_examples
+        ],
+        "shape": list(shape),
+        "source_encoder_spec_id": encoder_spec_id,
+        "training_split": training_split,
+        "version": BASELINE_MODEL_VERSION,
+    }
+    return BaselineNearestNeighborModelDTO(
+        model_id=_digest(_canonical_json(payload)),
+        dataset_id=manifest.dataset_id,
+        action_schema_id=manifest.action_schema_id,
+        source_encoder_spec_id=encoder_spec_id,
+        width=shape[0],
+        height=shape[1],
+        channels=shape[2],
+        action_labels=labels,
+        examples=ordered_examples,
+        config=resolved,
+    )
+
+
+def _distance(left: bytes, right: bytes) -> float:
+    left_values = np.frombuffer(left, dtype=np.uint8).astype(np.int16)
+    right_values = np.frombuffer(right, dtype=np.uint8).astype(np.int16)
+    return float(np.mean(np.abs(left_values - right_values)) / 255.0)
+
+
+def predict_baseline_action(
+    model: BaselineNearestNeighborModelDTO,
+    source: SourceVPMDTO,
+) -> BaselinePredictionDTO:
+    """Rank actions for one unknown source VPM with explicit rejection."""
+
+    if source.encoder_spec_id != model.source_encoder_spec_id:
+        raise PerceptionInferenceError("source encoder spec does not match model")
+    if (source.width, source.height, source.channels) != (
+        model.width,
+        model.height,
+        model.channels,
+    ):
+        raise PerceptionInferenceError("source shape does not match model")
+
+    unknown = _source_pixels(source)
+    ranked = sorted(
+        (
+            (_distance(unknown, item.pixels), item.interaction_id, item)
+            for item in model.examples
+        ),
+        key=lambda value: (value[0], value[1]),
+    )[: min(model.config.neighbor_count, len(model.examples))]
+
+    raw_weights: dict[str, float] = {label: 0.0 for label in model.action_labels}
+    support_counts: dict[str, int] = {label: 0 for label in model.action_labels}
+    nearest_by_action: dict[str, float] = {label: 1.0 for label in model.action_labels}
+    neighbors: list[NeighborEvidenceDTO] = []
+    for rank, (distance, _, item) in enumerate(ranked, start=1):
+        weight = 1.0 / (model.config.epsilon + distance)
+        raw_weights[item.action_label] += weight
+        support_counts[item.action_label] += 1
+        nearest_by_action[item.action_label] = min(
+            nearest_by_action[item.action_label], distance
+        )
+        neighbors.append(
+            NeighborEvidenceDTO(
+                interaction_id=item.interaction_id,
+                source_vpm_id=item.source_vpm_id,
+                action_label=item.action_label,
+                distance=distance,
+                weight=weight,
+                rank=rank,
+            )
+        )
+
+    total_weight = sum(raw_weights.values())
+    candidates = tuple(
+        sorted(
+            (
+                ActionCandidateDTO(
+                    action_label=label,
+                    score=raw_weights[label] / total_weight,
+                    support_count=support_counts[label],
+                    nearest_distance=nearest_by_action[label],
+                )
+                for label in model.action_labels
+            ),
+            key=lambda item: (-item.score, item.action_label),
+        )
+    )
+    best = candidates[0]
+    second_score = candidates[1].score if len(candidates) > 1 else 0.0
+    margin = best.score - second_score
+    nearest_distance = neighbors[0].distance
+
+    if nearest_distance > model.config.maximum_distance:
+        status = "rejected_out_of_distribution"
+        selected_action = None
+    elif margin < model.config.minimum_margin:
+        status = "rejected_ambiguous"
+        selected_action = None
+    else:
+        status = "accepted"
+        selected_action = best.action_label
+    assert status in _ALLOWED_STATUSES
+
+    payload: Mapping[str, object] = {
+        "candidates": [
+            {
+                "action_label": item.action_label,
+                "nearest_distance": item.nearest_distance,
+                "score": item.score,
+                "support_count": item.support_count,
+            }
+            for item in candidates
+        ],
+        "model_id": model.model_id,
+        "neighbors": [
+            {
+                "action_label": item.action_label,
+                "distance": item.distance,
+                "interaction_id": item.interaction_id,
+                "rank": item.rank,
+                "source_vpm_id": item.source_vpm_id,
+                "weight": item.weight,
+            }
+            for item in neighbors
+        ],
+        "selected_action": selected_action,
+        "source_vpm_id": source.source_vpm_id,
+        "status": status,
+        "version": PREDICTION_VERSION,
+    }
+    return BaselinePredictionDTO(
+        prediction_id=_digest(_canonical_json(payload)),
+        model_id=model.model_id,
+        source_vpm_id=source.source_vpm_id,
+        selected_action=selected_action,
+        status=status,
+        confidence=best.score,
+        confidence_semantics=CONFIDENCE_SEMANTICS,
+        distance_semantics=DISTANCE_SEMANTICS,
+        nearest_distance=nearest_distance,
+        margin=margin,
+        candidates=candidates,
+        neighbors=tuple(neighbors),
+    )

--- a/packages/perception/tests/test_baseline_inference.py
+++ b/packages/perception/tests/test_baseline_inference.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    BaselineInferenceConfigDTO,
+    DiscreteActionSchemaDTO,
+    PerceptionInferenceError,
+    RecordedInteractionDTO,
+    SourceImageEncoderSpecDTO,
+    build_dataset_manifest,
+    encode_discrete_action,
+    encode_source_array,
+    fit_baseline_nearest_neighbor,
+    predict_baseline_action,
+)
+
+
+def _dataset(values_and_actions: list[tuple[int, str]]):
+    spec = SourceImageEncoderSpecDTO(color_space="L")
+    schema = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
+    sources = {}
+    interactions = []
+    for index, (value, action) in enumerate(values_and_actions):
+        source = encode_source_array(
+            np.full((2, 2), value, dtype=np.uint8), spec
+        )
+        target = encode_discrete_action(action, schema)
+        sources[source.source_vpm_id] = source
+        interactions.append(
+            RecordedInteractionDTO.from_vpms(
+                sequence_id="episode",
+                step_index=index,
+                source=source,
+                target=target,
+            )
+        )
+    manifest = build_dataset_manifest(
+        interactions,
+        source_encoder_spec_ids=[spec.encoder_spec_id],
+    )
+    return manifest, sources, spec
+
+
+def test_model_identity_is_deterministic() -> None:
+    manifest, sources, _ = _dataset([(10, "LEFT"), (240, "RIGHT")])
+
+    first = fit_baseline_nearest_neighbor(manifest, sources, training_split="all")
+    second = fit_baseline_nearest_neighbor(manifest, dict(reversed(list(sources.items()))), training_split="all")
+
+    assert first == second
+    assert first.model_id == second.model_id
+    assert tuple(item.interaction_id for item in first.examples) == tuple(
+        sorted(item.interaction_id for item in first.examples)
+    )
+
+
+def test_prediction_selects_nearest_action_and_retains_evidence() -> None:
+    manifest, sources, spec = _dataset(
+        [(10, "LEFT"), (20, "LEFT"), (230, "RIGHT"), (240, "RIGHT")]
+    )
+    model = fit_baseline_nearest_neighbor(
+        manifest,
+        sources,
+        training_split="all",
+        config=BaselineInferenceConfigDTO(
+            neighbor_count=3,
+            maximum_distance=0.5,
+            minimum_margin=0.05,
+        ),
+    )
+    unknown = encode_source_array(np.full((2, 2), 15, dtype=np.uint8), spec)
+
+    prediction = predict_baseline_action(model, unknown)
+
+    assert prediction.status == "accepted"
+    assert prediction.selected_action == "LEFT"
+    assert prediction.candidates[0].action_label == "LEFT"
+    assert prediction.confidence > 0.5
+    assert len(prediction.neighbors) == 3
+    assert tuple(item.rank for item in prediction.neighbors) == (1, 2, 3)
+    assert prediction.neighbors[0].distance <= prediction.neighbors[1].distance
+
+
+def test_prediction_identity_is_deterministic() -> None:
+    manifest, sources, spec = _dataset([(0, "LEFT"), (255, "RIGHT")])
+    model = fit_baseline_nearest_neighbor(manifest, sources, training_split="all")
+    unknown = encode_source_array(np.full((2, 2), 5, dtype=np.uint8), spec)
+
+    first = predict_baseline_action(model, unknown)
+    second = predict_baseline_action(model, unknown)
+
+    assert first == second
+    assert first.prediction_id == second.prediction_id
+
+
+def test_far_unknown_is_rejected_out_of_distribution() -> None:
+    manifest, sources, spec = _dataset([(0, "LEFT"), (10, "LEFT")])
+    model = fit_baseline_nearest_neighbor(
+        manifest,
+        sources,
+        training_split="all",
+        config=BaselineInferenceConfigDTO(
+            neighbor_count=2,
+            maximum_distance=0.1,
+            minimum_margin=0.0,
+        ),
+    )
+    unknown = encode_source_array(np.full((2, 2), 255, dtype=np.uint8), spec)
+
+    prediction = predict_baseline_action(model, unknown)
+
+    assert prediction.status == "rejected_out_of_distribution"
+    assert prediction.selected_action is None
+    assert prediction.nearest_distance > 0.1
+
+
+def test_symmetric_unknown_is_rejected_as_ambiguous() -> None:
+    manifest, sources, spec = _dataset([(0, "LEFT"), (255, "RIGHT")])
+    model = fit_baseline_nearest_neighbor(
+        manifest,
+        sources,
+        training_split="all",
+        config=BaselineInferenceConfigDTO(
+            neighbor_count=2,
+            maximum_distance=1.0,
+            minimum_margin=0.01,
+        ),
+    )
+    unknown = encode_source_array(np.full((2, 2), 127, dtype=np.uint8), spec)
+
+    prediction = predict_baseline_action(model, unknown)
+
+    assert prediction.status == "rejected_ambiguous"
+    assert prediction.selected_action is None
+    assert prediction.margin < 0.01
+
+
+def test_fit_rejects_missing_source_and_identity_mismatch() -> None:
+    manifest, sources, _ = _dataset([(10, "LEFT")])
+
+    with pytest.raises(PerceptionInferenceError, match="missing SourceVPMDTO"):
+        fit_baseline_nearest_neighbor(manifest, {}, training_split="all")
+
+    source_id, source = next(iter(sources.items()))
+    changed = replace(source, pixel_digest="sha256:wrong")
+    with pytest.raises(PerceptionInferenceError, match="pixel identity"):
+        fit_baseline_nearest_neighbor(
+            manifest,
+            {source_id: changed},
+            training_split="all",
+        )
+
+
+def test_fit_and_predict_reject_incompatible_shapes_or_specs() -> None:
+    manifest, sources, spec = _dataset([(10, "LEFT")])
+    model = fit_baseline_nearest_neighbor(manifest, sources, training_split="all")
+
+    wrong_shape = encode_source_array(np.zeros((3, 3), dtype=np.uint8), spec)
+    with pytest.raises(PerceptionInferenceError, match="shape"):
+        predict_baseline_action(model, wrong_shape)
+
+    other_spec = SourceImageEncoderSpecDTO(color_space="L", max_width=100)
+    wrong_spec = encode_source_array(np.zeros((2, 2), dtype=np.uint8), other_spec)
+    with pytest.raises(PerceptionInferenceError, match="encoder spec"):
+        predict_baseline_action(model, wrong_spec)
+
+
+def test_config_rejects_invalid_thresholds() -> None:
+    with pytest.raises(PerceptionInferenceError, match="neighbor_count"):
+        BaselineInferenceConfigDTO(neighbor_count=0)
+    with pytest.raises(PerceptionInferenceError, match="maximum_distance"):
+        BaselineInferenceConfigDTO(maximum_distance=1.1)
+    with pytest.raises(PerceptionInferenceError, match="minimum_margin"):
+        BaselineInferenceConfigDTO(minimum_margin=-0.1)

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -3,18 +3,20 @@ from __future__ import annotations
 from zeromodel.perception import (
     PERCEPTION_PACKAGE_VERSION,
     PERCEPTION_STAGE,
+    BaselineInferenceConfigDTO,
     DiscreteActionSchemaDTO,
     InMemoryPerceptionDatasetStore,
     SourceImageEncoderSpecDTO,
 )
 
 
-def test_phase_two_public_contract() -> None:
+def test_phase_three_public_contract() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P2"
+    assert PERCEPTION_STAGE == "P3"
     assert SourceImageEncoderSpecDTO().color_space == "RGB"
     assert DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT"]).labels == (
         "LEFT",
         "RIGHT",
     )
     assert InMemoryPerceptionDatasetStore().list_ids() == ()
+    assert BaselineInferenceConfigDTO().neighbor_count == 3


### PR DESCRIPTION
## Summary

Implements Phase P3 of `zeromodel-perception`: deterministic whole-VPM nearest-neighbour action inference with ranked candidates, confidence, supporting observations, and explicit rejection.

## Model fitting

- adds `BaselineInferenceConfigDTO` with bounded neighbour count, maximum-distance rejection, minimum-margin rejection, and numerical epsilon;
- fits from a P2 `PerceptionDatasetManifestDTO` plus an explicit `source_vpm_id -> SourceVPMDTO` mapping;
- validates every source reference and pixel identity;
- requires one source encoder contract and one source shape;
- supports an explicit `train`, `validation`, `test`, or `all` fitting split;
- materializes a self-contained immutable `BaselineNearestNeighborModelDTO`;
- derives model identity from the dataset, fitting split, source contract, examples, and inference configuration.

## Prediction

- computes normalized mean absolute whole-pixel distance in `[0, 1]`;
- deterministically orders neighbours by distance and interaction identity;
- aggregates inverse-distance action weights;
- returns ranked `ActionCandidateDTO` values;
- retains exact `NeighborEvidenceDTO` records with distance, weight, action, source, and interaction identity;
- exposes winning weight share as confidence and the top-two score margin;
- derives deterministic prediction identity.

## Rejection

Predictions have one of three explicit statuses:

- `accepted`;
- `rejected_out_of_distribution` when nearest distance exceeds the configured bound;
- `rejected_ambiguous` when the top-two action margin is too small.

Rejected predictions still preserve candidates and neighbour evidence.

## Public API

Advances `PERCEPTION_STAGE` from `P2` to `P3` and exports the tested model, prediction, configuration, candidate, evidence, fitting, and prediction contracts.

## Tests

Adds focused coverage for deterministic model and prediction identity, nearest-action selection, ranked neighbour evidence, out-of-distribution rejection, ambiguity rejection, missing source artifacts, pixel-identity mismatch, incompatible shape/spec rejection, and invalid inference configuration.

## Scope boundary

This is intentionally a whole-image baseline. It introduces no field weighting, evidence VPM, sparse translator, semantic annotation, temporal inference, persistence, or domain-specific behavior.

## Validation note

A clone-based local test run could not execute because the current environment cannot resolve `github.com`. Repository CI should execute the focused package suite. Previously acknowledged unrelated check failures remain outside this PR's scope.