### PR TITLE
feat(perception): add P17 evidence-owned recommendations

### DIFF
--- a/packages/perception/docs/stage-p17-evidence-owned-recommendations.md
+++ b/packages/perception/docs/stage-p17-evidence-owned-recommendations.md
@@ -1,0 +1,42 @@
+# Stage P17 — Evidence-Owned Operational Recommendations
+
+## Objective
+
+Convert governed operational health evidence into an immutable, inspectable recommendation without allowing the recommendation layer to mutate model lifecycle state.
+
+## Inputs
+
+`recommend_operational_response` requires:
+
+- one `OperationalHealthReportDTO` produced by the statistically gated P16E path;
+- one immutable `ModelLifecycleSnapshotDTO`;
+- the active model's `ModelCompatibilityContractDTO`;
+- explicitly supplied compatibility contracts for historical candidates.
+
+The health report, active pointer, current compatibility contract, and active promoted model must describe the same operational state.
+
+## Recommendation states
+
+- `insufficient_evidence`: at least one governed health finding is underpowered, so action is withheld;
+- `no_action`: adequately supported health evidence is healthy;
+- `investigate`: drift is adequately supported, but no compatible previously active candidate is available;
+- `rollback_candidate`: drift is adequately supported and the most recently active compatible historical model is identified for operator review.
+
+## Safety contract
+
+P17 does not:
+
+- execute rollback;
+- activate, supersede, or deactivate a model;
+- invent a missing compatibility contract;
+- recommend action from insufficient evidence;
+- treat lifecycle history alone as rollback eligibility;
+- claim causal diagnosis from threshold-based drift evidence.
+
+Any lifecycle mutation remains an explicit operator action through the P12/P16F governed lifecycle APIs.
+
+## Determinism
+
+Recommendation identity includes the health report, lifecycle snapshot, active pointer revision, current compatibility contract, assessed compatibility artifacts, selected target when present, rationale, semantics, and version.
+
+Historical candidates are considered in reverse activation recency. The resulting immutable assessment collection is stored in canonical model-identity order.

--- a/packages/perception/src/zeromodel/perception/recommendation.py
+++ b/packages/perception/src/zeromodel/perception/recommendation.py
@@ -1,0 +1,220 @@
+"""Evidence-owned, non-mutating operational recommendations for Stage P17.
+
+P17 converts governed P16 health evidence, immutable lifecycle history, and P16F
+compatibility contracts into an inspectable recommendation artifact. Recommendations
+never mutate lifecycle state and never treat insufficient evidence as grounds for action.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .compatibility import (
+    ModelCompatibilityContractDTO,
+    RollbackCompatibilityAssessmentDTO,
+    assess_rollback_compatibility,
+)
+from .health import OperationalHealthReportDTO
+from .lifecycle import ModelLifecycleSnapshotDTO
+
+OPERATIONAL_RECOMMENDATION_VERSION: Final = "perception-operational-recommendation/1"
+OPERATIONAL_RECOMMENDATION_SEMANTICS: Final = (
+    "non_mutating_response_from_health_lifecycle_and_compatibility_evidence"
+)
+OPERATIONAL_RECOMMENDATION_STATUSES: Final = {
+    "insufficient_evidence",
+    "no_action",
+    "investigate",
+    "rollback_candidate",
+}
+
+
+class PerceptionOperationalRecommendationError(ValueError):
+    """Raised when recommendation evidence is incomplete or inconsistent."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class OperationalRecommendationDTO:
+    recommendation_id: str
+    health_report_id: str
+    lifecycle_snapshot_id: str
+    active_pointer_id: str
+    active_pointer_revision: int
+    active_promoted_model_id: str
+    current_contract_id: str
+    status: str
+    selected_target_promoted_model_id: str | None
+    selected_assessment_id: str | None
+    assessed_candidates: tuple[RollbackCompatibilityAssessmentDTO, ...]
+    rationale: str
+    semantics: str = OPERATIONAL_RECOMMENDATION_SEMANTICS
+    version: str = OPERATIONAL_RECOMMENDATION_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.recommendation_id,
+                self.health_report_id,
+                self.lifecycle_snapshot_id,
+                self.active_pointer_id,
+                self.active_promoted_model_id,
+                self.current_contract_id,
+                self.rationale,
+            )
+        ):
+            raise PerceptionOperationalRecommendationError(
+                "recommendation identities and rationale must be non-empty"
+            )
+        if self.active_pointer_revision <= 0:
+            raise PerceptionOperationalRecommendationError(
+                "recommendation requires an active non-zero pointer revision"
+            )
+        if self.status not in OPERATIONAL_RECOMMENDATION_STATUSES:
+            raise PerceptionOperationalRecommendationError(
+                "unsupported operational recommendation status"
+            )
+        selected = self.selected_target_promoted_model_id is not None
+        if selected != (self.selected_assessment_id is not None):
+            raise PerceptionOperationalRecommendationError(
+                "selected target and assessment must appear together"
+            )
+        if (self.status == "rollback_candidate") != selected:
+            raise PerceptionOperationalRecommendationError(
+                "only rollback_candidate recommendations may select a target"
+            )
+        if self.assessed_candidates != tuple(
+            sorted(self.assessed_candidates, key=lambda item: item.target_promoted_model_id)
+        ):
+            raise PerceptionOperationalRecommendationError(
+                "candidate assessments must be sorted by target model identity"
+            )
+        if self.semantics != OPERATIONAL_RECOMMENDATION_SEMANTICS:
+            raise PerceptionOperationalRecommendationError(
+                "unsupported recommendation semantics"
+            )
+        if self.version != OPERATIONAL_RECOMMENDATION_VERSION:
+            raise PerceptionOperationalRecommendationError(
+                "unsupported recommendation version"
+            )
+
+
+def recommend_operational_response(
+    health: OperationalHealthReportDTO,
+    lifecycle: ModelLifecycleSnapshotDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    candidate_contracts: Mapping[str, ModelCompatibilityContractDTO],
+) -> OperationalRecommendationDTO:
+    """Produce one deterministic recommendation without changing lifecycle state."""
+
+    active_id = lifecycle.active_pointer.active_promoted_model_id
+    if active_id is None:
+        raise PerceptionOperationalRecommendationError(
+            "recommendation requires an active promoted model"
+        )
+    if health.promoted_model_id != active_id:
+        raise PerceptionOperationalRecommendationError(
+            "health report does not describe the active promoted model"
+        )
+    if current_contract.promoted_model_id != active_id:
+        raise PerceptionOperationalRecommendationError(
+            "current compatibility contract does not describe the active model"
+        )
+
+    assessments: list[RollbackCompatibilityAssessmentDTO] = []
+    selected_target: str | None = None
+    selected_assessment: str | None = None
+
+    if health.overall_status == "insufficient_evidence" or any(
+        item.status == "insufficient_evidence" for item in health.findings
+    ):
+        status = "insufficient_evidence"
+        rationale = "health evidence is insufficient; operational action is withheld"
+    elif health.overall_status == "healthy":
+        status = "no_action"
+        rationale = "all governed health findings are adequately supported and healthy"
+    else:
+        most_recent: dict[str, int] = {}
+        for transition in lifecycle.transitions:
+            target = transition.next_promoted_model_id
+            if target is not None and target != active_id:
+                most_recent[target] = transition.sequence_number
+
+        ordered_candidates = tuple(
+            model_id
+            for model_id, _ in sorted(
+                most_recent.items(), key=lambda item: (-item[1], item[0])
+            )
+        )
+        for model_id in ordered_candidates:
+            contract = candidate_contracts.get(model_id)
+            if contract is None:
+                continue
+            assessment = assess_rollback_compatibility(current_contract, contract)
+            assessments.append(assessment)
+            if selected_target is None and assessment.status == "compatible":
+                selected_target = model_id
+                selected_assessment = assessment.assessment_id
+
+        if selected_target is None:
+            status = "investigate"
+            rationale = (
+                "drift is adequately supported, but no compatible previously active model "
+                "is available for operator consideration"
+            )
+        else:
+            status = "rollback_candidate"
+            rationale = (
+                "drift is adequately supported and the most recently active compatible "
+                "historical model is identified for operator review"
+            )
+
+    ordered_assessments = tuple(
+        sorted(assessments, key=lambda item: item.target_promoted_model_id)
+    )
+    payload: Mapping[str, object] = {
+        "active_pointer_id": lifecycle.active_pointer.pointer_id,
+        "active_pointer_revision": lifecycle.active_pointer.revision,
+        "active_promoted_model_id": active_id,
+        "assessed_candidate_ids": [item.assessment_id for item in ordered_assessments],
+        "current_contract_id": current_contract.contract_id,
+        "health_report_id": health.report_id,
+        "lifecycle_snapshot_id": lifecycle.snapshot_id,
+        "rationale": rationale,
+        "selected_assessment_id": selected_assessment,
+        "selected_target_promoted_model_id": selected_target,
+        "semantics": OPERATIONAL_RECOMMENDATION_SEMANTICS,
+        "status": status,
+        "version": OPERATIONAL_RECOMMENDATION_VERSION,
+    }
+    return OperationalRecommendationDTO(
+        recommendation_id=_digest(payload),
+        health_report_id=health.report_id,
+        lifecycle_snapshot_id=lifecycle.snapshot_id,
+        active_pointer_id=lifecycle.active_pointer.pointer_id,
+        active_pointer_revision=lifecycle.active_pointer.revision,
+        active_promoted_model_id=active_id,
+        current_contract_id=current_contract.contract_id,
+        status=status,
+        selected_target_promoted_model_id=selected_target,
+        selected_assessment_id=selected_assessment,
+        assessed_candidates=ordered_assessments,
+        rationale=rationale,
+    )

--- a/packages/perception/tests/test_operational_recommendation_p17.py
+++ b/packages/perception/tests/test_operational_recommendation_p17.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from zeromodel.perception.compatibility import build_model_compatibility_contract
+from zeromodel.perception.health import (
+    ActionFrequencyDTO,
+    OperationalHealthFindingDTO,
+    OperationalHealthReportDTO,
+)
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+from zeromodel.perception.recommendation import recommend_operational_response
+
+
+def _model(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"translator-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _contract(model: PromotedPerceptionModelDTO, *, action_schema_id: str = "actions-v1"):
+    return build_model_compatibility_contract(
+        model,
+        action_schema_id=action_schema_id,
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+
+
+def _health(model_id: str, status: str) -> OperationalHealthReportDTO:
+    finding_status = status
+    findings = tuple(
+        OperationalHealthFindingDTO(
+            finding_id=f"finding-{metric}-{status}",
+            metric=metric,
+            status=finding_status,
+            reference_value=0.9,
+            observed_value=0.9 if status == "healthy" else 0.5,
+            delta=0.0 if status == "healthy" else -0.4,
+            threshold=0.1,
+            evidence_count=50,
+            rationale=f"{metric} is {status}",
+        )
+        for metric in (
+            "coverage",
+            "mean_margin",
+            "action_distribution",
+            "raw_accuracy",
+            "accepted_accuracy",
+        )
+    )
+    return OperationalHealthReportDTO(
+        report_id=f"health-{status}",
+        reference_profile_id="reference-1",
+        promoted_model_id=model_id,
+        start_sequence_number=1,
+        end_sequence_number=50,
+        production_metrics_report_id="metrics-1",
+        production_action_distribution=(
+            ActionFrequencyDTO(action_label="LEFT", count=50, frequency=1.0),
+        ),
+        action_distribution_distance=0.0 if status == "healthy" else 0.4,
+        overall_status=status,
+        findings=findings,
+        inference_record_ids=tuple(f"inference-{index}" for index in range(50)),
+        outcome_ids=tuple(f"outcome-{index}" for index in range(50)),
+    )
+
+
+def _lifecycle():
+    store = InMemoryPerceptionModelLifecycleStore()
+    earlier = _model("earlier")
+    current = _model("current")
+    register_promoted_model(store, earlier, registered_by="test", registration_reason="earlier")
+    register_promoted_model(store, current, registered_by="test", registration_reason="current")
+    activate_promoted_model(store, earlier.promoted_model_id, actor="operator", reason="activate")
+    supersede_active_model(store, current.promoted_model_id, actor="operator", reason="supersede")
+    return earlier, current, build_model_lifecycle_snapshot(store)
+
+
+def test_insufficient_evidence_withholds_operational_action() -> None:
+    earlier, current, snapshot = _lifecycle()
+
+    recommendation = recommend_operational_response(
+        _health(current.promoted_model_id, "insufficient_evidence"),
+        snapshot,
+        current_contract=_contract(current),
+        candidate_contracts={earlier.promoted_model_id: _contract(earlier)},
+    )
+
+    assert recommendation.status == "insufficient_evidence"
+    assert recommendation.selected_target_promoted_model_id is None
+    assert recommendation.assessed_candidates == ()
+
+
+def test_healthy_evidence_recommends_no_action() -> None:
+    earlier, current, snapshot = _lifecycle()
+
+    recommendation = recommend_operational_response(
+        _health(current.promoted_model_id, "healthy"),
+        snapshot,
+        current_contract=_contract(current),
+        candidate_contracts={earlier.promoted_model_id: _contract(earlier)},
+    )
+
+    assert recommendation.status == "no_action"
+    assert recommendation.selected_target_promoted_model_id is None
+
+
+def test_supported_drift_identifies_compatible_historical_candidate() -> None:
+    earlier, current, snapshot = _lifecycle()
+
+    first = recommend_operational_response(
+        _health(current.promoted_model_id, "drifted"),
+        snapshot,
+        current_contract=_contract(current),
+        candidate_contracts={earlier.promoted_model_id: _contract(earlier)},
+    )
+    second = recommend_operational_response(
+        _health(current.promoted_model_id, "drifted"),
+        snapshot,
+        current_contract=_contract(current),
+        candidate_contracts={earlier.promoted_model_id: _contract(earlier)},
+    )
+
+    assert first == second
+    assert first.status == "rollback_candidate"
+    assert first.selected_target_promoted_model_id == earlier.promoted_model_id
+    assert first.assessed_candidates[0].status == "compatible"
+
+
+def test_supported_drift_without_compatible_candidate_requires_investigation() -> None:
+    earlier, current, snapshot = _lifecycle()
+
+    recommendation = recommend_operational_response(
+        _health(current.promoted_model_id, "drifted"),
+        snapshot,
+        current_contract=_contract(current),
+        candidate_contracts={
+            earlier.promoted_model_id: _contract(earlier, action_schema_id="actions-v0")
+        },
+    )
+
+    assert recommendation.status == "investigate"
+    assert recommendation.selected_target_promoted_model_id is None
+    assert recommendation.assessed_candidates[0].status == "incompatible"
+    assert recommendation.assessed_candidates[0].mismatched_fields == ("action_schema_id",)


### PR DESCRIPTION
## Summary

Implements the first P17 slice now that the P16 repair and integration sequence is complete: governed operational evidence can produce an immutable, inspectable recommendation artifact without mutating lifecycle state.

## Recommendation states

- `insufficient_evidence`: action is withheld whenever the health report or any finding is underpowered;
- `no_action`: adequately supported evidence is healthy;
- `investigate`: drift is supported but no compatible previously active model is available;
- `rollback_candidate`: drift is supported and the most recently active compatible historical model is identified for operator review.

## Evidence ownership

Recommendations bind:

- the P16E operational health report;
- the immutable lifecycle snapshot;
- the exact active pointer ID and revision;
- the active model compatibility contract;
- deterministic P16F compatibility assessments for historical candidates;
- the selected target and assessment when one exists.

## Safety boundary

P17 does not execute rollback or any other lifecycle mutation. It does not invent missing candidate contracts, recommend action from insufficient evidence, treat historical activation as compatibility, or claim causal diagnosis from threshold-based drift findings.

An explicit operator call through the governed lifecycle API remains required for every state change.

## Validation

The branch is based directly on merged P16G commit `ec2a75fe2d8fb044d1fe33ebf1066ca4bed8f429`.

Audit-Exempt: adds internal recommendation governance without changing an existing public evidence-status claim.

The complete suite was not executed locally through the connector. The dedicated perception GitHub Actions workflow is the authoritative validation run; no green result is claimed until it completes.