### PR TITLE
fix(perception): add P16E statistically gated operational health

### DIFF
--- a/packages/perception/docs/stage-p16e-statistically-gated-operational-health.md
+++ b/packages/perception/docs/stage-p16e-statistically-gated-operational-health.md
@@ -1,0 +1,48 @@
+# Stage P16E — Statistically Gated Operational Health
+
+P16E repairs the operational-health blocker identified by external adversarial review.
+A production window may not be classified as healthy or drifted merely because a
+point estimate crosses a fixed threshold.
+
+## Evidence gates
+
+The public `OperationalDriftPolicyDTO` now requires explicit minimums for:
+
+- reference examples;
+- production inferences;
+- labeled outcomes;
+- labeled accepted inferences;
+- production label coverage.
+
+By default, accuracy comparison requires complete production labeling because the
+frozen test reference is fully labeled. A selectively or partially labeled production
+cohort therefore produces `insufficient_evidence`, not an accuracy conclusion.
+
+## Window integrity
+
+Health diagnosis requires one active-model pointer revision by default. A window that
+spans activation, supersession, or rollback revisions is not treated as one homogeneous
+operational cohort.
+
+## Status precedence
+
+Underpowered metrics are first-class `insufficient_evidence` findings. An underpowered
+window cannot become `drifted` from one action-frequency observation and cannot become
+`healthy` from sparse evidence.
+
+Once every required metric is adequately supported, threshold crossings may produce
+`drifted`; otherwise all supported metrics remaining within policy produce `healthy`.
+
+## Compatibility
+
+The immutable P16 reference, finding, and report DTO formats remain unchanged. The
+public policy advances to `perception-operational-drift-policy/2`, and the package-level
+`diagnose_operational_health` entry point now uses the gated implementation.
+
+## Deliberate boundary
+
+P16E still uses operational tolerance thresholds and total-variation distance. It does
+not claim a formal hypothesis test, confidence interval, sequential-testing correction,
+or causal diagnosis. Those may be added only when a concrete monitoring requirement
+justifies them. P17 recommendations remain paused pending rollback compatibility and a
+full vertical integration test.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -38,14 +38,17 @@ from .fields import (
     reconstruct_source_array, validate_source_for_schema,
 )
 from .health import (
-    OPERATIONAL_DRIFT_POLICY_VERSION, OPERATIONAL_HEALTH_FINDING_VERSION,
-    OPERATIONAL_HEALTH_METRICS, OPERATIONAL_HEALTH_REPORT_VERSION,
-    OPERATIONAL_HEALTH_SEMANTICS, OPERATIONAL_HEALTH_STATUSES,
-    OPERATIONAL_REFERENCE_PROFILE_VERSION, OPERATIONAL_REFERENCE_SEMANTICS,
-    ActionFrequencyDTO, OperationalDriftPolicyDTO,
+    OPERATIONAL_HEALTH_FINDING_VERSION, OPERATIONAL_HEALTH_METRICS,
+    OPERATIONAL_HEALTH_REPORT_VERSION, OPERATIONAL_HEALTH_SEMANTICS,
+    OPERATIONAL_HEALTH_STATUSES, OPERATIONAL_REFERENCE_PROFILE_VERSION,
+    OPERATIONAL_REFERENCE_SEMANTICS, ActionFrequencyDTO,
     OperationalHealthFindingDTO, OperationalHealthReportDTO,
     OperationalReferenceProfileDTO, PerceptionOperationalHealthError,
-    build_operational_reference_profile, diagnose_operational_health,
+    build_operational_reference_profile,
+)
+from .gated_health import (
+    OPERATIONAL_DRIFT_POLICY_VERSION, OPERATIONAL_EVIDENCE_SEMANTICS,
+    OperationalDriftPolicyDTO, diagnose_operational_health,
 )
 from .inference import (
     BASELINE_MODEL_VERSION, CONFIDENCE_SEMANTICS, DISTANCE_SEMANTICS,

--- a/packages/perception/src/zeromodel/perception/gated_health.py
+++ b/packages/perception/src/zeromodel/perception/gated_health.py
@@ -1,0 +1,405 @@
+"""Statistically gated operational health diagnosis for Stage P16E.
+
+This governed implementation preserves the immutable P16 report contracts while requiring
+adequate inference, reference, label, and accepted-label evidence before any metric may be
+classified as healthy or drifted. Accuracy comparison is withheld unless the production
+label cohort is sufficiently complete to match the fully-labelled test reference estimand.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .health import (
+    OPERATIONAL_HEALTH_FINDING_VERSION,
+    OPERATIONAL_HEALTH_REPORT_VERSION,
+    OPERATIONAL_HEALTH_SEMANTICS,
+    ActionFrequencyDTO,
+    OperationalHealthFindingDTO,
+    OperationalHealthReportDTO,
+    OperationalReferenceProfileDTO,
+    PerceptionOperationalHealthError,
+)
+from .production import (
+    PerceptionProductionLedgerError,
+    PerceptionProductionLedgerStore,
+    ProductionInferenceRecordDTO,
+    build_production_metrics_report,
+)
+
+OPERATIONAL_DRIFT_POLICY_VERSION: Final = "perception-operational-drift-policy/2"
+OPERATIONAL_EVIDENCE_SEMANTICS: Final = (
+    "metric_specific_reference_inference_label_and_accepted_label_evidence_gates"
+)
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class OperationalDriftPolicyDTO:
+    maximum_coverage_drop: float = 0.10
+    maximum_mean_margin_drop: float = 0.10
+    maximum_action_distribution_distance: float = 0.20
+    maximum_raw_accuracy_drop: float = 0.10
+    maximum_accepted_accuracy_drop: float = 0.10
+    minimum_reference_count: int = 20
+    minimum_inference_count: int = 20
+    minimum_labeled_count: int = 20
+    minimum_accepted_labeled_count: int = 20
+    minimum_label_coverage: float = 1.0
+    require_single_pointer_revision: bool = True
+    evidence_semantics: str = OPERATIONAL_EVIDENCE_SEMANTICS
+    version: str = OPERATIONAL_DRIFT_POLICY_VERSION
+
+    def __post_init__(self) -> None:
+        for value in (
+            self.maximum_coverage_drop,
+            self.maximum_mean_margin_drop,
+            self.maximum_action_distribution_distance,
+            self.maximum_raw_accuracy_drop,
+            self.maximum_accepted_accuracy_drop,
+            self.minimum_label_coverage,
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise PerceptionOperationalHealthError("drift threshold or coverage gate outside [0, 1]")
+        for value in (
+            self.minimum_reference_count,
+            self.minimum_inference_count,
+            self.minimum_labeled_count,
+            self.minimum_accepted_labeled_count,
+        ):
+            if value <= 0:
+                raise PerceptionOperationalHealthError("health evidence counts must be positive")
+        if self.evidence_semantics != OPERATIONAL_EVIDENCE_SEMANTICS:
+            raise PerceptionOperationalHealthError("unsupported health evidence semantics")
+        if self.version != OPERATIONAL_DRIFT_POLICY_VERSION:
+            raise PerceptionOperationalHealthError("unsupported drift policy version")
+
+
+def _distribution(labels: tuple[str, ...]) -> tuple[ActionFrequencyDTO, ...]:
+    if not labels:
+        raise PerceptionOperationalHealthError("action distribution requires labels")
+    counts: dict[str, int] = {}
+    for label in labels:
+        counts[label] = counts.get(label, 0) + 1
+    total = len(labels)
+    return tuple(
+        ActionFrequencyDTO(action_label=label, count=count, frequency=count / total)
+        for label, count in sorted(counts.items())
+    )
+
+
+def _finding(
+    *,
+    metric: str,
+    status: str,
+    reference_value: float | None,
+    observed_value: float | None,
+    delta: float | None,
+    threshold: float,
+    evidence_count: int,
+    rationale: str,
+) -> OperationalHealthFindingDTO:
+    payload: Mapping[str, object] = {
+        "delta": delta,
+        "evidence_count": evidence_count,
+        "metric": metric,
+        "observed_value": observed_value,
+        "rationale": rationale,
+        "reference_value": reference_value,
+        "status": status,
+        "threshold": threshold,
+        "version": OPERATIONAL_HEALTH_FINDING_VERSION,
+    }
+    return OperationalHealthFindingDTO(finding_id=_digest(payload), **payload)  # type: ignore[arg-type]
+
+
+def _insufficient(
+    metric: str,
+    reference: float | None,
+    observed: float | None,
+    threshold: float,
+    evidence_count: int,
+    rationale: str,
+) -> OperationalHealthFindingDTO:
+    return _finding(
+        metric=metric,
+        status="insufficient_evidence",
+        reference_value=reference,
+        observed_value=observed,
+        delta=None,
+        threshold=threshold,
+        evidence_count=evidence_count,
+        rationale=rationale,
+    )
+
+
+def _drop_finding(
+    metric: str,
+    reference: float,
+    observed: float,
+    threshold: float,
+    evidence_count: int,
+) -> OperationalHealthFindingDTO:
+    drop = reference - observed
+    return _finding(
+        metric=metric,
+        status="drifted" if drop > threshold else "healthy",
+        reference_value=reference,
+        observed_value=observed,
+        delta=observed - reference,
+        threshold=threshold,
+        evidence_count=evidence_count,
+        rationale=(
+            f"observed {metric} is {drop:.6f} below reference; allowed drop is {threshold:.6f}"
+        ),
+    )
+
+
+def diagnose_operational_health(
+    reference: OperationalReferenceProfileDTO,
+    store: PerceptionProductionLedgerStore,
+    *,
+    start_sequence_number: int,
+    end_sequence_number: int | None = None,
+    policy: OperationalDriftPolicyDTO | None = None,
+) -> OperationalHealthReportDTO:
+    """Diagnose one production window only after metric-specific evidence gates pass."""
+
+    resolved = policy or OperationalDriftPolicyDTO()
+    try:
+        metrics = build_production_metrics_report(
+            store,
+            start_sequence_number=start_sequence_number,
+            end_sequence_number=end_sequence_number,
+            promoted_model_id=reference.promoted_model_id,
+        )
+    except PerceptionProductionLedgerError as exc:
+        raise PerceptionOperationalHealthError(str(exc)) from exc
+
+    selected: tuple[ProductionInferenceRecordDTO, ...] = tuple(
+        item
+        for item in store.list_inferences()
+        if metrics.start_sequence_number <= item.sequence_number <= metrics.end_sequence_number
+        and item.promoted_model_id == reference.promoted_model_id
+    )
+    actions = _distribution(tuple(item.selected_action for item in selected))
+    reference_map = {item.action_label: item.frequency for item in reference.action_distribution}
+    production_map = {item.action_label: item.frequency for item in actions}
+    labels = set(reference_map) | set(production_map)
+    distance = 0.5 * sum(
+        abs(reference_map.get(label, 0.0) - production_map.get(label, 0.0))
+        for label in labels
+    )
+
+    reference_ready = reference.example_count >= resolved.minimum_reference_count
+    inference_ready = metrics.inference_count >= resolved.minimum_inference_count
+    pointer_ready = (
+        not resolved.require_single_pointer_revision
+        or len(metrics.model_pointer_revisions) == 1
+    )
+    unlabeled_ready = reference_ready and inference_ready and pointer_ready
+    unlabeled_reason = (
+        f"requires reference_count>={resolved.minimum_reference_count}, "
+        f"inference_count>={resolved.minimum_inference_count}, and "
+        f"single_pointer_revision={resolved.require_single_pointer_revision}; observed "
+        f"reference_count={reference.example_count}, inference_count={metrics.inference_count}, "
+        f"pointer_revisions={list(metrics.model_pointer_revisions)}"
+    )
+
+    if unlabeled_ready:
+        findings: list[OperationalHealthFindingDTO] = [
+            _drop_finding(
+                "coverage",
+                reference.coverage,
+                metrics.coverage,
+                resolved.maximum_coverage_drop,
+                metrics.inference_count,
+            ),
+            _drop_finding(
+                "mean_margin",
+                reference.mean_margin,
+                metrics.mean_margin,
+                resolved.maximum_mean_margin_drop,
+                metrics.inference_count,
+            ),
+            _finding(
+                metric="action_distribution",
+                status=(
+                    "drifted"
+                    if distance > resolved.maximum_action_distribution_distance
+                    else "healthy"
+                ),
+                reference_value=0.0,
+                observed_value=distance,
+                delta=distance,
+                threshold=resolved.maximum_action_distribution_distance,
+                evidence_count=metrics.inference_count,
+                rationale=(
+                    f"total-variation distance is {distance:.6f}; allowed distance is "
+                    f"{resolved.maximum_action_distribution_distance:.6f}"
+                ),
+            ),
+        ]
+    else:
+        findings = [
+            _insufficient(
+                "coverage",
+                reference.coverage,
+                metrics.coverage,
+                resolved.maximum_coverage_drop,
+                metrics.inference_count,
+                unlabeled_reason,
+            ),
+            _insufficient(
+                "mean_margin",
+                reference.mean_margin,
+                metrics.mean_margin,
+                resolved.maximum_mean_margin_drop,
+                metrics.inference_count,
+                unlabeled_reason,
+            ),
+            _insufficient(
+                "action_distribution",
+                0.0,
+                distance,
+                resolved.maximum_action_distribution_distance,
+                metrics.inference_count,
+                unlabeled_reason,
+            ),
+        ]
+
+    label_coverage = metrics.labeled_count / metrics.inference_count
+    accuracy_ready = (
+        unlabeled_ready
+        and metrics.labeled_count >= resolved.minimum_labeled_count
+        and label_coverage >= resolved.minimum_label_coverage
+        and metrics.raw_accuracy is not None
+    )
+    if accuracy_ready:
+        assert metrics.raw_accuracy is not None
+        findings.append(
+            _drop_finding(
+                "raw_accuracy",
+                reference.raw_accuracy,
+                metrics.raw_accuracy,
+                resolved.maximum_raw_accuracy_drop,
+                metrics.labeled_count,
+            )
+        )
+    else:
+        findings.append(
+            _insufficient(
+                "raw_accuracy",
+                reference.raw_accuracy,
+                metrics.raw_accuracy,
+                resolved.maximum_raw_accuracy_drop,
+                metrics.labeled_count,
+                (
+                    f"requires labeled_count>={resolved.minimum_labeled_count} and "
+                    f"label_coverage>={resolved.minimum_label_coverage:.6f}; observed "
+                    f"labeled_count={metrics.labeled_count}, label_coverage={label_coverage:.6f}"
+                ),
+            )
+        )
+
+    outcomes_by_record = {
+        item.inference_record_id: item for item in store.list_outcomes()
+    }
+    accepted_labeled_count = sum(
+        1
+        for item in selected
+        if item.status == "accepted" and item.record_id in outcomes_by_record
+    )
+    accepted_ready = (
+        accuracy_ready
+        and accepted_labeled_count >= resolved.minimum_accepted_labeled_count
+        and reference.accepted_accuracy is not None
+        and metrics.accepted_accuracy is not None
+    )
+    if accepted_ready:
+        assert reference.accepted_accuracy is not None
+        assert metrics.accepted_accuracy is not None
+        findings.append(
+            _drop_finding(
+                "accepted_accuracy",
+                reference.accepted_accuracy,
+                metrics.accepted_accuracy,
+                resolved.maximum_accepted_accuracy_drop,
+                accepted_labeled_count,
+            )
+        )
+    else:
+        findings.append(
+            _insufficient(
+                "accepted_accuracy",
+                reference.accepted_accuracy,
+                metrics.accepted_accuracy,
+                resolved.maximum_accepted_accuracy_drop,
+                accepted_labeled_count,
+                (
+                    f"requires accepted_labeled_count>="
+                    f"{resolved.minimum_accepted_labeled_count} and defined reference/observed "
+                    f"accepted accuracy; observed accepted_labeled_count={accepted_labeled_count}"
+                ),
+            )
+        )
+
+    if any(item.status == "insufficient_evidence" for item in findings):
+        overall = "insufficient_evidence"
+    elif any(item.status == "drifted" for item in findings):
+        overall = "drifted"
+    else:
+        overall = "healthy"
+
+    payload: Mapping[str, object] = {
+        "action_distribution_distance": distance,
+        "end_sequence_number": metrics.end_sequence_number,
+        "findings": [item.finding_id for item in findings],
+        "inference_record_ids": list(metrics.inference_record_ids),
+        "outcome_ids": list(metrics.outcome_ids),
+        "overall_status": overall,
+        "production_action_distribution": [
+            {
+                "action_label": item.action_label,
+                "count": item.count,
+                "frequency": item.frequency,
+            }
+            for item in actions
+        ],
+        "production_metrics_report_id": metrics.report_id,
+        "promoted_model_id": reference.promoted_model_id,
+        "reference_profile_id": reference.reference_profile_id,
+        "semantics": OPERATIONAL_HEALTH_SEMANTICS,
+        "start_sequence_number": metrics.start_sequence_number,
+        "version": OPERATIONAL_HEALTH_REPORT_VERSION,
+    }
+    return OperationalHealthReportDTO(
+        report_id=_digest(payload),
+        reference_profile_id=reference.reference_profile_id,
+        promoted_model_id=reference.promoted_model_id,
+        start_sequence_number=metrics.start_sequence_number,
+        end_sequence_number=metrics.end_sequence_number,
+        production_metrics_report_id=metrics.report_id,
+        production_action_distribution=actions,
+        action_distribution_distance=distance,
+        overall_status=overall,
+        findings=tuple(findings),
+        inference_record_ids=metrics.inference_record_ids,
+        outcome_ids=metrics.outcome_ids,
+    )

--- a/packages/perception/tests/test_health.py
+++ b/packages/perception/tests/test_health.py
@@ -38,12 +38,19 @@ def _test_report() -> PromotedTestEvaluationReportDTO:
     )
 
 
-def _inference(sequence: int, action: str, margin: float, status: str) -> ProductionInferenceRecordDTO:
+def _inference(
+    sequence: int,
+    action: str,
+    margin: float,
+    status: str,
+    *,
+    pointer_revision: int = 1,
+) -> ProductionInferenceRecordDTO:
     return ProductionInferenceRecordDTO(
         record_id=f"production-{sequence}",
         sequence_number=sequence,
         pointer_id="pointer-1",
-        pointer_revision=1,
+        pointer_revision=pointer_revision,
         promoted_model_id="promoted-a",
         model_id="model-a",
         model_kind="single_frame",
@@ -68,6 +75,18 @@ def _outcome(sequence: int, observed: str, correct: bool) -> ProductionOutcomeRe
     )
 
 
+def _small_policy(**changes: object) -> OperationalDriftPolicyDTO:
+    values: dict[str, object] = {
+        "minimum_reference_count": 4,
+        "minimum_inference_count": 2,
+        "minimum_labeled_count": 2,
+        "minimum_accepted_labeled_count": 2,
+        "minimum_label_coverage": 1.0,
+    }
+    values.update(changes)
+    return OperationalDriftPolicyDTO(**values)  # type: ignore[arg-type]
+
+
 def test_reference_profile_is_deterministic_and_preserves_test_distribution() -> None:
     first = build_operational_reference_profile(_test_report())
     second = build_operational_reference_profile(_test_report())
@@ -80,6 +99,26 @@ def test_reference_profile_is_deterministic_and_preserves_test_distribution() ->
     )
 
 
+def test_one_unlabeled_inference_cannot_report_drift() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    store.append_inference(_inference(1, "right", 0.0, "rejected_ambiguous"))
+
+    report = diagnose_operational_health(
+        build_operational_reference_profile(_test_report()),
+        store,
+        start_sequence_number=1,
+    )
+
+    assert report.overall_status == "insufficient_evidence"
+    assert tuple(item.status for item in report.findings) == (
+        "insufficient_evidence",
+        "insufficient_evidence",
+        "insufficient_evidence",
+        "insufficient_evidence",
+        "insufficient_evidence",
+    )
+
+
 def test_health_reports_insufficient_accuracy_evidence_without_labels() -> None:
     store = InMemoryPerceptionProductionLedgerStore()
     store.append_inference(_inference(1, "left", 0.7, "accepted"))
@@ -89,22 +128,40 @@ def test_health_reports_insufficient_accuracy_evidence_without_labels() -> None:
         build_operational_reference_profile(_test_report()),
         store,
         start_sequence_number=1,
-        policy=OperationalDriftPolicyDTO(minimum_labeled_count=2),
+        policy=_small_policy(),
     )
 
     assert report.overall_status == "insufficient_evidence"
-    assert report.findings[0].status == "healthy"
+    assert tuple(item.status for item in report.findings[:3]) == (
+        "healthy",
+        "healthy",
+        "healthy",
+    )
     assert report.findings[3].status == "insufficient_evidence"
     assert report.findings[4].status == "insufficient_evidence"
 
 
-def test_health_detects_coverage_margin_action_and_accuracy_drift() -> None:
+def test_partial_labels_do_not_compare_accuracy_to_fully_labeled_reference() -> None:
     store = InMemoryPerceptionProductionLedgerStore()
-    records = (
-        _inference(1, "left", 0.1, "rejected_ambiguous"),
-        _inference(2, "left", 0.1, "rejected_ambiguous"),
-        _inference(3, "left", 0.2, "rejected_ambiguous"),
-        _inference(4, "left", 0.2, "rejected_ambiguous"),
+    store.append_inference(_inference(1, "left", 0.7, "accepted"))
+    store.append_inference(_inference(2, "right", 0.6, "accepted"))
+    store.append_outcome(_outcome(1, "left", True))
+
+    report = diagnose_operational_health(
+        build_operational_reference_profile(_test_report()),
+        store,
+        start_sequence_number=1,
+        policy=_small_policy(minimum_labeled_count=1),
+    )
+
+    assert report.findings[3].status == "insufficient_evidence"
+    assert "label_coverage" in report.findings[3].rationale
+
+
+def test_health_detects_supported_margin_action_and_accuracy_drift() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    records = tuple(
+        _inference(sequence, "left", 0.1, "accepted") for sequence in range(1, 5)
     )
     for record in records:
         store.append_inference(record)
@@ -115,25 +172,40 @@ def test_health_detects_coverage_margin_action_and_accuracy_drift() -> None:
         build_operational_reference_profile(_test_report()),
         store,
         start_sequence_number=1,
-        policy=OperationalDriftPolicyDTO(
-            maximum_coverage_drop=0.1,
-            maximum_mean_margin_drop=0.1,
-            maximum_action_distribution_distance=0.2,
-            maximum_raw_accuracy_drop=0.1,
-            maximum_accepted_accuracy_drop=0.1,
+        policy=_small_policy(
+            minimum_inference_count=4,
             minimum_labeled_count=4,
+            minimum_accepted_labeled_count=4,
         ),
     )
 
     assert report.overall_status == "drifted"
-    assert tuple(item.status for item in report.findings[:4]) == (
+    assert report.findings[0].status == "healthy"
+    assert tuple(item.status for item in report.findings[1:]) == (
         "drifted",
         "drifted",
         "drifted",
         "drifted",
     )
-    assert report.findings[4].status == "insufficient_evidence"
     assert report.action_distribution_distance == 0.25
+
+
+def test_window_spanning_pointer_revisions_is_insufficient() -> None:
+    store = InMemoryPerceptionProductionLedgerStore()
+    store.append_inference(_inference(1, "left", 0.7, "accepted", pointer_revision=1))
+    store.append_inference(_inference(2, "right", 0.6, "accepted", pointer_revision=2))
+    store.append_outcome(_outcome(1, "left", True))
+    store.append_outcome(_outcome(2, "right", True))
+
+    report = diagnose_operational_health(
+        build_operational_reference_profile(_test_report()),
+        store,
+        start_sequence_number=1,
+        policy=_small_policy(),
+    )
+
+    assert report.overall_status == "insufficient_evidence"
+    assert "pointer_revisions" in report.findings[0].rationale
 
 
 def test_healthy_window_preserves_exact_evidence_ids() -> None:
@@ -147,13 +219,12 @@ def test_healthy_window_preserves_exact_evidence_ids() -> None:
         build_operational_reference_profile(_test_report()),
         store,
         start_sequence_number=1,
-        policy=OperationalDriftPolicyDTO(
+        policy=_small_policy(
             maximum_coverage_drop=0.3,
             maximum_mean_margin_drop=0.3,
             maximum_action_distribution_distance=0.3,
             maximum_raw_accuracy_drop=0.3,
             maximum_accepted_accuracy_drop=0.3,
-            minimum_labeled_count=2,
         ),
     )
 

--- a/packages/perception/tests/test_public_api_p16.py
+++ b/packages/perception/tests/test_public_api_p16.py
@@ -3,7 +3,7 @@ import zeromodel.perception as perception
 
 def test_operational_health_public_contract() -> None:
     assert perception.OPERATIONAL_REFERENCE_PROFILE_VERSION.endswith("/1")
-    assert perception.OPERATIONAL_DRIFT_POLICY_VERSION.endswith("/1")
+    assert perception.OPERATIONAL_DRIFT_POLICY_VERSION.endswith("/2")
     assert perception.OPERATIONAL_HEALTH_FINDING_VERSION.endswith("/1")
     assert perception.OPERATIONAL_HEALTH_REPORT_VERSION.endswith("/1")
     assert perception.OPERATIONAL_HEALTH_STATUSES == {
@@ -11,6 +11,12 @@ def test_operational_health_public_contract() -> None:
         "drifted",
         "insufficient_evidence",
     }
-    assert perception.OperationalDriftPolicyDTO().minimum_labeled_count == 20
+    policy = perception.OperationalDriftPolicyDTO()
+    assert policy.minimum_reference_count == 20
+    assert policy.minimum_inference_count == 20
+    assert policy.minimum_labeled_count == 20
+    assert policy.minimum_accepted_labeled_count == 20
+    assert policy.minimum_label_coverage == 1.0
+    assert policy.require_single_pointer_revision
     assert callable(perception.build_operational_reference_profile)
     assert callable(perception.diagnose_operational_health)


### PR DESCRIPTION
## Summary

Implements P16E from the adversarial repair plan: operational health findings now require metric-specific evidence before they may be classified as healthy or drifted.

## Evidence gates

- advances `OperationalDriftPolicyDTO` to `/2`;
- adds minimum reference, inference, labeled, and accepted-labeled counts;
- adds a minimum production label-coverage requirement;
- requires a single active-pointer revision per health window by default;
- makes underpowered metrics first-class `insufficient_evidence` findings.

## Accuracy estimand repair

The frozen test reference is fully labeled, while P14 production accuracy is computed over labeled outcomes. P16E therefore withholds raw and accepted accuracy comparison unless production label coverage satisfies the declared completeness threshold. The default is complete labeling (`1.0`).

## Safety behavior

- one unlabeled inference cannot produce `drifted`;
- one unlabeled inference also cannot produce `healthy`;
- partial/selective labels cannot be compared directly with fully labeled test accuracy;
- windows spanning pointer revisions are withheld rather than blended;
- only adequately supported threshold crossings can produce `drifted`.

## Compatibility

The immutable P16 reference, finding, and report DTO formats remain unchanged. The package-level `diagnose_operational_health` and `OperationalDriftPolicyDTO` exports now point to the gated implementation.

## Deliberate boundary

This stage retains deterministic operational tolerance thresholds and total-variation distance. It does not claim formal hypothesis testing, confidence intervals, sequential-testing correction, or causal diagnosis. Rollback compatibility and the full end-to-end vertical test remain prerequisites before P17.

## Validation

The branch is based directly on merged P16D commit `55e5b402b89801bdbca7c2e47de16a505d937fbb`.

The complete suite was not executed locally through the connector. The dedicated perception GitHub Actions workflow is the authoritative validation run; no green result is claimed until it completes.