### PR TITLE
feat(perception): add Stage P8 temporal state diagnosis

### DIFF
--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -51,6 +51,15 @@ from .representation import (
     decode_discrete_action, encode_discrete_action, encode_source_array,
     encode_source_image_bytes,
 )
+from .temporal import (
+    TEMPORAL_DIAGNOSIS_SEMANTICS, TEMPORAL_DIAGNOSIS_STATUSES,
+    TEMPORAL_DIAGNOSIS_VERSION, TEMPORAL_LAYOUT_SEMANTICS,
+    TEMPORAL_SOURCE_VERSION, TEMPORAL_WINDOW_SPEC_VERSION,
+    PerceptionTemporalError, TemporalConflictGroupDTO,
+    TemporalSourceVPMDTO, TemporalStateDiagnosisReportDTO,
+    TemporalWindowSpecDTO, build_temporal_source_vpms,
+    diagnose_temporal_state_completeness,
+)
 from .translator import (
     COEFFICIENT_SEMANTICS, SOURCE_FEATURE_SEMANTICS, TARGET_SCORE_SEMANTICS,
     TRANSLATOR_PREDICTION_VERSION, TRANSLATOR_VERSION,
@@ -77,6 +86,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P7"
+PERCEPTION_STAGE = "P8"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/temporal.py
+++ b/packages/perception/src/zeromodel/perception/temporal.py
@@ -1,0 +1,410 @@
+"""Deterministic temporal source VPMs and incomplete-state diagnosis for Stage P8.
+
+P8 materializes fixed-length, sequence-owned frame windows as addressable montage PNGs.
+It then compares exact current-frame identity with exact temporal-context identity to report
+when a current image is insufficient to determine the recorded action. This is a dataset
+property under the declared encoding and window contract, not a claim about hidden-state
+semantics or causality.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+import numpy as np
+
+from .dataset import PerceptionDatasetManifestDTO, RecordedInteractionDTO
+from .representation import SourceImageEncoderSpecDTO, SourceVPMDTO, encode_source_array
+
+TEMPORAL_WINDOW_SPEC_VERSION: Final = "perception-temporal-window-spec/1"
+TEMPORAL_SOURCE_VERSION: Final = "perception-temporal-source-vpm/1"
+TEMPORAL_DIAGNOSIS_VERSION: Final = "perception-temporal-state-diagnosis/1"
+TEMPORAL_LAYOUT_SEMANTICS: Final = "oldest_to_current_horizontal_frame_montage"
+TEMPORAL_DIAGNOSIS_SEMANTICS: Final = (
+    "exact_current_pixel_identity_conflict_resolved_by_exact_prior_context_identity"
+)
+TEMPORAL_DIAGNOSIS_STATUSES: Final = {
+    "no_single_frame_conflict",
+    "incomplete_state_confirmed",
+    "unresolved_temporal_ambiguity",
+    "insufficient_temporal_support",
+}
+
+
+class PerceptionTemporalError(ValueError):
+    """Raised when temporal encoding or diagnosis violates the P8 contract."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+@dataclass(frozen=True)
+class TemporalWindowSpecDTO:
+    """Explicit fixed-window and montage layout contract."""
+
+    frame_count: int
+    require_contiguous_steps: bool = True
+    layout_semantics: str = TEMPORAL_LAYOUT_SEMANTICS
+    version: str = TEMPORAL_WINDOW_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        if self.frame_count < 2:
+            raise PerceptionTemporalError("temporal frame_count must be at least two")
+        if self.layout_semantics != TEMPORAL_LAYOUT_SEMANTICS:
+            raise PerceptionTemporalError("unsupported temporal layout semantics")
+
+    def canonical_payload(self) -> Mapping[str, object]:
+        return {
+            "frame_count": self.frame_count,
+            "layout_semantics": self.layout_semantics,
+            "require_contiguous_steps": self.require_contiguous_steps,
+            "version": self.version,
+        }
+
+    @property
+    def temporal_window_spec_id(self) -> str:
+        return _digest(_canonical_json(self.canonical_payload()))
+
+
+@dataclass(frozen=True)
+class TemporalSourceVPMDTO:
+    """One fixed temporal window materialized as a canonical montage Source VPM."""
+
+    temporal_source_id: str
+    temporal_window_spec_id: str
+    sequence_id: str
+    target_interaction_id: str
+    target_step_index: int
+    action_label: str
+    frame_source_vpm_ids: tuple[str, ...]
+    frame_pixel_digests: tuple[str, ...]
+    current_source_vpm_id: str
+    current_pixel_digest: str
+    montage_source_vpm: SourceVPMDTO
+    layout_semantics: str = TEMPORAL_LAYOUT_SEMANTICS
+    version: str = TEMPORAL_SOURCE_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.temporal_source_id,
+                self.temporal_window_spec_id,
+                self.sequence_id,
+                self.target_interaction_id,
+                self.action_label,
+                self.current_source_vpm_id,
+                self.current_pixel_digest,
+            )
+        ):
+            raise PerceptionTemporalError("temporal source identities must be non-empty")
+        if self.target_step_index < 0:
+            raise PerceptionTemporalError("target_step_index must be non-negative")
+        if len(self.frame_source_vpm_ids) < 2:
+            raise PerceptionTemporalError("temporal source requires at least two frames")
+        if len(self.frame_source_vpm_ids) != len(self.frame_pixel_digests):
+            raise PerceptionTemporalError("frame ids and pixel digests must align")
+        if self.frame_source_vpm_ids[-1] != self.current_source_vpm_id:
+            raise PerceptionTemporalError("last temporal frame must be the current source")
+        if self.frame_pixel_digests[-1] != self.current_pixel_digest:
+            raise PerceptionTemporalError("last temporal digest must be the current digest")
+        if self.layout_semantics != TEMPORAL_LAYOUT_SEMANTICS:
+            raise PerceptionTemporalError("unsupported temporal layout semantics")
+
+    @property
+    def temporal_context_signature(self) -> tuple[str, ...]:
+        return self.frame_pixel_digests
+
+
+@dataclass(frozen=True)
+class TemporalConflictGroupDTO:
+    """One byte-identical current-frame group and its temporal disambiguation result."""
+
+    group_id: str
+    current_pixel_digest: str
+    interaction_ids: tuple[str, ...]
+    action_labels: tuple[str, ...]
+    temporal_source_ids: tuple[str, ...]
+    temporal_context_count: int
+    temporally_conflicting_context_count: int
+    status: str
+
+    def __post_init__(self) -> None:
+        if self.status not in TEMPORAL_DIAGNOSIS_STATUSES:
+            raise PerceptionTemporalError("unsupported temporal conflict status")
+        if not self.group_id or not self.current_pixel_digest or not self.interaction_ids:
+            raise PerceptionTemporalError("temporal conflict identities must be non-empty")
+        if self.interaction_ids != tuple(sorted(set(self.interaction_ids))):
+            raise PerceptionTemporalError("interaction_ids must be unique and sorted")
+        if self.action_labels != tuple(sorted(set(self.action_labels))):
+            raise PerceptionTemporalError("action_labels must be unique and sorted")
+        if self.temporal_source_ids != tuple(sorted(set(self.temporal_source_ids))):
+            raise PerceptionTemporalError("temporal_source_ids must be unique and sorted")
+        if self.temporal_context_count < 0 or self.temporally_conflicting_context_count < 0:
+            raise PerceptionTemporalError("temporal counts must be non-negative")
+
+
+@dataclass(frozen=True)
+class TemporalStateDiagnosisReportDTO:
+    report_id: str
+    dataset_id: str
+    temporal_window_spec_id: str
+    split: str
+    groups: tuple[TemporalConflictGroupDTO, ...]
+    single_frame_conflict_group_count: int
+    resolved_by_temporal_context_count: int
+    unresolved_temporal_group_count: int
+    insufficient_support_group_count: int
+    diagnosis_semantics: str = TEMPORAL_DIAGNOSIS_SEMANTICS
+    version: str = TEMPORAL_DIAGNOSIS_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.report_id or not self.dataset_id or not self.temporal_window_spec_id:
+            raise PerceptionTemporalError("temporal diagnosis identities must be non-empty")
+        if self.split not in {"train", "validation", "test", "all"}:
+            raise PerceptionTemporalError("unsupported temporal diagnosis split")
+        if self.groups != tuple(sorted(self.groups, key=lambda item: item.current_pixel_digest)):
+            raise PerceptionTemporalError("temporal groups must be sorted by current digest")
+        if self.diagnosis_semantics != TEMPORAL_DIAGNOSIS_SEMANTICS:
+            raise PerceptionTemporalError("unsupported diagnosis semantics")
+        counts = (
+            self.single_frame_conflict_group_count,
+            self.resolved_by_temporal_context_count,
+            self.unresolved_temporal_group_count,
+            self.insufficient_support_group_count,
+        )
+        if any(value < 0 for value in counts):
+            raise PerceptionTemporalError("diagnosis counts must be non-negative")
+
+
+def _selected_interactions(
+    manifest: PerceptionDatasetManifestDTO,
+    split: str,
+) -> tuple[RecordedInteractionDTO, ...]:
+    if split not in {"train", "validation", "test", "all"}:
+        raise PerceptionTemporalError("split must be train, validation, test, or all")
+    selected = tuple(
+        item
+        for item in manifest.interactions
+        if split == "all" or manifest.split_for(item.interaction_id) == split
+    )
+    if not selected:
+        raise PerceptionTemporalError(f"dataset contains no {split!r} interactions")
+    return selected
+
+
+def _montage_array(frames: tuple[SourceVPMDTO, ...]) -> np.ndarray:
+    first = frames[0]
+    for frame in frames[1:]:
+        if (
+            frame.encoder_spec_id != first.encoder_spec_id
+            or frame.width != first.width
+            or frame.height != first.height
+            or frame.channels != first.channels
+            or frame.color_space != first.color_space
+            or frame.dtype != first.dtype
+        ):
+            raise PerceptionTemporalError(
+                "all temporal frames must share encoder, dimensions, channels, color space, and dtype"
+            )
+    arrays = tuple(frame.to_array() for frame in frames)
+    return np.concatenate(arrays, axis=1)
+
+
+def build_temporal_source_vpms(
+    manifest: PerceptionDatasetManifestDTO,
+    source_vpms: Mapping[str, SourceVPMDTO],
+    spec: TemporalWindowSpecDTO,
+    *,
+    split: str = "all",
+) -> tuple[TemporalSourceVPMDTO, ...]:
+    """Build deterministic oldest-to-current montage VPMs from authoritative sequences."""
+
+    selected = _selected_interactions(manifest, split)
+    by_sequence: dict[str, list[RecordedInteractionDTO]] = {}
+    for interaction in selected:
+        by_sequence.setdefault(interaction.sequence_id, []).append(interaction)
+
+    results: list[TemporalSourceVPMDTO] = []
+    for sequence_id, items in sorted(by_sequence.items()):
+        ordered = sorted(items, key=lambda item: (item.step_index, item.interaction_id))
+        for end_index in range(spec.frame_count - 1, len(ordered)):
+            window = tuple(ordered[end_index - spec.frame_count + 1 : end_index + 1])
+            if spec.require_contiguous_steps:
+                steps = tuple(item.step_index for item in window)
+                expected = tuple(range(steps[0], steps[0] + spec.frame_count))
+                if steps != expected:
+                    continue
+            try:
+                frames = tuple(source_vpms[item.source_vpm_id] for item in window)
+            except KeyError as exc:
+                raise PerceptionTemporalError(f"missing SourceVPMDTO for {exc.args[0]}") from exc
+            for interaction, frame in zip(window, frames):
+                if interaction.source_pixel_digest != frame.pixel_digest:
+                    raise PerceptionTemporalError(
+                        "source pixel identity disagrees with temporal interaction"
+                    )
+            montage = _montage_array(frames)
+            first = frames[0]
+            montage_spec = SourceImageEncoderSpecDTO(
+                color_space=first.color_space,
+                max_width=max(first.width * spec.frame_count, 1),
+                max_height=max(first.height, 1),
+                max_pixels=max(first.width * spec.frame_count * first.height, 1),
+                max_input_bytes=64 * 1024 * 1024,
+                version=(
+                    f"{TEMPORAL_SOURCE_VERSION};base={first.encoder_spec_id};"
+                    f"window={spec.temporal_window_spec_id}"
+                ),
+            )
+            montage_source = encode_source_array(montage, montage_spec)
+            current_interaction = window[-1]
+            frame_ids = tuple(frame.source_vpm_id for frame in frames)
+            frame_digests = tuple(frame.pixel_digest for frame in frames)
+            payload: Mapping[str, object] = {
+                "action_label": current_interaction.action_label,
+                "current_pixel_digest": frames[-1].pixel_digest,
+                "current_source_vpm_id": frames[-1].source_vpm_id,
+                "frame_pixel_digests": list(frame_digests),
+                "frame_source_vpm_ids": list(frame_ids),
+                "layout_semantics": TEMPORAL_LAYOUT_SEMANTICS,
+                "montage_source_vpm_id": montage_source.source_vpm_id,
+                "sequence_id": sequence_id,
+                "target_interaction_id": current_interaction.interaction_id,
+                "target_step_index": current_interaction.step_index,
+                "temporal_window_spec_id": spec.temporal_window_spec_id,
+                "version": TEMPORAL_SOURCE_VERSION,
+            }
+            results.append(
+                TemporalSourceVPMDTO(
+                    temporal_source_id=_digest(_canonical_json(payload)),
+                    temporal_window_spec_id=spec.temporal_window_spec_id,
+                    sequence_id=sequence_id,
+                    target_interaction_id=current_interaction.interaction_id,
+                    target_step_index=current_interaction.step_index,
+                    action_label=current_interaction.action_label,
+                    frame_source_vpm_ids=frame_ids,
+                    frame_pixel_digests=frame_digests,
+                    current_source_vpm_id=frames[-1].source_vpm_id,
+                    current_pixel_digest=frames[-1].pixel_digest,
+                    montage_source_vpm=montage_source,
+                )
+            )
+    return tuple(sorted(results, key=lambda item: item.temporal_source_id))
+
+
+def diagnose_temporal_state_completeness(
+    manifest: PerceptionDatasetManifestDTO,
+    temporal_sources: tuple[TemporalSourceVPMDTO, ...],
+    spec: TemporalWindowSpecDTO,
+    *,
+    split: str = "all",
+) -> TemporalStateDiagnosisReportDTO:
+    """Report whether exact prior context resolves exact current-frame action conflicts."""
+
+    selected = _selected_interactions(manifest, split)
+    temporal_by_interaction = {
+        item.target_interaction_id: item
+        for item in temporal_sources
+        if split == "all" or manifest.split_for(item.target_interaction_id) == split
+    }
+    by_current: dict[str, list[RecordedInteractionDTO]] = {}
+    for interaction in selected:
+        by_current.setdefault(interaction.source_pixel_digest, []).append(interaction)
+
+    groups: list[TemporalConflictGroupDTO] = []
+    for current_digest, interactions in sorted(by_current.items()):
+        action_labels = tuple(sorted({item.action_label for item in interactions}))
+        available = tuple(
+            temporal_by_interaction[item.interaction_id]
+            for item in interactions
+            if item.interaction_id in temporal_by_interaction
+        )
+        context_actions: dict[tuple[str, ...], set[str]] = {}
+        for temporal in available:
+            context_actions.setdefault(temporal.temporal_context_signature, set()).add(
+                temporal.action_label
+            )
+        conflicting_contexts = sum(1 for labels in context_actions.values() if len(labels) > 1)
+        if len(action_labels) <= 1:
+            status = "no_single_frame_conflict"
+        elif len(available) < len(interactions) or len(context_actions) < 2:
+            status = "insufficient_temporal_support"
+        elif conflicting_contexts > 0:
+            status = "unresolved_temporal_ambiguity"
+        else:
+            status = "incomplete_state_confirmed"
+        payload: Mapping[str, object] = {
+            "action_labels": list(action_labels),
+            "current_pixel_digest": current_digest,
+            "interaction_ids": sorted(item.interaction_id for item in interactions),
+            "status": status,
+            "temporal_context_count": len(context_actions),
+            "temporal_source_ids": sorted(item.temporal_source_id for item in available),
+            "temporally_conflicting_context_count": conflicting_contexts,
+        }
+        groups.append(
+            TemporalConflictGroupDTO(
+                group_id=_digest(_canonical_json(payload)),
+                current_pixel_digest=current_digest,
+                interaction_ids=tuple(payload["interaction_ids"]),  # type: ignore[arg-type]
+                action_labels=action_labels,
+                temporal_source_ids=tuple(payload["temporal_source_ids"]),  # type: ignore[arg-type]
+                temporal_context_count=len(context_actions),
+                temporally_conflicting_context_count=conflicting_contexts,
+                status=status,
+            )
+        )
+
+    ordered_groups = tuple(sorted(groups, key=lambda item: item.current_pixel_digest))
+    conflict_groups = tuple(
+        item for item in ordered_groups if len(item.action_labels) > 1
+    )
+    payload = {
+        "dataset_id": manifest.dataset_id,
+        "diagnosis_semantics": TEMPORAL_DIAGNOSIS_SEMANTICS,
+        "groups": [
+            {
+                "group_id": item.group_id,
+                "status": item.status,
+            }
+            for item in ordered_groups
+        ],
+        "split": split,
+        "temporal_window_spec_id": spec.temporal_window_spec_id,
+        "version": TEMPORAL_DIAGNOSIS_VERSION,
+    }
+    return TemporalStateDiagnosisReportDTO(
+        report_id=_digest(_canonical_json(payload)),
+        dataset_id=manifest.dataset_id,
+        temporal_window_spec_id=spec.temporal_window_spec_id,
+        split=split,
+        groups=ordered_groups,
+        single_frame_conflict_group_count=len(conflict_groups),
+        resolved_by_temporal_context_count=sum(
+            item.status == "incomplete_state_confirmed" for item in conflict_groups
+        ),
+        unresolved_temporal_group_count=sum(
+            item.status == "unresolved_temporal_ambiguity" for item in conflict_groups
+        ),
+        insufficient_support_group_count=sum(
+            item.status == "insufficient_temporal_support" for item in conflict_groups
+        ),
+    )

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -12,21 +12,24 @@ from zeromodel.perception import (
     REGISTRATION_SEMANTICS,
     REJECTION_SEMANTICS,
     TARGET_SCORE_SEMANTICS,
+    TEMPORAL_DIAGNOSIS_SEMANTICS,
+    TEMPORAL_LAYOUT_SEMANTICS,
     UNEXPLAINED_SURFACE_SEMANTICS,
     WEIGHTED_DISTANCE_SEMANTICS,
     BaselineInferenceConfigDTO,
     DiscreteActionSchemaDTO,
     InMemoryPerceptionDatasetStore,
     SourceImageEncoderSpecDTO,
+    TemporalWindowSpecDTO,
     TranslatorConfigDTO,
     build_grid_field_schema,
     encode_source_array,
 )
 
 
-def test_phase_seven_public_contract() -> None:
+def test_phase_eight_public_contract() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P7"
+    assert PERCEPTION_STAGE == "P8"
     assert FIELD_RELEVANCE_SEMANTICS == "eta_squared_of_field_mean_by_action"
     assert WEIGHTED_DISTANCE_SEMANTICS == (
         "field_relevance_weighted_normalized_mean_absolute_distance"
@@ -50,6 +53,13 @@ def test_phase_seven_public_contract() -> None:
     assert UNEXPLAINED_SURFACE_SEMANTICS == (
         "observed_registration_outside_declared_expected_annotations"
     )
+    assert TEMPORAL_LAYOUT_SEMANTICS == (
+        "oldest_to_current_horizontal_frame_montage"
+    )
+    assert TEMPORAL_DIAGNOSIS_SEMANTICS == (
+        "exact_current_pixel_identity_conflict_resolved_by_exact_prior_context_identity"
+    )
+    assert TemporalWindowSpecDTO(frame_count=2).frame_count == 2
     assert TranslatorConfigDTO().ridge_alpha == 1e-6
     assert SourceImageEncoderSpecDTO().color_space == "RGB"
     assert DiscreteActionSchemaDTO.from_labels(["RIGHT", "LEFT"]).labels == (

--- a/packages/perception/tests/test_temporal.py
+++ b/packages/perception/tests/test_temporal.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import numpy as np
+
+from zeromodel.perception import (
+    DiscreteActionSchemaDTO,
+    RecordedInteractionDTO,
+    SourceImageEncoderSpecDTO,
+    TemporalWindowSpecDTO,
+    build_dataset_manifest,
+    build_temporal_source_vpms,
+    diagnose_temporal_state_completeness,
+    encode_discrete_action,
+    encode_source_array,
+)
+
+
+def _fixture(*, unresolved: bool = False):
+    encoder = SourceImageEncoderSpecDTO(color_space="L")
+    action_schema = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
+
+    prior_left = encode_source_array(np.full((2, 2), 10, dtype=np.uint8), encoder)
+    prior_right = encode_source_array(
+        np.full((2, 2), 10 if unresolved else 240, dtype=np.uint8), encoder
+    )
+    shared_current = encode_source_array(np.full((2, 2), 100, dtype=np.uint8), encoder)
+
+    interactions = (
+        RecordedInteractionDTO.from_vpms(
+            sequence_id="left-sequence",
+            step_index=0,
+            source=prior_left,
+            target=encode_discrete_action("LEFT", action_schema),
+        ),
+        RecordedInteractionDTO.from_vpms(
+            sequence_id="left-sequence",
+            step_index=1,
+            source=shared_current,
+            target=encode_discrete_action("LEFT", action_schema),
+        ),
+        RecordedInteractionDTO.from_vpms(
+            sequence_id="right-sequence",
+            step_index=0,
+            source=prior_right,
+            target=encode_discrete_action("RIGHT", action_schema),
+        ),
+        RecordedInteractionDTO.from_vpms(
+            sequence_id="right-sequence",
+            step_index=1,
+            source=shared_current,
+            target=encode_discrete_action("RIGHT", action_schema),
+        ),
+    )
+    manifest = build_dataset_manifest(
+        interactions,
+        source_encoder_spec_ids=[encoder.encoder_spec_id],
+        reject_errors=False,
+    )
+    sources = {
+        source.source_vpm_id: source
+        for source in (prior_left, prior_right, shared_current)
+    }
+    return manifest, sources, shared_current
+
+
+def test_temporal_montage_is_deterministic_and_addressable() -> None:
+    manifest, sources, _ = _fixture()
+    spec = TemporalWindowSpecDTO(frame_count=2)
+
+    first = build_temporal_source_vpms(manifest, sources, spec)
+    second = build_temporal_source_vpms(manifest, sources, spec)
+
+    assert first == second
+    assert len(first) == 2
+    assert all(item.montage_source_vpm.width == 4 for item in first)
+    assert all(item.montage_source_vpm.height == 2 for item in first)
+    assert all(len(item.frame_source_vpm_ids) == 2 for item in first)
+    assert all(item.frame_source_vpm_ids[-1] == item.current_source_vpm_id for item in first)
+
+
+def test_prior_context_confirms_incomplete_single_frame_state() -> None:
+    manifest, sources, current = _fixture()
+    spec = TemporalWindowSpecDTO(frame_count=2)
+    temporal = build_temporal_source_vpms(manifest, sources, spec)
+
+    report = diagnose_temporal_state_completeness(manifest, temporal, spec)
+    conflict = next(
+        item for item in report.groups if item.current_pixel_digest == current.pixel_digest
+    )
+
+    assert conflict.action_labels == ("LEFT", "RIGHT")
+    assert conflict.temporal_context_count == 2
+    assert conflict.temporally_conflicting_context_count == 0
+    assert conflict.status == "incomplete_state_confirmed"
+    assert report.single_frame_conflict_group_count == 1
+    assert report.resolved_by_temporal_context_count == 1
+    assert report.unresolved_temporal_group_count == 0
+
+
+def test_identical_temporal_context_remains_unresolved() -> None:
+    manifest, sources, current = _fixture(unresolved=True)
+    spec = TemporalWindowSpecDTO(frame_count=2)
+    temporal = build_temporal_source_vpms(manifest, sources, spec)
+
+    report = diagnose_temporal_state_completeness(manifest, temporal, spec)
+    conflict = next(
+        item for item in report.groups if item.current_pixel_digest == current.pixel_digest
+    )
+
+    assert conflict.temporal_context_count == 1
+    assert conflict.temporally_conflicting_context_count == 1
+    assert conflict.status == "insufficient_temporal_support"
+    assert report.insufficient_support_group_count == 1
+
+
+def test_temporal_identity_changes_with_window_contract() -> None:
+    first = TemporalWindowSpecDTO(frame_count=2)
+    second = TemporalWindowSpecDTO(frame_count=3)
+
+    assert first.temporal_window_spec_id != second.temporal_window_spec_id


### PR DESCRIPTION
## Summary

Implements Stage P8: deterministic fixed-window temporal Source VPMs and exact incomplete-state diagnosis for byte-identical current frames with conflicting recorded actions.

## Temporal source artifacts

- adds immutable `TemporalWindowSpecDTO`;
- requires a fixed frame count of at least two;
- records whether step indices must be contiguous;
- materializes oldest-to-current horizontal frame montages as canonical Source VPM PNGs;
- binds temporal identity to the exact frame IDs, pixel digests, sequence, target interaction, target step, action, layout contract, and montage identity;
- validates that all frames share encoder, dimensions, channels, color space, and dtype;
- uses authoritative sequence and step metadata rather than filename adjacency.

## Incomplete-state diagnosis

- groups observations by exact current-frame pixel identity;
- identifies current frames associated with multiple recorded actions;
- compares exact temporal context signatures for every supported occurrence;
- reports `incomplete_state_confirmed` only when distinct prior-context signatures separate the conflicting actions without contradiction;
- reports `unresolved_temporal_ambiguity` when the same temporal signature still maps to conflicting actions;
- reports `insufficient_temporal_support` when required history is missing or only one temporal context is available;
- preserves no-conflict groups explicitly.

## Scientific boundary

This stage diagnoses a dataset property under exact normalized pixel identity and the declared fixed-window encoding. It does not claim that temporal context is causal, that the chosen window is sufficient in general, or that unresolved conflicts are random noise. Approximate similarity and learned temporal models remain later work.

## Public API

Advances `PERCEPTION_STAGE` from `P7` to `P8` and exports temporal versions, semantics, statuses, DTOs, errors, montage construction, and diagnosis contracts.

## Tests

Adds focused coverage for deterministic montage identity and dimensions, prior-context resolution of identical-current-frame conflicts, unresolved identical temporal contexts, temporal window identity, and the public P8 contract.

## Scope boundary

This PR does not yet fit a temporal translator, calibrate temporal rejection, compare held-out single-frame and temporal model accuracy, add frame-difference channels, infer motion, or persist temporal aggregates. Those remain later stages.

Existing unrelated repository check failures remain outside this PR's scope as previously agreed.