### PR TITLE
feat(perception): add P17B operator disposition governance

### DIFF
--- a/packages/perception/docs/stage-p17b-operator-disposition.md
+++ b/packages/perception/docs/stage-p17b-operator-disposition.md
@@ -1,0 +1,41 @@
+# Stage P17B — Operator Recommendation Disposition
+
+## Objective
+
+Turn a non-mutating P17 recommendation into an explicit, immutable operator decision while preserving a hard boundary between advice and lifecycle mutation.
+
+## Contract
+
+`OperationalRecommendationDispositionDTO` records:
+
+- the exact recommendation reviewed;
+- the active pointer identity and revision seen by the reviewer;
+- the active and selected promoted-model identities;
+- the selected compatibility assessment;
+- approval or rejection;
+- reviewer identity;
+- operator reason.
+
+Creating a disposition never changes lifecycle state.
+
+## Governed execution
+
+`execute_approved_rollback` accepts only an approved `rollback_candidate` disposition and revalidates:
+
+1. disposition and recommendation identity;
+2. active pointer identity;
+3. active pointer revision;
+4. active promoted model;
+5. current compatibility contract;
+6. selected target contract;
+7. selected compatible assessment.
+
+Only after these checks does it delegate to the existing P16F `rollback_compatible_model` operation.
+
+## Stale-decision rule
+
+An approval is not a standing authorization. Any pointer revision or model change after review makes the approval stale and execution fails without mutation.
+
+## Deliberate boundary
+
+P17B does not add automatic execution, scheduled execution, multi-party approval, or persistence for dispositions. Those require separate stages and explicit threat-model review.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -16,6 +16,12 @@ from .discovery import (
     EvidenceDiscrepancyVPMDTO, PerceptionDiscoveryError,
     UnexplainedEvidenceDTO, discover_unexpected_evidence,
 )
+from .disposition import (
+    OPERATIONAL_DISPOSITION_SEMANTICS, OPERATIONAL_DISPOSITION_STATUSES,
+    OPERATIONAL_DISPOSITION_VERSION, OperationalRecommendationDispositionDTO,
+    PerceptionOperationalDispositionError, disposition_operational_recommendation,
+    execute_approved_rollback,
+)
 from .evidence import (
     EVIDENCE_RENDER_SEMANTICS, EVIDENCE_VPM_VERSION, FIELD_RELEVANCE_SEMANTICS,
     FIELD_RELEVANCE_VERSION, EvidenceVPMDTO, FieldRelevanceDTO,
@@ -111,6 +117,11 @@ from .promotion import (
     PromotedPerceptionModelDTO, PromotionDecisionDTO, PromotionPolicyDTO,
     calibrate_comparison_candidates, promote_perception_model,
 )
+from .recommendation import (
+    OPERATIONAL_RECOMMENDATION_SEMANTICS, OPERATIONAL_RECOMMENDATION_STATUSES,
+    OPERATIONAL_RECOMMENDATION_VERSION, OperationalRecommendationDTO,
+    PerceptionOperationalRecommendationError, recommend_operational_response,
+)
 from .representation import (
     ACTION_SCHEMA_VERSION, SOURCE_ENCODER_VERSION, TARGET_ENCODER_VERSION,
     DiscreteActionSchemaDTO, PerceptionRepresentationError,
@@ -172,6 +183,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P16"
+PERCEPTION_STAGE = "P17B"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/disposition.py
+++ b/packages/perception/src/zeromodel/perception/disposition.py
@@ -1,0 +1,217 @@
+"""Operator disposition and governed execution linkage for Stage P17B.
+
+Recommendations remain non-mutating. An operator may approve or reject a recommendation,
+but execution revalidates the recommendation, active pointer revision, selected target, and
+compatibility contracts against the current lifecycle state before any rollback occurs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .compatibility import (
+    ModelCompatibilityContractDTO,
+    RollbackCompatibilityAssessmentDTO,
+    rollback_compatible_model,
+)
+from .lifecycle import (
+    ActiveModelPointerDTO,
+    ModelLifecycleTransitionDTO,
+    PerceptionModelLifecycleStore,
+)
+from .recommendation import OperationalRecommendationDTO
+
+OPERATIONAL_DISPOSITION_VERSION: Final = "perception-operational-disposition/1"
+OPERATIONAL_DISPOSITION_SEMANTICS: Final = (
+    "explicit_operator_review_of_non_mutating_operational_recommendation"
+)
+OPERATIONAL_DISPOSITION_STATUSES: Final = {"approved", "rejected"}
+
+
+class PerceptionOperationalDispositionError(ValueError):
+    """Raised when recommendation review or execution contracts are violated."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class OperationalRecommendationDispositionDTO:
+    disposition_id: str
+    recommendation_id: str
+    recommendation_status: str
+    active_pointer_id: str
+    active_pointer_revision: int
+    active_promoted_model_id: str
+    selected_target_promoted_model_id: str | None
+    selected_assessment_id: str | None
+    status: str
+    reviewed_by: str
+    reason: str
+    semantics: str = OPERATIONAL_DISPOSITION_SEMANTICS
+    version: str = OPERATIONAL_DISPOSITION_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.disposition_id,
+                self.recommendation_id,
+                self.recommendation_status,
+                self.active_pointer_id,
+                self.active_promoted_model_id,
+                self.reviewed_by,
+                self.reason,
+            )
+        ):
+            raise PerceptionOperationalDispositionError(
+                "disposition identities, reviewer, and reason must be non-empty"
+            )
+        if self.active_pointer_revision <= 0:
+            raise PerceptionOperationalDispositionError(
+                "disposition requires a non-zero pointer revision"
+            )
+        if self.status not in OPERATIONAL_DISPOSITION_STATUSES:
+            raise PerceptionOperationalDispositionError("unsupported disposition status")
+        selected = self.selected_target_promoted_model_id is not None
+        if selected != (self.selected_assessment_id is not None):
+            raise PerceptionOperationalDispositionError(
+                "selected target and assessment must appear together"
+            )
+        if self.status == "approved" and self.recommendation_status != "rollback_candidate":
+            raise PerceptionOperationalDispositionError(
+                "only rollback-candidate recommendations may be approved"
+            )
+        if self.status == "approved" and not selected:
+            raise PerceptionOperationalDispositionError(
+                "approved rollback disposition requires a selected target"
+            )
+        if self.semantics != OPERATIONAL_DISPOSITION_SEMANTICS:
+            raise PerceptionOperationalDispositionError("unsupported disposition semantics")
+        if self.version != OPERATIONAL_DISPOSITION_VERSION:
+            raise PerceptionOperationalDispositionError("unsupported disposition version")
+
+
+def disposition_operational_recommendation(
+    recommendation: OperationalRecommendationDTO,
+    *,
+    status: str,
+    reviewed_by: str,
+    reason: str,
+) -> OperationalRecommendationDispositionDTO:
+    """Record an explicit operator approval or rejection without mutating lifecycle state."""
+
+    payload: Mapping[str, object] = {
+        "active_pointer_id": recommendation.active_pointer_id,
+        "active_pointer_revision": recommendation.active_pointer_revision,
+        "active_promoted_model_id": recommendation.active_promoted_model_id,
+        "reason": reason,
+        "recommendation_id": recommendation.recommendation_id,
+        "recommendation_status": recommendation.status,
+        "reviewed_by": reviewed_by,
+        "selected_assessment_id": recommendation.selected_assessment_id,
+        "selected_target_promoted_model_id": recommendation.selected_target_promoted_model_id,
+        "semantics": OPERATIONAL_DISPOSITION_SEMANTICS,
+        "status": status,
+        "version": OPERATIONAL_DISPOSITION_VERSION,
+    }
+    return OperationalRecommendationDispositionDTO(
+        disposition_id=_digest(payload),
+        recommendation_id=recommendation.recommendation_id,
+        recommendation_status=recommendation.status,
+        active_pointer_id=recommendation.active_pointer_id,
+        active_pointer_revision=recommendation.active_pointer_revision,
+        active_promoted_model_id=recommendation.active_promoted_model_id,
+        selected_target_promoted_model_id=recommendation.selected_target_promoted_model_id,
+        selected_assessment_id=recommendation.selected_assessment_id,
+        status=status,
+        reviewed_by=reviewed_by,
+        reason=reason,
+    )
+
+
+def execute_approved_rollback(
+    store: PerceptionModelLifecycleStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+) -> tuple[
+    RollbackCompatibilityAssessmentDTO,
+    ModelLifecycleTransitionDTO,
+    ActiveModelPointerDTO,
+]:
+    """Execute an approved rollback only after revalidating all reviewed evidence."""
+
+    if disposition.status != "approved":
+        raise PerceptionOperationalDispositionError("rollback requires an approved disposition")
+    if disposition.recommendation_id != recommendation.recommendation_id:
+        raise PerceptionOperationalDispositionError(
+            "disposition does not describe the supplied recommendation"
+        )
+    if recommendation.status != "rollback_candidate":
+        raise PerceptionOperationalDispositionError(
+            "only rollback-candidate recommendations may be executed"
+        )
+    pointer = store.get_active_pointer()
+    if pointer.pointer_id != recommendation.active_pointer_id:
+        raise PerceptionOperationalDispositionError(
+            "active pointer identity changed after recommendation review"
+        )
+    if pointer.revision != recommendation.active_pointer_revision:
+        raise PerceptionOperationalDispositionError(
+            "active pointer revision changed after recommendation review"
+        )
+    if pointer.active_promoted_model_id != recommendation.active_promoted_model_id:
+        raise PerceptionOperationalDispositionError(
+            "active model changed after recommendation review"
+        )
+    target_id = recommendation.selected_target_promoted_model_id
+    assessment_id = recommendation.selected_assessment_id
+    if target_id is None or assessment_id is None:
+        raise PerceptionOperationalDispositionError(
+            "rollback recommendation lacks selected target evidence"
+        )
+    if current_contract.contract_id != recommendation.current_contract_id:
+        raise PerceptionOperationalDispositionError(
+            "current compatibility contract changed after recommendation review"
+        )
+    if target_contract.promoted_model_id != target_id:
+        raise PerceptionOperationalDispositionError(
+            "target compatibility contract does not describe recommended target"
+        )
+    selected = next(
+        (
+            item
+            for item in recommendation.assessed_candidates
+            if item.assessment_id == assessment_id
+            and item.target_promoted_model_id == target_id
+        ),
+        None,
+    )
+    if selected is None or selected.status != "compatible":
+        raise PerceptionOperationalDispositionError(
+            "selected compatibility assessment is missing or no longer eligible"
+        )
+    return rollback_compatible_model(
+        store,
+        target_id,
+        current_contract=current_contract,
+        target_contract=target_contract,
+        actor=disposition.reviewed_by,
+        reason=disposition.reason,
+    )

--- a/packages/perception/tests/test_operational_disposition_p17b.py
+++ b/packages/perception/tests/test_operational_disposition_p17b.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception.compatibility import (
+    assess_rollback_compatibility,
+    build_model_compatibility_contract,
+)
+from zeromodel.perception.disposition import (
+    PerceptionOperationalDispositionError,
+    disposition_operational_recommendation,
+    execute_approved_rollback,
+)
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+from zeromodel.perception.recommendation import OperationalRecommendationDTO
+
+
+def _promoted(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"model-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _contract(model: PromotedPerceptionModelDTO):
+    return build_model_compatibility_contract(
+        model,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+
+
+def _fixture():
+    store = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    for model in (earlier, current):
+        register_promoted_model(
+            store,
+            model,
+            registered_by="test",
+            registration_reason="candidate",
+        )
+    activate_promoted_model(store, earlier.promoted_model_id, actor="test", reason="activate")
+    supersede_active_model(store, current.promoted_model_id, actor="test", reason="supersede")
+    snapshot = build_model_lifecycle_snapshot(store)
+    current_contract = _contract(current)
+    target_contract = _contract(earlier)
+    assessment = assess_rollback_compatibility(current_contract, target_contract)
+    recommendation = OperationalRecommendationDTO(
+        recommendation_id="sha256:recommendation",
+        health_report_id="sha256:health",
+        lifecycle_snapshot_id=snapshot.snapshot_id,
+        active_pointer_id=snapshot.active_pointer.pointer_id,
+        active_pointer_revision=snapshot.active_pointer.revision,
+        active_promoted_model_id=current.promoted_model_id,
+        current_contract_id=current_contract.contract_id,
+        status="rollback_candidate",
+        selected_target_promoted_model_id=earlier.promoted_model_id,
+        selected_assessment_id=assessment.assessment_id,
+        assessed_candidates=(assessment,),
+        rationale="supported drift and compatible historical target",
+    )
+    return store, earlier, current, current_contract, target_contract, recommendation
+
+
+def test_approval_is_deterministic_and_non_mutating() -> None:
+    store, earlier, current, _, _, recommendation = _fixture()
+
+    first = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+    second = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+
+    assert first == second
+    assert store.get_active_pointer().active_promoted_model_id == current.promoted_model_id
+    assert first.selected_target_promoted_model_id == earlier.promoted_model_id
+
+
+def test_rejection_cannot_execute_or_mutate_lifecycle() -> None:
+    store, _, current, current_contract, target_contract, recommendation = _fixture()
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="rejected",
+        reviewed_by="operator",
+        reason="hold current model pending investigation",
+    )
+
+    with pytest.raises(PerceptionOperationalDispositionError, match="approved"):
+        execute_approved_rollback(
+            store,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+
+    assert store.get_active_pointer().active_promoted_model_id == current.promoted_model_id
+
+
+def test_approved_fresh_recommendation_executes_governed_rollback() -> None:
+    store, earlier, _, current_contract, target_contract, recommendation = _fixture()
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+
+    assessment, transition, pointer = execute_approved_rollback(
+        store,
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+
+    assert assessment.status == "compatible"
+    assert transition.transition_kind == "rollback"
+    assert pointer.active_promoted_model_id == earlier.promoted_model_id
+
+
+def test_approved_recommendation_is_rejected_after_pointer_revision_changes() -> None:
+    store, _, current, current_contract, target_contract, recommendation = _fixture()
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+    replacement = _promoted("replacement")
+    register_promoted_model(
+        store,
+        replacement,
+        registered_by="test",
+        registration_reason="new candidate",
+    )
+    supersede_active_model(
+        store,
+        replacement.promoted_model_id,
+        actor="other-operator",
+        reason="state changed before execution",
+    )
+
+    with pytest.raises(PerceptionOperationalDispositionError, match="pointer revision"):
+        execute_approved_rollback(
+            store,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+
+    assert store.get_active_pointer().active_promoted_model_id == replacement.promoted_model_id
+    assert current.promoted_model_id != replacement.promoted_model_id
+
+
+def test_non_rollback_recommendation_cannot_be_approved() -> None:
+    _, _, _, _, _, recommendation = _fixture()
+    healthy = OperationalRecommendationDTO(
+        **{
+            **recommendation.__dict__,
+            "recommendation_id": "sha256:healthy",
+            "status": "no_action",
+            "selected_target_promoted_model_id": None,
+            "selected_assessment_id": None,
+            "assessed_candidates": (),
+            "rationale": "healthy evidence",
+        }
+    )
+
+    with pytest.raises(PerceptionOperationalDispositionError, match="rollback-candidate"):
+        disposition_operational_recommendation(
+            healthy,
+            status="approved",
+            reviewed_by="operator",
+            reason="invalid approval",
+        )

--- a/packages/perception/tests/test_p17b_public_api.py
+++ b/packages/perception/tests/test_p17b_public_api.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import zeromodel.perception as perception
+
+
+def test_p17b_governance_is_public() -> None:
+    assert perception.PERCEPTION_STAGE == "P17B"
+    assert perception.OperationalRecommendationDTO is not None
+    assert perception.OperationalRecommendationDispositionDTO is not None
+    assert perception.recommend_operational_response is not None
+    assert perception.disposition_operational_recommendation is not None
+    assert perception.execute_approved_rollback is not None


### PR DESCRIPTION
## Summary

Implements P17B: an immutable operator approval/rejection record for P17 recommendations, plus a governed execution bridge that revalidates freshness before delegating to the existing compatible rollback operation.

## Changes

- adds `OperationalRecommendationDispositionDTO`;
- adds deterministic `disposition_operational_recommendation` for explicit approval or rejection;
- adds `execute_approved_rollback` with pointer, revision, active-model, recommendation, target, and compatibility revalidation;
- rejects stale approvals after any lifecycle pointer revision change;
- keeps disposition creation strictly non-mutating;
- exports P17/P17B recommendation governance from the package root;
- advances `PERCEPTION_STAGE` from `P16` to `P17B`;
- adds focused safety and public-API tests;
- documents the P17B boundary.

## Safety boundary

An approval is not a standing authorization. Execution fails without mutation when the active pointer identity or revision, active model, recommendation target, or compatibility contracts no longer match the reviewed evidence.

No automatic, scheduled, or background execution is introduced.

## Validation

The branch is based directly on merged P17 commit `0351494394f824074278aedf927185843c659360`.

Audit-Exempt: adds internal operator-governance and stale-decision safety; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains the authoritative validation run; no green result is claimed until it completes.