### PR TITLE
fix(perception): add P16B group-owned dataset splits

### DIFF
--- a/packages/perception/docs/p16b-migration-note.md
+++ b/packages/perception/docs/p16b-migration-note.md
@@ -1,0 +1,7 @@
+# P16B Migration Note
+
+`PerceptionDatasetManifestDTO` and `SplitAssignmentDTO` now use semantic version `/2`.
+
+Consumers must rebuild manifests from authoritative `RecordedInteractionDTO` inputs. Existing `/1` manifests were split by `interaction_id`; they cannot be upgraded by changing the version string because their partition ownership and dataset identity were derived under different semantics.
+
+Rebuilding may move interactions between train, validation, and test. Any calibration, promotion, untouched-test report, reference profile, or health report derived from `/1` splits belongs to the old lineage and must be regenerated before being used as current evidence.

--- a/packages/perception/docs/p16b-review-checklist.md
+++ b/packages/perception/docs/p16b-review-checklist.md
@@ -1,0 +1,11 @@
+# P16B Review Checklist
+
+Reviewers should verify:
+
+- every interaction sharing one `sequence_id` receives one split;
+- manifest construction is order-independent;
+- exact duplicate `source_pixel_digest` values cannot cross partitions silently;
+- conflicting actions for identical pixels remain a separate error;
+- manually assembled manifests cannot assign one sequence to multiple partitions;
+- `/1` dataset manifests are treated as historical lineage rather than silently reinterpreted;
+- downstream callers continue to resolve splits by interaction ID.

--- a/packages/perception/docs/p16b-scope-boundary.md
+++ b/packages/perception/docs/p16b-scope-boundary.md
@@ -1,0 +1,13 @@
+# P16B Scope Boundary
+
+This repair slice is limited to dataset partition ownership and exact duplicate leakage.
+
+It does not yet:
+
+- create manifest-owned validation or test partition DTOs;
+- change calibration or untouched-test APIs;
+- detect perceptual near-duplicates;
+- quantify temporal-window overlap;
+- repair floating-point model identity;
+- change P16 operational health statistics;
+- implement P17 recommendations.

--- a/packages/perception/docs/stage-p16b-group-owned-dataset-splits.md
+++ b/packages/perception/docs/stage-p16b-group-owned-dataset-splits.md
@@ -1,0 +1,11 @@
+# Stage P16B — Group-Owned Dataset Splits
+
+P16B repairs the dataset leakage identified by the P0–P16 adversarial review.
+
+Split ownership now belongs to `RecordedInteractionDTO.sequence_id`, not to individual interaction identity. Every frame or interaction in one sequence/episode therefore receives the same deterministic train, validation, or test assignment. `SplitAssignmentDTO` remains interaction-addressable so existing downstream consumers can resolve a partition without learning a new storage contract.
+
+The manifest and split-assignment semantic versions advance to `/2`. Existing P2 split artifacts remain historical lineage and must not be treated as equivalent to P16B manifests.
+
+Dataset validation also emits the error finding `identical_source_across_splits` whenever one exact `source_pixel_digest` appears in more than one partition, even when every duplicate has the same action label. Conflicting labels continue to emit `conflicting_actions_for_identical_source`. A defensive `sequence_crosses_splits` finding and manifest invariant prevent manually assembled manifests from violating group ownership.
+
+P16B does not yet introduce manifest-owned validation/test partition DTOs, temporal-window overlap analysis, near-duplicate image detection, or re-run the downstream calibration and promotion experiments. Those belong to the subsequent provenance and vertical-integration repair slices.

--- a/packages/perception/src/zeromodel/perception/dataset.py
+++ b/packages/perception/src/zeromodel/perception/dataset.py
@@ -2,6 +2,9 @@
 
 The dataset layer records authoritative image/action pairings. It does not infer
 alignment from filenames or directory order, and it does not perform learning.
+
+P16B strengthens split ownership: every interaction in one sequence/episode is
+assigned to the same partition, and identical source pixels may not cross partitions.
 """
 
 from __future__ import annotations
@@ -13,9 +16,9 @@ from typing import Final, Iterable, Mapping, Protocol, Sequence
 
 from .representation import SourceVPMDTO, TargetVPMDTO
 
-DATASET_MANIFEST_VERSION: Final = "perception-dataset-manifest/1"
+DATASET_MANIFEST_VERSION: Final = "perception-dataset-manifest/2"
 INTERACTION_VERSION: Final = "perception-recorded-interaction/1"
-SPLIT_ASSIGNMENT_VERSION: Final = "perception-split-assignment/1"
+SPLIT_ASSIGNMENT_VERSION: Final = "perception-split-assignment/2"
 
 _ALLOWED_SPLITS: Final = ("train", "validation", "test")
 
@@ -163,6 +166,20 @@ class PerceptionDatasetManifestDTO:
             raise PerceptionDatasetError(
                 "split assignments must be ordered one-to-one with interactions"
             )
+        assignment_by_id = {
+            item.interaction_id: item.split for item in self.split_assignments
+        }
+        sequence_splits: dict[str, set[str]] = {}
+        for interaction in self.interactions:
+            sequence_splits.setdefault(interaction.sequence_id, set()).add(
+                assignment_by_id[interaction.interaction_id]
+            )
+        if any(len(splits) != 1 for splits in sequence_splits.values()):
+            raise PerceptionDatasetError(
+                "all interactions in one sequence must belong to one split"
+            )
+        if self.version != DATASET_MANIFEST_VERSION:
+            raise PerceptionDatasetError("unsupported dataset manifest version")
 
     def split_for(self, interaction_id: str) -> str:
         for assignment in self.split_assignments:
@@ -203,8 +220,11 @@ class InMemoryPerceptionDatasetStore:
         return tuple(sorted(self._manifests))
 
 
-def _split_name(interaction_id: str, *, seed: str) -> str:
-    value = int(hashlib.sha256(f"{seed}\0{interaction_id}".encode("utf-8")).hexdigest()[:16], 16)
+def _split_name(split_owner_id: str, *, seed: str) -> str:
+    value = int(
+        hashlib.sha256(f"{seed}\0{split_owner_id}".encode("utf-8")).hexdigest()[:16],
+        16,
+    )
     bucket = value % 10_000
     if bucket < 8_000:
         return "train"
@@ -213,10 +233,14 @@ def _split_name(interaction_id: str, *, seed: str) -> str:
     return "test"
 
 
-def _findings(interactions: Sequence[RecordedInteractionDTO]) -> tuple[DatasetFindingDTO, ...]:
+def _findings(
+    interactions: Sequence[RecordedInteractionDTO],
+    assignments: Sequence[SplitAssignmentDTO],
+) -> tuple[DatasetFindingDTO, ...]:
     findings: list[DatasetFindingDTO] = []
     by_pixel: dict[str, list[RecordedInteractionDTO]] = {}
     by_sequence: dict[str, list[RecordedInteractionDTO]] = {}
+    assignment_by_id = {item.interaction_id: item.split for item in assignments}
     for item in interactions:
         by_pixel.setdefault(item.source_pixel_digest, []).append(item)
         by_sequence.setdefault(item.sequence_id, []).append(item)
@@ -230,6 +254,19 @@ def _findings(interactions: Sequence[RecordedInteractionDTO]) -> tuple[DatasetFi
                     severity="error",
                     interaction_ids=tuple(sorted(item.interaction_id for item in group)),
                     detail=f"source pixel digest {pixel_digest} maps to actions {sorted(labels)}",
+                )
+            )
+        splits = {assignment_by_id[item.interaction_id] for item in group}
+        if len(splits) > 1:
+            findings.append(
+                DatasetFindingDTO(
+                    code="identical_source_across_splits",
+                    severity="error",
+                    interaction_ids=tuple(sorted(item.interaction_id for item in group)),
+                    detail=(
+                        f"source pixel digest {pixel_digest} appears in partitions "
+                        f"{sorted(splits)}"
+                    ),
                 )
             )
 
@@ -255,6 +292,16 @@ def _findings(interactions: Sequence[RecordedInteractionDTO]) -> tuple[DatasetFi
                     detail=f"sequence {sequence_id!r} timestamps are not monotonic",
                 )
             )
+        splits = {assignment_by_id[item.interaction_id] for item in group}
+        if len(splits) > 1:
+            findings.append(
+                DatasetFindingDTO(
+                    code="sequence_crosses_splits",
+                    severity="error",
+                    interaction_ids=tuple(sorted(item.interaction_id for item in group)),
+                    detail=f"sequence {sequence_id!r} spans partitions {sorted(splits)}",
+                )
+            )
     return tuple(findings)
 
 
@@ -262,10 +309,10 @@ def build_dataset_manifest(
     interactions: Iterable[RecordedInteractionDTO],
     *,
     source_encoder_spec_ids: Iterable[str],
-    split_seed: str = "zeromodel-perception/p2",
+    split_seed: str = "zeromodel-perception/p16b",
     reject_errors: bool = True,
 ) -> PerceptionDatasetManifestDTO:
-    """Validate exact pairings and build an immutable content-addressed manifest."""
+    """Validate pairings and build a sequence-owned content-addressed manifest."""
 
     ordered = tuple(sorted(interactions, key=lambda item: item.interaction_id))
     if not ordered:
@@ -279,16 +326,21 @@ def build_dataset_manifest(
     encoder_ids = tuple(sorted(set(source_encoder_spec_ids)))
     if not encoder_ids or any(not value for value in encoder_ids):
         raise PerceptionDatasetError("source_encoder_spec_ids must be non-empty")
+    if not split_seed:
+        raise PerceptionDatasetError("split_seed must be non-empty")
 
-    findings = _findings(ordered)
+    assignments = tuple(
+        SplitAssignmentDTO(
+            item.interaction_id,
+            _split_name(item.sequence_id, seed=split_seed),
+        )
+        for item in ordered
+    )
+    findings = _findings(ordered, assignments)
     if reject_errors and any(item.severity == "error" for item in findings):
         codes = sorted({item.code for item in findings if item.severity == "error"})
         raise PerceptionDatasetError(f"dataset validation failed: {codes}")
 
-    assignments = tuple(
-        SplitAssignmentDTO(item.interaction_id, _split_name(item.interaction_id, seed=split_seed))
-        for item in ordered
-    )
     payload: Mapping[str, object] = {
         "action_schema_id": next(iter(schema_ids)),
         "findings": [
@@ -306,6 +358,7 @@ def build_dataset_manifest(
             {"interaction_id": item.interaction_id, "split": item.split, "version": item.version}
             for item in assignments
         ],
+        "split_owner": "sequence_id",
         "split_seed": split_seed,
         "version": DATASET_MANIFEST_VERSION,
     }

--- a/packages/perception/tests/test_dataset.py
+++ b/packages/perception/tests/test_dataset.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 
 from zeromodel.perception import (
+    DATASET_MANIFEST_VERSION,
+    SPLIT_ASSIGNMENT_VERSION,
     DiscreteActionSchemaDTO,
     InMemoryPerceptionDatasetStore,
     PerceptionDatasetError,
@@ -63,11 +65,36 @@ def test_manifest_identity_and_splits_are_order_independent() -> None:
 
     assert forward == reverse
     assert forward.dataset_id == reverse.dataset_id
+    assert forward.version == DATASET_MANIFEST_VERSION
+    assert {item.version for item in forward.split_assignments} == {
+        SPLIT_ASSIGNMENT_VERSION
+    }
     assert {item.split for item in forward.split_assignments} <= {
         "train",
         "validation",
         "test",
     }
+
+
+def test_all_interactions_in_one_sequence_share_one_split() -> None:
+    interactions = []
+    encoder_id = ""
+    for step_index in range(20):
+        interaction, encoder_id = _interaction(
+            step_index,
+            "LEFT" if step_index % 2 == 0 else "RIGHT",
+            sequence_id="episode-owned-as-one-unit",
+            step_index=step_index,
+        )
+        interactions.append(interaction)
+
+    manifest = build_dataset_manifest(
+        interactions,
+        source_encoder_spec_ids=[encoder_id],
+    )
+
+    assert len({item.split for item in manifest.split_assignments}) == 1
+    assert not any(item.code == "sequence_crosses_splits" for item in manifest.findings)
 
 
 def test_identical_pixels_with_conflicting_actions_are_rejected() -> None:
@@ -83,6 +110,40 @@ def test_identical_pixels_with_conflicting_actions_are_rejected() -> None:
         reject_errors=False,
     )
     assert manifest.findings[0].code == "conflicting_actions_for_identical_source"
+
+
+def test_identical_pixels_with_same_action_cannot_cross_splits() -> None:
+    interactions = []
+    encoder_id = ""
+    for index in range(64):
+        interaction, encoder_id = _interaction(
+            7,
+            "LEFT",
+            sequence_id=f"independent-episode-{index}",
+            step_index=0,
+        )
+        interactions.append(interaction)
+
+    manifest = build_dataset_manifest(
+        interactions,
+        source_encoder_spec_ids=[encoder_id],
+        reject_errors=False,
+    )
+
+    assert len({item.split for item in manifest.split_assignments}) > 1
+    finding = next(
+        item for item in manifest.findings if item.code == "identical_source_across_splits"
+    )
+    assert finding.severity == "error"
+    assert set(finding.interaction_ids) == {
+        item.interaction_id for item in interactions
+    }
+
+    with pytest.raises(PerceptionDatasetError, match="identical_source_across_splits"):
+        build_dataset_manifest(
+            interactions,
+            source_encoder_spec_ids=[encoder_id],
+        )
 
 
 def test_duplicate_sequence_steps_are_rejected() -> None:
@@ -136,10 +197,16 @@ def test_in_memory_store_is_idempotent_and_rejects_identity_collision() -> None:
         store.put(conflicting)
 
 
-def test_manifest_requires_interactions_and_encoder_identity() -> None:
+def test_manifest_requires_interactions_encoder_identity_and_seed() -> None:
     with pytest.raises(PerceptionDatasetError, match="at least one interaction"):
         build_dataset_manifest([], source_encoder_spec_ids=["sha256:x"])
 
     interaction, _ = _interaction(1, "LEFT")
     with pytest.raises(PerceptionDatasetError, match="source_encoder_spec_ids"):
         build_dataset_manifest([interaction], source_encoder_spec_ids=[])
+    with pytest.raises(PerceptionDatasetError, match="split_seed"):
+        build_dataset_manifest(
+            [interaction],
+            source_encoder_spec_ids=["sha256:x"],
+            split_seed="",
+        )


### PR DESCRIPTION
## Summary

Implements P16B from the adversarial review: episode/sequence-owned dataset splitting and explicit cross-split duplicate detection.

## Split ownership

- assigns train, validation, and test partitions from `RecordedInteractionDTO.sequence_id` rather than `interaction_id`;
- preserves interaction-addressable `SplitAssignmentDTO` values for downstream compatibility;
- enforces that every interaction in one sequence belongs to exactly one partition;
- records `split_owner = sequence_id` in the content-addressed manifest payload.

## Duplicate leakage

- adds the error finding `identical_source_across_splits` when one exact `source_pixel_digest` appears in multiple partitions, even when labels agree;
- retains the separate `conflicting_actions_for_identical_source` error;
- adds a defensive `sequence_crosses_splits` finding and manifest invariant.

## Versioning and migration

- advances `DATASET_MANIFEST_VERSION` to `perception-dataset-manifest/2`;
- advances `SPLIT_ASSIGNMENT_VERSION` to `perception-split-assignment/2`;
- documents that `/1` manifests and every downstream calibration, promotion, test, reference, or health artifact derived from them remain historical lineage and must be regenerated.

## Tests

Adds focused coverage for:

- order-independent manifest identity;
- one split per sequence across 20 steps;
- same-label exact duplicate pixels crossing partitions;
- preservation of conflicting-action detection;
- semantic version advancement;
- empty split seed rejection.

## Scope boundary

This PR does not yet add manifest-owned validation/test partition DTOs, near-duplicate detection, temporal-window overlap analysis, deterministic floating-point fitting, P16 health-statistics repairs, or P17 recommendations.

## Validation

The branch is based directly on merged P16A commit `83c2e9ccfddee61c29ac0a2d210676ac122b6718`.

The repository suite was not executed locally through the connector. The dedicated perception GitHub Actions workflow introduced by P16A is the authoritative validation run for this draft PR; no green result is claimed until it completes.