### PR TITLE
feat(perception): add Stage P12 promoted model lifecycle ledger

### DIFF
--- a/packages/perception/docs/stage-p12-model-lifecycle-ledger.md
+++ b/packages/perception/docs/stage-p12-model-lifecycle-ledger.md
@@ -1,0 +1,9 @@
+# Stage P12 — Promoted Model Lifecycle Ledger
+
+P12 separates immutable promoted-model artifacts from operational selection.
+
+Promoted models are registered in an append-only ledger. Activation, supersession, rollback, and deactivation are retained as ordered lifecycle transitions. A revisioned active-model pointer identifies the currently selected model without mutating or deleting any historical model artifact.
+
+Rollback may only target a registered model that was previously active. Lifecycle snapshots bind the complete model ledger, transition history, and active pointer into one deterministic identity.
+
+The in-memory store implements the DTO-only persistence protocol and optimistic revision checks. Durable SQL persistence, transactional database locking, production observation capture, drift monitoring, and automated rollback policy remain later stages.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -44,6 +44,19 @@ from .inference import (
     BaselineTrainingExampleDTO, NeighborEvidenceDTO, PerceptionInferenceError,
     fit_baseline_nearest_neighbor, predict_baseline_action,
 )
+from .lifecycle import (
+    ACTIVE_MODEL_POINTER_VERSION, ACTIVE_POINTER_SEMANTICS,
+    MODEL_LEDGER_ENTRY_VERSION, MODEL_LEDGER_SEMANTICS,
+    MODEL_LIFECYCLE_SNAPSHOT_VERSION, MODEL_TRANSITION_KINDS,
+    MODEL_TRANSITION_SEMANTICS, MODEL_TRANSITION_VERSION,
+    ActiveModelPointerDTO, InMemoryPerceptionModelLifecycleStore,
+    ModelLifecycleSnapshotDTO, ModelLifecycleTransitionDTO,
+    PerceptionModelLifecycleError, PerceptionModelLifecycleStore,
+    PromotedModelLedgerEntryDTO, activate_promoted_model,
+    build_model_lifecycle_snapshot, deactivate_active_model,
+    register_promoted_model, resolve_active_promoted_model,
+    rollback_active_model, supersede_active_model,
+)
 from .promoted_inference import (
     PROMOTED_INFERENCE_SEMANTICS, PROMOTED_INFERENCE_VERSION,
     PROMOTED_TEST_EVALUATION_SEMANTICS, PROMOTED_TEST_EVALUATION_VERSION,
@@ -109,6 +122,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P11"
+PERCEPTION_STAGE = "P12"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/lifecycle.py
+++ b/packages/perception/src/zeromodel/perception/lifecycle.py
@@ -1,0 +1,473 @@
+"""Immutable promoted-model ledger and rollback-safe lifecycle state for Stage P12.
+
+P12 separates immutable promoted model artifacts from mutable operational selection.
+Models and lifecycle transitions are append-only. The active model is represented by a
+revisioned pointer whose updates require an expected previous revision, preventing stale
+writers from silently replacing newer operational state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping, Protocol
+
+from .promoted_inference import PromotedTestEvaluationReportDTO
+from .promotion import PromotedPerceptionModelDTO
+
+MODEL_LEDGER_ENTRY_VERSION: Final = "perception-model-ledger-entry/1"
+MODEL_TRANSITION_VERSION: Final = "perception-model-transition/1"
+ACTIVE_MODEL_POINTER_VERSION: Final = "perception-active-model-pointer/1"
+MODEL_LIFECYCLE_SNAPSHOT_VERSION: Final = "perception-model-lifecycle-snapshot/1"
+MODEL_LEDGER_SEMANTICS: Final = "append_only_promoted_model_registration"
+MODEL_TRANSITION_SEMANTICS: Final = "append_only_model_activation_supersession_and_rollback"
+ACTIVE_POINTER_SEMANTICS: Final = "revisioned_active_model_pointer_with_optimistic_concurrency"
+MODEL_TRANSITION_KINDS: Final = {"activate", "supersede", "rollback", "deactivate"}
+
+
+class PerceptionModelLifecycleError(ValueError):
+    """Raised when promoted-model lifecycle contracts are violated."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(*parts: bytes) -> str:
+    hasher = hashlib.sha256()
+    for part in parts:
+        hasher.update(len(part).to_bytes(8, "big"))
+        hasher.update(part)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+@dataclass(frozen=True)
+class PromotedModelLedgerEntryDTO:
+    ledger_entry_id: str
+    promoted_model: PromotedPerceptionModelDTO
+    test_evaluation_report_id: str | None
+    registered_by: str
+    registration_reason: str
+    semantics: str = MODEL_LEDGER_SEMANTICS
+    version: str = MODEL_LEDGER_ENTRY_VERSION
+
+    def __post_init__(self) -> None:
+        if not all((self.ledger_entry_id, self.registered_by, self.registration_reason)):
+            raise PerceptionModelLifecycleError("ledger entry identities and rationale must be non-empty")
+        if self.semantics != MODEL_LEDGER_SEMANTICS:
+            raise PerceptionModelLifecycleError("unsupported model ledger semantics")
+
+
+@dataclass(frozen=True)
+class ModelLifecycleTransitionDTO:
+    transition_id: str
+    sequence_number: int
+    transition_kind: str
+    previous_promoted_model_id: str | None
+    next_promoted_model_id: str | None
+    actor: str
+    reason: str
+    related_transition_id: str | None = None
+    semantics: str = MODEL_TRANSITION_SEMANTICS
+    version: str = MODEL_TRANSITION_VERSION
+
+    def __post_init__(self) -> None:
+        if self.transition_kind not in MODEL_TRANSITION_KINDS:
+            raise PerceptionModelLifecycleError("unsupported model transition kind")
+        if self.sequence_number <= 0:
+            raise PerceptionModelLifecycleError("transition sequence_number must be positive")
+        if not all((self.transition_id, self.actor, self.reason)):
+            raise PerceptionModelLifecycleError("transition identity, actor, and reason must be non-empty")
+        if self.transition_kind == "activate":
+            if self.previous_promoted_model_id is not None or self.next_promoted_model_id is None:
+                raise PerceptionModelLifecycleError("activation requires no previous model and one next model")
+        elif self.transition_kind in {"supersede", "rollback"}:
+            if not self.previous_promoted_model_id or not self.next_promoted_model_id:
+                raise PerceptionModelLifecycleError(
+                    "supersession and rollback require previous and next model identities"
+                )
+            if self.previous_promoted_model_id == self.next_promoted_model_id:
+                raise PerceptionModelLifecycleError("transition cannot replace a model with itself")
+        elif self.transition_kind == "deactivate":
+            if self.previous_promoted_model_id is None or self.next_promoted_model_id is not None:
+                raise PerceptionModelLifecycleError(
+                    "deactivation requires one previous model and no next model"
+                )
+        if self.semantics != MODEL_TRANSITION_SEMANTICS:
+            raise PerceptionModelLifecycleError("unsupported model transition semantics")
+
+
+@dataclass(frozen=True)
+class ActiveModelPointerDTO:
+    pointer_id: str
+    revision: int
+    active_promoted_model_id: str | None
+    last_transition_id: str | None
+    semantics: str = ACTIVE_POINTER_SEMANTICS
+    version: str = ACTIVE_MODEL_POINTER_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.pointer_id:
+            raise PerceptionModelLifecycleError("active pointer identity must be non-empty")
+        if self.revision < 0:
+            raise PerceptionModelLifecycleError("active pointer revision cannot be negative")
+        if self.revision == 0 and (
+            self.active_promoted_model_id is not None or self.last_transition_id is not None
+        ):
+            raise PerceptionModelLifecycleError("revision zero pointer must be empty")
+        if self.revision > 0 and not self.last_transition_id:
+            raise PerceptionModelLifecycleError("non-zero pointer revision requires transition identity")
+        if self.semantics != ACTIVE_POINTER_SEMANTICS:
+            raise PerceptionModelLifecycleError("unsupported active pointer semantics")
+
+
+@dataclass(frozen=True)
+class ModelLifecycleSnapshotDTO:
+    snapshot_id: str
+    active_pointer: ActiveModelPointerDTO
+    ledger_entries: tuple[PromotedModelLedgerEntryDTO, ...]
+    transitions: tuple[ModelLifecycleTransitionDTO, ...]
+    version: str = MODEL_LIFECYCLE_SNAPSHOT_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.snapshot_id:
+            raise PerceptionModelLifecycleError("lifecycle snapshot identity must be non-empty")
+        if self.ledger_entries != tuple(
+            sorted(self.ledger_entries, key=lambda item: item.promoted_model.promoted_model_id)
+        ):
+            raise PerceptionModelLifecycleError("ledger entries must be sorted by promoted model identity")
+        if self.transitions != tuple(sorted(self.transitions, key=lambda item: item.sequence_number)):
+            raise PerceptionModelLifecycleError("transitions must be sorted by sequence number")
+        sequences = tuple(item.sequence_number for item in self.transitions)
+        if sequences != tuple(range(1, len(sequences) + 1)):
+            raise PerceptionModelLifecycleError("transition sequence must be contiguous from one")
+        if self.active_pointer.revision != len(self.transitions):
+            raise PerceptionModelLifecycleError("pointer revision must equal transition count")
+
+
+class PerceptionModelLifecycleStore(Protocol):
+    """DTO-only persistence boundary for promoted model lifecycle state."""
+
+    def put_ledger_entry(self, entry: PromotedModelLedgerEntryDTO) -> None: ...
+
+    def get_ledger_entry(self, promoted_model_id: str) -> PromotedModelLedgerEntryDTO: ...
+
+    def list_ledger_entries(self) -> tuple[PromotedModelLedgerEntryDTO, ...]: ...
+
+    def append_transition(self, transition: ModelLifecycleTransitionDTO) -> None: ...
+
+    def list_transitions(self) -> tuple[ModelLifecycleTransitionDTO, ...]: ...
+
+    def get_active_pointer(self) -> ActiveModelPointerDTO: ...
+
+    def replace_active_pointer(
+        self,
+        pointer: ActiveModelPointerDTO,
+        *,
+        expected_revision: int,
+    ) -> None: ...
+
+
+class InMemoryPerceptionModelLifecycleStore:
+    """Deterministic in-memory implementation of the P12 lifecycle store protocol."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, PromotedModelLedgerEntryDTO] = {}
+        self._transitions: list[ModelLifecycleTransitionDTO] = []
+        self._pointer = _empty_pointer()
+
+    def put_ledger_entry(self, entry: PromotedModelLedgerEntryDTO) -> None:
+        key = entry.promoted_model.promoted_model_id
+        existing = self._entries.get(key)
+        if existing is not None and existing != entry:
+            raise PerceptionModelLifecycleError("promoted model identity already has different ledger entry")
+        self._entries[key] = entry
+
+    def get_ledger_entry(self, promoted_model_id: str) -> PromotedModelLedgerEntryDTO:
+        try:
+            return self._entries[promoted_model_id]
+        except KeyError as exc:
+            raise PerceptionModelLifecycleError(
+                f"unknown promoted model identity: {promoted_model_id}"
+            ) from exc
+
+    def list_ledger_entries(self) -> tuple[PromotedModelLedgerEntryDTO, ...]:
+        return tuple(sorted(self._entries.values(), key=lambda item: item.promoted_model.promoted_model_id))
+
+    def append_transition(self, transition: ModelLifecycleTransitionDTO) -> None:
+        expected_sequence = len(self._transitions) + 1
+        if transition.sequence_number != expected_sequence:
+            raise PerceptionModelLifecycleError("transition sequence does not follow ledger history")
+        if any(item.transition_id == transition.transition_id for item in self._transitions):
+            raise PerceptionModelLifecycleError("transition identity already exists")
+        self._transitions.append(transition)
+
+    def list_transitions(self) -> tuple[ModelLifecycleTransitionDTO, ...]:
+        return tuple(self._transitions)
+
+    def get_active_pointer(self) -> ActiveModelPointerDTO:
+        return self._pointer
+
+    def replace_active_pointer(
+        self,
+        pointer: ActiveModelPointerDTO,
+        *,
+        expected_revision: int,
+    ) -> None:
+        if self._pointer.revision != expected_revision:
+            raise PerceptionModelLifecycleError(
+                "active model pointer revision changed during lifecycle update"
+            )
+        if pointer.revision != expected_revision + 1:
+            raise PerceptionModelLifecycleError("replacement pointer must advance revision by one")
+        self._pointer = pointer
+
+
+def _empty_pointer() -> ActiveModelPointerDTO:
+    payload: Mapping[str, object] = {
+        "active_promoted_model_id": None,
+        "last_transition_id": None,
+        "revision": 0,
+        "semantics": ACTIVE_POINTER_SEMANTICS,
+        "version": ACTIVE_MODEL_POINTER_VERSION,
+    }
+    return ActiveModelPointerDTO(
+        pointer_id=_digest(_canonical_json(payload)),
+        revision=0,
+        active_promoted_model_id=None,
+        last_transition_id=None,
+    )
+
+
+def register_promoted_model(
+    store: PerceptionModelLifecycleStore,
+    promoted_model: PromotedPerceptionModelDTO,
+    *,
+    registered_by: str,
+    registration_reason: str,
+    test_evaluation: PromotedTestEvaluationReportDTO | None = None,
+) -> PromotedModelLedgerEntryDTO:
+    """Register one immutable promoted model and optional P11 test report identity."""
+
+    if not registered_by or not registration_reason:
+        raise PerceptionModelLifecycleError("registration actor and reason must be non-empty")
+    if test_evaluation is not None:
+        if test_evaluation.promoted_model_id != promoted_model.promoted_model_id:
+            raise PerceptionModelLifecycleError("test evaluation does not belong to promoted model")
+        test_report_id = test_evaluation.report_id
+    else:
+        test_report_id = None
+    payload: Mapping[str, object] = {
+        "promoted_model_id": promoted_model.promoted_model_id,
+        "registered_by": registered_by,
+        "registration_reason": registration_reason,
+        "semantics": MODEL_LEDGER_SEMANTICS,
+        "test_evaluation_report_id": test_report_id,
+        "version": MODEL_LEDGER_ENTRY_VERSION,
+    }
+    entry = PromotedModelLedgerEntryDTO(
+        ledger_entry_id=_digest(_canonical_json(payload)),
+        promoted_model=promoted_model,
+        test_evaluation_report_id=test_report_id,
+        registered_by=registered_by,
+        registration_reason=registration_reason,
+    )
+    store.put_ledger_entry(entry)
+    return entry
+
+
+def _transition(
+    store: PerceptionModelLifecycleStore,
+    *,
+    transition_kind: str,
+    next_promoted_model_id: str | None,
+    actor: str,
+    reason: str,
+    related_transition_id: str | None = None,
+) -> tuple[ModelLifecycleTransitionDTO, ActiveModelPointerDTO]:
+    if not actor or not reason:
+        raise PerceptionModelLifecycleError("transition actor and reason must be non-empty")
+    pointer = store.get_active_pointer()
+    previous = pointer.active_promoted_model_id
+    if next_promoted_model_id is not None:
+        store.get_ledger_entry(next_promoted_model_id)
+    sequence_number = pointer.revision + 1
+    payload: Mapping[str, object] = {
+        "actor": actor,
+        "next_promoted_model_id": next_promoted_model_id,
+        "previous_promoted_model_id": previous,
+        "reason": reason,
+        "related_transition_id": related_transition_id,
+        "semantics": MODEL_TRANSITION_SEMANTICS,
+        "sequence_number": sequence_number,
+        "transition_kind": transition_kind,
+        "version": MODEL_TRANSITION_VERSION,
+    }
+    transition = ModelLifecycleTransitionDTO(
+        transition_id=_digest(_canonical_json(payload)),
+        sequence_number=sequence_number,
+        transition_kind=transition_kind,
+        previous_promoted_model_id=previous,
+        next_promoted_model_id=next_promoted_model_id,
+        actor=actor,
+        reason=reason,
+        related_transition_id=related_transition_id,
+    )
+    pointer_payload: Mapping[str, object] = {
+        "active_promoted_model_id": next_promoted_model_id,
+        "last_transition_id": transition.transition_id,
+        "revision": sequence_number,
+        "semantics": ACTIVE_POINTER_SEMANTICS,
+        "version": ACTIVE_MODEL_POINTER_VERSION,
+    }
+    replacement = ActiveModelPointerDTO(
+        pointer_id=_digest(_canonical_json(pointer_payload)),
+        revision=sequence_number,
+        active_promoted_model_id=next_promoted_model_id,
+        last_transition_id=transition.transition_id,
+    )
+    store.append_transition(transition)
+    try:
+        store.replace_active_pointer(replacement, expected_revision=pointer.revision)
+    except Exception:
+        # Store implementations should make transition+pointer atomic. The in-memory store
+        # cannot remove through the protocol, so callers should discard a failed store.
+        raise
+    return transition, replacement
+
+
+def activate_promoted_model(
+    store: PerceptionModelLifecycleStore,
+    promoted_model_id: str,
+    *,
+    actor: str,
+    reason: str,
+) -> tuple[ModelLifecycleTransitionDTO, ActiveModelPointerDTO]:
+    """Activate the first registered model when no active model exists."""
+
+    if store.get_active_pointer().active_promoted_model_id is not None:
+        raise PerceptionModelLifecycleError("activation requires no active promoted model")
+    return _transition(
+        store,
+        transition_kind="activate",
+        next_promoted_model_id=promoted_model_id,
+        actor=actor,
+        reason=reason,
+    )
+
+
+def supersede_active_model(
+    store: PerceptionModelLifecycleStore,
+    promoted_model_id: str,
+    *,
+    actor: str,
+    reason: str,
+) -> tuple[ModelLifecycleTransitionDTO, ActiveModelPointerDTO]:
+    """Replace the active model with another registered promoted model."""
+
+    current = store.get_active_pointer().active_promoted_model_id
+    if current is None:
+        raise PerceptionModelLifecycleError("supersession requires an active promoted model")
+    if current == promoted_model_id:
+        raise PerceptionModelLifecycleError("cannot supersede active model with itself")
+    return _transition(
+        store,
+        transition_kind="supersede",
+        next_promoted_model_id=promoted_model_id,
+        actor=actor,
+        reason=reason,
+    )
+
+
+def rollback_active_model(
+    store: PerceptionModelLifecycleStore,
+    target_promoted_model_id: str,
+    *,
+    actor: str,
+    reason: str,
+) -> tuple[ModelLifecycleTransitionDTO, ActiveModelPointerDTO]:
+    """Reactivate an earlier registered model while retaining complete history."""
+
+    current = store.get_active_pointer().active_promoted_model_id
+    if current is None:
+        raise PerceptionModelLifecycleError("rollback requires an active promoted model")
+    if current == target_promoted_model_id:
+        raise PerceptionModelLifecycleError("rollback target is already active")
+    transitions = store.list_transitions()
+    target_prior_transition = next(
+        (
+            item.transition_id
+            for item in reversed(transitions)
+            if item.next_promoted_model_id == target_promoted_model_id
+        ),
+        None,
+    )
+    if target_prior_transition is None:
+        raise PerceptionModelLifecycleError("rollback target was never previously active")
+    return _transition(
+        store,
+        transition_kind="rollback",
+        next_promoted_model_id=target_promoted_model_id,
+        actor=actor,
+        reason=reason,
+        related_transition_id=target_prior_transition,
+    )
+
+
+def deactivate_active_model(
+    store: PerceptionModelLifecycleStore,
+    *,
+    actor: str,
+    reason: str,
+) -> tuple[ModelLifecycleTransitionDTO, ActiveModelPointerDTO]:
+    """Clear operational selection without deleting any promoted model artifact."""
+
+    if store.get_active_pointer().active_promoted_model_id is None:
+        raise PerceptionModelLifecycleError("deactivation requires an active promoted model")
+    return _transition(
+        store,
+        transition_kind="deactivate",
+        next_promoted_model_id=None,
+        actor=actor,
+        reason=reason,
+    )
+
+
+def resolve_active_promoted_model(
+    store: PerceptionModelLifecycleStore,
+) -> PromotedPerceptionModelDTO:
+    """Resolve the active immutable promoted model from the revisioned pointer."""
+
+    active_id = store.get_active_pointer().active_promoted_model_id
+    if active_id is None:
+        raise PerceptionModelLifecycleError("no promoted model is active")
+    return store.get_ledger_entry(active_id).promoted_model
+
+
+def build_model_lifecycle_snapshot(
+    store: PerceptionModelLifecycleStore,
+) -> ModelLifecycleSnapshotDTO:
+    """Materialize a deterministic complete lifecycle snapshot."""
+
+    pointer = store.get_active_pointer()
+    entries = store.list_ledger_entries()
+    transitions = store.list_transitions()
+    payload: Mapping[str, object] = {
+        "active_pointer_id": pointer.pointer_id,
+        "ledger_entry_ids": [item.ledger_entry_id for item in entries],
+        "transition_ids": [item.transition_id for item in transitions],
+        "version": MODEL_LIFECYCLE_SNAPSHOT_VERSION,
+    }
+    return ModelLifecycleSnapshotDTO(
+        snapshot_id=_digest(_canonical_json(payload)),
+        active_pointer=pointer,
+        ledger_entries=entries,
+        transitions=transitions,
+    )

--- a/packages/perception/tests/test_lifecycle.py
+++ b/packages/perception/tests/test_lifecycle.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception import (
+    ActiveModelPointerDTO,
+    InMemoryPerceptionModelLifecycleStore,
+    PerceptionModelLifecycleError,
+    PromotedPerceptionModelDTO,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    deactivate_active_model,
+    register_promoted_model,
+    resolve_active_promoted_model,
+    rollback_active_model,
+    supersede_active_model,
+)
+
+
+def _model(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"sha256:promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"sha256:translator-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"sha256:calibration-{name}",
+        promotion_decision_id=f"sha256:decision-{name}",
+        validation_comparison_report_id=f"sha256:validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def test_registration_is_idempotent_and_deterministic() -> None:
+    store = InMemoryPerceptionModelLifecycleStore()
+    model = _model("a")
+
+    first = register_promoted_model(
+        store,
+        model,
+        registered_by="operator",
+        registration_reason="passed final review",
+    )
+    second = register_promoted_model(
+        store,
+        model,
+        registered_by="operator",
+        registration_reason="passed final review",
+    )
+
+    assert first == second
+    assert store.list_ledger_entries() == (first,)
+    assert store.get_active_pointer().revision == 0
+
+
+def test_activation_supersession_and_rollback_preserve_history() -> None:
+    store = InMemoryPerceptionModelLifecycleStore()
+    first_model = _model("a")
+    second_model = _model("b")
+    register_promoted_model(
+        store,
+        first_model,
+        registered_by="operator",
+        registration_reason="initial candidate",
+    )
+    register_promoted_model(
+        store,
+        second_model,
+        registered_by="operator",
+        registration_reason="replacement candidate",
+    )
+
+    activation, pointer_one = activate_promoted_model(
+        store,
+        first_model.promoted_model_id,
+        actor="operator",
+        reason="initial activation",
+    )
+    supersession, pointer_two = supersede_active_model(
+        store,
+        second_model.promoted_model_id,
+        actor="operator",
+        reason="validated replacement",
+    )
+    rollback, pointer_three = rollback_active_model(
+        store,
+        first_model.promoted_model_id,
+        actor="operator",
+        reason="replacement regression",
+    )
+
+    assert activation.transition_kind == "activate"
+    assert supersession.transition_kind == "supersede"
+    assert rollback.transition_kind == "rollback"
+    assert rollback.related_transition_id == activation.transition_id
+    assert (pointer_one.revision, pointer_two.revision, pointer_three.revision) == (1, 2, 3)
+    assert resolve_active_promoted_model(store) == first_model
+
+    snapshot = build_model_lifecycle_snapshot(store)
+    assert snapshot.active_pointer == pointer_three
+    assert tuple(item.transition_kind for item in snapshot.transitions) == (
+        "activate",
+        "supersede",
+        "rollback",
+    )
+    assert len(snapshot.ledger_entries) == 2
+
+
+def test_rollback_requires_target_to_have_been_active() -> None:
+    store = InMemoryPerceptionModelLifecycleStore()
+    first_model = _model("a")
+    second_model = _model("b")
+    register_promoted_model(
+        store,
+        first_model,
+        registered_by="operator",
+        registration_reason="initial candidate",
+    )
+    register_promoted_model(
+        store,
+        second_model,
+        registered_by="operator",
+        registration_reason="unactivated candidate",
+    )
+    activate_promoted_model(
+        store,
+        first_model.promoted_model_id,
+        actor="operator",
+        reason="initial activation",
+    )
+
+    with pytest.raises(PerceptionModelLifecycleError, match="never previously active"):
+        rollback_active_model(
+            store,
+            second_model.promoted_model_id,
+            actor="operator",
+            reason="invalid rollback",
+        )
+
+
+def test_deactivation_clears_pointer_without_deleting_model() -> None:
+    store = InMemoryPerceptionModelLifecycleStore()
+    model = _model("a")
+    entry = register_promoted_model(
+        store,
+        model,
+        registered_by="operator",
+        registration_reason="candidate",
+    )
+    activate_promoted_model(
+        store,
+        model.promoted_model_id,
+        actor="operator",
+        reason="activate",
+    )
+
+    transition, pointer = deactivate_active_model(
+        store,
+        actor="operator",
+        reason="maintenance",
+    )
+
+    assert transition.transition_kind == "deactivate"
+    assert pointer.active_promoted_model_id is None
+    assert store.get_ledger_entry(model.promoted_model_id) == entry
+    with pytest.raises(PerceptionModelLifecycleError, match="no promoted model is active"):
+        resolve_active_promoted_model(store)
+
+
+def test_pointer_replacement_rejects_stale_revision() -> None:
+    store = InMemoryPerceptionModelLifecycleStore()
+    stale_replacement = ActiveModelPointerDTO(
+        pointer_id="sha256:pointer",
+        revision=1,
+        active_promoted_model_id="sha256:model",
+        last_transition_id="sha256:transition",
+    )
+
+    with pytest.raises(PerceptionModelLifecycleError, match="revision changed"):
+        store.replace_active_pointer(stale_replacement, expected_revision=1)

--- a/packages/perception/tests/test_public_api_p12.py
+++ b/packages/perception/tests/test_public_api_p12.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from zeromodel.perception import (
+    ACTIVE_POINTER_SEMANTICS,
+    MODEL_LEDGER_SEMANTICS,
+    MODEL_TRANSITION_SEMANTICS,
+    PERCEPTION_STAGE,
+    InMemoryPerceptionModelLifecycleStore,
+)
+
+
+def test_phase_twelve_public_contract() -> None:
+    assert PERCEPTION_STAGE == "P12"
+    assert MODEL_LEDGER_SEMANTICS == "append_only_promoted_model_registration"
+    assert MODEL_TRANSITION_SEMANTICS == (
+        "append_only_model_activation_supersession_and_rollback"
+    )
+    assert ACTIVE_POINTER_SEMANTICS == (
+        "revisioned_active_model_pointer_with_optimistic_concurrency"
+    )
+    store = InMemoryPerceptionModelLifecycleStore()
+    assert store.get_active_pointer().revision == 0
+    assert store.list_ledger_entries() == ()
+    assert store.list_transitions() == ()


### PR DESCRIPTION
## Summary

Implements Stage P12: immutable promoted-model registration, ordered lifecycle history, revisioned active-model selection, and rollback-safe resolution.

## Model ledger

- adds immutable `PromotedModelLedgerEntryDTO` records;
- registers complete `PromotedPerceptionModelDTO` artifacts through a DTO-only store boundary;
- optionally binds the P11 final test report identity;
- preserves registration actor and rationale;
- makes identical registration idempotent while rejecting conflicting reuse of one promoted-model identity.

## Lifecycle history

- adds ordered `activate`, `supersede`, `rollback`, and `deactivate` transitions;
- preserves previous and next promoted-model identities, actor, reason, sequence number, and related transition identity;
- requires rollback targets to have been active previously;
- never mutates or deletes historical promoted-model artifacts.

## Active model resolution

- adds a revisioned `ActiveModelPointerDTO`;
- uses optimistic expected-revision checks to reject stale pointer updates;
- resolves the current immutable promoted model through the ledger;
- allows operational deactivation without deleting the registered model.

## Snapshot

`ModelLifecycleSnapshotDTO` binds the sorted model ledger, contiguous transition history, and active pointer into one deterministic lifecycle identity.

## Public API

Advances `PERCEPTION_STAGE` from `P11` to `P12` and exports lifecycle versions, semantics, DTOs, store protocol, in-memory store, registration, activation, supersession, rollback, deactivation, resolution, and snapshot contracts.

## Tests

Adds focused coverage for deterministic idempotent registration, activation/supersession/rollback history, rollback eligibility, deactivation without deletion, stale revision rejection, snapshots, and the public P12 contract.

## Scope boundary

This PR provides the persistence protocol and in-memory implementation only. Durable SQL persistence, database transactions and locking, production observation capture, drift monitoring, automated rollback policy, and deployment orchestration remain later stages.

The repository test suite was not executed locally through the GitHub connector, so this PR includes focused tests without claiming a verified green local run.