### PR TITLE
feat(perception): add Stage P16 operational drift health diagnosis

### DIFF
--- a/packages/perception/docs/stage-p16-operational-drift-health.md
+++ b/packages/perception/docs/stage-p16-operational-drift-health.md
@@ -1,0 +1,11 @@
+# Stage P16 — Operational Drift and Health Diagnosis
+
+P16 freezes an `OperationalReferenceProfileDTO` from the exact untouched P11 test evaluation associated with a promoted model, then compares immutable P14/P15 production sequence windows against that reference.
+
+The diagnosis keeps five signals separate: coverage drop, mean-margin drop, selected-action distribution distance, raw labeled-accuracy drop, and accepted-only labeled-accuracy drop. Action drift uses total-variation distance over the union of reference and production action labels.
+
+`OperationalDriftPolicyDTO` declares every threshold and the minimum labeled-outcome count required for accuracy findings. When the label requirement is not met, accuracy is reported as `insufficient_evidence`; missing labels are never treated as errors and rejected predictions are never automatically treated as incorrect.
+
+`OperationalHealthReportDTO` preserves the frozen reference identity, P14 metrics-report identity, inclusive production window, exact inference and outcome identities, production action distribution, per-metric findings, and deterministic overall status.
+
+P16 is diagnostic only. It does not mutate the promoted model, recalibrate thresholds, alter lifecycle state, emit external alerts, or automatically trigger rollback.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -37,6 +37,16 @@ from .fields import (
     build_grid_field_schema, extract_source_fields, mask_source_fields,
     reconstruct_source_array, validate_source_for_schema,
 )
+from .health import (
+    OPERATIONAL_DRIFT_POLICY_VERSION, OPERATIONAL_HEALTH_FINDING_VERSION,
+    OPERATIONAL_HEALTH_METRICS, OPERATIONAL_HEALTH_REPORT_VERSION,
+    OPERATIONAL_HEALTH_SEMANTICS, OPERATIONAL_HEALTH_STATUSES,
+    OPERATIONAL_REFERENCE_PROFILE_VERSION, OPERATIONAL_REFERENCE_SEMANTICS,
+    ActionFrequencyDTO, OperationalDriftPolicyDTO,
+    OperationalHealthFindingDTO, OperationalHealthReportDTO,
+    OperationalReferenceProfileDTO, PerceptionOperationalHealthError,
+    build_operational_reference_profile, diagnose_operational_health,
+)
 from .inference import (
     BASELINE_MODEL_VERSION, CONFIDENCE_SEMANTICS, DISTANCE_SEMANTICS,
     PREDICTION_VERSION, ActionCandidateDTO, BaselineInferenceConfigDTO,
@@ -142,6 +152,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P15"
+PERCEPTION_STAGE = "P16"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/health.py
+++ b/packages/perception/src/zeromodel/perception/health.py
@@ -1,0 +1,503 @@
+"""Operational drift and health diagnosis for Stage P16.
+
+P16 freezes a reference profile from the promoted model's untouched P11 test report,
+then compares an immutable P14/P15 production sequence window against that profile.
+Coverage, margin, selected-action distribution, and labeled accuracy remain separate
+signals. Missing production labels produce insufficient evidence rather than an
+invented accuracy finding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .production import (
+    PerceptionProductionLedgerError,
+    PerceptionProductionLedgerStore,
+    ProductionInferenceRecordDTO,
+    build_production_metrics_report,
+)
+from .promoted_inference import PromotedTestEvaluationReportDTO
+
+OPERATIONAL_REFERENCE_PROFILE_VERSION: Final = "perception-operational-reference-profile/1"
+OPERATIONAL_DRIFT_POLICY_VERSION: Final = "perception-operational-drift-policy/1"
+OPERATIONAL_HEALTH_FINDING_VERSION: Final = "perception-operational-health-finding/1"
+OPERATIONAL_HEALTH_REPORT_VERSION: Final = "perception-operational-health-report/1"
+OPERATIONAL_REFERENCE_SEMANTICS: Final = (
+    "frozen_reference_profile_from_untouched_promoted_test_evaluation"
+)
+OPERATIONAL_HEALTH_SEMANTICS: Final = (
+    "production_window_health_against_frozen_promoted_model_reference"
+)
+OPERATIONAL_HEALTH_STATUSES: Final = {"healthy", "drifted", "insufficient_evidence"}
+OPERATIONAL_HEALTH_METRICS: Final = {
+    "coverage",
+    "mean_margin",
+    "action_distribution",
+    "raw_accuracy",
+    "accepted_accuracy",
+}
+
+
+class PerceptionOperationalHealthError(ValueError):
+    """Raised when P16 drift and health contracts are violated."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class ActionFrequencyDTO:
+    action_label: str
+    count: int
+    frequency: float
+
+    def __post_init__(self) -> None:
+        if not self.action_label or self.count < 0:
+            raise PerceptionOperationalHealthError("invalid action-frequency entry")
+        if not 0.0 <= self.frequency <= 1.0:
+            raise PerceptionOperationalHealthError("action frequency must be in [0, 1]")
+
+
+@dataclass(frozen=True)
+class OperationalReferenceProfileDTO:
+    reference_profile_id: str
+    promoted_model_id: str
+    model_kind: str
+    model_id: str
+    test_report_id: str
+    example_count: int
+    coverage: float
+    mean_margin: float
+    raw_accuracy: float
+    accepted_accuracy: float | None
+    action_distribution: tuple[ActionFrequencyDTO, ...]
+    semantics: str = OPERATIONAL_REFERENCE_SEMANTICS
+    version: str = OPERATIONAL_REFERENCE_PROFILE_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.reference_profile_id,
+                self.promoted_model_id,
+                self.model_kind,
+                self.model_id,
+                self.test_report_id,
+            )
+        ):
+            raise PerceptionOperationalHealthError("reference identities must be non-empty")
+        if self.model_kind not in {"single_frame", "temporal"}:
+            raise PerceptionOperationalHealthError("unsupported reference model kind")
+        if self.example_count <= 0:
+            raise PerceptionOperationalHealthError("reference profile requires examples")
+        for value in (self.coverage, self.mean_margin, self.raw_accuracy):
+            if not 0.0 <= value <= 1.0:
+                raise PerceptionOperationalHealthError("reference metric outside [0, 1]")
+        if self.accepted_accuracy is not None and not 0.0 <= self.accepted_accuracy <= 1.0:
+            raise PerceptionOperationalHealthError("reference accepted accuracy outside [0, 1]")
+        if not self.action_distribution:
+            raise PerceptionOperationalHealthError("reference action distribution cannot be empty")
+        if self.action_distribution != tuple(
+            sorted(self.action_distribution, key=lambda item: item.action_label)
+        ):
+            raise PerceptionOperationalHealthError("reference actions must be sorted")
+        if sum(item.count for item in self.action_distribution) != self.example_count:
+            raise PerceptionOperationalHealthError("reference action counts must exhaust examples")
+        if abs(sum(item.frequency for item in self.action_distribution) - 1.0) > 1e-9:
+            raise PerceptionOperationalHealthError("reference action frequencies must sum to one")
+        if self.semantics != OPERATIONAL_REFERENCE_SEMANTICS:
+            raise PerceptionOperationalHealthError("unsupported reference semantics")
+
+
+@dataclass(frozen=True)
+class OperationalDriftPolicyDTO:
+    maximum_coverage_drop: float = 0.10
+    maximum_mean_margin_drop: float = 0.10
+    maximum_action_distribution_distance: float = 0.20
+    maximum_raw_accuracy_drop: float = 0.10
+    maximum_accepted_accuracy_drop: float = 0.10
+    minimum_labeled_count: int = 20
+    version: str = OPERATIONAL_DRIFT_POLICY_VERSION
+
+    def __post_init__(self) -> None:
+        for value in (
+            self.maximum_coverage_drop,
+            self.maximum_mean_margin_drop,
+            self.maximum_action_distribution_distance,
+            self.maximum_raw_accuracy_drop,
+            self.maximum_accepted_accuracy_drop,
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise PerceptionOperationalHealthError("drift threshold outside [0, 1]")
+        if self.minimum_labeled_count <= 0:
+            raise PerceptionOperationalHealthError("minimum_labeled_count must be positive")
+
+
+@dataclass(frozen=True)
+class OperationalHealthFindingDTO:
+    finding_id: str
+    metric: str
+    status: str
+    reference_value: float | None
+    observed_value: float | None
+    delta: float | None
+    threshold: float
+    evidence_count: int
+    rationale: str
+    version: str = OPERATIONAL_HEALTH_FINDING_VERSION
+
+    def __post_init__(self) -> None:
+        if self.metric not in OPERATIONAL_HEALTH_METRICS:
+            raise PerceptionOperationalHealthError("unsupported health metric")
+        if self.status not in OPERATIONAL_HEALTH_STATUSES:
+            raise PerceptionOperationalHealthError("unsupported health status")
+        if not self.finding_id or not self.rationale:
+            raise PerceptionOperationalHealthError("health finding identity and rationale required")
+        if self.evidence_count < 0 or not 0.0 <= self.threshold <= 1.0:
+            raise PerceptionOperationalHealthError("invalid finding evidence or threshold")
+        for value in (self.reference_value, self.observed_value):
+            if value is not None and not 0.0 <= value <= 1.0:
+                raise PerceptionOperationalHealthError("finding value outside [0, 1]")
+        if self.delta is not None and not -1.0 <= self.delta <= 1.0:
+            raise PerceptionOperationalHealthError("finding delta outside [-1, 1]")
+
+
+@dataclass(frozen=True)
+class OperationalHealthReportDTO:
+    report_id: str
+    reference_profile_id: str
+    promoted_model_id: str
+    start_sequence_number: int
+    end_sequence_number: int
+    production_metrics_report_id: str
+    production_action_distribution: tuple[ActionFrequencyDTO, ...]
+    action_distribution_distance: float
+    overall_status: str
+    findings: tuple[OperationalHealthFindingDTO, ...]
+    inference_record_ids: tuple[str, ...]
+    outcome_ids: tuple[str, ...]
+    semantics: str = OPERATIONAL_HEALTH_SEMANTICS
+    version: str = OPERATIONAL_HEALTH_REPORT_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.report_id,
+                self.reference_profile_id,
+                self.promoted_model_id,
+                self.production_metrics_report_id,
+            )
+        ):
+            raise PerceptionOperationalHealthError("health report identities must be non-empty")
+        if self.start_sequence_number <= 0 or self.end_sequence_number < self.start_sequence_number:
+            raise PerceptionOperationalHealthError("invalid health report window")
+        if self.overall_status not in OPERATIONAL_HEALTH_STATUSES:
+            raise PerceptionOperationalHealthError("unsupported overall health status")
+        if not 0.0 <= self.action_distribution_distance <= 1.0:
+            raise PerceptionOperationalHealthError("action distribution distance outside [0, 1]")
+        if tuple(item.metric for item in self.findings) != (
+            "coverage",
+            "mean_margin",
+            "action_distribution",
+            "raw_accuracy",
+            "accepted_accuracy",
+        ):
+            raise PerceptionOperationalHealthError("health findings must use canonical order")
+        if self.production_action_distribution != tuple(
+            sorted(self.production_action_distribution, key=lambda item: item.action_label)
+        ):
+            raise PerceptionOperationalHealthError("production actions must be sorted")
+        if self.semantics != OPERATIONAL_HEALTH_SEMANTICS:
+            raise PerceptionOperationalHealthError("unsupported health report semantics")
+
+
+def _distribution(labels: tuple[str, ...]) -> tuple[ActionFrequencyDTO, ...]:
+    if not labels:
+        raise PerceptionOperationalHealthError("action distribution requires labels")
+    counts: dict[str, int] = {}
+    for label in labels:
+        counts[label] = counts.get(label, 0) + 1
+    total = len(labels)
+    return tuple(
+        ActionFrequencyDTO(action_label=label, count=count, frequency=count / total)
+        for label, count in sorted(counts.items())
+    )
+
+
+def _frequency_map(items: tuple[ActionFrequencyDTO, ...]) -> dict[str, float]:
+    return {item.action_label: item.frequency for item in items}
+
+
+def build_operational_reference_profile(
+    test_report: PromotedTestEvaluationReportDTO,
+) -> OperationalReferenceProfileDTO:
+    """Freeze the P11 untouched-test operating profile for later production comparison."""
+
+    actions = _distribution(tuple(item.selected_action for item in test_report.examples))
+    payload: Mapping[str, object] = {
+        "accepted_accuracy": test_report.accepted_accuracy,
+        "action_distribution": [
+            {"action_label": item.action_label, "count": item.count, "frequency": item.frequency}
+            for item in actions
+        ],
+        "coverage": test_report.coverage,
+        "example_count": test_report.example_count,
+        "mean_margin": test_report.mean_margin,
+        "model_id": test_report.model_id,
+        "model_kind": test_report.model_kind,
+        "promoted_model_id": test_report.promoted_model_id,
+        "raw_accuracy": test_report.raw_accuracy,
+        "semantics": OPERATIONAL_REFERENCE_SEMANTICS,
+        "test_report_id": test_report.report_id,
+        "version": OPERATIONAL_REFERENCE_PROFILE_VERSION,
+    }
+    return OperationalReferenceProfileDTO(
+        reference_profile_id=_digest(payload),
+        promoted_model_id=test_report.promoted_model_id,
+        model_kind=test_report.model_kind,
+        model_id=test_report.model_id,
+        test_report_id=test_report.report_id,
+        example_count=test_report.example_count,
+        coverage=test_report.coverage,
+        mean_margin=test_report.mean_margin,
+        raw_accuracy=test_report.raw_accuracy,
+        accepted_accuracy=test_report.accepted_accuracy,
+        action_distribution=actions,
+    )
+
+
+def _finding(
+    *,
+    metric: str,
+    status: str,
+    reference_value: float | None,
+    observed_value: float | None,
+    delta: float | None,
+    threshold: float,
+    evidence_count: int,
+    rationale: str,
+) -> OperationalHealthFindingDTO:
+    payload: Mapping[str, object] = {
+        "delta": delta,
+        "evidence_count": evidence_count,
+        "metric": metric,
+        "observed_value": observed_value,
+        "rationale": rationale,
+        "reference_value": reference_value,
+        "status": status,
+        "threshold": threshold,
+        "version": OPERATIONAL_HEALTH_FINDING_VERSION,
+    }
+    return OperationalHealthFindingDTO(finding_id=_digest(payload), **payload)  # type: ignore[arg-type]
+
+
+def _drop_finding(
+    metric: str,
+    reference: float,
+    observed: float,
+    threshold: float,
+    evidence_count: int,
+) -> OperationalHealthFindingDTO:
+    drop = reference - observed
+    status = "drifted" if drop > threshold else "healthy"
+    return _finding(
+        metric=metric,
+        status=status,
+        reference_value=reference,
+        observed_value=observed,
+        delta=observed - reference,
+        threshold=threshold,
+        evidence_count=evidence_count,
+        rationale=(
+            f"observed {metric} is {drop:.6f} below reference; allowed drop is {threshold:.6f}"
+        ),
+    )
+
+
+def diagnose_operational_health(
+    reference: OperationalReferenceProfileDTO,
+    store: PerceptionProductionLedgerStore,
+    *,
+    start_sequence_number: int,
+    end_sequence_number: int | None = None,
+    policy: OperationalDriftPolicyDTO | None = None,
+) -> OperationalHealthReportDTO:
+    """Diagnose one immutable production window against its frozen promoted-model reference."""
+
+    resolved_policy = policy or OperationalDriftPolicyDTO()
+    try:
+        metrics = build_production_metrics_report(
+            store,
+            start_sequence_number=start_sequence_number,
+            end_sequence_number=end_sequence_number,
+            promoted_model_id=reference.promoted_model_id,
+        )
+    except PerceptionProductionLedgerError as exc:
+        raise PerceptionOperationalHealthError(str(exc)) from exc
+
+    all_records = store.list_inferences()
+    selected: tuple[ProductionInferenceRecordDTO, ...] = tuple(
+        item
+        for item in all_records
+        if metrics.start_sequence_number <= item.sequence_number <= metrics.end_sequence_number
+        and item.promoted_model_id == reference.promoted_model_id
+    )
+    actions = _distribution(tuple(item.selected_action for item in selected))
+    reference_map = _frequency_map(reference.action_distribution)
+    production_map = _frequency_map(actions)
+    labels = set(reference_map) | set(production_map)
+    distance = 0.5 * sum(abs(reference_map.get(label, 0.0) - production_map.get(label, 0.0)) for label in labels)
+
+    findings: list[OperationalHealthFindingDTO] = [
+        _drop_finding(
+            "coverage",
+            reference.coverage,
+            metrics.coverage,
+            resolved_policy.maximum_coverage_drop,
+            metrics.inference_count,
+        ),
+        _drop_finding(
+            "mean_margin",
+            reference.mean_margin,
+            metrics.mean_margin,
+            resolved_policy.maximum_mean_margin_drop,
+            metrics.inference_count,
+        ),
+        _finding(
+            metric="action_distribution",
+            status=(
+                "drifted"
+                if distance > resolved_policy.maximum_action_distribution_distance
+                else "healthy"
+            ),
+            reference_value=0.0,
+            observed_value=distance,
+            delta=distance,
+            threshold=resolved_policy.maximum_action_distribution_distance,
+            evidence_count=metrics.inference_count,
+            rationale=(
+                f"total-variation distance is {distance:.6f}; allowed distance is "
+                f"{resolved_policy.maximum_action_distribution_distance:.6f}"
+            ),
+        ),
+    ]
+
+    if metrics.labeled_count < resolved_policy.minimum_labeled_count:
+        findings.extend(
+            (
+                _finding(
+                    metric="raw_accuracy",
+                    status="insufficient_evidence",
+                    reference_value=reference.raw_accuracy,
+                    observed_value=metrics.raw_accuracy,
+                    delta=None,
+                    threshold=resolved_policy.maximum_raw_accuracy_drop,
+                    evidence_count=metrics.labeled_count,
+                    rationale=(
+                        f"requires {resolved_policy.minimum_labeled_count} labeled outcomes; "
+                        f"observed {metrics.labeled_count}"
+                    ),
+                ),
+                _finding(
+                    metric="accepted_accuracy",
+                    status="insufficient_evidence",
+                    reference_value=reference.accepted_accuracy,
+                    observed_value=metrics.accepted_accuracy,
+                    delta=None,
+                    threshold=resolved_policy.maximum_accepted_accuracy_drop,
+                    evidence_count=metrics.labeled_count,
+                    rationale=(
+                        f"requires {resolved_policy.minimum_labeled_count} labeled outcomes; "
+                        f"observed {metrics.labeled_count}"
+                    ),
+                ),
+            )
+        )
+    else:
+        assert metrics.raw_accuracy is not None
+        findings.append(
+            _drop_finding(
+                "raw_accuracy",
+                reference.raw_accuracy,
+                metrics.raw_accuracy,
+                resolved_policy.maximum_raw_accuracy_drop,
+                metrics.labeled_count,
+            )
+        )
+        if reference.accepted_accuracy is None or metrics.accepted_accuracy is None:
+            findings.append(
+                _finding(
+                    metric="accepted_accuracy",
+                    status="insufficient_evidence",
+                    reference_value=reference.accepted_accuracy,
+                    observed_value=metrics.accepted_accuracy,
+                    delta=None,
+                    threshold=resolved_policy.maximum_accepted_accuracy_drop,
+                    evidence_count=metrics.labeled_count,
+                    rationale="accepted accuracy is undefined for the reference or production window",
+                )
+            )
+        else:
+            findings.append(
+                _drop_finding(
+                    "accepted_accuracy",
+                    reference.accepted_accuracy,
+                    metrics.accepted_accuracy,
+                    resolved_policy.maximum_accepted_accuracy_drop,
+                    metrics.labeled_count,
+                )
+            )
+
+    if any(item.status == "drifted" for item in findings):
+        overall = "drifted"
+    elif any(item.status == "insufficient_evidence" for item in findings):
+        overall = "insufficient_evidence"
+    else:
+        overall = "healthy"
+
+    payload: Mapping[str, object] = {
+        "action_distribution_distance": distance,
+        "end_sequence_number": metrics.end_sequence_number,
+        "findings": [item.finding_id for item in findings],
+        "inference_record_ids": list(metrics.inference_record_ids),
+        "outcome_ids": list(metrics.outcome_ids),
+        "overall_status": overall,
+        "production_action_distribution": [
+            {"action_label": item.action_label, "count": item.count, "frequency": item.frequency}
+            for item in actions
+        ],
+        "production_metrics_report_id": metrics.report_id,
+        "promoted_model_id": reference.promoted_model_id,
+        "reference_profile_id": reference.reference_profile_id,
+        "semantics": OPERATIONAL_HEALTH_SEMANTICS,
+        "start_sequence_number": metrics.start_sequence_number,
+        "version": OPERATIONAL_HEALTH_REPORT_VERSION,
+    }
+    return OperationalHealthReportDTO(
+        report_id=_digest(payload),
+        reference_profile_id=reference.reference_profile_id,
+        promoted_model_id=reference.promoted_model_id,
+        start_sequence_number=metrics.start_sequence_number,
+        end_sequence_number=metrics.end_sequence_number,
+        production_metrics_report_id=metrics.report_id,
+        production_action_distribution=actions,
+        action_distribution_distance=distance,
+        overall_status=overall,
+        findings=tuple(findings),
+        inference_record_ids=metrics.inference_record_ids,
+        outcome_ids=metrics.outcome_ids,
+    )

--- a/packages/perception/tests/test_health.py
+++ b/packages/perception/tests/test_health.py
@@ -1,0 +1,162 @@
+from zeromodel.perception import (
+    InMemoryPerceptionProductionLedgerStore,
+    OperationalDriftPolicyDTO,
+    ProductionInferenceRecordDTO,
+    ProductionOutcomeRecordDTO,
+    PromotedTestEvaluationReportDTO,
+    PromotedTestExampleDTO,
+    build_operational_reference_profile,
+    diagnose_operational_health,
+)
+
+
+def _test_report() -> PromotedTestEvaluationReportDTO:
+    examples = (
+        PromotedTestExampleDTO("t1", "left", "r1", "left", 0.8, "accepted", True),
+        PromotedTestExampleDTO("t2", "right", "r2", "right", 0.6, "accepted", True),
+        PromotedTestExampleDTO("t3", "left", "r3", "left", 0.4, "accepted", True),
+        PromotedTestExampleDTO("t4", "right", "r4", "left", 0.2, "rejected_ambiguous", False),
+    )
+    return PromotedTestEvaluationReportDTO(
+        report_id="test-report",
+        promoted_model_id="promoted-a",
+        model_kind="single_frame",
+        model_id="model-a",
+        calibration_id="calibration-a",
+        promotion_decision_id="decision-a",
+        validation_comparison_report_id="validation-a",
+        split="test",
+        example_count=4,
+        accepted_count=3,
+        rejected_count=1,
+        raw_accuracy=0.75,
+        accepted_accuracy=1.0,
+        coverage=0.75,
+        mean_margin=0.5,
+        rejection_threshold=0.3,
+        examples=examples,
+    )
+
+
+def _inference(sequence: int, action: str, margin: float, status: str) -> ProductionInferenceRecordDTO:
+    return ProductionInferenceRecordDTO(
+        record_id=f"production-{sequence}",
+        sequence_number=sequence,
+        pointer_id="pointer-1",
+        pointer_revision=1,
+        promoted_model_id="promoted-a",
+        model_id="model-a",
+        model_kind="single_frame",
+        input_id=f"input-{sequence}",
+        interaction_id=f"interaction-{sequence}",
+        inference_result_id=f"result-{sequence}",
+        selected_action=action,
+        margin=margin,
+        status=status,
+        rejection_threshold=0.3,
+    )
+
+
+def _outcome(sequence: int, observed: str, correct: bool) -> ProductionOutcomeRecordDTO:
+    return ProductionOutcomeRecordDTO(
+        outcome_id=f"outcome-{sequence}",
+        inference_record_id=f"production-{sequence}",
+        outcome_sequence_number=sequence,
+        observed_action=observed,
+        source="environment",
+        correct=correct,
+    )
+
+
+def test_reference_profile_is_deterministic_and_preserves_test_distribution() -> None:
+    first = build_operational_reference_profile(_test_report())
+    second = build_operational_reference_profile(_test_report())
+
+    assert first == second
+    assert first.coverage == 0.75
+    assert tuple((item.action_label, item.count) for item in first.action_distribution) == (
+        ("left", 3),
+        ("right", 1),
+    )
+
+
+def test_health_reports_insufficient_accuracy_evidence_without_labels() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    store.append_inference(_inference(1, "left", 0.7, "accepted"))
+    store.append_inference(_inference(2, "right", 0.6, "accepted"))
+
+    report = diagnose_operational_health(
+        build_operational_reference_profile(_test_report()),
+        store,
+        start_sequence_number=1,
+        policy=OperationalDriftPolicyDTO(minimum_labeled_count=2),
+    )
+
+    assert report.overall_status == "insufficient_evidence"
+    assert report.findings[0].status == "healthy"
+    assert report.findings[3].status == "insufficient_evidence"
+    assert report.findings[4].status == "insufficient_evidence"
+
+
+def test_health_detects_coverage_margin_action_and_accuracy_drift() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    records = (
+        _inference(1, "left", 0.1, "rejected_ambiguous"),
+        _inference(2, "left", 0.1, "rejected_ambiguous"),
+        _inference(3, "left", 0.2, "rejected_ambiguous"),
+        _inference(4, "left", 0.2, "rejected_ambiguous"),
+    )
+    for record in records:
+        store.append_inference(record)
+    for sequence in range(1, 5):
+        store.append_outcome(_outcome(sequence, "right", False))
+
+    report = diagnose_operational_health(
+        build_operational_reference_profile(_test_report()),
+        store,
+        start_sequence_number=1,
+        policy=OperationalDriftPolicyDTO(
+            maximum_coverage_drop=0.1,
+            maximum_mean_margin_drop=0.1,
+            maximum_action_distribution_distance=0.2,
+            maximum_raw_accuracy_drop=0.1,
+            maximum_accepted_accuracy_drop=0.1,
+            minimum_labeled_count=4,
+        ),
+    )
+
+    assert report.overall_status == "drifted"
+    assert tuple(item.status for item in report.findings[:4]) == (
+        "drifted",
+        "drifted",
+        "drifted",
+        "drifted",
+    )
+    assert report.findings[4].status == "insufficient_evidence"
+    assert report.action_distribution_distance == 0.25
+
+
+def test_healthy_window_preserves_exact_evidence_ids() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    store.append_inference(_inference(1, "left", 0.7, "accepted"))
+    store.append_inference(_inference(2, "right", 0.6, "accepted"))
+    store.append_outcome(_outcome(1, "left", True))
+    store.append_outcome(_outcome(2, "right", True))
+
+    report = diagnose_operational_health(
+        build_operational_reference_profile(_test_report()),
+        store,
+        start_sequence_number=1,
+        policy=OperationalDriftPolicyDTO(
+            maximum_coverage_drop=0.3,
+            maximum_mean_margin_drop=0.3,
+            maximum_action_distribution_distance=0.3,
+            maximum_raw_accuracy_drop=0.3,
+            maximum_accepted_accuracy_drop=0.3,
+            minimum_labeled_count=2,
+        ),
+    )
+
+    assert report.overall_status == "healthy"
+    assert report.inference_record_ids == ("production-1", "production-2")
+    assert report.outcome_ids == ("outcome-1", "outcome-2")

--- a/packages/perception/tests/test_public_api_p16.py
+++ b/packages/perception/tests/test_public_api_p16.py
@@ -1,0 +1,17 @@
+import zeromodel.perception as perception
+
+
+def test_phase_sixteen_public_contract() -> None:
+    assert perception.PERCEPTION_STAGE == "P16"
+    assert perception.OPERATIONAL_REFERENCE_PROFILE_VERSION.endswith("/1")
+    assert perception.OPERATIONAL_DRIFT_POLICY_VERSION.endswith("/1")
+    assert perception.OPERATIONAL_HEALTH_FINDING_VERSION.endswith("/1")
+    assert perception.OPERATIONAL_HEALTH_REPORT_VERSION.endswith("/1")
+    assert perception.OPERATIONAL_HEALTH_STATUSES == {
+        "healthy",
+        "drifted",
+        "insufficient_evidence",
+    }
+    assert perception.OperationalDriftPolicyDTO().minimum_labeled_count == 20
+    assert callable(perception.build_operational_reference_profile)
+    assert callable(perception.diagnose_operational_health)


### PR DESCRIPTION
## Summary

Implements Stage P16: immutable operational reference profiles and production-window drift diagnosis.

## Frozen reference profile

- builds `OperationalReferenceProfileDTO` from the exact untouched P11 promoted-model test report;
- preserves promoted-model, candidate, and test-report identities;
- freezes test coverage, mean margin, raw accuracy, accepted-only accuracy, and selected-action distribution;
- uses deterministic content-addressed reference identity.

## Drift policy

- adds `OperationalDriftPolicyDTO` with explicit maximum drops for coverage, margin, raw accuracy, and accepted accuracy;
- adds an explicit maximum selected-action distribution distance;
- requires a declared minimum labeled-outcome count before production accuracy can be judged.

## Health diagnosis

- compares one inclusive immutable P14/P15 production sequence window against the frozen reference;
- diagnoses coverage drop, margin drop, action-distribution drift, raw accuracy drop, and accepted-only accuracy drop independently;
- uses total-variation distance for action distributions;
- reports `healthy`, `drifted`, or `insufficient_evidence` per metric and overall;
- never treats missing labels as incorrect and never treats rejected predictions as automatically incorrect.

## Provenance

`OperationalHealthReportDTO` preserves the reference-profile identity, production metrics-report identity, exact inference and outcome identities, sequence window, production action distribution, per-metric findings, and deterministic overall diagnosis.

## Public API

Advances `PERCEPTION_STAGE` from `P15` to `P16` and exports reference, policy, finding, report, status, metric, and diagnosis contracts.

## Tests

Adds focused coverage for deterministic reference construction, insufficient labeled evidence, multi-signal drift detection, healthy windows, exact evidence identity preservation, and the public P16 contract.

## Scope boundary

P16 is diagnostic only. It does not persist health reports, add timestamps or rolling schedules, emit alerts, change lifecycle state, recalibrate models, or automatically trigger rollback.

The repository test suite was not executed locally through the GitHub connector, so this PR includes focused tests without claiming a verified green local run.