### PR TITLE
feat(perception): add Stage P5B translator evaluation and calibration

### DIFF
--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -34,18 +34,20 @@ from .representation import (
     encode_source_image_bytes,
 )
 from .translator import (
-    COEFFICIENT_SEMANTICS,
-    SOURCE_FEATURE_SEMANTICS,
-    TARGET_SCORE_SEMANTICS,
-    TRANSLATOR_PREDICTION_VERSION,
-    TRANSLATOR_VERSION,
-    PerceptionTranslatorError,
-    PredictedTargetVPMDTO,
-    SourceTargetTranslatorDTO,
-    TargetActionScoreDTO,
-    TranslatorConfigDTO,
-    fit_source_target_translator,
+    COEFFICIENT_SEMANTICS, SOURCE_FEATURE_SEMANTICS, TARGET_SCORE_SEMANTICS,
+    TRANSLATOR_PREDICTION_VERSION, TRANSLATOR_VERSION,
+    PerceptionTranslatorError, PredictedTargetVPMDTO, SourceTargetTranslatorDTO,
+    TargetActionScoreDTO, TranslatorConfigDTO, fit_source_target_translator,
     predict_target_vpm,
+)
+from .translator_evaluation import (
+    RECONSTRUCTION_ERROR_SEMANTICS, REJECTED_TRANSLATOR_PREDICTION_VERSION,
+    REJECTION_SEMANTICS, SPARSITY_SEMANTICS, TRANSLATOR_CALIBRATION_VERSION,
+    TRANSLATOR_EVALUATION_VERSION, CalibratedTranslatorPredictionDTO,
+    PerceptionTranslatorEvaluationError, TranslatorCalibrationDTO,
+    TranslatorEvaluationReportDTO, TranslatorExampleEvaluationDTO,
+    calibrate_translator_rejection, evaluate_source_target_translator,
+    predict_calibrated_target_vpm,
 )
 from .weighted import (
     INTERVENTION_REPORT_VERSION, WEIGHTED_DISTANCE_SEMANTICS,
@@ -57,6 +59,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P5A"
+PERCEPTION_STAGE = "P5B"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/translator_evaluation.py
+++ b/packages/perception/src/zeromodel/perception/translator_evaluation.py
@@ -1,0 +1,276 @@
+"""Held-out translator evaluation, calibration, rejection, and sparsity diagnostics.
+
+Calibration consumes a declared calibration split. Final evaluation must use a different
+split; this module rejects accidental reuse of the translator training split.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+import numpy as np
+
+from .dataset import PerceptionDatasetManifestDTO
+from .fields import VPMFieldSchemaDTO
+from .representation import DiscreteActionSchemaDTO, SourceVPMDTO
+from .translator import (
+    PredictedTargetVPMDTO,
+    SourceTargetTranslatorDTO,
+    predict_target_vpm,
+)
+
+TRANSLATOR_EVALUATION_VERSION: Final = "perception-translator-evaluation/1"
+TRANSLATOR_CALIBRATION_VERSION: Final = "perception-translator-calibration/1"
+REJECTED_TRANSLATOR_PREDICTION_VERSION: Final = "perception-calibrated-target-prediction/1"
+RECONSTRUCTION_ERROR_SEMANTICS: Final = "mean_absolute_error_against_one_hot_target"
+SPARSITY_SEMANTICS: Final = "coefficient_absolute_value_at_or_below_threshold"
+REJECTION_SEMANTICS: Final = "reject_when_top_two_margin_below_calibrated_threshold"
+
+
+class PerceptionTranslatorEvaluationError(ValueError):
+    """Raised when held-out evaluation or calibration violates the P5B contract."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+@dataclass(frozen=True)
+class TranslatorExampleEvaluationDTO:
+    interaction_id: str
+    source_vpm_id: str
+    expected_action: str
+    predicted_action: str
+    correct: bool
+    margin: float
+    reconstruction_error: float
+    prediction_id: str
+
+
+@dataclass(frozen=True)
+class TranslatorEvaluationReportDTO:
+    report_id: str
+    translator_id: str
+    dataset_id: str
+    evaluation_split: str
+    example_count: int
+    correct_count: int
+    accuracy: float
+    mean_reconstruction_error: float
+    mean_margin: float
+    minimum_margin: float
+    maximum_margin: float
+    coefficient_count: int
+    near_zero_coefficient_count: int
+    sparsity_ratio: float
+    sparsity_threshold: float
+    reconstruction_error_semantics: str
+    sparsity_semantics: str
+    examples: tuple[TranslatorExampleEvaluationDTO, ...]
+    version: str = TRANSLATOR_EVALUATION_VERSION
+
+    def __post_init__(self) -> None:
+        if self.example_count <= 0 or self.correct_count < 0:
+            raise PerceptionTranslatorEvaluationError("evaluation counts are invalid")
+        if not 0.0 <= self.accuracy <= 1.0 or not 0.0 <= self.sparsity_ratio <= 1.0:
+            raise PerceptionTranslatorEvaluationError("evaluation ratios must be in [0, 1]")
+
+
+@dataclass(frozen=True)
+class TranslatorCalibrationDTO:
+    calibration_id: str
+    translator_id: str
+    dataset_id: str
+    calibration_split: str
+    minimum_margin: float
+    retained_accuracy: float
+    retained_count: int
+    rejected_count: int
+    rejection_semantics: str
+    version: str = TRANSLATOR_CALIBRATION_VERSION
+
+
+@dataclass(frozen=True)
+class CalibratedTranslatorPredictionDTO:
+    prediction_id: str
+    translator_id: str
+    source_vpm_id: str
+    selected_action: str | None
+    status: str
+    margin: float
+    minimum_margin: float
+    raw_prediction: PredictedTargetVPMDTO
+    rejection_semantics: str
+    version: str = REJECTED_TRANSLATOR_PREDICTION_VERSION
+
+
+def _split_interactions(manifest: PerceptionDatasetManifestDTO, split: str):
+    if split not in {"train", "validation", "test"}:
+        raise PerceptionTranslatorEvaluationError("split must be train, validation, or test")
+    selected = {item.interaction_id for item in manifest.split_assignments if item.split == split}
+    interactions = tuple(item for item in manifest.interactions if item.interaction_id in selected)
+    if not interactions:
+        raise PerceptionTranslatorEvaluationError(f"dataset contains no {split!r} interactions")
+    return interactions
+
+
+def evaluate_source_target_translator(
+    translator: SourceTargetTranslatorDTO,
+    manifest: PerceptionDatasetManifestDTO,
+    source_vpms: Mapping[str, SourceVPMDTO],
+    source_field_schema: VPMFieldSchemaDTO,
+    action_schema: DiscreteActionSchemaDTO,
+    *,
+    evaluation_split: str = "validation",
+    sparsity_threshold: float = 1e-9,
+) -> TranslatorEvaluationReportDTO:
+    """Evaluate target reconstruction and action decoding on a non-training split."""
+    if evaluation_split == translator.training_split:
+        raise PerceptionTranslatorEvaluationError("evaluation split must differ from translator training split")
+    if sparsity_threshold < 0.0 or not np.isfinite(sparsity_threshold):
+        raise PerceptionTranslatorEvaluationError("sparsity_threshold must be finite and non-negative")
+    interactions = _split_interactions(manifest, evaluation_split)
+    records: list[TranslatorExampleEvaluationDTO] = []
+    for interaction in interactions:
+        try:
+            source = source_vpms[interaction.source_vpm_id]
+        except KeyError as exc:
+            raise PerceptionTranslatorEvaluationError(f"missing SourceVPMDTO for {interaction.source_vpm_id}") from exc
+        if source.pixel_digest != interaction.source_pixel_digest:
+            raise PerceptionTranslatorEvaluationError("source pixel identity disagrees with interaction")
+        prediction = predict_target_vpm(translator, source, source_field_schema, action_schema)
+        expected = np.zeros(len(action_schema.labels), dtype=np.float64)
+        expected[action_schema.index_of(interaction.action_label)] = 1.0
+        ordered_scores = np.asarray([
+            next(item.score for item in prediction.scores if item.action_label == label)
+            for label in action_schema.labels
+        ], dtype=np.float64)
+        error = float(np.mean(np.abs(ordered_scores - expected)))
+        records.append(TranslatorExampleEvaluationDTO(
+            interaction_id=interaction.interaction_id,
+            source_vpm_id=source.source_vpm_id,
+            expected_action=interaction.action_label,
+            predicted_action=prediction.selected_action,
+            correct=prediction.selected_action == interaction.action_label,
+            margin=prediction.margin,
+            reconstruction_error=error,
+            prediction_id=prediction.prediction_id,
+        ))
+    ordered = tuple(sorted(records, key=lambda item: item.interaction_id))
+    margins = np.asarray([item.margin for item in ordered], dtype=np.float64)
+    errors = np.asarray([item.reconstruction_error for item in ordered], dtype=np.float64)
+    coefficient_values = np.abs(np.asarray(translator.coefficients, dtype=np.float64)).reshape(-1)
+    near_zero = int(np.sum(coefficient_values <= sparsity_threshold))
+    correct = sum(item.correct for item in ordered)
+    payload: Mapping[str, object] = {
+        "translator_id": translator.translator_id,
+        "dataset_id": manifest.dataset_id,
+        "evaluation_split": evaluation_split,
+        "examples": [item.__dict__ for item in ordered],
+        "sparsity_threshold": sparsity_threshold,
+        "version": TRANSLATOR_EVALUATION_VERSION,
+    }
+    return TranslatorEvaluationReportDTO(
+        report_id=_digest(_canonical_json(payload)),
+        translator_id=translator.translator_id,
+        dataset_id=manifest.dataset_id,
+        evaluation_split=evaluation_split,
+        example_count=len(ordered),
+        correct_count=correct,
+        accuracy=correct / len(ordered),
+        mean_reconstruction_error=float(np.mean(errors)),
+        mean_margin=float(np.mean(margins)),
+        minimum_margin=float(np.min(margins)),
+        maximum_margin=float(np.max(margins)),
+        coefficient_count=int(coefficient_values.size),
+        near_zero_coefficient_count=near_zero,
+        sparsity_ratio=near_zero / int(coefficient_values.size),
+        sparsity_threshold=sparsity_threshold,
+        reconstruction_error_semantics=RECONSTRUCTION_ERROR_SEMANTICS,
+        sparsity_semantics=SPARSITY_SEMANTICS,
+        examples=ordered,
+    )
+
+
+def calibrate_translator_rejection(
+    report: TranslatorEvaluationReportDTO,
+    *,
+    target_retained_accuracy: float = 1.0,
+) -> TranslatorCalibrationDTO:
+    """Choose the lowest margin threshold meeting retained calibration accuracy."""
+    if report.evaluation_split == "test":
+        raise PerceptionTranslatorEvaluationError("test split cannot be used for calibration")
+    if not 0.0 < target_retained_accuracy <= 1.0:
+        raise PerceptionTranslatorEvaluationError("target_retained_accuracy must be in (0, 1]")
+    candidates = sorted({0.0, *(item.margin for item in report.examples)})
+    chosen = candidates[-1]
+    retained = tuple(item for item in report.examples if item.margin >= chosen)
+    for threshold in candidates:
+        current = tuple(item for item in report.examples if item.margin >= threshold)
+        if current and sum(item.correct for item in current) / len(current) >= target_retained_accuracy:
+            chosen = threshold
+            retained = current
+            break
+    retained_accuracy = sum(item.correct for item in retained) / len(retained)
+    payload: Mapping[str, object] = {
+        "report_id": report.report_id,
+        "minimum_margin": chosen,
+        "target_retained_accuracy": target_retained_accuracy,
+        "version": TRANSLATOR_CALIBRATION_VERSION,
+    }
+    return TranslatorCalibrationDTO(
+        calibration_id=_digest(_canonical_json(payload)),
+        translator_id=report.translator_id,
+        dataset_id=report.dataset_id,
+        calibration_split=report.evaluation_split,
+        minimum_margin=chosen,
+        retained_accuracy=retained_accuracy,
+        retained_count=len(retained),
+        rejected_count=report.example_count - len(retained),
+        rejection_semantics=REJECTION_SEMANTICS,
+    )
+
+
+def predict_calibrated_target_vpm(
+    translator: SourceTargetTranslatorDTO,
+    calibration: TranslatorCalibrationDTO,
+    source: SourceVPMDTO,
+    source_field_schema: VPMFieldSchemaDTO,
+    action_schema: DiscreteActionSchemaDTO,
+) -> CalibratedTranslatorPredictionDTO:
+    """Predict and explicitly reject when the calibrated top-two margin is too small."""
+    if calibration.translator_id != translator.translator_id:
+        raise PerceptionTranslatorEvaluationError("calibration does not belong to translator")
+    raw = predict_target_vpm(translator, source, source_field_schema, action_schema)
+    accepted = raw.margin >= calibration.minimum_margin
+    status = "accepted" if accepted else "rejected_ambiguous"
+    selected = raw.selected_action if accepted else None
+    payload: Mapping[str, object] = {
+        "calibration_id": calibration.calibration_id,
+        "raw_prediction_id": raw.prediction_id,
+        "selected_action": selected,
+        "status": status,
+        "version": REJECTED_TRANSLATOR_PREDICTION_VERSION,
+    }
+    return CalibratedTranslatorPredictionDTO(
+        prediction_id=_digest(_canonical_json(payload)),
+        translator_id=translator.translator_id,
+        source_vpm_id=source.source_vpm_id,
+        selected_action=selected,
+        status=status,
+        margin=raw.margin,
+        minimum_margin=calibration.minimum_margin,
+        raw_prediction=raw,
+        rejection_semantics=REJECTION_SEMANTICS,
+    )

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -7,6 +7,8 @@ from zeromodel.perception import (
     FIELD_RELEVANCE_SEMANTICS,
     PERCEPTION_PACKAGE_VERSION,
     PERCEPTION_STAGE,
+    RECONSTRUCTION_ERROR_SEMANTICS,
+    REJECTION_SEMANTICS,
     TARGET_SCORE_SEMANTICS,
     WEIGHTED_DISTANCE_SEMANTICS,
     BaselineInferenceConfigDTO,
@@ -19,9 +21,9 @@ from zeromodel.perception import (
 )
 
 
-def test_phase_five_a_public_contract() -> None:
+def test_phase_five_b_public_contract() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P5A"
+    assert PERCEPTION_STAGE == "P5B"
     assert FIELD_RELEVANCE_SEMANTICS == "eta_squared_of_field_mean_by_action"
     assert WEIGHTED_DISTANCE_SEMANTICS == (
         "field_relevance_weighted_normalized_mean_absolute_distance"
@@ -30,6 +32,12 @@ def test_phase_five_a_public_contract() -> None:
         "ridge_linear_mapping_with_unregularized_intercept"
     )
     assert TARGET_SCORE_SEMANTICS == "clipped_ridge_predicted_one_hot_field_value"
+    assert RECONSTRUCTION_ERROR_SEMANTICS == (
+        "mean_absolute_error_against_one_hot_target"
+    )
+    assert REJECTION_SEMANTICS == (
+        "reject_when_top_two_margin_below_calibrated_threshold"
+    )
     assert TranslatorConfigDTO().ridge_alpha == 1e-6
     assert SourceImageEncoderSpecDTO().color_space == "RGB"
     assert DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT"]).labels == (

--- a/packages/perception/tests/test_translator_evaluation.py
+++ b/packages/perception/tests/test_translator_evaluation.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    DiscreteActionSchemaDTO,
+    PerceptionTranslatorEvaluationError,
+    RecordedInteractionDTO,
+    SourceImageEncoderSpecDTO,
+    SplitAssignmentDTO,
+    build_dataset_manifest,
+    build_grid_field_schema,
+    calibrate_translator_rejection,
+    encode_discrete_action,
+    encode_source_array,
+    evaluate_source_target_translator,
+    fit_source_target_translator,
+    predict_calibrated_target_vpm,
+)
+
+
+def _fixture():
+    spec = SourceImageEncoderSpecDTO(color_space="L")
+    actions = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
+    arrays = [
+        np.array([[0, 0]], dtype=np.uint8),
+        np.array([[10, 0]], dtype=np.uint8),
+        np.array([[245, 0]], dtype=np.uint8),
+        np.array([[255, 0]], dtype=np.uint8),
+        np.array([[5, 0]], dtype=np.uint8),
+        np.array([[250, 0]], dtype=np.uint8),
+    ]
+    labels = ["LEFT", "LEFT", "RIGHT", "RIGHT", "LEFT", "RIGHT"]
+    sources = [encode_source_array(array, spec) for array in arrays]
+    interactions = [
+        RecordedInteractionDTO.from_vpms(
+            sequence_id="evaluation",
+            step_index=index,
+            source=source,
+            target=encode_discrete_action(label, actions),
+        )
+        for index, (source, label) in enumerate(zip(sources, labels, strict=True))
+    ]
+    base = build_dataset_manifest(
+        interactions,
+        source_encoder_spec_ids=[spec.encoder_spec_id],
+    )
+    ordered = base.interactions
+    assignments = tuple(
+        SplitAssignmentDTO(
+            interaction_id=item.interaction_id,
+            split="train" if item.step_index < 4 else "validation",
+        )
+        for item in ordered
+    )
+    manifest = replace(base, split_assignments=assignments)
+    mapping = {source.source_vpm_id: source for source in sources}
+    schema = build_grid_field_schema(sources[0], tile_width=1, tile_height=1)
+    translator = fit_source_target_translator(
+        manifest,
+        mapping,
+        schema,
+        actions,
+        training_split="train",
+    )
+    return actions, manifest, mapping, schema, translator, sources
+
+
+def test_evaluation_is_held_out_and_deterministic() -> None:
+    actions, manifest, mapping, schema, translator, _ = _fixture()
+    first = evaluate_source_target_translator(
+        translator,
+        manifest,
+        mapping,
+        schema,
+        actions,
+        evaluation_split="validation",
+    )
+    second = evaluate_source_target_translator(
+        translator,
+        manifest,
+        mapping,
+        schema,
+        actions,
+        evaluation_split="validation",
+    )
+    assert first == second
+    assert first.example_count == 2
+    assert 0.0 <= first.accuracy <= 1.0
+    assert first.coefficient_count == len(translator.action_labels) * len(translator.source_field_ids)
+
+
+def test_calibration_and_rejection_contract() -> None:
+    actions, manifest, mapping, schema, translator, sources = _fixture()
+    report = evaluate_source_target_translator(
+        translator,
+        manifest,
+        mapping,
+        schema,
+        actions,
+        evaluation_split="validation",
+    )
+    calibration = calibrate_translator_rejection(report, target_retained_accuracy=0.5)
+    prediction = predict_calibrated_target_vpm(
+        translator,
+        calibration,
+        sources[0],
+        schema,
+        actions,
+    )
+    assert prediction.status in {"accepted", "rejected_ambiguous"}
+    assert prediction.minimum_margin == calibration.minimum_margin
+
+
+def test_training_split_cannot_be_reported_as_held_out() -> None:
+    actions, manifest, mapping, schema, translator, _ = _fixture()
+    with pytest.raises(PerceptionTranslatorEvaluationError):
+        evaluate_source_target_translator(
+            translator,
+            manifest,
+            mapping,
+            schema,
+            actions,
+            evaluation_split="train",
+        )


### PR DESCRIPTION
## Summary

Completes Stage P5 with P5B: held-out translator evaluation, validation-owned rejection calibration, calibrated prediction, and explicit coefficient sparsity diagnostics.

## Held-out evaluation

- adds immutable per-example and aggregate evaluation DTOs;
- requires evaluation on `train`, `validation`, or `test` and rejects reuse of the translator's own training split;
- records expected and predicted actions, correctness, top-two margin, prediction identity, and target reconstruction error;
- reports action accuracy, mean absolute reconstruction error against the canonical one-hot target, and margin distribution;
- derives deterministic report identity from translator, dataset, split, examples, and sparsity threshold.

## Sparsity diagnostics

- counts all source-field/action coefficients;
- reports coefficients whose absolute value is at or below an explicit threshold;
- retains the threshold and exact sparsity semantics in the report;
- does not mutate or prune the fitted translator.

## Calibration and rejection

- derives a margin threshold from a declared non-test calibration report;
- forbids using the final `test` split for threshold selection;
- records retained accuracy, retained count, rejected count, source split, and immutable calibration identity;
- adds calibrated prediction with explicit `accepted` or `rejected_ambiguous` status;
- preserves the complete raw predicted Target VPM even when the decoded action is rejected.

## Scientific boundary

The margin threshold is an operating rule selected on a declared calibration split. It is not a calibrated probability and does not convert target scores into posterior probabilities. Final performance must be reported on a separate test split.

## Public API

Advances `PERCEPTION_STAGE` from `P5A` to `P5B` and exports evaluation, calibration, rejection, metric-semantics, and prediction contracts.

## Tests

Adds focused coverage for deterministic held-out reports, training/evaluation split separation, reconstruction and coefficient diagnostics, calibration provenance, and calibrated accept/reject prediction.

## Scope boundary

This PR does not add semantic annotations, expected-evidence conformance, temporal inference, persistence, or domain-specific code. Coefficient pruning remains a future optional experiment rather than being silently applied here.

Existing unrelated repository check failures remain outside this PR's scope as previously agreed.