### PR TITLE
fix(perception): add P16F rollback compatibility contracts

### DIFF
--- a/packages/perception/docs/stage-p16f-rollback-compatibility.md
+++ b/packages/perception/docs/stage-p16f-rollback-compatibility.md
@@ -1,0 +1,30 @@
+# Stage P16F — Rollback Compatibility Contracts
+
+## Objective
+
+Prevent lifecycle history alone from making a promoted model rollback-eligible.
+
+## Contract
+
+`ModelCompatibilityContractDTO` binds a promoted model to the exact runtime contract it can consume:
+
+- model kind;
+- action schema identity;
+- source encoder identity;
+- field schema identity;
+- temporal window identity when applicable;
+- inference semantics version;
+- deployment slot.
+
+`assess_rollback_compatibility` compares the active and target contracts field by field and emits an immutable assessment containing the exact mismatches.
+
+`rollback_compatible_model` requires both:
+
+1. the existing P12 historical rule that the target was previously active; and
+2. an exact compatible runtime signature.
+
+An incompatible target leaves the active pointer unchanged.
+
+## Deliberate boundary
+
+This stage does not automatically select a rollback candidate and does not mutate lifecycle state without an explicit operator call. P17 recommendations remain paused until the full end-to-end integration stage is complete.

--- a/packages/perception/src/zeromodel/perception/compatibility.py
+++ b/packages/perception/src/zeromodel/perception/compatibility.py
@@ -1,0 +1,230 @@
+"""Deployment and rollback compatibility contracts for Stage P16F.
+
+Historical activation is necessary but not sufficient for rollback. A candidate must also
+match the current action, representation, temporal, inference, and deployment contracts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .lifecycle import (
+    ActiveModelPointerDTO,
+    ModelLifecycleTransitionDTO,
+    PerceptionModelLifecycleError,
+    PerceptionModelLifecycleStore,
+    rollback_active_model,
+)
+from .promotion import PromotedPerceptionModelDTO
+
+MODEL_COMPATIBILITY_VERSION: Final = "perception-model-compatibility/1"
+ROLLBACK_COMPATIBILITY_VERSION: Final = "perception-rollback-compatibility/1"
+MODEL_COMPATIBILITY_SEMANTICS: Final = (
+    "exact_action_representation_temporal_inference_and_deployment_contract"
+)
+ROLLBACK_COMPATIBILITY_STATUSES: Final = {"compatible", "incompatible"}
+
+
+class PerceptionModelCompatibilityError(ValueError):
+    """Raised when deployment or rollback compatibility cannot be established."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class ModelCompatibilityContractDTO:
+    contract_id: str
+    promoted_model_id: str
+    model_kind: str
+    action_schema_id: str
+    source_encoder_spec_id: str
+    field_schema_id: str
+    temporal_window_spec_id: str | None
+    inference_semantics_version: str
+    deployment_slot: str
+    semantics: str = MODEL_COMPATIBILITY_SEMANTICS
+    version: str = MODEL_COMPATIBILITY_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.contract_id,
+                self.promoted_model_id,
+                self.action_schema_id,
+                self.source_encoder_spec_id,
+                self.field_schema_id,
+                self.inference_semantics_version,
+                self.deployment_slot,
+            )
+        ):
+            raise PerceptionModelCompatibilityError("compatibility identities must be non-empty")
+        if self.model_kind not in {"single_frame", "temporal"}:
+            raise PerceptionModelCompatibilityError("unsupported compatibility model kind")
+        if self.model_kind == "temporal" and not self.temporal_window_spec_id:
+            raise PerceptionModelCompatibilityError("temporal compatibility requires window identity")
+        if self.model_kind == "single_frame" and self.temporal_window_spec_id is not None:
+            raise PerceptionModelCompatibilityError(
+                "single-frame compatibility cannot carry temporal window identity"
+            )
+        if self.semantics != MODEL_COMPATIBILITY_SEMANTICS:
+            raise PerceptionModelCompatibilityError("unsupported compatibility semantics")
+        if self.version != MODEL_COMPATIBILITY_VERSION:
+            raise PerceptionModelCompatibilityError("unsupported compatibility version")
+
+    def runtime_signature(self) -> tuple[str, ...]:
+        return (
+            self.model_kind,
+            self.action_schema_id,
+            self.source_encoder_spec_id,
+            self.field_schema_id,
+            self.temporal_window_spec_id or "",
+            self.inference_semantics_version,
+            self.deployment_slot,
+        )
+
+
+@dataclass(frozen=True)
+class RollbackCompatibilityAssessmentDTO:
+    assessment_id: str
+    current_contract_id: str
+    target_contract_id: str
+    current_promoted_model_id: str
+    target_promoted_model_id: str
+    status: str
+    mismatched_fields: tuple[str, ...]
+    version: str = ROLLBACK_COMPATIBILITY_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.assessment_id,
+                self.current_contract_id,
+                self.target_contract_id,
+                self.current_promoted_model_id,
+                self.target_promoted_model_id,
+            )
+        ):
+            raise PerceptionModelCompatibilityError("rollback assessment identities required")
+        if self.status not in ROLLBACK_COMPATIBILITY_STATUSES:
+            raise PerceptionModelCompatibilityError("unsupported rollback compatibility status")
+        if self.mismatched_fields != tuple(sorted(set(self.mismatched_fields))):
+            raise PerceptionModelCompatibilityError("mismatched fields must be unique and sorted")
+        if (self.status == "compatible") != (not self.mismatched_fields):
+            raise PerceptionModelCompatibilityError("assessment status must match mismatches")
+
+
+def build_model_compatibility_contract(
+    promoted: PromotedPerceptionModelDTO,
+    *,
+    action_schema_id: str,
+    source_encoder_spec_id: str,
+    field_schema_id: str,
+    inference_semantics_version: str,
+    deployment_slot: str,
+) -> ModelCompatibilityContractDTO:
+    payload: Mapping[str, object] = {
+        "action_schema_id": action_schema_id,
+        "deployment_slot": deployment_slot,
+        "field_schema_id": field_schema_id,
+        "inference_semantics_version": inference_semantics_version,
+        "model_kind": promoted.model_kind,
+        "promoted_model_id": promoted.promoted_model_id,
+        "semantics": MODEL_COMPATIBILITY_SEMANTICS,
+        "source_encoder_spec_id": source_encoder_spec_id,
+        "temporal_window_spec_id": promoted.temporal_window_spec_id,
+        "version": MODEL_COMPATIBILITY_VERSION,
+    }
+    return ModelCompatibilityContractDTO(contract_id=_digest(payload), **payload)  # type: ignore[arg-type]
+
+
+def assess_rollback_compatibility(
+    current: ModelCompatibilityContractDTO,
+    target: ModelCompatibilityContractDTO,
+) -> RollbackCompatibilityAssessmentDTO:
+    fields = (
+        "model_kind",
+        "action_schema_id",
+        "source_encoder_spec_id",
+        "field_schema_id",
+        "temporal_window_spec_id",
+        "inference_semantics_version",
+        "deployment_slot",
+    )
+    mismatches = tuple(
+        sorted(name for name in fields if getattr(current, name) != getattr(target, name))
+    )
+    status = "compatible" if not mismatches else "incompatible"
+    payload: Mapping[str, object] = {
+        "current_contract_id": current.contract_id,
+        "current_promoted_model_id": current.promoted_model_id,
+        "mismatched_fields": list(mismatches),
+        "status": status,
+        "target_contract_id": target.contract_id,
+        "target_promoted_model_id": target.promoted_model_id,
+        "version": ROLLBACK_COMPATIBILITY_VERSION,
+    }
+    return RollbackCompatibilityAssessmentDTO(
+        assessment_id=_digest(payload),
+        current_contract_id=current.contract_id,
+        target_contract_id=target.contract_id,
+        current_promoted_model_id=current.promoted_model_id,
+        target_promoted_model_id=target.promoted_model_id,
+        status=status,
+        mismatched_fields=mismatches,
+    )
+
+
+def rollback_compatible_model(
+    store: PerceptionModelLifecycleStore,
+    target_promoted_model_id: str,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+    actor: str,
+    reason: str,
+) -> tuple[
+    RollbackCompatibilityAssessmentDTO,
+    ModelLifecycleTransitionDTO,
+    ActiveModelPointerDTO,
+]:
+    """Rollback only when lifecycle history and exact runtime compatibility both hold."""
+
+    active_id = store.get_active_pointer().active_promoted_model_id
+    if active_id != current_contract.promoted_model_id:
+        raise PerceptionModelCompatibilityError(
+            "current compatibility contract does not describe the active model"
+        )
+    if target_promoted_model_id != target_contract.promoted_model_id:
+        raise PerceptionModelCompatibilityError(
+            "target compatibility contract does not describe rollback target"
+        )
+    assessment = assess_rollback_compatibility(current_contract, target_contract)
+    if assessment.status != "compatible":
+        raise PerceptionModelCompatibilityError(
+            f"rollback target is incompatible: {list(assessment.mismatched_fields)}"
+        )
+    try:
+        transition, pointer = rollback_active_model(
+            store,
+            target_promoted_model_id,
+            actor=actor,
+            reason=reason,
+        )
+    except PerceptionModelLifecycleError:
+        raise
+    return assessment, transition, pointer

--- a/packages/perception/tests/test_rollback_compatibility_p16f.py
+++ b/packages/perception/tests/test_rollback_compatibility_p16f.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception.compatibility import (
+    PerceptionModelCompatibilityError,
+    assess_rollback_compatibility,
+    build_model_compatibility_contract,
+    rollback_compatible_model,
+)
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+
+
+def _promoted(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"model-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _contract(model: PromotedPerceptionModelDTO, **overrides: str):
+    values = {
+        "action_schema_id": "actions-v1",
+        "source_encoder_spec_id": "encoder-v1",
+        "field_schema_id": "fields-v1",
+        "inference_semantics_version": "inference-v1",
+        "deployment_slot": "primary",
+    }
+    values.update(overrides)
+    return build_model_compatibility_contract(model, **values)
+
+
+def test_compatibility_assessment_is_deterministic_and_exact() -> None:
+    current = _contract(_promoted("current"))
+    target = _contract(_promoted("target"))
+
+    first = assess_rollback_compatibility(current, target)
+    second = assess_rollback_compatibility(current, target)
+
+    assert first == second
+    assert first.status == "compatible"
+    assert first.mismatched_fields == ()
+
+
+def test_action_schema_mismatch_blocks_rollback_eligibility() -> None:
+    current = _contract(_promoted("current"))
+    target = _contract(_promoted("target"), action_schema_id="actions-v2")
+
+    assessment = assess_rollback_compatibility(current, target)
+
+    assert assessment.status == "incompatible"
+    assert assessment.mismatched_fields == ("action_schema_id",)
+
+
+def test_compatible_historical_model_can_be_rolled_back() -> None:
+    store = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    register_promoted_model(store, earlier, registered_by="test", registration_reason="candidate")
+    register_promoted_model(store, current, registered_by="test", registration_reason="candidate")
+    activate_promoted_model(store, earlier.promoted_model_id, actor="test", reason="activate")
+    supersede_active_model(store, current.promoted_model_id, actor="test", reason="supersede")
+
+    assessment, transition, pointer = rollback_compatible_model(
+        store,
+        earlier.promoted_model_id,
+        current_contract=_contract(current),
+        target_contract=_contract(earlier),
+        actor="operator",
+        reason="restore compatible prior model",
+    )
+
+    assert assessment.status == "compatible"
+    assert transition.transition_kind == "rollback"
+    assert pointer.active_promoted_model_id == earlier.promoted_model_id
+
+
+def test_incompatible_historical_model_is_not_rolled_back() -> None:
+    store = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    register_promoted_model(store, earlier, registered_by="test", registration_reason="candidate")
+    register_promoted_model(store, current, registered_by="test", registration_reason="candidate")
+    activate_promoted_model(store, earlier.promoted_model_id, actor="test", reason="activate")
+    supersede_active_model(store, current.promoted_model_id, actor="test", reason="supersede")
+
+    with pytest.raises(PerceptionModelCompatibilityError, match="action_schema_id"):
+        rollback_compatible_model(
+            store,
+            earlier.promoted_model_id,
+            current_contract=_contract(current),
+            target_contract=_contract(earlier, action_schema_id="actions-v0"),
+            actor="operator",
+            reason="unsafe rollback",
+        )
+
+    assert store.get_active_pointer().active_promoted_model_id == current.promoted_model_id


### PR DESCRIPTION
## Summary

Implements P16F from the adversarial repair plan: a model is no longer rollback-eligible merely because it was active in the past.

## Changes

- adds immutable `ModelCompatibilityContractDTO` artifacts;
- binds promoted models to exact model kind, action schema, source encoder, field schema, temporal window, inference semantics, and deployment slot;
- adds deterministic `RollbackCompatibilityAssessmentDTO` artifacts with exact mismatched fields;
- adds `rollback_compatible_model`, which requires both historical lifecycle eligibility and exact runtime compatibility;
- leaves the active pointer unchanged when compatibility fails;
- adds focused lifecycle tests for compatible and incompatible historical rollback targets;
- documents the P16F boundary.

## Safety boundary

This stage does not automatically choose or execute a rollback. An explicit operator call, actor, and reason remain mandatory. P17 recommendations remain paused until the end-to-end integration stage is complete.

## Validation

The branch is based directly on merged P16E commit `0759bd4213a55a72241815d0604fdf1daad9df46`.

The complete suite was not executed locally through the connector. The dedicated perception GitHub Actions workflow is the authoritative validation run; no green result is claimed until it completes.