### PR TITLE
fix(perception): enforce P16D partition-owned governance

### DIFF
--- a/packages/perception/docs/stage-p16d-enforced-partition-ownership.md
+++ b/packages/perception/docs/stage-p16d-enforced-partition-ownership.md
@@ -1,0 +1,30 @@
+# Stage P16D — Enforced partition ownership
+
+P16D closes the caller-declared validation and test ownership gap identified by the external adversarial review.
+
+The low-level comparison and inference functions remain reusable numerical primitives. Governed calibration, promotion, and final test evaluation now use content-addressed `DatasetPartitionDTO` evidence through `partitioned_governance.py`.
+
+The governed chain is:
+
+```text
+P16B dataset manifest
+    ↓
+P16C DatasetPartitionDTO
+    ↓
+PartitionOwnedComparisonReportDTO
+    ↓
+validation-only calibration and promotion
+    ↓
+PartitionOwnedTestEvaluationReportDTO
+```
+
+The boundary rejects:
+
+- comparison examples not owned by the supplied partition;
+- split declarations that disagree with partition ownership;
+- calibration or promotion from a test partition;
+- final evaluation without a test partition;
+- test action-schema mismatches;
+- test interactions outside the supplied partition.
+
+This stage does not yet repair P16 statistical evidence sufficiency, production label-estimand mismatch, rollback compatibility, or automatic recommendations. P17 remains paused.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -67,6 +67,23 @@ from .lifecycle import (
     register_promoted_model, resolve_active_promoted_model,
     rollback_active_model, supersede_active_model,
 )
+from .partitions import (
+    DATASET_PARTITION_SEMANTICS, DATASET_PARTITION_VERSION,
+    DatasetPartitionDTO, PerceptionDatasetPartitionError,
+    build_dataset_partition,
+)
+from .partitioned_governance import (
+    PARTITION_GOVERNANCE_SEMANTICS,
+    PARTITION_OWNED_COMPARISON_VERSION,
+    PARTITION_OWNED_TEST_VERSION,
+    PartitionOwnedComparisonReportDTO,
+    PartitionOwnedTestEvaluationReportDTO,
+    PerceptionPartitionGovernanceError,
+    bind_comparison_report_to_partition,
+    calibrate_partition_owned_candidates,
+    evaluate_partition_owned_model_on_test,
+    promote_partition_owned_model,
+)
 from .production import (
     PRODUCTION_INFERENCE_RECORD_VERSION, PRODUCTION_INFERENCE_SEMANTICS,
     PRODUCTION_METRICS_REPORT_VERSION, PRODUCTION_METRICS_SEMANTICS,

--- a/packages/perception/src/zeromodel/perception/partitioned_governance.py
+++ b/packages/perception/src/zeromodel/perception/partitioned_governance.py
@@ -12,6 +12,7 @@ import json
 from dataclasses import dataclass
 from typing import Final, Mapping
 
+from .fields import VPMFieldSchemaDTO
 from .partitions import DatasetPartitionDTO
 from .promoted_inference import (
     PromotedTestEvaluationReportDTO,
@@ -26,7 +27,6 @@ from .promotion import (
     promote_perception_model,
 )
 from .representation import DiscreteActionSchemaDTO, SourceVPMDTO
-from .fields import VPMFieldSchemaDTO
 from .temporal import TemporalSourceVPMDTO
 from .temporal_inference import (
     TemporalInferenceComparisonReportDTO,
@@ -79,15 +79,25 @@ class PartitionOwnedComparisonReportDTO:
                 self.action_schema_id,
             )
         ):
-            raise PerceptionPartitionGovernanceError("owned comparison identities must be non-empty")
+            raise PerceptionPartitionGovernanceError(
+                "owned comparison identities must be non-empty"
+            )
         if self.split not in {"validation", "test"}:
-            raise PerceptionPartitionGovernanceError("owned comparison split must be validation or test")
+            raise PerceptionPartitionGovernanceError(
+                "owned comparison split must be validation or test"
+            )
         if self.comparison_report.split != self.split:
-            raise PerceptionPartitionGovernanceError("comparison split does not match partition ownership")
+            raise PerceptionPartitionGovernanceError(
+                "comparison split does not match partition ownership"
+            )
         if self.semantics != PARTITION_GOVERNANCE_SEMANTICS:
-            raise PerceptionPartitionGovernanceError("unsupported partition governance semantics")
+            raise PerceptionPartitionGovernanceError(
+                "unsupported partition governance semantics"
+            )
         if self.version != PARTITION_OWNED_COMPARISON_VERSION:
-            raise PerceptionPartitionGovernanceError("unsupported owned comparison version")
+            raise PerceptionPartitionGovernanceError(
+                "unsupported owned comparison version"
+            )
 
 
 @dataclass(frozen=True)
@@ -109,13 +119,21 @@ class PartitionOwnedTestEvaluationReportDTO:
                 self.action_schema_id,
             )
         ):
-            raise PerceptionPartitionGovernanceError("owned test identities must be non-empty")
+            raise PerceptionPartitionGovernanceError(
+                "owned test identities must be non-empty"
+            )
         if self.test_report.split != "test":
-            raise PerceptionPartitionGovernanceError("owned final evaluation must be test-owned")
+            raise PerceptionPartitionGovernanceError(
+                "owned final evaluation must be test-owned"
+            )
         if self.semantics != PARTITION_GOVERNANCE_SEMANTICS:
-            raise PerceptionPartitionGovernanceError("unsupported partition governance semantics")
+            raise PerceptionPartitionGovernanceError(
+                "unsupported partition governance semantics"
+            )
         if self.version != PARTITION_OWNED_TEST_VERSION:
-            raise PerceptionPartitionGovernanceError("unsupported owned test version")
+            raise PerceptionPartitionGovernanceError(
+                "unsupported owned test version"
+            )
 
 
 def bind_comparison_report_to_partition(
@@ -129,9 +147,13 @@ def bind_comparison_report_to_partition(
             "comparison ownership requires a validation or test partition"
         )
     if report.split != partition.split:
-        raise PerceptionPartitionGovernanceError("comparison report split does not match partition")
+        raise PerceptionPartitionGovernanceError(
+            "comparison report split does not match partition"
+        )
     report_ids = tuple(sorted(item.interaction_id for item in report.examples))
-    unowned = tuple(value for value in report_ids if not partition.owns_interaction(value))
+    unowned = tuple(
+        value for value in report_ids if not partition.owns_interaction(value)
+    )
     if unowned:
         raise PerceptionPartitionGovernanceError(
             f"comparison contains interactions outside partition: {list(unowned)}"
@@ -164,7 +186,9 @@ def calibrate_partition_owned_candidates(
     """Calibrate only from a manifest-owned validation partition."""
 
     if owned_report.split != "validation":
-        raise PerceptionPartitionGovernanceError("calibration requires validation partition ownership")
+        raise PerceptionPartitionGovernanceError(
+            "calibration requires validation partition ownership"
+        )
     return calibrate_comparison_candidates(owned_report.comparison_report, policy=policy)
 
 
@@ -176,7 +200,9 @@ def promote_partition_owned_model(
     """Promote only from a manifest-owned validation partition."""
 
     if owned_report.split != "validation":
-        raise PerceptionPartitionGovernanceError("promotion requires validation partition ownership")
+        raise PerceptionPartitionGovernanceError(
+            "promotion requires validation partition ownership"
+        )
     return promote_perception_model(owned_report.comparison_report, policy=policy)
 
 
@@ -192,14 +218,22 @@ def evaluate_partition_owned_model_on_test(
     single_field_schema: VPMFieldSchemaDTO | None = None,
     temporal_field_schema: VPMFieldSchemaDTO | None = None,
 ) -> PartitionOwnedTestEvaluationReportDTO:
-    """Evaluate the frozen model only against an exact manifest-owned test partition."""
+    """Evaluate the frozen model against an exact manifest-owned test partition."""
 
     if partition.split != "test":
-        raise PerceptionPartitionGovernanceError("final evaluation requires test partition ownership")
+        raise PerceptionPartitionGovernanceError(
+            "final evaluation requires test partition ownership"
+        )
     if partition.action_schema_id != action_schema.action_schema_id:
-        raise PerceptionPartitionGovernanceError("test partition action schema mismatch")
-    target_ids = tuple(sorted(item.target_interaction_id for item in test_temporal_sources))
-    unowned = tuple(value for value in target_ids if not partition.owns_interaction(value))
+        raise PerceptionPartitionGovernanceError(
+            "test partition action schema mismatch"
+        )
+    target_ids = tuple(
+        sorted(item.target_interaction_id for item in test_temporal_sources)
+    )
+    unowned = tuple(
+        value for value in target_ids if not partition.owns_interaction(value)
+    )
     if unowned:
         raise PerceptionPartitionGovernanceError(
             f"test evaluation contains interactions outside partition: {list(unowned)}"

--- a/packages/perception/src/zeromodel/perception/partitioned_governance.py
+++ b/packages/perception/src/zeromodel/perception/partitioned_governance.py
@@ -1,0 +1,232 @@
+"""Manifest-owned calibration, promotion, and final-test governance for P16D.
+
+Low-level comparison and inference functions remain reusable numerical primitives. This
+module is the governed entry point: validation and test ownership must be proven by a
+content-addressed DatasetPartitionDTO rather than asserted with a split-name string.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .partitions import DatasetPartitionDTO
+from .promoted_inference import (
+    PromotedTestEvaluationReportDTO,
+    evaluate_promoted_model_on_test,
+)
+from .promotion import (
+    ModelCalibrationDTO,
+    PromotedPerceptionModelDTO,
+    PromotionDecisionDTO,
+    PromotionPolicyDTO,
+    calibrate_comparison_candidates,
+    promote_perception_model,
+)
+from .representation import DiscreteActionSchemaDTO, SourceVPMDTO
+from .fields import VPMFieldSchemaDTO
+from .temporal import TemporalSourceVPMDTO
+from .temporal_inference import (
+    TemporalInferenceComparisonReportDTO,
+    TemporalTranslatorDTO,
+)
+from .translator import SourceTargetTranslatorDTO
+
+PARTITION_OWNED_COMPARISON_VERSION: Final = "perception-partition-owned-comparison/1"
+PARTITION_OWNED_TEST_VERSION: Final = "perception-partition-owned-test-evaluation/1"
+PARTITION_GOVERNANCE_SEMANTICS: Final = (
+    "manifest_partition_identity_required_for_validation_calibration_promotion_and_test"
+)
+
+
+class PerceptionPartitionGovernanceError(ValueError):
+    """Raised when model governance is not backed by manifest-owned evidence."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class PartitionOwnedComparisonReportDTO:
+    owned_report_id: str
+    partition_id: str
+    dataset_id: str
+    action_schema_id: str
+    split: str
+    comparison_report: TemporalInferenceComparisonReportDTO
+    semantics: str = PARTITION_GOVERNANCE_SEMANTICS
+    version: str = PARTITION_OWNED_COMPARISON_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.owned_report_id,
+                self.partition_id,
+                self.dataset_id,
+                self.action_schema_id,
+            )
+        ):
+            raise PerceptionPartitionGovernanceError("owned comparison identities must be non-empty")
+        if self.split not in {"validation", "test"}:
+            raise PerceptionPartitionGovernanceError("owned comparison split must be validation or test")
+        if self.comparison_report.split != self.split:
+            raise PerceptionPartitionGovernanceError("comparison split does not match partition ownership")
+        if self.semantics != PARTITION_GOVERNANCE_SEMANTICS:
+            raise PerceptionPartitionGovernanceError("unsupported partition governance semantics")
+        if self.version != PARTITION_OWNED_COMPARISON_VERSION:
+            raise PerceptionPartitionGovernanceError("unsupported owned comparison version")
+
+
+@dataclass(frozen=True)
+class PartitionOwnedTestEvaluationReportDTO:
+    owned_report_id: str
+    partition_id: str
+    dataset_id: str
+    action_schema_id: str
+    test_report: PromotedTestEvaluationReportDTO
+    semantics: str = PARTITION_GOVERNANCE_SEMANTICS
+    version: str = PARTITION_OWNED_TEST_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.owned_report_id,
+                self.partition_id,
+                self.dataset_id,
+                self.action_schema_id,
+            )
+        ):
+            raise PerceptionPartitionGovernanceError("owned test identities must be non-empty")
+        if self.test_report.split != "test":
+            raise PerceptionPartitionGovernanceError("owned final evaluation must be test-owned")
+        if self.semantics != PARTITION_GOVERNANCE_SEMANTICS:
+            raise PerceptionPartitionGovernanceError("unsupported partition governance semantics")
+        if self.version != PARTITION_OWNED_TEST_VERSION:
+            raise PerceptionPartitionGovernanceError("unsupported owned test version")
+
+
+def bind_comparison_report_to_partition(
+    report: TemporalInferenceComparisonReportDTO,
+    partition: DatasetPartitionDTO,
+) -> PartitionOwnedComparisonReportDTO:
+    """Bind a comparison report to exact manifest-owned validation or test evidence."""
+
+    if partition.split not in {"validation", "test"}:
+        raise PerceptionPartitionGovernanceError(
+            "comparison ownership requires a validation or test partition"
+        )
+    if report.split != partition.split:
+        raise PerceptionPartitionGovernanceError("comparison report split does not match partition")
+    report_ids = tuple(sorted(item.interaction_id for item in report.examples))
+    unowned = tuple(value for value in report_ids if not partition.owns_interaction(value))
+    if unowned:
+        raise PerceptionPartitionGovernanceError(
+            f"comparison contains interactions outside partition: {list(unowned)}"
+        )
+    payload: Mapping[str, object] = {
+        "action_schema_id": partition.action_schema_id,
+        "comparison_report_id": report.report_id,
+        "dataset_id": partition.dataset_id,
+        "partition_id": partition.partition_id,
+        "report_interaction_ids": list(report_ids),
+        "semantics": PARTITION_GOVERNANCE_SEMANTICS,
+        "split": partition.split,
+        "version": PARTITION_OWNED_COMPARISON_VERSION,
+    }
+    return PartitionOwnedComparisonReportDTO(
+        owned_report_id=_digest(payload),
+        partition_id=partition.partition_id,
+        dataset_id=partition.dataset_id,
+        action_schema_id=partition.action_schema_id,
+        split=partition.split,
+        comparison_report=report,
+    )
+
+
+def calibrate_partition_owned_candidates(
+    owned_report: PartitionOwnedComparisonReportDTO,
+    *,
+    policy: PromotionPolicyDTO | None = None,
+) -> tuple[ModelCalibrationDTO, ModelCalibrationDTO]:
+    """Calibrate only from a manifest-owned validation partition."""
+
+    if owned_report.split != "validation":
+        raise PerceptionPartitionGovernanceError("calibration requires validation partition ownership")
+    return calibrate_comparison_candidates(owned_report.comparison_report, policy=policy)
+
+
+def promote_partition_owned_model(
+    owned_report: PartitionOwnedComparisonReportDTO,
+    *,
+    policy: PromotionPolicyDTO | None = None,
+) -> tuple[PromotionDecisionDTO, PromotedPerceptionModelDTO]:
+    """Promote only from a manifest-owned validation partition."""
+
+    if owned_report.split != "validation":
+        raise PerceptionPartitionGovernanceError("promotion requires validation partition ownership")
+    return promote_perception_model(owned_report.comparison_report, policy=policy)
+
+
+def evaluate_partition_owned_model_on_test(
+    partition: DatasetPartitionDTO,
+    promoted: PromotedPerceptionModelDTO,
+    action_schema: DiscreteActionSchemaDTO,
+    test_temporal_sources: tuple[TemporalSourceVPMDTO, ...],
+    current_sources: Mapping[str, SourceVPMDTO],
+    *,
+    single_translator: SourceTargetTranslatorDTO | None = None,
+    temporal_translator: TemporalTranslatorDTO | None = None,
+    single_field_schema: VPMFieldSchemaDTO | None = None,
+    temporal_field_schema: VPMFieldSchemaDTO | None = None,
+) -> PartitionOwnedTestEvaluationReportDTO:
+    """Evaluate the frozen model only against an exact manifest-owned test partition."""
+
+    if partition.split != "test":
+        raise PerceptionPartitionGovernanceError("final evaluation requires test partition ownership")
+    if partition.action_schema_id != action_schema.action_schema_id:
+        raise PerceptionPartitionGovernanceError("test partition action schema mismatch")
+    target_ids = tuple(sorted(item.target_interaction_id for item in test_temporal_sources))
+    unowned = tuple(value for value in target_ids if not partition.owns_interaction(value))
+    if unowned:
+        raise PerceptionPartitionGovernanceError(
+            f"test evaluation contains interactions outside partition: {list(unowned)}"
+        )
+    report = evaluate_promoted_model_on_test(
+        promoted,
+        action_schema,
+        test_temporal_sources,
+        current_sources,
+        single_translator=single_translator,
+        temporal_translator=temporal_translator,
+        single_field_schema=single_field_schema,
+        temporal_field_schema=temporal_field_schema,
+        split="test",
+    )
+    payload: Mapping[str, object] = {
+        "action_schema_id": partition.action_schema_id,
+        "dataset_id": partition.dataset_id,
+        "partition_id": partition.partition_id,
+        "semantics": PARTITION_GOVERNANCE_SEMANTICS,
+        "test_report_id": report.report_id,
+        "version": PARTITION_OWNED_TEST_VERSION,
+    }
+    return PartitionOwnedTestEvaluationReportDTO(
+        owned_report_id=_digest(payload),
+        partition_id=partition.partition_id,
+        dataset_id=partition.dataset_id,
+        action_schema_id=partition.action_schema_id,
+        test_report=report,
+    )

--- a/packages/perception/tests/test_partitioned_governance_p16d.py
+++ b/packages/perception/tests/test_partitioned_governance_p16d.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception import (
+    DATASET_PARTITION_SEMANTICS,
+    DATASET_PARTITION_VERSION,
+    DatasetPartitionDTO,
+    PerceptionPartitionGovernanceError,
+    TemporalComparisonExampleDTO,
+    TemporalInferenceComparisonReportDTO,
+    bind_comparison_report_to_partition,
+    calibrate_partition_owned_candidates,
+    promote_partition_owned_model,
+)
+
+
+def _partition(split: str, interaction_ids: tuple[str, ...]) -> DatasetPartitionDTO:
+    return DatasetPartitionDTO(
+        partition_id=f"sha256:{split}-partition",
+        dataset_id="sha256:dataset",
+        split=split,
+        action_schema_id="sha256:actions",
+        interaction_ids=tuple(sorted(interaction_ids)),
+        sequence_ids=(f"{split}-sequence",),
+        source_pixel_digests=(f"sha256:{split}-pixels",),
+        semantics=DATASET_PARTITION_SEMANTICS,
+        version=DATASET_PARTITION_VERSION,
+    )
+
+
+def _report(split: str = "validation") -> TemporalInferenceComparisonReportDTO:
+    examples = (
+        TemporalComparisonExampleDTO(
+            interaction_id="interaction-1",
+            expected_action="LEFT",
+            single_selected_action="RIGHT",
+            temporal_selected_action="LEFT",
+            single_margin=0.05,
+            temporal_margin=0.8,
+            single_status="accepted",
+            temporal_status="accepted",
+            single_correct=False,
+            temporal_correct=True,
+            conflict_group=True,
+        ),
+        TemporalComparisonExampleDTO(
+            interaction_id="interaction-2",
+            expected_action="RIGHT",
+            single_selected_action="RIGHT",
+            temporal_selected_action="RIGHT",
+            single_margin=0.7,
+            temporal_margin=0.9,
+            single_status="accepted",
+            temporal_status="accepted",
+            single_correct=True,
+            temporal_correct=True,
+            conflict_group=True,
+        ),
+    )
+    return TemporalInferenceComparisonReportDTO(
+        report_id=f"sha256:{split}-comparison",
+        split=split,
+        single_translator_id="sha256:single",
+        temporal_translator_id="sha256:temporal",
+        temporal_window_spec_id="sha256:window",
+        example_count=2,
+        single_accuracy=0.5,
+        temporal_accuracy=1.0,
+        accuracy_improvement=0.5,
+        single_accepted_accuracy=0.5,
+        temporal_accepted_accuracy=1.0,
+        single_coverage=1.0,
+        temporal_coverage=1.0,
+        mean_single_margin=0.375,
+        mean_temporal_margin=0.85,
+        conflict_example_count=2,
+        conflict_single_accuracy=0.5,
+        conflict_temporal_accuracy=1.0,
+        conflict_resolution_improvement=0.5,
+        rejection_threshold=0.0,
+        examples=examples,
+    )
+
+
+def test_validation_partition_owns_calibration_and_promotion() -> None:
+    partition = _partition("validation", ("interaction-1", "interaction-2"))
+    owned = bind_comparison_report_to_partition(_report(), partition)
+
+    first = bind_comparison_report_to_partition(_report(), partition)
+    calibrations = calibrate_partition_owned_candidates(owned)
+    decision, promoted = promote_partition_owned_model(owned)
+
+    assert owned == first
+    assert owned.partition_id == partition.partition_id
+    assert calibrations[1].model_kind == "temporal"
+    assert decision.selected_model_kind == "temporal"
+    assert promoted.validation_comparison_report_id == _report().report_id
+
+
+def test_binding_rejects_report_interaction_outside_partition() -> None:
+    partition = _partition("validation", ("interaction-1",))
+
+    with pytest.raises(
+        PerceptionPartitionGovernanceError,
+        match="outside partition",
+    ):
+        bind_comparison_report_to_partition(_report(), partition)
+
+
+def test_calibration_and_promotion_reject_test_partition() -> None:
+    partition = _partition("test", ("interaction-1", "interaction-2"))
+    owned = bind_comparison_report_to_partition(_report(split="test"), partition)
+
+    with pytest.raises(
+        PerceptionPartitionGovernanceError,
+        match="validation partition ownership",
+    ):
+        calibrate_partition_owned_candidates(owned)
+
+    with pytest.raises(
+        PerceptionPartitionGovernanceError,
+        match="validation partition ownership",
+    ):
+        promote_partition_owned_model(owned)
+
+
+def test_binding_rejects_declared_split_mismatch() -> None:
+    partition = _partition("test", ("interaction-1", "interaction-2"))
+
+    with pytest.raises(
+        PerceptionPartitionGovernanceError,
+        match="does not match partition",
+    ):
+        bind_comparison_report_to_partition(_report(), partition)

--- a/packages/perception/tests/test_public_api_p16d.py
+++ b/packages/perception/tests/test_public_api_p16d.py
@@ -1,0 +1,11 @@
+from zeromodel import perception
+
+
+def test_p16d_partition_governance_public_contract() -> None:
+    assert perception.PARTITION_OWNED_COMPARISON_VERSION.endswith("/1")
+    assert perception.PARTITION_OWNED_TEST_VERSION.endswith("/1")
+    assert perception.DATASET_PARTITION_VERSION.endswith("/1")
+    assert callable(perception.bind_comparison_report_to_partition)
+    assert callable(perception.calibrate_partition_owned_candidates)
+    assert callable(perception.promote_partition_owned_model)
+    assert callable(perception.evaluate_partition_owned_model_on_test)


### PR DESCRIPTION
## Summary

Implements P16D from the adversarial repair plan: governed calibration, promotion, and final test evaluation must be backed by manifest-owned `DatasetPartitionDTO` evidence.

## Changes

- adds `partitioned_governance.py` as the governed entry point;
- adds `PartitionOwnedComparisonReportDTO` and `PartitionOwnedTestEvaluationReportDTO`;
- binds comparison reports to exact partition, dataset, action-schema, and interaction identities;
- rejects comparison examples outside the supplied partition;
- permits calibration and promotion only from a validation partition;
- permits final evaluation only from a test partition;
- rejects test action-schema mismatches and unowned test interactions;
- publicly exports the P16C partition contract and the P16D governance API;
- adds focused adversarial and public-contract tests;
- documents the stage boundary and remaining repair work.

## Architectural boundary

The existing comparison and inference functions remain low-level numerical primitives for compatibility. The new governed path does not accept a naked caller-declared split string as sufficient evidence of validation or test ownership.

## Deliberate exclusions

This PR does not yet repair P16 minimum inference evidence, production/reference accuracy-estimand mismatch, rollback compatibility, or P17 recommendations. P17 remains paused.

## Validation

The branch is based directly on merged P16C commit `5f81d4f4821ac84de9b903669fe04c53682f1a35`.

The complete suite was not executed locally through the connector. The dedicated perception GitHub Actions workflow is the authoritative validation run; no green result is claimed until it completes.