### PR TITLE
feat(perception): add Stage P14 production inference ledger

### DIFF
--- a/packages/perception/docs/stage-p14-production-inference-ledger.md
+++ b/packages/perception/docs/stage-p14-production-inference-ledger.md
@@ -1,0 +1,11 @@
+# Stage P14 — Production Observation and Inference Ledger
+
+P14 records every runtime inference as immutable operational evidence tied to the exact active promoted-model pointer revision.
+
+Observed outcomes are appended later as separate immutable records. They do not rewrite the original prediction, margin, rejection status, model identity, pointer identity, or input identity.
+
+Windowed reports derive coverage, mean margin, raw labeled accuracy, accepted-only labeled accuracy, model revisions, and evidence identities over an inclusive inference sequence range.
+
+Rejection remains separate from correctness: a rejected inference can later receive an outcome, and unlabeled records remain part of coverage and margin metrics without being treated as correct or incorrect.
+
+P14 provides a DTO-only store protocol and deterministic in-memory implementation. Durable SQL production-ledger persistence, feature-distribution drift, alert policy, automated rollback, retention policy, and deployment orchestration remain future stages.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -57,6 +57,16 @@ from .lifecycle import (
     register_promoted_model, resolve_active_promoted_model,
     rollback_active_model, supersede_active_model,
 )
+from .production import (
+    PRODUCTION_INFERENCE_RECORD_VERSION, PRODUCTION_INFERENCE_SEMANTICS,
+    PRODUCTION_METRICS_REPORT_VERSION, PRODUCTION_METRICS_SEMANTICS,
+    PRODUCTION_OUTCOME_RECORD_VERSION, PRODUCTION_OUTCOME_SEMANTICS,
+    InMemoryPerceptionProductionLedgerStore, PerceptionProductionLedgerError,
+    PerceptionProductionLedgerStore, ProductionInferenceRecordDTO,
+    ProductionMetricsReportDTO, ProductionOutcomeRecordDTO,
+    build_production_metrics_report, record_production_inference,
+    record_production_outcome,
+)
 from .promoted_inference import (
     PROMOTED_INFERENCE_SEMANTICS, PROMOTED_INFERENCE_VERSION,
     PROMOTED_TEST_EVALUATION_SEMANTICS, PROMOTED_TEST_EVALUATION_VERSION,
@@ -127,6 +137,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P13"
+PERCEPTION_STAGE = "P14"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/production.py
+++ b/packages/perception/src/zeromodel/perception/production.py
@@ -1,0 +1,383 @@
+"""Immutable production inference and outcome ledger for Stage P14.
+
+P14 records each operational inference against the exact P12/P13 active-model
+pointer revision. Outcomes are appended later as separate immutable records. Windowed
+metrics are derived from ledger records and never mutate the underlying evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping, Protocol
+
+from .lifecycle import ActiveModelPointerDTO, PromotedModelLedgerEntryDTO
+from .promoted_inference import PromotedInferenceResultDTO
+
+PRODUCTION_INFERENCE_RECORD_VERSION: Final = "perception-production-inference-record/1"
+PRODUCTION_OUTCOME_RECORD_VERSION: Final = "perception-production-outcome-record/1"
+PRODUCTION_METRICS_REPORT_VERSION: Final = "perception-production-metrics-report/1"
+PRODUCTION_INFERENCE_SEMANTICS: Final = (
+    "append_only_runtime_inference_bound_to_active_model_pointer_revision"
+)
+PRODUCTION_OUTCOME_SEMANTICS: Final = "append_only_observed_outcome_for_runtime_inference"
+PRODUCTION_METRICS_SEMANTICS: Final = (
+    "windowed_operational_metrics_over_immutable_inference_and_outcome_records"
+)
+
+
+class PerceptionProductionLedgerError(ValueError):
+    """Raised when production-ledger contracts are violated."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class ProductionInferenceRecordDTO:
+    record_id: str
+    sequence_number: int
+    pointer_id: str
+    pointer_revision: int
+    promoted_model_id: str
+    model_id: str
+    model_kind: str
+    input_id: str
+    interaction_id: str | None
+    inference_result_id: str
+    selected_action: str
+    margin: float
+    status: str
+    rejection_threshold: float
+    semantics: str = PRODUCTION_INFERENCE_SEMANTICS
+    version: str = PRODUCTION_INFERENCE_RECORD_VERSION
+
+    def __post_init__(self) -> None:
+        if self.sequence_number <= 0:
+            raise PerceptionProductionLedgerError("inference sequence_number must be positive")
+        if self.pointer_revision <= 0:
+            raise PerceptionProductionLedgerError("production inference requires active pointer revision")
+        if self.model_kind not in {"single_frame", "temporal"}:
+            raise PerceptionProductionLedgerError("unsupported production model kind")
+        if self.status not in {"accepted", "rejected_ambiguous"}:
+            raise PerceptionProductionLedgerError("unsupported production inference status")
+        if not all(
+            (
+                self.record_id,
+                self.pointer_id,
+                self.promoted_model_id,
+                self.model_id,
+                self.input_id,
+                self.inference_result_id,
+                self.selected_action,
+            )
+        ):
+            raise PerceptionProductionLedgerError("production inference identities must be non-empty")
+        for value in (self.margin, self.rejection_threshold):
+            if not 0.0 <= value <= 1.0:
+                raise PerceptionProductionLedgerError("production inference metric outside [0, 1]")
+        if self.semantics != PRODUCTION_INFERENCE_SEMANTICS:
+            raise PerceptionProductionLedgerError("unsupported production inference semantics")
+
+
+@dataclass(frozen=True)
+class ProductionOutcomeRecordDTO:
+    outcome_id: str
+    inference_record_id: str
+    outcome_sequence_number: int
+    observed_action: str
+    source: str
+    correct: bool
+    semantics: str = PRODUCTION_OUTCOME_SEMANTICS
+    version: str = PRODUCTION_OUTCOME_RECORD_VERSION
+
+    def __post_init__(self) -> None:
+        if self.outcome_sequence_number <= 0:
+            raise PerceptionProductionLedgerError("outcome sequence_number must be positive")
+        if not all((self.outcome_id, self.inference_record_id, self.observed_action, self.source)):
+            raise PerceptionProductionLedgerError("production outcome fields must be non-empty")
+        if self.semantics != PRODUCTION_OUTCOME_SEMANTICS:
+            raise PerceptionProductionLedgerError("unsupported production outcome semantics")
+
+
+@dataclass(frozen=True)
+class ProductionMetricsReportDTO:
+    report_id: str
+    promoted_model_id: str | None
+    start_sequence_number: int
+    end_sequence_number: int
+    inference_count: int
+    accepted_count: int
+    rejected_count: int
+    labeled_count: int
+    correct_count: int
+    raw_accuracy: float | None
+    accepted_accuracy: float | None
+    coverage: float
+    mean_margin: float
+    model_pointer_revisions: tuple[int, ...]
+    inference_record_ids: tuple[str, ...]
+    outcome_ids: tuple[str, ...]
+    semantics: str = PRODUCTION_METRICS_SEMANTICS
+    version: str = PRODUCTION_METRICS_REPORT_VERSION
+
+    def __post_init__(self) -> None:
+        if self.start_sequence_number <= 0 or self.end_sequence_number < self.start_sequence_number:
+            raise PerceptionProductionLedgerError("invalid production metrics window")
+        if self.inference_count <= 0 or self.inference_count != len(self.inference_record_ids):
+            raise PerceptionProductionLedgerError("production metrics inference count is invalid")
+        if self.accepted_count + self.rejected_count != self.inference_count:
+            raise PerceptionProductionLedgerError("accepted and rejected counts must exhaust inferences")
+        if self.correct_count > self.labeled_count or self.labeled_count != len(self.outcome_ids):
+            raise PerceptionProductionLedgerError("production metrics outcome counts are invalid")
+        for value in (self.coverage, self.mean_margin):
+            if not 0.0 <= value <= 1.0:
+                raise PerceptionProductionLedgerError("production metric outside [0, 1]")
+        for value in (self.raw_accuracy, self.accepted_accuracy):
+            if value is not None and not 0.0 <= value <= 1.0:
+                raise PerceptionProductionLedgerError("production accuracy outside [0, 1]")
+        if tuple(sorted(set(self.model_pointer_revisions))) != self.model_pointer_revisions:
+            raise PerceptionProductionLedgerError("pointer revisions must be unique and sorted")
+        if self.semantics != PRODUCTION_METRICS_SEMANTICS:
+            raise PerceptionProductionLedgerError("unsupported production metrics semantics")
+
+
+class PerceptionProductionLedgerStore(Protocol):
+    def append_inference(self, record: ProductionInferenceRecordDTO) -> None: ...
+
+    def get_inference(self, record_id: str) -> ProductionInferenceRecordDTO: ...
+
+    def list_inferences(self) -> tuple[ProductionInferenceRecordDTO, ...]: ...
+
+    def append_outcome(self, outcome: ProductionOutcomeRecordDTO) -> None: ...
+
+    def get_outcome_for_inference(self, record_id: str) -> ProductionOutcomeRecordDTO | None: ...
+
+    def list_outcomes(self) -> tuple[ProductionOutcomeRecordDTO, ...]: ...
+
+
+class InMemoryPerceptionProductionLedgerStore:
+    """Deterministic append-only P14 store implementation."""
+
+    def __init__(self) -> None:
+        self._inferences: list[ProductionInferenceRecordDTO] = []
+        self._inference_by_id: dict[str, ProductionInferenceRecordDTO] = {}
+        self._outcomes: list[ProductionOutcomeRecordDTO] = []
+        self._outcome_by_inference: dict[str, ProductionOutcomeRecordDTO] = {}
+
+    def append_inference(self, record: ProductionInferenceRecordDTO) -> None:
+        expected = len(self._inferences) + 1
+        if record.sequence_number != expected:
+            raise PerceptionProductionLedgerError("production inference sequence is not contiguous")
+        existing = self._inference_by_id.get(record.record_id)
+        if existing is not None:
+            if existing == record:
+                return
+            raise PerceptionProductionLedgerError("production inference identity conflict")
+        self._inferences.append(record)
+        self._inference_by_id[record.record_id] = record
+
+    def get_inference(self, record_id: str) -> ProductionInferenceRecordDTO:
+        try:
+            return self._inference_by_id[record_id]
+        except KeyError as exc:
+            raise PerceptionProductionLedgerError(f"unknown production inference: {record_id}") from exc
+
+    def list_inferences(self) -> tuple[ProductionInferenceRecordDTO, ...]:
+        return tuple(self._inferences)
+
+    def append_outcome(self, outcome: ProductionOutcomeRecordDTO) -> None:
+        self.get_inference(outcome.inference_record_id)
+        existing = self._outcome_by_inference.get(outcome.inference_record_id)
+        if existing is not None:
+            if existing == outcome:
+                return
+            raise PerceptionProductionLedgerError("inference already has a different outcome")
+        expected = len(self._outcomes) + 1
+        if outcome.outcome_sequence_number != expected:
+            raise PerceptionProductionLedgerError("production outcome sequence is not contiguous")
+        self._outcomes.append(outcome)
+        self._outcome_by_inference[outcome.inference_record_id] = outcome
+
+    def get_outcome_for_inference(self, record_id: str) -> ProductionOutcomeRecordDTO | None:
+        return self._outcome_by_inference.get(record_id)
+
+    def list_outcomes(self) -> tuple[ProductionOutcomeRecordDTO, ...]:
+        return tuple(self._outcomes)
+
+
+def record_production_inference(
+    store: PerceptionProductionLedgerStore,
+    pointer: ActiveModelPointerDTO,
+    ledger_entry: PromotedModelLedgerEntryDTO,
+    result: PromotedInferenceResultDTO,
+) -> ProductionInferenceRecordDTO:
+    """Append one runtime inference tied to the exact active pointer revision."""
+
+    if pointer.active_promoted_model_id is None:
+        raise PerceptionProductionLedgerError("cannot record production inference without active model")
+    promoted = ledger_entry.promoted_model
+    if pointer.active_promoted_model_id != promoted.promoted_model_id:
+        raise PerceptionProductionLedgerError("ledger entry is not the active promoted model")
+    if result.promoted_model_id != promoted.promoted_model_id:
+        raise PerceptionProductionLedgerError("inference result does not belong to active promoted model")
+    if result.model_id != promoted.model_id or result.model_kind != promoted.model_kind:
+        raise PerceptionProductionLedgerError("inference result candidate does not match promoted model")
+    sequence_number = len(store.list_inferences()) + 1
+    payload: Mapping[str, object] = {
+        "inference_result_id": result.result_id,
+        "input_id": result.input_id,
+        "interaction_id": result.interaction_id,
+        "margin": result.margin,
+        "model_id": result.model_id,
+        "model_kind": result.model_kind,
+        "pointer_id": pointer.pointer_id,
+        "pointer_revision": pointer.revision,
+        "promoted_model_id": result.promoted_model_id,
+        "rejection_threshold": result.rejection_threshold,
+        "selected_action": result.selected_action,
+        "semantics": PRODUCTION_INFERENCE_SEMANTICS,
+        "sequence_number": sequence_number,
+        "status": result.status,
+        "version": PRODUCTION_INFERENCE_RECORD_VERSION,
+    }
+    record = ProductionInferenceRecordDTO(
+        record_id=_digest(payload),
+        sequence_number=sequence_number,
+        pointer_id=pointer.pointer_id,
+        pointer_revision=pointer.revision,
+        promoted_model_id=result.promoted_model_id,
+        model_id=result.model_id,
+        model_kind=result.model_kind,
+        input_id=result.input_id,
+        interaction_id=result.interaction_id,
+        inference_result_id=result.result_id,
+        selected_action=result.selected_action,
+        margin=result.margin,
+        status=result.status,
+        rejection_threshold=result.rejection_threshold,
+    )
+    store.append_inference(record)
+    return record
+
+
+def record_production_outcome(
+    store: PerceptionProductionLedgerStore,
+    inference_record_id: str,
+    *,
+    observed_action: str,
+    source: str,
+) -> ProductionOutcomeRecordDTO:
+    """Append one authoritative observed outcome for a prior production inference."""
+
+    if not observed_action or not source:
+        raise PerceptionProductionLedgerError("observed action and source must be non-empty")
+    inference = store.get_inference(inference_record_id)
+    sequence_number = len(store.list_outcomes()) + 1
+    correct = inference.selected_action == observed_action
+    payload: Mapping[str, object] = {
+        "correct": correct,
+        "inference_record_id": inference_record_id,
+        "observed_action": observed_action,
+        "outcome_sequence_number": sequence_number,
+        "semantics": PRODUCTION_OUTCOME_SEMANTICS,
+        "source": source,
+        "version": PRODUCTION_OUTCOME_RECORD_VERSION,
+    }
+    outcome = ProductionOutcomeRecordDTO(
+        outcome_id=_digest(payload),
+        inference_record_id=inference_record_id,
+        outcome_sequence_number=sequence_number,
+        observed_action=observed_action,
+        source=source,
+        correct=correct,
+    )
+    store.append_outcome(outcome)
+    return outcome
+
+
+def build_production_metrics_report(
+    store: PerceptionProductionLedgerStore,
+    *,
+    start_sequence_number: int,
+    end_sequence_number: int | None = None,
+    promoted_model_id: str | None = None,
+) -> ProductionMetricsReportDTO:
+    """Derive metrics over an inclusive inference sequence window."""
+
+    all_records = store.list_inferences()
+    if not all_records:
+        raise PerceptionProductionLedgerError("production metrics require inference records")
+    resolved_end = end_sequence_number or all_records[-1].sequence_number
+    if start_sequence_number <= 0 or resolved_end < start_sequence_number:
+        raise PerceptionProductionLedgerError("invalid production metrics sequence window")
+    records = tuple(
+        item
+        for item in all_records
+        if start_sequence_number <= item.sequence_number <= resolved_end
+        and (promoted_model_id is None or item.promoted_model_id == promoted_model_id)
+    )
+    if not records:
+        raise PerceptionProductionLedgerError("production metrics window contains no matching records")
+    outcomes = tuple(
+        outcome
+        for item in records
+        if (outcome := store.get_outcome_for_inference(item.record_id)) is not None
+    )
+    accepted = tuple(item for item in records if item.status == "accepted")
+    accepted_ids = {item.record_id for item in accepted}
+    accepted_outcomes = tuple(item for item in outcomes if item.inference_record_id in accepted_ids)
+    correct_count = sum(1 for item in outcomes if item.correct)
+    raw_accuracy = correct_count / len(outcomes) if outcomes else None
+    accepted_correct = sum(1 for item in accepted_outcomes if item.correct)
+    accepted_accuracy = (
+        accepted_correct / len(accepted_outcomes) if accepted_outcomes else None
+    )
+    payload: Mapping[str, object] = {
+        "accepted_accuracy": accepted_accuracy,
+        "accepted_count": len(accepted),
+        "correct_count": correct_count,
+        "coverage": len(accepted) / len(records),
+        "end_sequence_number": resolved_end,
+        "inference_record_ids": [item.record_id for item in records],
+        "labeled_count": len(outcomes),
+        "mean_margin": sum(item.margin for item in records) / len(records),
+        "model_pointer_revisions": sorted({item.pointer_revision for item in records}),
+        "outcome_ids": [item.outcome_id for item in outcomes],
+        "promoted_model_id": promoted_model_id,
+        "raw_accuracy": raw_accuracy,
+        "rejected_count": len(records) - len(accepted),
+        "semantics": PRODUCTION_METRICS_SEMANTICS,
+        "start_sequence_number": start_sequence_number,
+        "version": PRODUCTION_METRICS_REPORT_VERSION,
+    }
+    return ProductionMetricsReportDTO(
+        report_id=_digest(payload),
+        promoted_model_id=promoted_model_id,
+        start_sequence_number=start_sequence_number,
+        end_sequence_number=resolved_end,
+        inference_count=len(records),
+        accepted_count=len(accepted),
+        rejected_count=len(records) - len(accepted),
+        labeled_count=len(outcomes),
+        correct_count=correct_count,
+        raw_accuracy=raw_accuracy,
+        accepted_accuracy=accepted_accuracy,
+        coverage=len(accepted) / len(records),
+        mean_margin=sum(item.margin for item in records) / len(records),
+        model_pointer_revisions=tuple(sorted({item.pointer_revision for item in records})),
+        inference_record_ids=tuple(item.record_id for item in records),
+        outcome_ids=tuple(item.outcome_id for item in outcomes),
+    )

--- a/packages/perception/tests/test_production.py
+++ b/packages/perception/tests/test_production.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception import (
+    InMemoryPerceptionProductionLedgerStore,
+    PerceptionProductionLedgerError,
+    ProductionInferenceRecordDTO,
+    build_production_metrics_report,
+    record_production_outcome,
+)
+
+
+def _record(
+    sequence: int,
+    *,
+    status: str = "accepted",
+    action: str = "LEFT",
+    margin: float = 0.8,
+    revision: int = 1,
+    model: str = "promoted-a",
+) -> ProductionInferenceRecordDTO:
+    return ProductionInferenceRecordDTO(
+        record_id=f"record-{sequence}",
+        sequence_number=sequence,
+        pointer_id=f"pointer-{revision}",
+        pointer_revision=revision,
+        promoted_model_id=model,
+        model_id="translator-a",
+        model_kind="single_frame",
+        input_id=f"input-{sequence}",
+        interaction_id=f"interaction-{sequence}",
+        inference_result_id=f"result-{sequence}",
+        selected_action=action,
+        margin=margin,
+        status=status,
+        rejection_threshold=0.5,
+    )
+
+
+def test_append_only_inference_and_outcome_ledger() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    first = _record(1)
+    second = _record(2, status="rejected_ambiguous", action="RIGHT", margin=0.2)
+    store.append_inference(first)
+    store.append_inference(second)
+
+    outcome = record_production_outcome(
+        store,
+        first.record_id,
+        observed_action="LEFT",
+        source="environment-step",
+    )
+
+    assert store.list_inferences() == (first, second)
+    assert outcome.correct is True
+    assert store.get_outcome_for_inference(first.record_id) == outcome
+
+
+def test_outcome_is_immutable_per_inference() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    first = _record(1)
+    store.append_inference(first)
+    record_production_outcome(
+        store,
+        first.record_id,
+        observed_action="LEFT",
+        source="environment-step",
+    )
+
+    with pytest.raises(PerceptionProductionLedgerError):
+        record_production_outcome(
+            store,
+            first.record_id,
+            observed_action="RIGHT",
+            source="manual-correction",
+        )
+
+
+def test_windowed_metrics_keep_rejection_separate_from_correctness() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    first = _record(1, status="accepted", action="LEFT", margin=0.9)
+    second = _record(2, status="rejected_ambiguous", action="RIGHT", margin=0.1)
+    third = _record(3, status="accepted", action="RIGHT", margin=0.7, revision=2)
+    for item in (first, second, third):
+        store.append_inference(item)
+
+    record_production_outcome(
+        store, first.record_id, observed_action="LEFT", source="environment-step"
+    )
+    record_production_outcome(
+        store, second.record_id, observed_action="LEFT", source="environment-step"
+    )
+
+    report = build_production_metrics_report(
+        store,
+        start_sequence_number=1,
+        end_sequence_number=3,
+    )
+
+    assert report.inference_count == 3
+    assert report.accepted_count == 2
+    assert report.rejected_count == 1
+    assert report.labeled_count == 2
+    assert report.raw_accuracy == 0.5
+    assert report.accepted_accuracy == 1.0
+    assert report.coverage == pytest.approx(2 / 3)
+    assert report.model_pointer_revisions == (1, 2)
+
+
+def test_metrics_can_filter_one_promoted_model() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    store.append_inference(_record(1, model="promoted-a"))
+    store.append_inference(_record(2, model="promoted-b"))
+
+    report = build_production_metrics_report(
+        store,
+        start_sequence_number=1,
+        promoted_model_id="promoted-b",
+    )
+
+    assert report.inference_count == 1
+    assert report.promoted_model_id == "promoted-b"
+
+
+def test_inference_sequence_must_be_contiguous() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    with pytest.raises(PerceptionProductionLedgerError):
+        store.append_inference(_record(2))

--- a/packages/perception/tests/test_public_api_p14.py
+++ b/packages/perception/tests/test_public_api_p14.py
@@ -1,0 +1,21 @@
+from zeromodel.perception import (
+    PERCEPTION_STAGE,
+    PRODUCTION_INFERENCE_SEMANTICS,
+    PRODUCTION_METRICS_SEMANTICS,
+    PRODUCTION_OUTCOME_SEMANTICS,
+    InMemoryPerceptionProductionLedgerStore,
+)
+
+
+def test_phase_fourteen_public_contract() -> None:
+    assert PERCEPTION_STAGE == "P14"
+    assert PRODUCTION_INFERENCE_SEMANTICS == (
+        "append_only_runtime_inference_bound_to_active_model_pointer_revision"
+    )
+    assert PRODUCTION_OUTCOME_SEMANTICS == (
+        "append_only_observed_outcome_for_runtime_inference"
+    )
+    assert PRODUCTION_METRICS_SEMANTICS == (
+        "windowed_operational_metrics_over_immutable_inference_and_outcome_records"
+    )
+    assert InMemoryPerceptionProductionLedgerStore().list_inferences() == ()


### PR DESCRIPTION
## Summary

Implements Stage P14: immutable production inference capture, append-only observed outcomes, and deterministic windowed operational metrics.

## Production inference ledger

- adds immutable `ProductionInferenceRecordDTO` records;
- binds every runtime inference to the exact active-model pointer identity and revision;
- preserves promoted-model identity, underlying model identity and kind, input identity, interaction identity, inference-result identity, selected action, margin, rejection threshold, and accepted/rejected status;
- validates that the runtime result belongs to the model selected by the supplied active pointer and ledger entry;
- uses contiguous sequence numbers and deterministic record identities.

## Outcome capture

- adds immutable `ProductionOutcomeRecordDTO` records appended after inference;
- preserves the authoritative observed action and outcome source;
- derives correctness without modifying the original prediction;
- allows at most one immutable outcome per inference and rejects conflicting replacement.

## Operational metrics

- adds `ProductionMetricsReportDTO` over an inclusive inference sequence window;
- reports inference count, accepted/rejected counts, labeled/correct counts, coverage, mean margin, raw labeled accuracy, accepted-only labeled accuracy, pointer revisions, and exact evidence identities;
- supports filtering one promoted model while retaining the original global sequence window;
- keeps rejection, missing labels, and incorrectness as separate states.

## Store boundary

Adds a DTO-only `PerceptionProductionLedgerStore` protocol and deterministic `InMemoryPerceptionProductionLedgerStore` implementation.

## Public API

Advances `PERCEPTION_STAGE` from `P13` to `P14` and exports production ledger versions, semantics, DTOs, errors, store contracts, recording functions, and metrics reporting.

## Tests

Adds focused coverage for append-only inference and outcome records, immutable outcome conflicts, rejection-aware metrics, model filtering, contiguous sequence enforcement, and the public P14 contract.

## Scope boundary

P14 does not yet add durable SQL production-ledger persistence, timestamps or retention policy, feature-distribution drift, alert thresholds, automated rollback, or deployment orchestration.

The repository test suite was not executed locally through the GitHub connector, so this PR includes focused tests without claiming a verified green local run.