### PR TITLE
feat(perception): add Stage P4A deterministic field partitioning

### DIFF
--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -15,6 +15,19 @@ from .dataset import (
     SplitAssignmentDTO,
     build_dataset_manifest,
 )
+from .fields import (
+    FIELD_SAMPLE_VERSION,
+    FIELD_SCHEMA_VERSION,
+    ExtractedFieldDTO,
+    PerceptionFieldError,
+    VPMFieldAddressDTO,
+    VPMFieldSchemaDTO,
+    build_grid_field_schema,
+    extract_source_fields,
+    mask_source_fields,
+    reconstruct_source_array,
+    validate_source_for_schema,
+)
 from .inference import (
     BASELINE_MODEL_VERSION,
     CONFIDENCE_SEMANTICS,
@@ -46,7 +59,7 @@ from .representation import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P3"
+PERCEPTION_STAGE = "P4A"
 
 __all__ = [
     "ACTION_SCHEMA_VERSION",
@@ -54,6 +67,8 @@ __all__ = [
     "CONFIDENCE_SEMANTICS",
     "DATASET_MANIFEST_VERSION",
     "DISTANCE_SEMANTICS",
+    "FIELD_SAMPLE_VERSION",
+    "FIELD_SCHEMA_VERSION",
     "INTERACTION_VERSION",
     "PERCEPTION_PACKAGE_VERSION",
     "PERCEPTION_STAGE",
@@ -68,11 +83,13 @@ __all__ = [
     "BaselineTrainingExampleDTO",
     "DatasetFindingDTO",
     "DiscreteActionSchemaDTO",
+    "ExtractedFieldDTO",
     "InMemoryPerceptionDatasetStore",
     "NeighborEvidenceDTO",
     "PerceptionDatasetError",
     "PerceptionDatasetManifestDTO",
     "PerceptionDatasetStore",
+    "PerceptionFieldError",
     "PerceptionInferenceError",
     "PerceptionRepresentationError",
     "RecordedInteractionDTO",
@@ -80,11 +97,18 @@ __all__ = [
     "SourceVPMDTO",
     "SplitAssignmentDTO",
     "TargetVPMDTO",
+    "VPMFieldAddressDTO",
+    "VPMFieldSchemaDTO",
     "build_dataset_manifest",
+    "build_grid_field_schema",
     "decode_discrete_action",
     "encode_discrete_action",
     "encode_source_array",
     "encode_source_image_bytes",
+    "extract_source_fields",
     "fit_baseline_nearest_neighbor",
+    "mask_source_fields",
     "predict_baseline_action",
+    "reconstruct_source_array",
+    "validate_source_for_schema",
 ]

--- a/packages/perception/src/zeromodel/perception/fields.py
+++ b/packages/perception/src/zeromodel/perception/fields.py
@@ -1,0 +1,380 @@
+"""Deterministic addressable VPM field schemas for Stage P4A.
+
+P4A establishes exact spatial fields only. It does not estimate relevance, assign
+importance, create Evidence VPMs, or claim causal meaning.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Iterable, Mapping
+
+import numpy as np
+
+from .representation import SourceVPMDTO
+
+FIELD_SCHEMA_VERSION: Final = "perception-field-schema/1"
+FIELD_SAMPLE_VERSION: Final = "perception-field-sample/1"
+_ALLOWED_CHANNEL_MODES: Final = {"joint", "separate"}
+_ALLOWED_MASK_MODES: Final = {"keep", "remove"}
+
+
+class PerceptionFieldError(ValueError):
+    """Raised when a VPM field contract is invalid or incompatible."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+@dataclass(frozen=True)
+class VPMFieldAddressDTO:
+    """One half-open rectangular field in a declared channel range."""
+
+    field_id: str
+    field_schema_id: str
+    channel_start: int
+    channel_end: int
+    x0: int
+    y0: int
+    x1: int
+    y1: int
+    level: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.field_id or not self.field_schema_id:
+            raise PerceptionFieldError("field identities must be non-empty")
+        if self.channel_start < 0 or self.channel_end <= self.channel_start:
+            raise PerceptionFieldError("field channel range must be positive")
+        if self.x0 < 0 or self.y0 < 0 or self.x1 <= self.x0 or self.y1 <= self.y0:
+            raise PerceptionFieldError("field spatial bounds must be positive")
+        if self.level < 0:
+            raise PerceptionFieldError("field level must be non-negative")
+
+    @property
+    def width(self) -> int:
+        return self.x1 - self.x0
+
+    @property
+    def height(self) -> int:
+        return self.y1 - self.y0
+
+    @property
+    def channels(self) -> int:
+        return self.channel_end - self.channel_start
+
+
+@dataclass(frozen=True)
+class VPMFieldSchemaDTO:
+    """Reusable deterministic partition contract for one source shape/spec."""
+
+    field_schema_id: str
+    source_encoder_spec_id: str
+    width: int
+    height: int
+    channels: int
+    tile_width: int
+    tile_height: int
+    channel_mode: str
+    fields: tuple[VPMFieldAddressDTO, ...]
+    version: str = FIELD_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.field_schema_id or not self.source_encoder_spec_id:
+            raise PerceptionFieldError("schema identities must be non-empty")
+        if min(self.width, self.height, self.channels, self.tile_width, self.tile_height) <= 0:
+            raise PerceptionFieldError("schema dimensions must be positive")
+        if self.channel_mode not in _ALLOWED_CHANNEL_MODES:
+            raise PerceptionFieldError(
+                f"channel_mode must be one of {sorted(_ALLOWED_CHANNEL_MODES)}"
+            )
+        if not self.fields:
+            raise PerceptionFieldError("field schema requires at least one field")
+        ids = tuple(field.field_id for field in self.fields)
+        if ids != tuple(sorted(ids)) or len(ids) != len(set(ids)):
+            raise PerceptionFieldError("fields must be unique and sorted by field_id")
+        if any(field.field_schema_id != self.field_schema_id for field in self.fields):
+            raise PerceptionFieldError("every field must reference its owning schema")
+        self._validate_exact_partition()
+
+    def _validate_exact_partition(self) -> None:
+        coverage = np.zeros((self.height, self.width, self.channels), dtype=np.uint8)
+        for field in self.fields:
+            if field.x1 > self.width or field.y1 > self.height:
+                raise PerceptionFieldError("field exceeds schema spatial bounds")
+            if field.channel_end > self.channels:
+                raise PerceptionFieldError("field exceeds schema channel bounds")
+            coverage[
+                field.y0 : field.y1,
+                field.x0 : field.x1,
+                field.channel_start : field.channel_end,
+            ] += 1
+        if not np.all(coverage == 1):
+            raise PerceptionFieldError("fields must cover every source value exactly once")
+
+    def field(self, field_id: str) -> VPMFieldAddressDTO:
+        for item in self.fields:
+            if item.field_id == field_id:
+                return item
+        raise KeyError(field_id)
+
+
+@dataclass(frozen=True)
+class ExtractedFieldDTO:
+    """Exact immutable values extracted from one Source VPM field."""
+
+    sample_id: str
+    source_vpm_id: str
+    field_schema_id: str
+    field_id: str
+    shape: tuple[int, int, int]
+    dtype: str
+    values_digest: str
+    values: bytes
+    version: str = FIELD_SAMPLE_VERSION
+
+    def __post_init__(self) -> None:
+        if not all((self.sample_id, self.source_vpm_id, self.field_schema_id, self.field_id)):
+            raise PerceptionFieldError("sample identities must be non-empty")
+        if self.dtype != "uint8":
+            raise PerceptionFieldError("P4A samples must use uint8")
+        expected = self.shape[0] * self.shape[1] * self.shape[2]
+        if expected <= 0 or len(self.values) != expected:
+            raise PerceptionFieldError("sample byte length does not match shape")
+
+    def to_array(self) -> np.ndarray:
+        return np.frombuffer(self.values, dtype=np.uint8).reshape(self.shape).copy()
+
+
+def _schema_payload(
+    source: SourceVPMDTO,
+    *,
+    tile_width: int,
+    tile_height: int,
+    channel_mode: str,
+) -> Mapping[str, object]:
+    return {
+        "channel_mode": channel_mode,
+        "channels": source.channels,
+        "height": source.height,
+        "source_encoder_spec_id": source.encoder_spec_id,
+        "tile_height": tile_height,
+        "tile_width": tile_width,
+        "version": FIELD_SCHEMA_VERSION,
+        "width": source.width,
+    }
+
+
+def build_grid_field_schema(
+    source: SourceVPMDTO,
+    *,
+    tile_width: int,
+    tile_height: int,
+    channel_mode: str = "joint",
+) -> VPMFieldSchemaDTO:
+    """Partition a source shape into deterministic edge-aware rectangular fields."""
+
+    if tile_width <= 0 or tile_height <= 0:
+        raise PerceptionFieldError("tile dimensions must be positive")
+    if channel_mode not in _ALLOWED_CHANNEL_MODES:
+        raise PerceptionFieldError(
+            f"channel_mode must be one of {sorted(_ALLOWED_CHANNEL_MODES)}"
+        )
+    payload = _schema_payload(
+        source,
+        tile_width=tile_width,
+        tile_height=tile_height,
+        channel_mode=channel_mode,
+    )
+    schema_id = _digest(_canonical_json(payload))
+    channels = (
+        ((0, source.channels),)
+        if channel_mode == "joint"
+        else tuple((channel, channel + 1) for channel in range(source.channels))
+    )
+    fields: list[VPMFieldAddressDTO] = []
+    for y0 in range(0, source.height, tile_height):
+        for x0 in range(0, source.width, tile_width):
+            y1 = min(y0 + tile_height, source.height)
+            x1 = min(x0 + tile_width, source.width)
+            for channel_start, channel_end in channels:
+                address_payload: Mapping[str, object] = {
+                    "channel_end": channel_end,
+                    "channel_start": channel_start,
+                    "field_schema_id": schema_id,
+                    "level": 0,
+                    "x0": x0,
+                    "x1": x1,
+                    "y0": y0,
+                    "y1": y1,
+                }
+                fields.append(
+                    VPMFieldAddressDTO(
+                        field_id=_digest(_canonical_json(address_payload)),
+                        field_schema_id=schema_id,
+                        channel_start=channel_start,
+                        channel_end=channel_end,
+                        x0=x0,
+                        y0=y0,
+                        x1=x1,
+                        y1=y1,
+                    )
+                )
+    return VPMFieldSchemaDTO(
+        field_schema_id=schema_id,
+        source_encoder_spec_id=source.encoder_spec_id,
+        width=source.width,
+        height=source.height,
+        channels=source.channels,
+        tile_width=tile_width,
+        tile_height=tile_height,
+        channel_mode=channel_mode,
+        fields=tuple(sorted(fields, key=lambda field: field.field_id)),
+    )
+
+
+def _canonical_source_array(source: SourceVPMDTO) -> np.ndarray:
+    array = source.to_array()
+    if source.channels == 1:
+        return array.reshape(source.height, source.width, 1)
+    return array.reshape(source.height, source.width, source.channels)
+
+
+def validate_source_for_schema(source: SourceVPMDTO, schema: VPMFieldSchemaDTO) -> None:
+    if source.encoder_spec_id != schema.source_encoder_spec_id:
+        raise PerceptionFieldError("source encoder spec does not match field schema")
+    if (source.width, source.height, source.channels) != (
+        schema.width,
+        schema.height,
+        schema.channels,
+    ):
+        raise PerceptionFieldError("source shape does not match field schema")
+
+
+def extract_source_fields(
+    source: SourceVPMDTO, schema: VPMFieldSchemaDTO
+) -> tuple[ExtractedFieldDTO, ...]:
+    """Extract every schema field without pooling, quantization, or information loss."""
+
+    validate_source_for_schema(source, schema)
+    array = _canonical_source_array(source)
+    samples: list[ExtractedFieldDTO] = []
+    for field in schema.fields:
+        values_array = np.ascontiguousarray(
+            array[
+                field.y0 : field.y1,
+                field.x0 : field.x1,
+                field.channel_start : field.channel_end,
+            ],
+            dtype=np.uint8,
+        )
+        values = values_array.tobytes()
+        values_digest = _digest(values)
+        sample_payload: Mapping[str, object] = {
+            "field_id": field.field_id,
+            "field_schema_id": schema.field_schema_id,
+            "shape": list(values_array.shape),
+            "source_vpm_id": source.source_vpm_id,
+            "values_digest": values_digest,
+            "version": FIELD_SAMPLE_VERSION,
+        }
+        samples.append(
+            ExtractedFieldDTO(
+                sample_id=_digest(_canonical_json(sample_payload)),
+                source_vpm_id=source.source_vpm_id,
+                field_schema_id=schema.field_schema_id,
+                field_id=field.field_id,
+                shape=tuple(int(value) for value in values_array.shape),
+                dtype="uint8",
+                values_digest=values_digest,
+                values=values,
+            )
+        )
+    return tuple(samples)
+
+
+def reconstruct_source_array(
+    samples: Iterable[ExtractedFieldDTO], schema: VPMFieldSchemaDTO
+) -> np.ndarray:
+    """Reconstruct the exact normalized source values represented by all fields."""
+
+    by_id = {sample.field_id: sample for sample in samples}
+    expected_ids = {field.field_id for field in schema.fields}
+    if set(by_id) != expected_ids:
+        raise PerceptionFieldError("samples must contain exactly one value for every field")
+    output = np.zeros((schema.height, schema.width, schema.channels), dtype=np.uint8)
+    for field in schema.fields:
+        sample = by_id[field.field_id]
+        if sample.field_schema_id != schema.field_schema_id:
+            raise PerceptionFieldError("sample field schema identity mismatch")
+        if _digest(sample.values) != sample.values_digest:
+            raise PerceptionFieldError("sample value digest mismatch")
+        expected_shape = (field.height, field.width, field.channels)
+        if sample.shape != expected_shape:
+            raise PerceptionFieldError("sample shape does not match field address")
+        output[
+            field.y0 : field.y1,
+            field.x0 : field.x1,
+            field.channel_start : field.channel_end,
+        ] = sample.to_array()
+    if schema.channels == 1:
+        return output[:, :, 0]
+    return output
+
+
+def mask_source_fields(
+    source: SourceVPMDTO,
+    schema: VPMFieldSchemaDTO,
+    field_ids: Iterable[str],
+    *,
+    mode: str,
+    neutral_value: int = 0,
+) -> np.ndarray:
+    """Apply a deterministic keep/remove mask without claiming intervention validity."""
+
+    validate_source_for_schema(source, schema)
+    if mode not in _ALLOWED_MASK_MODES:
+        raise PerceptionFieldError(f"mode must be one of {sorted(_ALLOWED_MASK_MODES)}")
+    if not 0 <= neutral_value <= 255:
+        raise PerceptionFieldError("neutral_value must be in [0, 255]")
+    selected = set(field_ids)
+    known = {field.field_id for field in schema.fields}
+    unknown = selected - known
+    if unknown:
+        raise PerceptionFieldError(f"unknown field identities: {sorted(unknown)}")
+    source_array = _canonical_source_array(source)
+    output = (
+        np.full_like(source_array, neutral_value)
+        if mode == "keep"
+        else source_array.copy()
+    )
+    for field in schema.fields:
+        is_selected = field.field_id in selected
+        region = np.s_[
+            field.y0 : field.y1,
+            field.x0 : field.x1,
+            field.channel_start : field.channel_end,
+        ]
+        if mode == "keep" and is_selected:
+            output[region] = source_array[region]
+        elif mode == "remove" and is_selected:
+            output[region] = neutral_value
+    if schema.channels == 1:
+        return output[:, :, 0]
+    return output

--- a/packages/perception/tests/test_fields.py
+++ b/packages/perception/tests/test_fields.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    PerceptionFieldError,
+    SourceImageEncoderSpecDTO,
+    build_grid_field_schema,
+    encode_source_array,
+    extract_source_fields,
+    mask_source_fields,
+    reconstruct_source_array,
+)
+
+
+def _source(values: np.ndarray, *, color_space: str = "L"):
+    return encode_source_array(
+        values,
+        SourceImageEncoderSpecDTO(color_space=color_space),
+    )
+
+
+def test_grid_schema_is_deterministic_and_edge_aware() -> None:
+    source = _source(np.arange(15, dtype=np.uint8).reshape(3, 5))
+
+    first = build_grid_field_schema(source, tile_width=2, tile_height=2)
+    second = build_grid_field_schema(source, tile_width=2, tile_height=2)
+
+    assert first == second
+    assert first.field_schema_id == second.field_schema_id
+    assert len(first.fields) == 6
+    assert sorted((field.width, field.height) for field in first.fields) == [
+        (1, 1),
+        (1, 2),
+        (2, 1),
+        (2, 1),
+        (2, 2),
+        (2, 2),
+    ]
+
+
+def test_extract_and_reconstruct_are_exact_for_grayscale() -> None:
+    values = np.arange(35, dtype=np.uint8).reshape(5, 7)
+    source = _source(values)
+    schema = build_grid_field_schema(source, tile_width=3, tile_height=2)
+
+    samples = extract_source_fields(source, schema)
+    reconstructed = reconstruct_source_array(reversed(samples), schema)
+
+    np.testing.assert_array_equal(reconstructed, values)
+    assert tuple(sample.field_id for sample in samples) == tuple(
+        field.field_id for field in schema.fields
+    )
+
+
+def test_separate_channel_partition_reconstructs_rgb_exactly() -> None:
+    values = np.arange(4 * 5 * 3, dtype=np.uint8).reshape(4, 5, 3)
+    source = _source(values, color_space="RGB")
+    schema = build_grid_field_schema(
+        source,
+        tile_width=3,
+        tile_height=3,
+        channel_mode="separate",
+    )
+
+    assert len(schema.fields) == 12
+    assert all(field.channels == 1 for field in schema.fields)
+    np.testing.assert_array_equal(
+        reconstruct_source_array(extract_source_fields(source, schema), schema),
+        values,
+    )
+
+
+def test_joint_channel_partition_uses_one_field_per_spatial_tile() -> None:
+    values = np.zeros((4, 4, 3), dtype=np.uint8)
+    source = _source(values, color_space="RGB")
+    schema = build_grid_field_schema(
+        source,
+        tile_width=2,
+        tile_height=2,
+        channel_mode="joint",
+    )
+
+    assert len(schema.fields) == 4
+    assert all(field.channels == 3 for field in schema.fields)
+
+
+def test_keep_and_remove_masks_are_exact_complements_for_selected_field() -> None:
+    values = np.arange(16, dtype=np.uint8).reshape(4, 4)
+    source = _source(values)
+    schema = build_grid_field_schema(source, tile_width=2, tile_height=2)
+    selected = schema.fields[0]
+
+    kept = mask_source_fields(
+        source,
+        schema,
+        [selected.field_id],
+        mode="keep",
+        neutral_value=0,
+    )
+    removed = mask_source_fields(
+        source,
+        schema,
+        [selected.field_id],
+        mode="remove",
+        neutral_value=0,
+    )
+
+    selected_mask = np.zeros_like(values, dtype=bool)
+    selected_mask[selected.y0 : selected.y1, selected.x0 : selected.x1] = True
+    np.testing.assert_array_equal(kept[selected_mask], values[selected_mask])
+    assert np.all(kept[~selected_mask] == 0)
+    assert np.all(removed[selected_mask] == 0)
+    np.testing.assert_array_equal(removed[~selected_mask], values[~selected_mask])
+
+
+def test_schema_rejects_invalid_partition_parameters() -> None:
+    source = _source(np.zeros((2, 2), dtype=np.uint8))
+
+    with pytest.raises(PerceptionFieldError, match="tile dimensions"):
+        build_grid_field_schema(source, tile_width=0, tile_height=1)
+    with pytest.raises(PerceptionFieldError, match="channel_mode"):
+        build_grid_field_schema(
+            source,
+            tile_width=1,
+            tile_height=1,
+            channel_mode="unknown",
+        )
+
+
+def test_schema_rejects_incompatible_source_shape_and_spec() -> None:
+    source = _source(np.zeros((2, 2), dtype=np.uint8))
+    schema = build_grid_field_schema(source, tile_width=1, tile_height=1)
+    changed_shape = _source(np.zeros((3, 2), dtype=np.uint8))
+    changed_spec = encode_source_array(
+        np.zeros((2, 2, 3), dtype=np.uint8),
+        SourceImageEncoderSpecDTO(color_space="RGB"),
+    )
+
+    with pytest.raises(PerceptionFieldError, match="shape"):
+        extract_source_fields(changed_shape, schema)
+    with pytest.raises(PerceptionFieldError, match="encoder spec"):
+        extract_source_fields(changed_spec, schema)
+
+
+def test_reconstruction_rejects_missing_or_tampered_samples() -> None:
+    source = _source(np.arange(9, dtype=np.uint8).reshape(3, 3))
+    schema = build_grid_field_schema(source, tile_width=2, tile_height=2)
+    samples = extract_source_fields(source, schema)
+
+    with pytest.raises(PerceptionFieldError, match="exactly one"):
+        reconstruct_source_array(samples[:-1], schema)
+
+    tampered = replace(samples[0], values=bytes([0]) * len(samples[0].values))
+    with pytest.raises(PerceptionFieldError, match="digest"):
+        reconstruct_source_array((tampered, *samples[1:]), schema)
+
+
+def test_mask_rejects_unknown_field_and_invalid_neutral_value() -> None:
+    source = _source(np.zeros((2, 2), dtype=np.uint8))
+    schema = build_grid_field_schema(source, tile_width=1, tile_height=1)
+
+    with pytest.raises(PerceptionFieldError, match="unknown field"):
+        mask_source_fields(source, schema, ["sha256:missing"], mode="keep")
+    with pytest.raises(PerceptionFieldError, match="neutral_value"):
+        mask_source_fields(
+            source,
+            schema,
+            [schema.fields[0].field_id],
+            mode="remove",
+            neutral_value=256,
+        )

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy as np
+
 from zeromodel.perception import (
     PERCEPTION_PACKAGE_VERSION,
     PERCEPTION_STAGE,
@@ -7,12 +9,14 @@ from zeromodel.perception import (
     DiscreteActionSchemaDTO,
     InMemoryPerceptionDatasetStore,
     SourceImageEncoderSpecDTO,
+    build_grid_field_schema,
+    encode_source_array,
 )
 
 
-def test_phase_three_public_contract() -> None:
+def test_phase_four_a_public_contract() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P3"
+    assert PERCEPTION_STAGE == "P4A"
     assert SourceImageEncoderSpecDTO().color_space == "RGB"
     assert DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT"]).labels == (
         "LEFT",
@@ -20,3 +24,10 @@ def test_phase_three_public_contract() -> None:
     )
     assert InMemoryPerceptionDatasetStore().list_ids() == ()
     assert BaselineInferenceConfigDTO().neighbor_count == 3
+
+    source = encode_source_array(
+        np.zeros((2, 2), dtype=np.uint8),
+        SourceImageEncoderSpecDTO(color_space="L"),
+    )
+    schema = build_grid_field_schema(source, tile_width=1, tile_height=1)
+    assert len(schema.fields) == 4


### PR DESCRIPTION
## Summary

Begins Stage P4 with P4A: deterministic, addressable field schemas for Source VPMs. This establishes the exact spatial substrate required before relevance estimation, Evidence VPMs, or evidence-weighted inference can be implemented responsibly.

## Field schema

- adds `VPMFieldAddressDTO` with explicit half-open spatial and channel bounds;
- adds reusable `VPMFieldSchemaDTO` identities derived from source shape, encoder contract, tile dimensions, channel mode, and version;
- supports edge-aware rectangular grid partitioning without implicit padding or cropping;
- supports `joint` channel fields and per-channel `separate` fields;
- validates that every normalized source value is covered exactly once, with no gaps or overlap.

## Extraction and reconstruction

- adds immutable `ExtractedFieldDTO` values with exact byte payloads and content digests;
- extracts fields without pooling, quantization, averaging, or information loss;
- reconstructs the complete normalized source array from field samples;
- rejects missing, extra, malformed, schema-mismatched, or digest-tampered samples.

## Masking primitive

- adds deterministic `keep` and `remove` masking over declared field identities;
- supports an explicit bounded neutral value;
- rejects unknown field identities and incompatible source shape/spec contracts;
- intentionally does not label masking as causal intervention or evidence validity yet.

## Public API

Advances `PERCEPTION_STAGE` from `P3` to `P4A` and exports the tested field schema, address, extraction, reconstruction, validation, and masking contracts.

## Tests

Adds focused coverage for deterministic schema identity, non-divisible edge tiles, exact grayscale and RGB reconstruction, joint and separate channel layouts, keep/remove masks, invalid schema parameters, source incompatibility, missing/tampered samples, and invalid masking inputs.

## Scope boundary

This PR does not estimate field relevance, create Evidence VPMs, weight nearest-neighbour distance, compare against the P3 baseline, or claim causal evidence. Those belong to P4B and P4C.

Existing unrelated repository check failures remain outside this PR's scope as previously agreed.