### PR TITLE
feat(perception): add Stage P10 calibration and model promotion

### DIFF
--- a/packages/perception/docs/stage-p10-calibration-promotion.md
+++ b/packages/perception/docs/stage-p10-calibration-promotion.md
@@ -1,0 +1,9 @@
+# Stage P10 — Calibration and Model Promotion
+
+P10 calibrates single-frame and temporal rejection thresholds from a P9 validation comparison, then deterministically promotes one immutable candidate.
+
+Calibration maximizes accepted accuracy subject to explicit minimum coverage, using coverage and the lower threshold as deterministic tie-breaks. Promotion compares calibrated accepted accuracy, raw accuracy, coverage, and finally model simplicity according to an explicit policy.
+
+The promoted model records the selected candidate identity, calibrated rejection threshold, calibration identity, promotion-decision identity, validation comparison identity, training split, evaluation split, and temporal window identity when applicable.
+
+P10 does not retrain candidates, use the test split for operating decisions, claim that the selected model is universally optimal, or erase the rejected candidate and its evidence.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -44,6 +44,13 @@ from .inference import (
     BaselineTrainingExampleDTO, NeighborEvidenceDTO, PerceptionInferenceError,
     fit_baseline_nearest_neighbor, predict_baseline_action,
 )
+from .promotion import (
+    CALIBRATION_SEMANTICS, MODEL_CALIBRATION_VERSION, MODEL_PROMOTION_VERSION,
+    PROMOTED_MODEL_KINDS, PROMOTION_DECISION_VERSION, PROMOTION_POLICY_VERSION,
+    PROMOTION_SEMANTICS, ModelCalibrationDTO, PerceptionPromotionError,
+    PromotedPerceptionModelDTO, PromotionDecisionDTO, PromotionPolicyDTO,
+    calibrate_comparison_candidates, promote_perception_model,
+)
 from .representation import (
     ACTION_SCHEMA_VERSION, SOURCE_ENCODER_VERSION, TARGET_ENCODER_VERSION,
     DiscreteActionSchemaDTO, PerceptionRepresentationError,
@@ -95,6 +102,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P9"
+PERCEPTION_STAGE = "P10"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/promotion.py
+++ b/packages/perception/src/zeromodel/perception/promotion.py
@@ -1,0 +1,342 @@
+"""Validation-owned rejection calibration and immutable model promotion for Stage P10.
+
+P10 converts P9 comparison artifacts into an explicit operating decision. Thresholds
+are selected only from validation examples. Promotion is deterministic, preserves all
+candidate identities and metrics, and does not retrain or mutate either candidate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .temporal_inference import TemporalInferenceComparisonReportDTO
+
+PROMOTION_POLICY_VERSION: Final = "perception-promotion-policy/1"
+MODEL_CALIBRATION_VERSION: Final = "perception-model-calibration/1"
+MODEL_PROMOTION_VERSION: Final = "perception-promoted-model/1"
+PROMOTION_DECISION_VERSION: Final = "perception-promotion-decision/1"
+CALIBRATION_SEMANTICS: Final = (
+    "validation_margin_threshold_maximizing_accepted_accuracy_then_coverage"
+)
+PROMOTION_SEMANTICS: Final = (
+    "validation_candidate_selection_by_accepted_accuracy_accuracy_coverage_then_simplicity"
+)
+PROMOTED_MODEL_KINDS: Final = {"single_frame", "temporal"}
+
+
+class PerceptionPromotionError(ValueError):
+    """Raised when P10 calibration or promotion contracts are invalid."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+@dataclass(frozen=True)
+class PromotionPolicyDTO:
+    """Explicit deterministic operating constraints for calibration and promotion."""
+
+    minimum_coverage: float = 0.5
+    minimum_accuracy_gain: float = 0.0
+    prefer_simpler_on_tie: bool = True
+    version: str = PROMOTION_POLICY_VERSION
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.minimum_coverage <= 1.0:
+            raise PerceptionPromotionError("minimum_coverage must be in [0, 1]")
+        if not -1.0 <= self.minimum_accuracy_gain <= 1.0:
+            raise PerceptionPromotionError("minimum_accuracy_gain must be in [-1, 1]")
+
+    def canonical_payload(self) -> Mapping[str, object]:
+        return {
+            "minimum_accuracy_gain": self.minimum_accuracy_gain,
+            "minimum_coverage": self.minimum_coverage,
+            "prefer_simpler_on_tie": self.prefer_simpler_on_tie,
+            "version": self.version,
+        }
+
+
+@dataclass(frozen=True)
+class ModelCalibrationDTO:
+    calibration_id: str
+    comparison_report_id: str
+    model_kind: str
+    model_id: str
+    validation_split: str
+    rejection_threshold: float
+    accepted_count: int
+    rejected_count: int
+    coverage: float
+    accepted_accuracy: float
+    raw_accuracy: float
+    candidate_thresholds: tuple[float, ...]
+    semantics: str = CALIBRATION_SEMANTICS
+    version: str = MODEL_CALIBRATION_VERSION
+
+    def __post_init__(self) -> None:
+        if self.model_kind not in PROMOTED_MODEL_KINDS:
+            raise PerceptionPromotionError("unsupported calibration model_kind")
+        if self.validation_split != "validation":
+            raise PerceptionPromotionError("calibration must be validation-owned")
+        if not all((self.calibration_id, self.comparison_report_id, self.model_id)):
+            raise PerceptionPromotionError("calibration identities must be non-empty")
+        for value in (
+            self.rejection_threshold,
+            self.coverage,
+            self.accepted_accuracy,
+            self.raw_accuracy,
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise PerceptionPromotionError("calibration metric outside [0, 1]")
+        if self.accepted_count <= 0 or self.rejected_count < 0:
+            raise PerceptionPromotionError("calibration counts are invalid")
+        if self.candidate_thresholds != tuple(sorted(set(self.candidate_thresholds))):
+            raise PerceptionPromotionError("candidate_thresholds must be unique and sorted")
+        if self.semantics != CALIBRATION_SEMANTICS:
+            raise PerceptionPromotionError("unsupported calibration semantics")
+
+
+@dataclass(frozen=True)
+class PromotionDecisionDTO:
+    decision_id: str
+    comparison_report_id: str
+    selected_model_kind: str
+    selected_model_id: str
+    single_calibration_id: str
+    temporal_calibration_id: str
+    selection_reason: str
+    policy: PromotionPolicyDTO
+    semantics: str = PROMOTION_SEMANTICS
+    version: str = PROMOTION_DECISION_VERSION
+
+    def __post_init__(self) -> None:
+        if self.selected_model_kind not in PROMOTED_MODEL_KINDS:
+            raise PerceptionPromotionError("unsupported selected model kind")
+        if not all(
+            (
+                self.decision_id,
+                self.comparison_report_id,
+                self.selected_model_id,
+                self.single_calibration_id,
+                self.temporal_calibration_id,
+                self.selection_reason,
+            )
+        ):
+            raise PerceptionPromotionError("promotion decision identities must be non-empty")
+        if self.semantics != PROMOTION_SEMANTICS:
+            raise PerceptionPromotionError("unsupported promotion semantics")
+
+
+@dataclass(frozen=True)
+class PromotedPerceptionModelDTO:
+    promoted_model_id: str
+    model_kind: str
+    model_id: str
+    rejection_threshold: float
+    calibration_id: str
+    promotion_decision_id: str
+    validation_comparison_report_id: str
+    training_split: str
+    evaluation_split: str
+    temporal_window_spec_id: str | None = None
+    version: str = MODEL_PROMOTION_VERSION
+
+    def __post_init__(self) -> None:
+        if self.model_kind not in PROMOTED_MODEL_KINDS:
+            raise PerceptionPromotionError("unsupported promoted model kind")
+        if not all(
+            (
+                self.promoted_model_id,
+                self.model_id,
+                self.calibration_id,
+                self.promotion_decision_id,
+                self.validation_comparison_report_id,
+            )
+        ):
+            raise PerceptionPromotionError("promoted model identities must be non-empty")
+        if not 0.0 <= self.rejection_threshold <= 1.0:
+            raise PerceptionPromotionError("rejection_threshold must be in [0, 1]")
+        if self.training_split != "train" or self.evaluation_split != "validation":
+            raise PerceptionPromotionError("promotion requires train/validation provenance")
+        if self.model_kind == "temporal" and not self.temporal_window_spec_id:
+            raise PerceptionPromotionError("temporal promotion requires window identity")
+        if self.model_kind == "single_frame" and self.temporal_window_spec_id is not None:
+            raise PerceptionPromotionError("single-frame promotion cannot carry temporal window")
+
+
+def _calibrate_one(
+    report: TemporalInferenceComparisonReportDTO,
+    model_kind: str,
+    policy: PromotionPolicyDTO,
+) -> ModelCalibrationDTO:
+    if report.split != "validation":
+        raise PerceptionPromotionError("calibration requires a validation comparison report")
+    margins = tuple(
+        item.single_margin if model_kind == "single_frame" else item.temporal_margin
+        for item in report.examples
+    )
+    correct = tuple(
+        item.single_correct if model_kind == "single_frame" else item.temporal_correct
+        for item in report.examples
+    )
+    thresholds = tuple(sorted(set((0.0, *margins))))
+    candidates: list[tuple[float, float, float, int, int]] = []
+    for threshold in thresholds:
+        accepted = tuple(index for index, margin in enumerate(margins) if margin >= threshold)
+        if not accepted:
+            continue
+        coverage = len(accepted) / len(margins)
+        if coverage < policy.minimum_coverage:
+            continue
+        accuracy = sum(1 for index in accepted if correct[index]) / len(accepted)
+        candidates.append((accuracy, coverage, -threshold, len(accepted), threshold))
+    if not candidates:
+        raise PerceptionPromotionError("no calibration threshold satisfies minimum coverage")
+    _, coverage, _, accepted_count, threshold = max(candidates)
+    accepted_indices = tuple(index for index, margin in enumerate(margins) if margin >= threshold)
+    accepted_accuracy = sum(1 for index in accepted_indices if correct[index]) / len(accepted_indices)
+    raw_accuracy = sum(1 for value in correct if value) / len(correct)
+    model_id = report.single_translator_id if model_kind == "single_frame" else report.temporal_translator_id
+    payload: Mapping[str, object] = {
+        "accepted_accuracy": accepted_accuracy,
+        "accepted_count": accepted_count,
+        "candidate_thresholds": list(thresholds),
+        "comparison_report_id": report.report_id,
+        "coverage": coverage,
+        "model_id": model_id,
+        "model_kind": model_kind,
+        "raw_accuracy": raw_accuracy,
+        "rejected_count": len(margins) - accepted_count,
+        "rejection_threshold": threshold,
+        "semantics": CALIBRATION_SEMANTICS,
+        "validation_split": report.split,
+        "version": MODEL_CALIBRATION_VERSION,
+    }
+    return ModelCalibrationDTO(
+        calibration_id=_digest(_canonical_json(payload)),
+        comparison_report_id=report.report_id,
+        model_kind=model_kind,
+        model_id=model_id,
+        validation_split=report.split,
+        rejection_threshold=threshold,
+        accepted_count=accepted_count,
+        rejected_count=len(margins) - accepted_count,
+        coverage=coverage,
+        accepted_accuracy=accepted_accuracy,
+        raw_accuracy=raw_accuracy,
+        candidate_thresholds=thresholds,
+    )
+
+
+def calibrate_comparison_candidates(
+    report: TemporalInferenceComparisonReportDTO,
+    *,
+    policy: PromotionPolicyDTO | None = None,
+) -> tuple[ModelCalibrationDTO, ModelCalibrationDTO]:
+    """Calibrate single-frame and temporal rejection using validation examples only."""
+
+    resolved = policy or PromotionPolicyDTO()
+    return (
+        _calibrate_one(report, "single_frame", resolved),
+        _calibrate_one(report, "temporal", resolved),
+    )
+
+
+def promote_perception_model(
+    report: TemporalInferenceComparisonReportDTO,
+    *,
+    policy: PromotionPolicyDTO | None = None,
+) -> tuple[PromotionDecisionDTO, PromotedPerceptionModelDTO]:
+    """Select and promote one immutable candidate from a validation comparison."""
+
+    resolved = policy or PromotionPolicyDTO()
+    single, temporal = calibrate_comparison_candidates(report, policy=resolved)
+    temporal_gain = temporal.accepted_accuracy - single.accepted_accuracy
+    if temporal_gain > resolved.minimum_accuracy_gain:
+        selected = temporal
+        reason = "temporal_exceeds_required_accepted_accuracy_gain"
+    elif temporal_gain < resolved.minimum_accuracy_gain:
+        selected = single
+        reason = "temporal_does_not_meet_required_accepted_accuracy_gain"
+    else:
+        single_rank = (single.raw_accuracy, single.coverage)
+        temporal_rank = (temporal.raw_accuracy, temporal.coverage)
+        if temporal_rank > single_rank:
+            selected = temporal
+            reason = "temporal_wins_raw_accuracy_or_coverage_tiebreak"
+        elif temporal_rank < single_rank:
+            selected = single
+            reason = "single_frame_wins_raw_accuracy_or_coverage_tiebreak"
+        elif resolved.prefer_simpler_on_tie:
+            selected = single
+            reason = "exact_tie_prefers_simpler_single_frame_model"
+        else:
+            selected = temporal
+            reason = "exact_tie_policy_prefers_temporal_model"
+    decision_payload: Mapping[str, object] = {
+        "comparison_report_id": report.report_id,
+        "policy": resolved.canonical_payload(),
+        "selected_model_id": selected.model_id,
+        "selected_model_kind": selected.model_kind,
+        "selection_reason": reason,
+        "semantics": PROMOTION_SEMANTICS,
+        "single_calibration_id": single.calibration_id,
+        "temporal_calibration_id": temporal.calibration_id,
+        "version": PROMOTION_DECISION_VERSION,
+    }
+    decision = PromotionDecisionDTO(
+        decision_id=_digest(_canonical_json(decision_payload)),
+        comparison_report_id=report.report_id,
+        selected_model_kind=selected.model_kind,
+        selected_model_id=selected.model_id,
+        single_calibration_id=single.calibration_id,
+        temporal_calibration_id=temporal.calibration_id,
+        selection_reason=reason,
+        policy=resolved,
+    )
+    promoted_payload: Mapping[str, object] = {
+        "calibration_id": selected.calibration_id,
+        "evaluation_split": "validation",
+        "model_id": selected.model_id,
+        "model_kind": selected.model_kind,
+        "promotion_decision_id": decision.decision_id,
+        "rejection_threshold": selected.rejection_threshold,
+        "temporal_window_spec_id": (
+            report.temporal_window_spec_id if selected.model_kind == "temporal" else None
+        ),
+        "training_split": "train",
+        "validation_comparison_report_id": report.report_id,
+        "version": MODEL_PROMOTION_VERSION,
+    }
+    promoted = PromotedPerceptionModelDTO(
+        promoted_model_id=_digest(_canonical_json(promoted_payload)),
+        model_kind=selected.model_kind,
+        model_id=selected.model_id,
+        rejection_threshold=selected.rejection_threshold,
+        calibration_id=selected.calibration_id,
+        promotion_decision_id=decision.decision_id,
+        validation_comparison_report_id=report.report_id,
+        training_split="train",
+        evaluation_split="validation",
+        temporal_window_spec_id=(
+            report.temporal_window_spec_id if selected.model_kind == "temporal" else None
+        ),
+    )
+    return decision, promoted

--- a/packages/perception/tests/test_promotion.py
+++ b/packages/perception/tests/test_promotion.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception import (
+    PerceptionPromotionError,
+    PromotionPolicyDTO,
+    TemporalComparisonExampleDTO,
+    TemporalInferenceComparisonReportDTO,
+    calibrate_comparison_candidates,
+    promote_perception_model,
+)
+
+
+def _report(*, split: str = "validation") -> TemporalInferenceComparisonReportDTO:
+    examples = (
+        TemporalComparisonExampleDTO(
+            interaction_id="interaction-1",
+            expected_action="LEFT",
+            single_selected_action="RIGHT",
+            temporal_selected_action="LEFT",
+            single_margin=0.05,
+            temporal_margin=0.8,
+            single_status="accepted",
+            temporal_status="accepted",
+            single_correct=False,
+            temporal_correct=True,
+            conflict_group=True,
+        ),
+        TemporalComparisonExampleDTO(
+            interaction_id="interaction-2",
+            expected_action="RIGHT",
+            single_selected_action="RIGHT",
+            temporal_selected_action="RIGHT",
+            single_margin=0.7,
+            temporal_margin=0.9,
+            single_status="accepted",
+            temporal_status="accepted",
+            single_correct=True,
+            temporal_correct=True,
+            conflict_group=True,
+        ),
+    )
+    return TemporalInferenceComparisonReportDTO(
+        report_id="sha256:validation-report",
+        split=split,
+        single_translator_id="sha256:single",
+        temporal_translator_id="sha256:temporal",
+        temporal_window_spec_id="sha256:window",
+        example_count=2,
+        single_accuracy=0.5,
+        temporal_accuracy=1.0,
+        accuracy_improvement=0.5,
+        single_accepted_accuracy=0.5,
+        temporal_accepted_accuracy=1.0,
+        single_coverage=1.0,
+        temporal_coverage=1.0,
+        mean_single_margin=0.375,
+        mean_temporal_margin=0.85,
+        conflict_example_count=2,
+        conflict_single_accuracy=0.5,
+        conflict_temporal_accuracy=1.0,
+        conflict_resolution_improvement=0.5,
+        rejection_threshold=0.0,
+        examples=examples,
+    )
+
+
+def test_calibration_is_validation_owned_and_deterministic() -> None:
+    report = _report()
+    first = calibrate_comparison_candidates(report)
+    second = calibrate_comparison_candidates(report)
+
+    assert first == second
+    single, temporal = first
+    assert single.rejection_threshold == 0.05
+    assert single.accepted_accuracy == 0.5
+    assert temporal.accepted_accuracy == 1.0
+    assert temporal.coverage == 1.0
+
+
+def test_promotion_selects_temporal_when_it_improves_validation_accuracy() -> None:
+    decision, promoted = promote_perception_model(_report())
+
+    assert decision.selected_model_kind == "temporal"
+    assert promoted.model_kind == "temporal"
+    assert promoted.model_id == "sha256:temporal"
+    assert promoted.temporal_window_spec_id == "sha256:window"
+    assert promoted.validation_comparison_report_id == "sha256:validation-report"
+
+
+def test_exact_tie_prefers_simpler_single_frame_candidate() -> None:
+    report = _report()
+    tied_examples = tuple(
+        TemporalComparisonExampleDTO(
+            interaction_id=item.interaction_id,
+            expected_action=item.expected_action,
+            single_selected_action=item.temporal_selected_action,
+            temporal_selected_action=item.temporal_selected_action,
+            single_margin=item.temporal_margin,
+            temporal_margin=item.temporal_margin,
+            single_status=item.single_status,
+            temporal_status=item.temporal_status,
+            single_correct=item.temporal_correct,
+            temporal_correct=item.temporal_correct,
+            conflict_group=item.conflict_group,
+        )
+        for item in report.examples
+    )
+    tied = TemporalInferenceComparisonReportDTO(
+        report_id="sha256:tied",
+        split="validation",
+        single_translator_id=report.single_translator_id,
+        temporal_translator_id=report.temporal_translator_id,
+        temporal_window_spec_id=report.temporal_window_spec_id,
+        example_count=2,
+        single_accuracy=1.0,
+        temporal_accuracy=1.0,
+        accuracy_improvement=0.0,
+        single_accepted_accuracy=1.0,
+        temporal_accepted_accuracy=1.0,
+        single_coverage=1.0,
+        temporal_coverage=1.0,
+        mean_single_margin=0.85,
+        mean_temporal_margin=0.85,
+        conflict_example_count=2,
+        conflict_single_accuracy=1.0,
+        conflict_temporal_accuracy=1.0,
+        conflict_resolution_improvement=0.0,
+        rejection_threshold=0.0,
+        examples=tied_examples,
+    )
+
+    decision, promoted = promote_perception_model(tied)
+
+    assert decision.selected_model_kind == "single_frame"
+    assert promoted.model_kind == "single_frame"
+    assert promoted.temporal_window_spec_id is None
+
+
+def test_calibration_rejects_test_report() -> None:
+    with pytest.raises(PerceptionPromotionError, match="validation"):
+        calibrate_comparison_candidates(_report(split="test"))
+
+
+def test_policy_validates_coverage() -> None:
+    with pytest.raises(PerceptionPromotionError, match="minimum_coverage"):
+        PromotionPolicyDTO(minimum_coverage=1.1)

--- a/packages/perception/tests/test_promotion.py
+++ b/packages/perception/tests/test_promotion.py
@@ -73,13 +73,14 @@ def test_calibration_is_validation_owned_and_deterministic() -> None:
 
     assert first == second
     single, temporal = first
-    assert single.rejection_threshold == 0.05
-    assert single.accepted_accuracy == 0.5
+    assert single.rejection_threshold == 0.7
+    assert single.accepted_accuracy == 1.0
+    assert single.coverage == 0.5
     assert temporal.accepted_accuracy == 1.0
     assert temporal.coverage == 1.0
 
 
-def test_promotion_selects_temporal_when_it_improves_validation_accuracy() -> None:
+def test_promotion_selects_temporal_when_it_improves_validation_operating_point() -> None:
     decision, promoted = promote_perception_model(_report())
 
     assert decision.selected_model_kind == "temporal"

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 from zeromodel.perception import (
+    CALIBRATION_SEMANTICS,
     COEFFICIENT_SEMANTICS,
     DIFFERENCE_SURFACE_SEMANTICS,
     FIELD_RELEVANCE_SEMANTICS,
     PERCEPTION_PACKAGE_VERSION,
     PERCEPTION_STAGE,
+    PROMOTION_SEMANTICS,
     RECONSTRUCTION_ERROR_SEMANTICS,
     REGISTRATION_SEMANTICS,
     REJECTION_SEMANTICS,
@@ -21,6 +23,7 @@ from zeromodel.perception import (
     BaselineInferenceConfigDTO,
     DiscreteActionSchemaDTO,
     InMemoryPerceptionDatasetStore,
+    PromotionPolicyDTO,
     SourceImageEncoderSpecDTO,
     TemporalWindowSpecDTO,
     TranslatorConfigDTO,
@@ -29,9 +32,9 @@ from zeromodel.perception import (
 )
 
 
-def test_phase_nine_public_contract() -> None:
+def test_phase_ten_public_contract() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P9"
+    assert PERCEPTION_STAGE == "P10"
     assert FIELD_RELEVANCE_SEMANTICS == "eta_squared_of_field_mean_by_action"
     assert WEIGHTED_DISTANCE_SEMANTICS == (
         "field_relevance_weighted_normalized_mean_absolute_distance"
@@ -60,6 +63,13 @@ def test_phase_nine_public_contract() -> None:
     assert TEMPORAL_REJECTION_SEMANTICS == (
         "reject_when_top_two_margin_below_declared_comparison_threshold"
     )
+    assert CALIBRATION_SEMANTICS == (
+        "validation_margin_threshold_maximizing_accepted_accuracy_then_coverage"
+    )
+    assert PROMOTION_SEMANTICS == (
+        "validation_candidate_selection_by_accepted_accuracy_accuracy_coverage_then_simplicity"
+    )
+    assert PromotionPolicyDTO().minimum_coverage == 0.5
     assert TemporalWindowSpecDTO(frame_count=2).frame_count == 2
     assert TranslatorConfigDTO().ridge_alpha == 1e-6
     assert SourceImageEncoderSpecDTO().color_space == "RGB"


### PR DESCRIPTION
## Summary

Implements Stage P10: validation-owned rejection calibration, deterministic candidate selection, and immutable promoted perception-model artifacts.

## Calibration

- adds explicit `PromotionPolicyDTO` with minimum coverage, minimum accepted-accuracy gain, and tie simplicity preference;
- calibrates single-frame and temporal candidates only from a P9 validation comparison;
- searches observed margin thresholds plus zero;
- maximizes accepted accuracy subject to minimum coverage;
- uses coverage and lower threshold as deterministic tie-breaks;
- records accepted/rejected counts, coverage, accepted accuracy, raw accuracy, all candidate thresholds, model identity, and comparison identity.

## Promotion

- adds immutable `PromotionDecisionDTO` and `PromotedPerceptionModelDTO`;
- compares calibrated accepted accuracy, required temporal gain, raw accuracy, coverage, and finally declared simplicity preference;
- retains identities for both candidate calibrations even though only one model is promoted;
- freezes the selected model identity, rejection threshold, calibration identity, decision identity, validation comparison identity, train/validation provenance, and temporal window identity when applicable;
- does not mutate or retrain either candidate.

## Scientific and operational boundary

Training creates candidates. Validation calibrates thresholds and selects the operating candidate. Test data remains untouched for later final evaluation. Promotion is an explicit policy decision under one dataset and comparison artifact, not proof of universal model superiority.

## Public API

Advances `PERCEPTION_STAGE` from `P9` to `P10` and exports promotion versions, semantics, DTOs, errors, calibration, and promotion contracts.

## Tests

Adds focused coverage for deterministic validation calibration, coverage-constrained threshold selection, temporal promotion when it wins the operating comparison, simpler single-frame tie preference, invalid policy rejection, test-split calibration rejection, and the public P10 contract.

## Scope boundary

This PR does not yet run the promoted model behind one polymorphic inference service, evaluate the promoted operating point on the untouched test split, persist model aggregates, manage replacement history, or monitor production drift. Those remain later stages.

The repository test suite was not executed locally through the GitHub connector, so this PR includes focused tests without claiming a verified green local run.