### PR TITLE
ci(perception): add P16A test and CI integrity gate

### DIFF
--- a/.github/workflows/perception-package.yml
+++ b/.github/workflows/perception-package.yml
@@ -1,0 +1,52 @@
+name: perception-package
+
+on:
+  push:
+    paths:
+      - "packages/core/**"
+      - "packages/observation/**"
+      - "packages/perception/**"
+      - "pyproject.toml"
+      - ".github/workflows/perception-package.yml"
+  pull_request:
+    paths:
+      - "packages/core/**"
+      - "packages/observation/**"
+      - "packages/perception/**"
+      - "pyproject.toml"
+      - ".github/workflows/perception-package.yml"
+
+jobs:
+  validate-perception:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build and test tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine pytest "numpy<2.0"
+      - name: Build dependency and perception wheels
+        run: |
+          python -m build packages/core
+          python -m twine check packages/core/dist/*
+          python -m build packages/observation
+          python -m twine check packages/observation/dist/*
+          python -m build packages/perception
+          python -m twine check packages/perception/dist/*
+      - name: Install wheels in a clean environment
+        run: |
+          python -m venv build/perception-ci-venv
+          build/perception-ci-venv/bin/python -m pip install --upgrade pip
+          build/perception-ci-venv/bin/python -m pip install pytest
+          build/perception-ci-venv/bin/python -m pip install packages/core/dist/*.whl
+          build/perception-ci-venv/bin/python -m pip install packages/observation/dist/*.whl
+          build/perception-ci-venv/bin/python -m pip install packages/perception/dist/*.whl
+          build/perception-ci-venv/bin/python -m pip check
+      - name: Run perception package tests
+        run: build/perception-ci-venv/bin/python -m pytest -q packages/perception/tests
+      - name: Verify installed import locations
+        run: |
+          build/perception-ci-venv/bin/python -c "import inspect, zeromodel, zeromodel.observation, zeromodel.perception; print(inspect.getfile(zeromodel)); print(inspect.getfile(zeromodel.observation)); print(inspect.getfile(zeromodel.perception))"

--- a/packages/perception/docs/stage-p16a-test-ci-integrity.md
+++ b/packages/perception/docs/stage-p16a-test-ci-integrity.md
@@ -1,0 +1,15 @@
+# Stage P16A — Perception Test and CI Integrity
+
+P16A establishes the perception package test suite as a repository-level merge gate before further operational recommendation work.
+
+Historical public API tests no longer assert that an earlier development stage is the current `PERCEPTION_STAGE`. They instead verify the durable symbols, semantics, DTOs, stores, and service contracts introduced by those stages. This prevents every new stage from invalidating all earlier public-contract tests by construction.
+
+The new `perception-package` GitHub Actions workflow builds the core, observation, and perception wheels, installs them into a clean Python 3.12 environment, runs `pip check`, executes the complete `packages/perception/tests` suite, and verifies that imports resolve from the installed wheels.
+
+Canonical local command:
+
+```bash
+python -m pytest -q packages/perception/tests
+```
+
+P16A does not alter dataset splitting, temporal grouping, statistical health thresholds, lifecycle compatibility, production sequencing, or P17 recommendation behavior. Behavioral failures exposed by the new merge gate must be repaired explicitly rather than hidden or excluded.

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -7,7 +7,6 @@ from zeromodel.perception import (
     DIFFERENCE_SURFACE_SEMANTICS,
     FIELD_RELEVANCE_SEMANTICS,
     PERCEPTION_PACKAGE_VERSION,
-    PERCEPTION_STAGE,
     PROMOTED_INFERENCE_SEMANTICS,
     PROMOTED_TEST_EVALUATION_SEMANTICS,
     PROMOTION_SEMANTICS,
@@ -34,9 +33,8 @@ from zeromodel.perception import (
 )
 
 
-def test_phase_eleven_public_contract() -> None:
+def test_public_contract_through_promoted_inference() -> None:
     assert PERCEPTION_PACKAGE_VERSION == "1.0.13"
-    assert PERCEPTION_STAGE == "P11"
     assert FIELD_RELEVANCE_SEMANTICS == "eta_squared_of_field_mean_by_action"
     assert WEIGHTED_DISTANCE_SEMANTICS == (
         "field_relevance_weighted_normalized_mean_absolute_distance"

--- a/packages/perception/tests/test_public_api_p12.py
+++ b/packages/perception/tests/test_public_api_p12.py
@@ -4,13 +4,11 @@ from zeromodel.perception import (
     ACTIVE_POINTER_SEMANTICS,
     MODEL_LEDGER_SEMANTICS,
     MODEL_TRANSITION_SEMANTICS,
-    PERCEPTION_STAGE,
     InMemoryPerceptionModelLifecycleStore,
 )
 
 
-def test_phase_twelve_public_contract() -> None:
-    assert PERCEPTION_STAGE == "P12"
+def test_model_lifecycle_public_contract() -> None:
     assert MODEL_LEDGER_SEMANTICS == "append_only_promoted_model_registration"
     assert MODEL_TRANSITION_SEMANTICS == (
         "append_only_model_activation_supersession_and_rollback"

--- a/packages/perception/tests/test_public_api_p13.py
+++ b/packages/perception/tests/test_public_api_p13.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from zeromodel.perception import (
-    PERCEPTION_STAGE,
     SQL_LIFECYCLE_SCHEMA_VERSION,
     SQL_LIFECYCLE_SEMANTICS,
     SQL_LIFECYCLE_STORE_VERSION,
@@ -9,8 +8,7 @@ from zeromodel.perception import (
 )
 
 
-def test_phase_thirteen_public_contract() -> None:
-    assert PERCEPTION_STAGE == "P13"
+def test_sql_lifecycle_public_contract() -> None:
     assert SQL_LIFECYCLE_SCHEMA_VERSION == "perception-sql-lifecycle-schema/1"
     assert SQL_LIFECYCLE_STORE_VERSION == "perception-sql-lifecycle-store/1"
     assert SQL_LIFECYCLE_SEMANTICS == (

--- a/packages/perception/tests/test_public_api_p14.py
+++ b/packages/perception/tests/test_public_api_p14.py
@@ -1,5 +1,4 @@
 from zeromodel.perception import (
-    PERCEPTION_STAGE,
     PRODUCTION_INFERENCE_SEMANTICS,
     PRODUCTION_METRICS_SEMANTICS,
     PRODUCTION_OUTCOME_SEMANTICS,
@@ -7,8 +6,7 @@ from zeromodel.perception import (
 )
 
 
-def test_phase_fourteen_public_contract() -> None:
-    assert PERCEPTION_STAGE == "P14"
+def test_production_ledger_public_contract() -> None:
     assert PRODUCTION_INFERENCE_SEMANTICS == (
         "append_only_runtime_inference_bound_to_active_model_pointer_revision"
     )

--- a/packages/perception/tests/test_public_api_p15.py
+++ b/packages/perception/tests/test_public_api_p15.py
@@ -1,8 +1,7 @@
 from zeromodel import perception
 
 
-def test_public_api_exposes_p15_sql_production_contract() -> None:
-    assert perception.PERCEPTION_STAGE == "P15"
+def test_sql_production_public_contract() -> None:
     assert perception.SQL_PRODUCTION_SCHEMA_VERSION == "perception-sql-production-schema/1"
     assert perception.SQL_PRODUCTION_STORE_VERSION == "perception-sql-production-store/1"
     assert perception.SQL_PRODUCTION_SEMANTICS == (

--- a/packages/perception/tests/test_public_api_p16.py
+++ b/packages/perception/tests/test_public_api_p16.py
@@ -1,8 +1,7 @@
 import zeromodel.perception as perception
 
 
-def test_phase_sixteen_public_contract() -> None:
-    assert perception.PERCEPTION_STAGE == "P16"
+def test_operational_health_public_contract() -> None:
     assert perception.OPERATIONAL_REFERENCE_PROFILE_VERSION.endswith("/1")
     assert perception.OPERATIONAL_DRIFT_POLICY_VERSION.endswith("/1")
     assert perception.OPERATIONAL_HEALTH_FINDING_VERSION.endswith("/1")


### PR DESCRIPTION
## Summary

Implements the first P16 repair slice from the adversarial review: perception test and CI integrity.

## Changes

- adds a dedicated `perception-package` GitHub Actions workflow;
- builds core, observation, and perception wheels;
- installs them into a clean Python 3.12 environment;
- runs `pip check` and the complete `packages/perception/tests` suite;
- verifies imports resolve from installed wheels;
- removes obsolete `PERCEPTION_STAGE == Pxx` assertions from historical public API tests;
- keeps each historical test focused on the durable contracts introduced by that stage;
- documents the canonical package test command and P16A scope.

## Why

The external review found that perception tests were not part of CI and that five failures were guaranteed by historical stage assertions. A prior public contract must remain valid when a later stage is introduced; implementation history should not make old tests fail by construction.

## Deliberate boundary

This PR does not hide, exclude, or mark known behavioral failures as expected. The new workflow runs the complete suite so remaining evidence-conformance, temporal-grouping, dataset-split, and health-sufficiency defects stay visible and must be repaired explicitly in follow-up P16 slices.

## Validation

The branch is based directly on merged P16 commit `702d2933118ea0afc3e763e89b718712839b8344`.

The suite could not be executed locally in this environment because direct GitHub/network access and `gh` are unavailable. The GitHub Actions workflow is therefore the authoritative validation run for this draft PR; no green result is claimed yet.