### PR TITLE
fix(perception): add P16C deterministic fitting provenance

### DIFF
--- a/packages/perception/docs/stage-p16c-deterministic-fitting-and-partition-provenance.md
+++ b/packages/perception/docs/stage-p16c-deterministic-fitting-and-partition-provenance.md
@@ -1,0 +1,34 @@
+# Stage P16C — Deterministic fitting and partition provenance
+
+P16C repairs two provenance foundations identified by the external review.
+
+## Canonical temporal fitting
+
+`fit_temporal_translator` now sorts examples by `temporal_source_id` before validation,
+feature extraction, target construction, matrix multiplication, fitting, and identity
+construction. Duplicate temporal source identities are rejected. The translator records
+`canonical_temporal_source_id_order_before_numerical_fit`, and its artifact version is
+advanced to `/2` because fitted identities change for previously non-canonical inputs.
+
+This removes caller-order floating-point variation. It does not claim bitwise equality
+across different NumPy, BLAS, CPU, or operating-system implementations; cross-platform
+coefficient canonicalization remains a separate question.
+
+## Manifest-owned partition provenance
+
+`DatasetPartitionDTO` is derived from an immutable P16B manifest and contains the exact:
+
+- dataset and action-schema identities;
+- split name;
+- interaction identities;
+- sequence identities;
+- source-pixel digests.
+
+A string such as `"validation"` or `"test"` is therefore no longer the only available
+statement of ownership. The next provenance repair will require calibration and final test
+evaluation to consume these partition identities rather than trusting caller declarations.
+
+## Scope boundary
+
+P16C does not yet alter the P10/P11 function signatures, promoted model compatibility,
+health statistics, production labeling semantics, or lifecycle recommendations.

--- a/packages/perception/src/zeromodel/perception/partitions.py
+++ b/packages/perception/src/zeromodel/perception/partitions.py
@@ -1,0 +1,115 @@
+"""Manifest-owned dataset partition provenance for Stage P16C.
+
+A split name alone is not evidence of split ownership. This module materializes one
+content-addressed partition from an immutable P16B manifest, preserving the exact
+interaction, sequence, and source-pixel identities owned by that partition.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .dataset import PerceptionDatasetManifestDTO
+
+DATASET_PARTITION_VERSION: Final = "perception-dataset-partition/1"
+DATASET_PARTITION_SEMANTICS: Final = (
+    "manifest_derived_exact_interaction_sequence_and_source_identity_partition"
+)
+_ALLOWED_PARTITIONS: Final = {"train", "validation", "test"}
+
+
+class PerceptionDatasetPartitionError(ValueError):
+    """Raised when manifest-owned partition provenance is invalid."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class DatasetPartitionDTO:
+    partition_id: str
+    dataset_id: str
+    split: str
+    action_schema_id: str
+    interaction_ids: tuple[str, ...]
+    sequence_ids: tuple[str, ...]
+    source_pixel_digests: tuple[str, ...]
+    semantics: str = DATASET_PARTITION_SEMANTICS
+    version: str = DATASET_PARTITION_VERSION
+
+    def __post_init__(self) -> None:
+        if not all((self.partition_id, self.dataset_id, self.action_schema_id)):
+            raise PerceptionDatasetPartitionError("partition identities must be non-empty")
+        if self.split not in _ALLOWED_PARTITIONS:
+            raise PerceptionDatasetPartitionError("unsupported dataset partition")
+        for name, values in (
+            ("interaction_ids", self.interaction_ids),
+            ("sequence_ids", self.sequence_ids),
+            ("source_pixel_digests", self.source_pixel_digests),
+        ):
+            if not values or values != tuple(sorted(set(values))):
+                raise PerceptionDatasetPartitionError(
+                    f"{name} must be non-empty, unique, and sorted"
+                )
+        if self.semantics != DATASET_PARTITION_SEMANTICS:
+            raise PerceptionDatasetPartitionError("unsupported partition semantics")
+        if self.version != DATASET_PARTITION_VERSION:
+            raise PerceptionDatasetPartitionError("unsupported partition version")
+
+    def owns_interaction(self, interaction_id: str) -> bool:
+        return interaction_id in self.interaction_ids
+
+
+def build_dataset_partition(
+    manifest: PerceptionDatasetManifestDTO,
+    split: str,
+) -> DatasetPartitionDTO:
+    """Materialize one exact partition from the manifest's authoritative assignments."""
+
+    if split not in _ALLOWED_PARTITIONS:
+        raise PerceptionDatasetPartitionError("unsupported dataset partition")
+    selected = tuple(
+        interaction
+        for interaction in manifest.interactions
+        if manifest.split_for(interaction.interaction_id) == split
+    )
+    if not selected:
+        raise PerceptionDatasetPartitionError(
+            f"manifest {manifest.dataset_id} has no interactions in {split!r}"
+        )
+    interaction_ids = tuple(sorted(item.interaction_id for item in selected))
+    sequence_ids = tuple(sorted({item.sequence_id for item in selected}))
+    source_pixel_digests = tuple(sorted({item.source_pixel_digest for item in selected}))
+    payload: Mapping[str, object] = {
+        "action_schema_id": manifest.action_schema_id,
+        "dataset_id": manifest.dataset_id,
+        "interaction_ids": list(interaction_ids),
+        "semantics": DATASET_PARTITION_SEMANTICS,
+        "sequence_ids": list(sequence_ids),
+        "source_pixel_digests": list(source_pixel_digests),
+        "split": split,
+        "version": DATASET_PARTITION_VERSION,
+    }
+    return DatasetPartitionDTO(
+        partition_id=_digest(payload),
+        dataset_id=manifest.dataset_id,
+        split=split,
+        action_schema_id=manifest.action_schema_id,
+        interaction_ids=interaction_ids,
+        sequence_ids=sequence_ids,
+        source_pixel_digests=source_pixel_digests,
+    )

--- a/packages/perception/src/zeromodel/perception/temporal_inference.py
+++ b/packages/perception/src/zeromodel/perception/temporal_inference.py
@@ -1,9 +1,7 @@
-"""Learned temporal inference and held-out single-frame comparison for Stage P9.
+"""Learned temporal inference and held-out single-frame comparison.
 
-P9 fits the same deterministic ridge family used by P5 over P8 temporal montage
-fields. Comparison is performed on aligned held-out interactions so any measured
-change is attributable to the declared temporal representation rather than a
-change of solver family. Metrics remain empirical and split-owned.
+P16C canonicalizes temporal training examples before every numerical operation. Caller
+order therefore cannot change fitted coefficients or content-addressed model identity.
 """
 
 from __future__ import annotations
@@ -29,7 +27,7 @@ from .translator import (
     predict_target_vpm,
 )
 
-TEMPORAL_TRANSLATOR_VERSION: Final = "perception-temporal-translator/1"
+TEMPORAL_TRANSLATOR_VERSION: Final = "perception-temporal-translator/2"
 TEMPORAL_PREDICTION_VERSION: Final = "perception-temporal-prediction/1"
 TEMPORAL_COMPARISON_VERSION: Final = "perception-temporal-comparison/1"
 TEMPORAL_FEATURE_SEMANTICS: Final = (
@@ -41,10 +39,11 @@ TEMPORAL_COMPARISON_SEMANTICS: Final = (
 TEMPORAL_REJECTION_SEMANTICS: Final = (
     "reject_when_top_two_margin_below_declared_comparison_threshold"
 )
+TEMPORAL_FIT_ORDER_SEMANTICS: Final = "canonical_temporal_source_id_order_before_numerical_fit"
 
 
 class PerceptionTemporalInferenceError(ValueError):
-    """Raised when P9 temporal fitting or comparison contracts are violated."""
+    """Raised when temporal fitting or comparison contracts are violated."""
 
 
 def _canonical_json(payload: Mapping[str, object]) -> bytes:
@@ -95,6 +94,7 @@ class TemporalTranslatorDTO:
     target_score_semantics: str
     coefficient_semantics: str
     config: TranslatorConfigDTO
+    fit_order_semantics: str = TEMPORAL_FIT_ORDER_SEMANTICS
     version: str = TEMPORAL_TRANSLATOR_VERSION
 
     def __post_init__(self) -> None:
@@ -132,6 +132,8 @@ class TemporalTranslatorDTO:
             raise PerceptionTemporalInferenceError("unsupported target score semantics")
         if self.coefficient_semantics != COEFFICIENT_SEMANTICS:
             raise PerceptionTemporalInferenceError("unsupported coefficient semantics")
+        if self.fit_order_semantics != TEMPORAL_FIT_ORDER_SEMANTICS:
+            raise PerceptionTemporalInferenceError("unsupported temporal fit-order semantics")
         values = np.asarray(self.coefficients, dtype=np.float64)
         intercepts = np.asarray(self.intercepts, dtype=np.float64)
         if not np.all(np.isfinite(values)) or not np.all(np.isfinite(intercepts)):
@@ -253,14 +255,18 @@ def fit_temporal_translator(
     training_split: str = "train",
     config: TranslatorConfigDTO | None = None,
 ) -> TemporalTranslatorDTO:
-    """Fit an inspectable ridge translator over deterministic temporal montage fields."""
+    """Fit a ridge translator after canonicalizing source order."""
 
     if training_split not in {"train", "validation", "test", "all"}:
         raise PerceptionTemporalInferenceError("unsupported temporal training split")
     if not temporal_sources:
         raise PerceptionTemporalInferenceError("temporal fitting requires examples")
+    ordered_sources = tuple(sorted(temporal_sources, key=lambda item: item.temporal_source_id))
+    source_ids = tuple(item.temporal_source_id for item in ordered_sources)
+    if len(source_ids) != len(set(source_ids)):
+        raise PerceptionTemporalInferenceError("temporal source identities must be unique")
     resolved = config or TranslatorConfigDTO()
-    for item in temporal_sources:
+    for item in ordered_sources:
         if item.temporal_window_spec_id != temporal_window_spec.temporal_window_spec_id:
             raise PerceptionTemporalInferenceError("temporal source window spec mismatch")
         if item.action_label not in action_schema.labels:
@@ -271,11 +277,11 @@ def fit_temporal_translator(
     x = np.vstack(
         [
             _feature_vector(item.montage_source_vpm, temporal_field_schema, field_ids)
-            for item in temporal_sources
+            for item in ordered_sources
         ]
     )
-    y = np.zeros((len(temporal_sources), len(action_schema.labels)), dtype=np.float64)
-    for row_index, item in enumerate(temporal_sources):
+    y = np.zeros((len(ordered_sources), len(action_schema.labels)), dtype=np.float64)
+    for row_index, item in enumerate(ordered_sources):
         y[row_index, action_schema.index_of(item.action_label)] = 1.0
     design = np.column_stack((np.ones(x.shape[0], dtype=np.float64), x))
     regularizer = np.eye(design.shape[1], dtype=np.float64) * resolved.ridge_alpha
@@ -286,13 +292,13 @@ def fit_temporal_translator(
         tuple(float(value) for value in parameters[1:, action_index])
         for action_index in range(len(action_schema.labels))
     )
-    source_ids = tuple(sorted(item.temporal_source_id for item in temporal_sources))
     payload: Mapping[str, object] = {
         "action_labels": list(action_schema.labels),
         "action_schema_id": action_schema.action_schema_id,
         "coefficient_semantics": COEFFICIENT_SEMANTICS,
         "coefficients": [list(row) for row in coefficients],
         "config": resolved.canonical_payload(),
+        "fit_order_semantics": TEMPORAL_FIT_ORDER_SEMANTICS,
         "intercepts": list(intercepts),
         "source_feature_semantics": TEMPORAL_FEATURE_SEMANTICS,
         "target_score_semantics": TARGET_SCORE_SEMANTICS,
@@ -345,10 +351,7 @@ def predict_temporal_action(
         np.asarray(translator.coefficients, dtype=np.float64) @ vector
     )
     clipped = np.clip(raw, 0.0, 1.0)
-    ranked = sorted(
-        zip(translator.action_labels, clipped.tolist()),
-        key=lambda item: (-item[1], item[0]),
-    )
+    ranked = sorted(zip(translator.action_labels, clipped.tolist()), key=lambda item: (-item[1], item[0]))
     scores = tuple(
         TargetActionScoreDTO(action_label=label, score=float(score), rank=index + 1)
         for index, (label, score) in enumerate(ranked)
@@ -440,9 +443,7 @@ def compare_single_and_temporal_inference(
             rejection_threshold=rejection_threshold,
         )
         single_status = (
-            "accepted"
-            if single_prediction.margin >= rejection_threshold
-            else "rejected_ambiguous"
+            "accepted" if single_prediction.margin >= rejection_threshold else "rejected_ambiguous"
         )
         expected = temporal_source.action_label
         single_is_correct = single_prediction.selected_action == expected
@@ -471,14 +472,10 @@ def compare_single_and_temporal_inference(
 
     conflict_rows = [item for item in rows if item.conflict_group]
     conflict_single_accuracy = (
-        None
-        if not conflict_rows
-        else sum(item.single_correct for item in conflict_rows) / len(conflict_rows)
+        None if not conflict_rows else sum(item.single_correct for item in conflict_rows) / len(conflict_rows)
     )
     conflict_temporal_accuracy = (
-        None
-        if not conflict_rows
-        else sum(item.temporal_correct for item in conflict_rows) / len(conflict_rows)
+        None if not conflict_rows else sum(item.temporal_correct for item in conflict_rows) / len(conflict_rows)
     )
     conflict_improvement = (
         None

--- a/packages/perception/tests/test_partitions_p16c.py
+++ b/packages/perception/tests/test_partitions_p16c.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    DiscreteActionSchemaDTO,
+    RecordedInteractionDTO,
+    SourceImageEncoderSpecDTO,
+    build_dataset_manifest,
+    encode_discrete_action,
+    encode_source_array,
+)
+from zeromodel.perception.partitions import (
+    DATASET_PARTITION_SEMANTICS,
+    DATASET_PARTITION_VERSION,
+    PerceptionDatasetPartitionError,
+    build_dataset_partition,
+)
+
+
+def _manifest():
+    encoder = SourceImageEncoderSpecDTO(color_space="L")
+    schema = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
+    interactions = []
+    for index in range(120):
+        source = encode_source_array(
+            np.asarray([[index, 255 - index]], dtype=np.uint8),
+            encoder,
+        )
+        interactions.append(
+            RecordedInteractionDTO.from_vpms(
+                sequence_id=f"episode-{index}",
+                step_index=0,
+                source=source,
+                target=encode_discrete_action(
+                    "LEFT" if index % 2 == 0 else "RIGHT",
+                    schema,
+                ),
+            )
+        )
+    return build_dataset_manifest(
+        interactions,
+        source_encoder_spec_ids=[encoder.encoder_spec_id],
+        split_seed="p16c-partition-test",
+    )
+
+
+def test_partition_is_manifest_derived_and_deterministic() -> None:
+    manifest = _manifest()
+    first = build_dataset_partition(manifest, "validation")
+    second = build_dataset_partition(manifest, "validation")
+
+    assert first == second
+    assert first.dataset_id == manifest.dataset_id
+    assert first.action_schema_id == manifest.action_schema_id
+    assert first.split == "validation"
+    assert first.interaction_ids == tuple(
+        item.interaction_id
+        for item in manifest.interactions
+        if manifest.split_for(item.interaction_id) == "validation"
+    )
+    assert all(first.owns_interaction(value) for value in first.interaction_ids)
+    assert first.semantics == DATASET_PARTITION_SEMANTICS
+    assert first.version == DATASET_PARTITION_VERSION
+
+
+def test_partition_identity_changes_with_owned_evidence() -> None:
+    manifest = _manifest()
+    validation = build_dataset_partition(manifest, "validation")
+    test = build_dataset_partition(manifest, "test")
+
+    assert validation.partition_id != test.partition_id
+    assert set(validation.interaction_ids).isdisjoint(test.interaction_ids)
+    assert set(validation.sequence_ids).isdisjoint(test.sequence_ids)
+    assert set(validation.source_pixel_digests).isdisjoint(test.source_pixel_digests)
+
+
+def test_partition_rejects_unsupported_or_empty_split() -> None:
+    manifest = _manifest()
+    with pytest.raises(PerceptionDatasetPartitionError, match="unsupported"):
+        build_dataset_partition(manifest, "shadow")
+
+    train_only = build_dataset_manifest(
+        [manifest.interactions[0]],
+        source_encoder_spec_ids=manifest.source_encoder_spec_ids,
+        split_seed="find-train-only",
+    )
+    empty_split = next(
+        split
+        for split in ("train", "validation", "test")
+        if not any(
+            train_only.split_for(item.interaction_id) == split
+            for item in train_only.interactions
+        )
+    )
+    with pytest.raises(PerceptionDatasetPartitionError, match="has no interactions"):
+        build_dataset_partition(train_only, empty_split)

--- a/packages/perception/tests/test_temporal_fit_order_p16c.py
+++ b/packages/perception/tests/test_temporal_fit_order_p16c.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from itertools import permutations
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    DiscreteActionSchemaDTO,
+    PerceptionTemporalInferenceError,
+    SourceImageEncoderSpecDTO,
+    TemporalSourceVPMDTO,
+    TemporalWindowSpecDTO,
+    build_grid_field_schema,
+    encode_source_array,
+    fit_temporal_translator,
+)
+from zeromodel.perception.temporal_inference import (
+    TEMPORAL_FIT_ORDER_SEMANTICS,
+    TEMPORAL_TRANSLATOR_VERSION,
+)
+
+
+def _source(value0: int, value1: int, action: str, index: int) -> TemporalSourceVPMDTO:
+    frame_spec = SourceImageEncoderSpecDTO(color_space="L")
+    first = encode_source_array(np.asarray([[value0]], dtype=np.uint8), frame_spec)
+    current = encode_source_array(np.asarray([[value1]], dtype=np.uint8), frame_spec)
+    montage_spec = SourceImageEncoderSpecDTO(
+        color_space="L",
+        max_width=2,
+        max_height=1,
+        max_pixels=2,
+        version="test-p16c-montage/1",
+    )
+    montage = encode_source_array(
+        np.asarray([[value0, value1]], dtype=np.uint8),
+        montage_spec,
+    )
+    window = TemporalWindowSpecDTO(frame_count=2)
+    return TemporalSourceVPMDTO(
+        temporal_source_id=f"sha256:p16c-{index}",
+        temporal_window_spec_id=window.temporal_window_spec_id,
+        sequence_id=f"sequence-{index}",
+        target_interaction_id=f"interaction-{index}",
+        target_step_index=1,
+        action_label=action,
+        frame_source_vpm_ids=(first.source_vpm_id, current.source_vpm_id),
+        frame_pixel_digests=(first.pixel_digest, current.pixel_digest),
+        current_source_vpm_id=current.source_vpm_id,
+        current_pixel_digest=current.pixel_digest,
+        montage_source_vpm=montage,
+    )
+
+
+def test_every_caller_permutation_produces_exactly_one_translator() -> None:
+    actions = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
+    window = TemporalWindowSpecDTO(frame_count=2)
+    examples = (
+        _source(0, 128, "LEFT", 0),
+        _source(255, 128, "RIGHT", 1),
+        _source(10, 128, "LEFT", 2),
+        _source(245, 128, "RIGHT", 3),
+    )
+    fields = build_grid_field_schema(
+        examples[0].montage_source_vpm,
+        tile_width=1,
+        tile_height=1,
+    )
+
+    fitted = tuple(
+        fit_temporal_translator(tuple(order), window, fields, actions)
+        for order in permutations(examples)
+    )
+
+    assert len({item.temporal_translator_id for item in fitted}) == 1
+    assert len({item.coefficients for item in fitted}) == 1
+    assert len({item.intercepts for item in fitted}) == 1
+    assert all(
+        item.training_temporal_source_ids
+        == tuple(sorted(source.temporal_source_id for source in examples))
+        for item in fitted
+    )
+    assert all(item.fit_order_semantics == TEMPORAL_FIT_ORDER_SEMANTICS for item in fitted)
+    assert all(item.version == TEMPORAL_TRANSLATOR_VERSION for item in fitted)
+
+
+def test_duplicate_temporal_source_identity_is_rejected() -> None:
+    actions = DiscreteActionSchemaDTO.from_labels(["LEFT", "RIGHT"])
+    window = TemporalWindowSpecDTO(frame_count=2)
+    source = _source(0, 128, "LEFT", 0)
+    fields = build_grid_field_schema(
+        source.montage_source_vpm,
+        tile_width=1,
+        tile_height=1,
+    )
+
+    with pytest.raises(PerceptionTemporalInferenceError, match="identities must be unique"):
+        fit_temporal_translator((source, source), window, fields, actions)


### PR DESCRIPTION
## Summary

Implements P16C from the adversarial repair plan: canonical temporal fitting order and manifest-owned partition provenance.

## Deterministic fitting

- sorts temporal examples by `temporal_source_id` before validation, feature extraction, target construction, matrix multiplication, solver execution, and identity construction;
- rejects duplicate temporal source identities;
- advances `TEMPORAL_TRANSLATOR_VERSION` to `/2`;
- records explicit `TEMPORAL_FIT_ORDER_SEMANTICS` in the translator artifact;
- adds an exhaustive four-example permutation test covering all 24 caller orders.

## Partition provenance

- adds `DatasetPartitionDTO` and `build_dataset_partition`;
- derives partition identity from the immutable P16B manifest;
- preserves exact dataset, action schema, split, interaction, sequence, and source-pixel identities;
- rejects unsupported and empty partitions;
- adds deterministic identity and split-disjointness tests.

## Epistemic boundary

This PR creates the evidence object needed to replace caller-declared `"validation"` and `"test"` strings. It deliberately does not yet change the P10/P11 calibration and final-test function signatures; that enforcement is the next provenance repair.

It also fixes caller-order determinism but does not claim bitwise identity across different NumPy/BLAS/CPU implementations.

## Validation

The branch is based directly on merged P16B commit `35c048fc3aea12619a01c00cbc3a89c7a601cb0f`.

The suite was not executed locally through the connector. The dedicated `perception-package` GitHub Actions workflow is the authoritative validation run; no green result is claimed until it completes.