### PR TITLE
feat(perception): add Stage P4B field relevance and Evidence VPM

### DIFF
--- a/packages/perception/P4B-NOTES.md
+++ b/packages/perception/P4B-NOTES.md
@@ -1,0 +1,22 @@
+# Stage P4B relevance semantics
+
+P4B measures field/action association with `eta_squared_of_field_mean_by_action`.
+
+For each field and training interaction:
+
+1. extract the exact field bytes using the P4A schema;
+2. reduce the field to its normalized mean intensity;
+3. partition those scalar values by action label;
+4. report the fraction of total variation explained by between-action variation.
+
+The resulting score is bounded in `[0, 1]` and is retained together with support
+count, action count, within-action variance, and between-action variance.
+
+The Evidence VPM PNG is a deterministic grayscale rendering of the exact scores.
+For schemas with separate channel fields, overlapping channel relevance is rendered
+using the maximum score while every channel-specific score remains available in the
+DTO.
+
+These values describe predictive association only. They are not causal effects,
+necessity, sufficiency, calibrated confidence, or intervention results. Those
+claims require P4C controls.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -15,6 +15,16 @@ from .dataset import (
     SplitAssignmentDTO,
     build_dataset_manifest,
 )
+from .evidence import (
+    EVIDENCE_RENDER_SEMANTICS,
+    EVIDENCE_VPM_VERSION,
+    FIELD_RELEVANCE_SEMANTICS,
+    FIELD_RELEVANCE_VERSION,
+    EvidenceVPMDTO,
+    FieldRelevanceDTO,
+    PerceptionEvidenceError,
+    estimate_field_relevance,
+)
 from .fields import (
     FIELD_SAMPLE_VERSION,
     FIELD_SCHEMA_VERSION,
@@ -59,7 +69,7 @@ from .representation import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P4A"
+PERCEPTION_STAGE = "P4B"
 
 __all__ = [
     "ACTION_SCHEMA_VERSION",
@@ -67,6 +77,10 @@ __all__ = [
     "CONFIDENCE_SEMANTICS",
     "DATASET_MANIFEST_VERSION",
     "DISTANCE_SEMANTICS",
+    "EVIDENCE_RENDER_SEMANTICS",
+    "EVIDENCE_VPM_VERSION",
+    "FIELD_RELEVANCE_SEMANTICS",
+    "FIELD_RELEVANCE_VERSION",
     "FIELD_SAMPLE_VERSION",
     "FIELD_SCHEMA_VERSION",
     "INTERACTION_VERSION",
@@ -83,12 +97,15 @@ __all__ = [
     "BaselineTrainingExampleDTO",
     "DatasetFindingDTO",
     "DiscreteActionSchemaDTO",
+    "EvidenceVPMDTO",
     "ExtractedFieldDTO",
+    "FieldRelevanceDTO",
     "InMemoryPerceptionDatasetStore",
     "NeighborEvidenceDTO",
     "PerceptionDatasetError",
     "PerceptionDatasetManifestDTO",
     "PerceptionDatasetStore",
+    "PerceptionEvidenceError",
     "PerceptionFieldError",
     "PerceptionInferenceError",
     "PerceptionRepresentationError",
@@ -105,6 +122,7 @@ __all__ = [
     "encode_discrete_action",
     "encode_source_array",
     "encode_source_image_bytes",
+    "estimate_field_relevance",
     "extract_source_fields",
     "fit_baseline_nearest_neighbor",
     "mask_source_fields",

--- a/packages/perception/src/zeromodel/perception/evidence.py
+++ b/packages/perception/src/zeromodel/perception/evidence.py
@@ -1,0 +1,248 @@
+"""Measured field relevance and deterministic Evidence VPMs for Stage P4B.
+
+P4B estimates predictive association only. Scores are not causal claims; keep/remove
+intervention evaluation and weighted inference belong to P4C.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+import numpy as np
+from PIL import Image
+
+from .dataset import PerceptionDatasetManifestDTO
+from .fields import VPMFieldSchemaDTO, extract_source_fields, validate_source_for_schema
+from .representation import SourceVPMDTO
+
+FIELD_RELEVANCE_VERSION: Final = "perception-field-relevance/1"
+EVIDENCE_VPM_VERSION: Final = "perception-evidence-vpm/1"
+FIELD_RELEVANCE_SEMANTICS: Final = "eta_squared_of_field_mean_by_action"
+EVIDENCE_RENDER_SEMANTICS: Final = "rounded_uint8_field_relevance_max_over_channels"
+
+
+class PerceptionEvidenceError(ValueError):
+    """Raised when field relevance or Evidence VPM materialization is invalid."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def _png_bytes(array: np.ndarray) -> bytes:
+    output = io.BytesIO()
+    Image.fromarray(array, mode="L").save(
+        output,
+        format="PNG",
+        optimize=False,
+        compress_level=9,
+    )
+    return output.getvalue()
+
+
+@dataclass(frozen=True)
+class FieldRelevanceDTO:
+    field_id: str
+    score: float
+    score_semantics: str
+    support_count: int
+    action_count: int
+    within_action_variance: float
+    between_action_variance: float
+    version: str = FIELD_RELEVANCE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.field_id:
+            raise PerceptionEvidenceError("field_id must be non-empty")
+        if self.score_semantics != FIELD_RELEVANCE_SEMANTICS:
+            raise PerceptionEvidenceError("unsupported field relevance semantics")
+        if not 0.0 <= self.score <= 1.0:
+            raise PerceptionEvidenceError("field relevance score must be in [0, 1]")
+        if self.support_count <= 0 or self.action_count <= 0:
+            raise PerceptionEvidenceError("relevance support counts must be positive")
+        if self.within_action_variance < 0.0 or self.between_action_variance < 0.0:
+            raise PerceptionEvidenceError("variance components must be non-negative")
+
+
+@dataclass(frozen=True)
+class EvidenceVPMDTO:
+    evidence_vpm_id: str
+    dataset_id: str
+    field_schema_id: str
+    source_encoder_spec_id: str
+    training_split: str
+    width: int
+    height: int
+    score_semantics: str
+    render_semantics: str
+    relevances: tuple[FieldRelevanceDTO, ...]
+    png_digest: str
+    png_bytes: bytes
+    version: str = EVIDENCE_VPM_VERSION
+
+    def __post_init__(self) -> None:
+        if not all((self.evidence_vpm_id, self.dataset_id, self.field_schema_id)):
+            raise PerceptionEvidenceError("Evidence VPM identities must be non-empty")
+        if self.width <= 0 or self.height <= 0:
+            raise PerceptionEvidenceError("Evidence VPM dimensions must be positive")
+        ids = tuple(item.field_id for item in self.relevances)
+        if ids != tuple(sorted(ids)) or len(ids) != len(set(ids)):
+            raise PerceptionEvidenceError("relevances must be unique and sorted")
+        if _digest(self.png_bytes) != self.png_digest:
+            raise PerceptionEvidenceError("Evidence VPM PNG digest mismatch")
+
+    def to_array(self) -> np.ndarray:
+        with Image.open(io.BytesIO(self.png_bytes)) as image:
+            array = np.asarray(image.convert("L"), dtype=np.uint8)
+        if array.shape != (self.height, self.width):
+            raise PerceptionEvidenceError("Evidence VPM PNG shape mismatch")
+        return array.copy()
+
+    def relevance_for(self, field_id: str) -> FieldRelevanceDTO:
+        for item in self.relevances:
+            if item.field_id == field_id:
+                return item
+        raise KeyError(field_id)
+
+
+def _eta_squared(values: np.ndarray, labels: tuple[str, ...]) -> tuple[float, float, float]:
+    grand_mean = float(np.mean(values))
+    total = float(np.sum((values - grand_mean) ** 2))
+    within = 0.0
+    between = 0.0
+    for label in sorted(set(labels)):
+        group = values[np.asarray([item == label for item in labels], dtype=bool)]
+        group_mean = float(np.mean(group))
+        within += float(np.sum((group - group_mean) ** 2))
+        between += float(group.size * ((group_mean - grand_mean) ** 2))
+    if total <= 0.0:
+        return 0.0, within, between
+    score = min(1.0, max(0.0, between / total))
+    return score, within, between
+
+
+def estimate_field_relevance(
+    manifest: PerceptionDatasetManifestDTO,
+    source_vpms: Mapping[str, SourceVPMDTO],
+    field_schema: VPMFieldSchemaDTO,
+    *,
+    training_split: str = "train",
+) -> EvidenceVPMDTO:
+    """Estimate action association from per-field mean intensity and render evidence."""
+
+    if training_split not in {"train", "validation", "test", "all"}:
+        raise PerceptionEvidenceError(
+            "training_split must be train, validation, test, or all"
+        )
+    selected_ids = {
+        item.interaction_id
+        for item in manifest.split_assignments
+        if training_split == "all" or item.split == training_split
+    }
+    interactions = tuple(
+        item for item in manifest.interactions if item.interaction_id in selected_ids
+    )
+    if not interactions:
+        raise PerceptionEvidenceError(
+            f"dataset contains no {training_split!r} interactions"
+        )
+    labels = tuple(item.action_label for item in interactions)
+    action_count = len(set(labels))
+    if action_count < 2:
+        raise PerceptionEvidenceError("field relevance requires at least two actions")
+
+    values_by_field: dict[str, list[float]] = {
+        field.field_id: [] for field in field_schema.fields
+    }
+    for interaction in interactions:
+        try:
+            source = source_vpms[interaction.source_vpm_id]
+        except KeyError as exc:
+            raise PerceptionEvidenceError(
+                f"missing SourceVPMDTO for {interaction.source_vpm_id}"
+            ) from exc
+        if source.pixel_digest != interaction.source_pixel_digest:
+            raise PerceptionEvidenceError("source pixel identity disagrees with interaction")
+        validate_source_for_schema(source, field_schema)
+        for sample in extract_source_fields(source, field_schema):
+            values_by_field[sample.field_id].append(float(np.mean(sample.to_array())) / 255.0)
+
+    relevances: list[FieldRelevanceDTO] = []
+    for field in field_schema.fields:
+        values = np.asarray(values_by_field[field.field_id], dtype=np.float64)
+        score, within, between = _eta_squared(values, labels)
+        relevances.append(
+            FieldRelevanceDTO(
+                field_id=field.field_id,
+                score=score,
+                score_semantics=FIELD_RELEVANCE_SEMANTICS,
+                support_count=len(interactions),
+                action_count=action_count,
+                within_action_variance=within,
+                between_action_variance=between,
+            )
+        )
+    ordered = tuple(sorted(relevances, key=lambda item: item.field_id))
+    score_by_id = {item.field_id: item.score for item in ordered}
+    evidence = np.zeros((field_schema.height, field_schema.width), dtype=np.uint8)
+    for field in field_schema.fields:
+        rendered = np.uint8(round(score_by_id[field.field_id] * 255.0))
+        region = evidence[field.y0 : field.y1, field.x0 : field.x1]
+        np.maximum(region, rendered, out=region)
+    png_bytes = _png_bytes(evidence)
+    png_digest = _digest(png_bytes)
+    payload: Mapping[str, object] = {
+        "dataset_id": manifest.dataset_id,
+        "field_schema_id": field_schema.field_schema_id,
+        "png_digest": png_digest,
+        "relevances": [
+            {
+                "action_count": item.action_count,
+                "between_action_variance": item.between_action_variance,
+                "field_id": item.field_id,
+                "score": item.score,
+                "score_semantics": item.score_semantics,
+                "support_count": item.support_count,
+                "version": item.version,
+                "within_action_variance": item.within_action_variance,
+            }
+            for item in ordered
+        ],
+        "render_semantics": EVIDENCE_RENDER_SEMANTICS,
+        "score_semantics": FIELD_RELEVANCE_SEMANTICS,
+        "source_encoder_spec_id": field_schema.source_encoder_spec_id,
+        "training_split": training_split,
+        "version": EVIDENCE_VPM_VERSION,
+    }
+    return EvidenceVPMDTO(
+        evidence_vpm_id=_digest(_canonical_json(payload)),
+        dataset_id=manifest.dataset_id,
+        field_schema_id=field_schema.field_schema_id,
+        source_encoder_spec_id=field_schema.source_encoder_spec_id,
+        training_split=training_split,
+        width=field_schema.width,
+        height=field_schema.height,
+        score_semantics=FIELD_RELEVANCE_SEMANTICS,
+        render_semantics=EVIDENCE_RENDER_SEMANTICS,
+        relevances=ordered,
+        png_digest=png_digest,
+        png_bytes=png_bytes,
+    )

--- a/packages/perception/tests/test_evidence.py
+++ b/packages/perception/tests/test_evidence.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    DiscreteActionSchemaDTO,
+    PerceptionEvidenceError,
+    RecordedInteractionDTO,
+    SourceImageEncoderSpecDTO,
+    build_dataset_manifest,
+    build_grid_field_schema,
+    encode_discrete_action,
+    encode_source_array,
+    estimate_field_relevance,
+)
+
+
+def _fixture():
+    spec = SourceImageEncoderSpecDTO(color_space="L")
+    actions = DiscreteActionSchemaDTO.from_labels(["A", "B"])
+    arrays = [
+        np.array([[0, 0, 0, 0], [0, 0, 0, 0]], dtype=np.uint8),
+        np.array([[0, 0, 255, 255], [0, 0, 255, 255]], dtype=np.uint8),
+        np.array([[255, 255, 0, 0], [255, 255, 0, 0]], dtype=np.uint8),
+        np.full((2, 4), 255, dtype=np.uint8),
+    ]
+    labels = ["A", "A", "B", "B"]
+    sources = [encode_source_array(array, spec) for array in arrays]
+    interactions = [
+        RecordedInteractionDTO.from_vpms(
+            sequence_id="evidence",
+            step_index=index,
+            source=source,
+            target=encode_discrete_action(label, actions),
+        )
+        for index, (source, label) in enumerate(zip(sources, labels, strict=True))
+    ]
+    manifest = build_dataset_manifest(
+        interactions,
+        source_encoder_spec_ids=[spec.encoder_spec_id],
+        split_seed="p4b-fixture",
+    )
+    schema = build_grid_field_schema(
+        sources[0], tile_width=2, tile_height=2, channel_mode="joint"
+    )
+    return manifest, {item.source_vpm_id: item for item in sources}, schema
+
+
+def _left_and_right(schema):
+    left = next(field for field in schema.fields if field.x0 == 0)
+    right = next(field for field in schema.fields if field.x0 == 2)
+    return left, right
+
+
+def test_relevance_identifies_action_discriminative_field() -> None:
+    manifest, sources, schema = _fixture()
+    evidence = estimate_field_relevance(
+        manifest, sources, schema, training_split="all"
+    )
+    left, right = _left_and_right(schema)
+
+    assert evidence.relevance_for(left.field_id).score == pytest.approx(1.0)
+    assert evidence.relevance_for(right.field_id).score == pytest.approx(0.0)
+    rendered = evidence.to_array()
+    assert np.all(rendered[:, :2] == 255)
+    assert np.all(rendered[:, 2:] == 0)
+
+
+def test_evidence_identity_and_png_are_deterministic() -> None:
+    manifest, sources, schema = _fixture()
+    first = estimate_field_relevance(manifest, sources, schema, training_split="all")
+    second = estimate_field_relevance(manifest, sources, schema, training_split="all")
+
+    assert first == second
+    assert first.evidence_vpm_id == second.evidence_vpm_id
+    assert first.png_bytes == second.png_bytes
+
+
+def test_separate_channel_render_uses_max_while_preserving_exact_scores() -> None:
+    spec = SourceImageEncoderSpecDTO(color_space="RGB")
+    actions = DiscreteActionSchemaDTO.from_labels(["A", "B"])
+    arrays = [
+        np.zeros((1, 1, 3), dtype=np.uint8),
+        np.array([[[0, 255, 0]]], dtype=np.uint8),
+        np.array([[[255, 0, 0]]], dtype=np.uint8),
+        np.array([[[255, 255, 0]]], dtype=np.uint8),
+    ]
+    labels = ["A", "A", "B", "B"]
+    sources = [encode_source_array(array, spec) for array in arrays]
+    interactions = [
+        RecordedInteractionDTO.from_vpms(
+            sequence_id="channels",
+            step_index=index,
+            source=source,
+            target=encode_discrete_action(label, actions),
+        )
+        for index, (source, label) in enumerate(zip(sources, labels, strict=True))
+    ]
+    manifest = build_dataset_manifest(
+        interactions, source_encoder_spec_ids=[spec.encoder_spec_id]
+    )
+    schema = build_grid_field_schema(
+        sources[0], tile_width=1, tile_height=1, channel_mode="separate"
+    )
+    evidence = estimate_field_relevance(
+        manifest,
+        {item.source_vpm_id: item for item in sources},
+        schema,
+        training_split="all",
+    )
+
+    scores = {
+        field.channel_start: evidence.relevance_for(field.field_id).score
+        for field in schema.fields
+    }
+    assert scores[0] == pytest.approx(1.0)
+    assert scores[1] == pytest.approx(0.0)
+    assert scores[2] == pytest.approx(0.0)
+    assert evidence.to_array()[0, 0] == 255
+
+
+def test_relevance_rejects_missing_or_tampered_sources() -> None:
+    manifest, sources, schema = _fixture()
+    missing = dict(sources)
+    missing.pop(next(iter(missing)))
+    with pytest.raises(PerceptionEvidenceError, match="missing SourceVPMDTO"):
+        estimate_field_relevance(manifest, missing, schema, training_split="all")
+
+    first_id = manifest.interactions[0].source_vpm_id
+    tampered = dict(sources)
+    tampered[first_id] = replace(tampered[first_id], pixel_digest="sha256:wrong")
+    with pytest.raises(PerceptionEvidenceError, match="pixel identity"):
+        estimate_field_relevance(manifest, tampered, schema, training_split="all")
+
+
+def test_relevance_requires_valid_split_and_two_actions() -> None:
+    manifest, sources, schema = _fixture()
+    with pytest.raises(PerceptionEvidenceError, match="training_split"):
+        estimate_field_relevance(manifest, sources, schema, training_split="invalid")
+
+    one_action_manifest = replace(
+        manifest,
+        interactions=tuple(
+            replace(item, action_label="A") for item in manifest.interactions
+        ),
+    )
+    with pytest.raises(PerceptionEvidenceError, match="at least two actions"):
+        estimate_field_relevance(
+            one_action_manifest, sources, schema, training_split="all"
+        )
+
+
+def test_evidence_dto_detects_png_tampering() -> None:
+    manifest, sources, schema = _fixture()
+    evidence = estimate_field_relevance(
+        manifest, sources, schema, training_split="all"
+    )
+    with pytest.raises(PerceptionEvidenceError, match="PNG digest"):
+        replace(evidence, png_bytes=evidence.png_bytes + b"tamper")

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from zeromodel.perception import (
+    FIELD_RELEVANCE_SEMANTICS,
     PERCEPTION_PACKAGE_VERSION,
     PERCEPTION_STAGE,
     BaselineInferenceConfigDTO,
@@ -14,9 +15,10 @@ from zeromodel.perception import (
 )
 
 
-def test_phase_four_a_public_contract() -> None:
+def test_phase_four_b_public_contract() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P4A"
+    assert PERCEPTION_STAGE == "P4B"
+    assert FIELD_RELEVANCE_SEMANTICS == "eta_squared_of_field_mean_by_action"
     assert SourceImageEncoderSpecDTO().color_space == "RGB"
     assert DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT"]).labels == (
         "LEFT",


### PR DESCRIPTION
## Summary

Continues Stage P4 with P4B: measured field/action association and deterministic Evidence VPM artifacts built on the exact P4A field schema.

## Relevance method

- adds `FieldRelevanceDTO` with explicit score semantics, support count, action count, and within/between-action variance components;
- uses `eta_squared_of_field_mean_by_action` as the first bounded, deterministic relevance estimator;
- extracts exact P4A field values and reduces each field to normalized mean intensity per interaction;
- reports the fraction of total field variation explained by action-group separation;
- requires at least two represented actions and validates every source reference, pixel identity, shape, and encoder contract.

## Evidence VPM

- adds immutable `EvidenceVPMDTO`;
- retains every exact field score as the machine-readable source of truth;
- renders scores as a deterministic grayscale PNG using rounded uint8 values;
- for separate-channel schemas, renders the maximum overlapping channel score while preserving all channel-specific scores in the DTO;
- derives content identity from dataset, field schema, split, score values, rendering semantics, and PNG digest;
- validates PNG digest and decoded dimensions.

## Scientific boundary

P4B measures predictive association only. It does not claim causality, necessity, sufficiency, calibrated confidence, or intervention validity. Keep-only/remove-only evaluation, random controls, and evidence-weighted inference remain P4C work.

## Public API

Advances `PERCEPTION_STAGE` from `P4A` to `P4B` and exports the evidence DTOs, constants, error contract, and estimator.

## Tests

Adds focused synthetic coverage where one field perfectly separates actions and another varies equally within both action classes. Also covers deterministic identity and PNG bytes, separate-channel rendering, missing and tampered sources, invalid splits, single-action rejection, and PNG tamper detection.

## Scope boundary

This PR does not alter P3 nearest-neighbour inference, weight distances, run keep/remove interventions, compare baseline accuracy, or introduce semantic annotations.

Existing unrelated repository check failures remain outside this PR's scope as previously agreed.