### PR TITLE
feat(perception): add P17D crash-recoverable governed execution

### DIFF
--- a/packages/perception/docs/stage-p17d-crash-recoverable-governed-execution.md
+++ b/packages/perception/docs/stage-p17d-crash-recoverable-governed-execution.md
@@ -1,0 +1,55 @@
+# Stage P17D — Crash-Recoverable Governed Execution
+
+## Objective
+
+Close the interruption gap between P17B lifecycle rollback and P17C execution-receipt persistence without creating a second active-model authority.
+
+The governed path is:
+
+```text
+persisted recommendation
+    ↓
+persisted approved disposition
+    ↓
+exact reviewed lifecycle pre-state
+    ↓
+compatible rollback
+    ↓
+persisted execution receipt
+```
+
+## Failure window
+
+P17C can persist a receipt after rollback, but these are separate store operations. A process may stop after the lifecycle store commits the rollback and before the governance store commits the receipt.
+
+The rollback is then real, but the durable governance chain appears incomplete.
+
+## P17D operation
+
+`execute_or_reconcile_approved_rollback` requires the exact persisted recommendation and disposition.
+
+It supports three states:
+
+1. **Receipt already exists** — return it idempotently without lifecycle mutation.
+2. **Reviewed pre-state is still active** — execute the governed compatible rollback and append its receipt.
+3. **Exact next rollback state exists without a receipt** — prove the transition and append the missing receipt.
+
+## Reconciliation proof
+
+Recovery requires all of the following:
+
+- pointer revision is exactly the reviewed revision plus one;
+- resulting active model is the approved target;
+- pointer references an existing lifecycle transition;
+- transition kind is `rollback`;
+- transition sequence is exactly the expected next revision;
+- previous and next model identities match the recommendation;
+- transition actor and reason match the operator disposition.
+
+Any unrelated supersession, rollback, deactivation, additional revision, different actor, or different reason is rejected.
+
+## Authority boundary
+
+The lifecycle store remains the sole authority for active-model state. The governance ledger does not replay or reconstruct lifecycle mutations. It only records a receipt for an already-proven exact transition.
+
+P17D does not claim distributed atomic transactions across arbitrary stores. It provides deterministic, restart-safe reconciliation for the single known crash window.

--- a/packages/perception/src/zeromodel/perception/governed_execution.py
+++ b/packages/perception/src/zeromodel/perception/governed_execution.py
@@ -11,11 +11,7 @@ from __future__ import annotations
 from typing import Final
 
 from .compatibility import ModelCompatibilityContractDTO, RollbackCompatibilityAssessmentDTO
-from .disposition import (
-    OperationalRecommendationDispositionDTO,
-    PerceptionOperationalDispositionError,
-    execute_approved_rollback,
-)
+from .disposition import OperationalRecommendationDispositionDTO, execute_approved_rollback
 from .lifecycle import (
     ActiveModelPointerDTO,
     ModelLifecycleTransitionDTO,
@@ -63,20 +59,16 @@ def _selected_assessment(
     return selected
 
 
-def _persisted_chain_matches(
+def _require_persisted_chain(
     governance_store: SqlitePerceptionGovernanceLedgerStore,
     recommendation: OperationalRecommendationDTO,
     disposition: OperationalRecommendationDispositionDTO,
 ) -> None:
-    persisted_recommendation = governance_store.get_recommendation(
-        recommendation.recommendation_id
-    )
-    if persisted_recommendation != recommendation:
+    if governance_store.get_recommendation(recommendation.recommendation_id) != recommendation:
         raise PerceptionGovernedExecutionError(
             "execution requires the exact persisted recommendation"
         )
-    persisted_disposition = governance_store.get_disposition(disposition.disposition_id)
-    if persisted_disposition != disposition:
+    if governance_store.get_disposition(disposition.disposition_id) != disposition:
         raise PerceptionGovernedExecutionError(
             "execution requires the exact persisted disposition"
         )
@@ -90,12 +82,12 @@ def _persisted_chain_matches(
 
 def _existing_receipt(
     governance_store: SqlitePerceptionGovernanceLedgerStore,
-    disposition: OperationalRecommendationDispositionDTO,
+    disposition_id: str,
 ) -> GovernanceExecutionReceiptDTO | None:
     matches = tuple(
         item
         for item in governance_store.list_execution_receipts()
-        if item.disposition_id == disposition.disposition_id
+        if item.disposition_id == disposition_id
     )
     if len(matches) > 1:
         raise PerceptionGovernedExecutionError(
@@ -114,10 +106,6 @@ def _reconciled_transition(
     if target_id is None:
         raise PerceptionGovernedExecutionError("approved disposition lacks rollback target")
     expected_revision = recommendation.active_pointer_revision + 1
-    if pointer.pointer_id != recommendation.active_pointer_id:
-        raise PerceptionGovernedExecutionError(
-            "active pointer identity differs from reviewed execution state"
-        )
     if pointer.revision != expected_revision:
         raise PerceptionGovernedExecutionError(
             "active pointer is neither reviewed pre-state nor exact rollback post-state"
@@ -138,7 +126,7 @@ def _reconciled_transition(
         raise PerceptionGovernedExecutionError(
             "rollback post-state references an unknown lifecycle transition"
         )
-    if not all(
+    exact_match = all(
         (
             transition.transition_kind == "rollback",
             transition.sequence_number == expected_revision,
@@ -148,7 +136,8 @@ def _reconciled_transition(
             transition.actor == disposition.reviewed_by,
             transition.reason == disposition.reason,
         )
-    ):
+    )
+    if not exact_match:
         raise PerceptionGovernedExecutionError(
             "post-state transition does not exactly match the approved rollback"
         )
@@ -164,27 +153,24 @@ def execute_or_reconcile_approved_rollback(
     current_contract: ModelCompatibilityContractDTO,
     target_contract: ModelCompatibilityContractDTO,
 ) -> GovernanceExecutionReceiptDTO:
-    """Execute once, or recover the missing receipt for one exact committed rollback.
+    """Execute once, or recover a missing receipt for one exact committed rollback."""
 
-    The recommendation and disposition must already be persisted. Repeated calls are
-    idempotent after a receipt exists. If lifecycle mutation committed before a process crash,
-    the exact next pointer revision and rollback transition are reconciled into the receipt.
-    Any other lifecycle movement is treated as stale or conflicting evidence.
-    """
-
-    _persisted_chain_matches(governance_store, recommendation, disposition)
+    _require_persisted_chain(governance_store, recommendation, disposition)
     assessment = _selected_assessment(recommendation, disposition)
-    existing = _existing_receipt(governance_store, disposition)
+    existing = _existing_receipt(governance_store, disposition.disposition_id)
     if existing is not None:
         return existing
 
     pointer = lifecycle_store.get_active_pointer()
-    if (
-        pointer.pointer_id == recommendation.active_pointer_id
-        and pointer.revision == recommendation.active_pointer_revision
-        and pointer.active_promoted_model_id
-        == recommendation.active_promoted_model_id
-    ):
+    reviewed_pre_state = all(
+        (
+            pointer.pointer_id == recommendation.active_pointer_id,
+            pointer.revision == recommendation.active_pointer_revision,
+            pointer.active_promoted_model_id
+            == recommendation.active_promoted_model_id,
+        )
+    )
+    if reviewed_pre_state:
         try:
             executed_assessment, transition, resulting_pointer = execute_approved_rollback(
                 lifecycle_store,
@@ -193,7 +179,7 @@ def execute_or_reconcile_approved_rollback(
                 current_contract=current_contract,
                 target_contract=target_contract,
             )
-        except (PerceptionOperationalDispositionError, ValueError) as error:
+        except ValueError as error:
             raise PerceptionGovernedExecutionError(str(error)) from error
         if executed_assessment.assessment_id != assessment.assessment_id:
             raise PerceptionGovernedExecutionError(

--- a/packages/perception/src/zeromodel/perception/governed_execution.py
+++ b/packages/perception/src/zeromodel/perception/governed_execution.py
@@ -1,0 +1,221 @@
+"""Crash-recoverable governed rollback execution for Stage P17D.
+
+The lifecycle store remains the sole authority for active-model state. The governance ledger
+records the reviewed recommendation, disposition, and resulting execution receipt. This
+module closes the process-crash gap between lifecycle mutation and receipt persistence by
+reconciling an exact already-committed rollback transition after restart.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .compatibility import ModelCompatibilityContractDTO, RollbackCompatibilityAssessmentDTO
+from .disposition import (
+    OperationalRecommendationDispositionDTO,
+    PerceptionOperationalDispositionError,
+    execute_approved_rollback,
+)
+from .lifecycle import (
+    ActiveModelPointerDTO,
+    ModelLifecycleTransitionDTO,
+    PerceptionModelLifecycleStore,
+)
+from .recommendation import OperationalRecommendationDTO
+from .sql_governance import (
+    GovernanceExecutionReceiptDTO,
+    PerceptionSqlGovernanceError,
+    SqlitePerceptionGovernanceLedgerStore,
+)
+
+GOVERNED_EXECUTION_SEMANTICS: Final = (
+    "persisted_approval_with_exact_lifecycle_execution_or_restart_reconciliation"
+)
+
+
+class PerceptionGovernedExecutionError(ValueError):
+    """Raised when durable execution cannot be proven safe or recoverable."""
+
+
+def _selected_assessment(
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+) -> RollbackCompatibilityAssessmentDTO:
+    assessment_id = disposition.selected_assessment_id
+    target_id = disposition.selected_target_promoted_model_id
+    if assessment_id is None or target_id is None:
+        raise PerceptionGovernedExecutionError(
+            "approved disposition lacks selected rollback evidence"
+        )
+    selected = next(
+        (
+            item
+            for item in recommendation.assessed_candidates
+            if item.assessment_id == assessment_id
+            and item.target_promoted_model_id == target_id
+        ),
+        None,
+    )
+    if selected is None or selected.status != "compatible":
+        raise PerceptionGovernedExecutionError(
+            "approved disposition does not identify a compatible assessment"
+        )
+    return selected
+
+
+def _persisted_chain_matches(
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+) -> None:
+    persisted_recommendation = governance_store.get_recommendation(
+        recommendation.recommendation_id
+    )
+    if persisted_recommendation != recommendation:
+        raise PerceptionGovernedExecutionError(
+            "execution requires the exact persisted recommendation"
+        )
+    persisted_disposition = governance_store.get_disposition(disposition.disposition_id)
+    if persisted_disposition != disposition:
+        raise PerceptionGovernedExecutionError(
+            "execution requires the exact persisted disposition"
+        )
+    if disposition.recommendation_id != recommendation.recommendation_id:
+        raise PerceptionGovernedExecutionError(
+            "persisted disposition does not belong to recommendation"
+        )
+    if disposition.status != "approved":
+        raise PerceptionGovernedExecutionError("execution requires persisted approval")
+
+
+def _existing_receipt(
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    disposition: OperationalRecommendationDispositionDTO,
+) -> GovernanceExecutionReceiptDTO | None:
+    matches = tuple(
+        item
+        for item in governance_store.list_execution_receipts()
+        if item.disposition_id == disposition.disposition_id
+    )
+    if len(matches) > 1:
+        raise PerceptionGovernedExecutionError(
+            "governance ledger contains multiple receipts for one disposition"
+        )
+    return matches[0] if matches else None
+
+
+def _reconciled_transition(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    pointer: ActiveModelPointerDTO,
+) -> ModelLifecycleTransitionDTO:
+    target_id = disposition.selected_target_promoted_model_id
+    if target_id is None:
+        raise PerceptionGovernedExecutionError("approved disposition lacks rollback target")
+    expected_revision = recommendation.active_pointer_revision + 1
+    if pointer.pointer_id != recommendation.active_pointer_id:
+        raise PerceptionGovernedExecutionError(
+            "active pointer identity differs from reviewed execution state"
+        )
+    if pointer.revision != expected_revision:
+        raise PerceptionGovernedExecutionError(
+            "active pointer is neither reviewed pre-state nor exact rollback post-state"
+        )
+    if pointer.active_promoted_model_id != target_id or pointer.last_transition_id is None:
+        raise PerceptionGovernedExecutionError(
+            "active pointer does not contain the reviewed rollback result"
+        )
+    transition = next(
+        (
+            item
+            for item in lifecycle_store.list_transitions()
+            if item.transition_id == pointer.last_transition_id
+        ),
+        None,
+    )
+    if transition is None:
+        raise PerceptionGovernedExecutionError(
+            "rollback post-state references an unknown lifecycle transition"
+        )
+    if not all(
+        (
+            transition.transition_kind == "rollback",
+            transition.sequence_number == expected_revision,
+            transition.previous_promoted_model_id
+            == recommendation.active_promoted_model_id,
+            transition.next_promoted_model_id == target_id,
+            transition.actor == disposition.reviewed_by,
+            transition.reason == disposition.reason,
+        )
+    ):
+        raise PerceptionGovernedExecutionError(
+            "post-state transition does not exactly match the approved rollback"
+        )
+    return transition
+
+
+def execute_or_reconcile_approved_rollback(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+) -> GovernanceExecutionReceiptDTO:
+    """Execute once, or recover the missing receipt for one exact committed rollback.
+
+    The recommendation and disposition must already be persisted. Repeated calls are
+    idempotent after a receipt exists. If lifecycle mutation committed before a process crash,
+    the exact next pointer revision and rollback transition are reconciled into the receipt.
+    Any other lifecycle movement is treated as stale or conflicting evidence.
+    """
+
+    _persisted_chain_matches(governance_store, recommendation, disposition)
+    assessment = _selected_assessment(recommendation, disposition)
+    existing = _existing_receipt(governance_store, disposition)
+    if existing is not None:
+        return existing
+
+    pointer = lifecycle_store.get_active_pointer()
+    if (
+        pointer.pointer_id == recommendation.active_pointer_id
+        and pointer.revision == recommendation.active_pointer_revision
+        and pointer.active_promoted_model_id
+        == recommendation.active_promoted_model_id
+    ):
+        try:
+            executed_assessment, transition, resulting_pointer = execute_approved_rollback(
+                lifecycle_store,
+                recommendation,
+                disposition,
+                current_contract=current_contract,
+                target_contract=target_contract,
+            )
+        except (PerceptionOperationalDispositionError, ValueError) as error:
+            raise PerceptionGovernedExecutionError(str(error)) from error
+        if executed_assessment.assessment_id != assessment.assessment_id:
+            raise PerceptionGovernedExecutionError(
+                "executed compatibility assessment differs from approved evidence"
+            )
+    else:
+        transition = _reconciled_transition(
+            lifecycle_store,
+            recommendation,
+            disposition,
+            pointer,
+        )
+        resulting_pointer = pointer
+
+    receipt = GovernanceExecutionReceiptDTO.from_execution(
+        disposition,
+        assessment,
+        transition,
+        resulting_pointer,
+    )
+    try:
+        governance_store.append_execution_receipt(receipt)
+    except PerceptionSqlGovernanceError as error:
+        raise PerceptionGovernedExecutionError(str(error)) from error
+    return receipt

--- a/packages/perception/tests/test_governed_execution_p17d.py
+++ b/packages/perception/tests/test_governed_execution_p17d.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception.compatibility import (
+    assess_rollback_compatibility,
+    build_model_compatibility_contract,
+)
+from zeromodel.perception.disposition import (
+    disposition_operational_recommendation,
+    execute_approved_rollback,
+)
+from zeromodel.perception.governed_execution import (
+    PerceptionGovernedExecutionError,
+    execute_or_reconcile_approved_rollback,
+)
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+from zeromodel.perception.recommendation import OperationalRecommendationDTO
+from zeromodel.perception.sql_governance import SqlitePerceptionGovernanceLedgerStore
+
+
+def _promoted(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"model-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _contract(model: PromotedPerceptionModelDTO):
+    return build_model_compatibility_contract(
+        model,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+
+
+def _fixture(tmp_path):
+    lifecycle = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    other = _promoted("other")
+    for model in (earlier, current, other):
+        register_promoted_model(
+            lifecycle,
+            model,
+            registered_by="test",
+            registration_reason="candidate",
+        )
+    activate_promoted_model(lifecycle, earlier.promoted_model_id, actor="test", reason="activate")
+    supersede_active_model(
+        lifecycle,
+        current.promoted_model_id,
+        actor="test",
+        reason="supersede",
+    )
+    snapshot = build_model_lifecycle_snapshot(lifecycle)
+    current_contract = _contract(current)
+    target_contract = _contract(earlier)
+    assessment = assess_rollback_compatibility(current_contract, target_contract)
+    recommendation = OperationalRecommendationDTO(
+        recommendation_id="sha256:recommendation",
+        health_report_id="sha256:health",
+        lifecycle_snapshot_id=snapshot.snapshot_id,
+        active_pointer_id=snapshot.active_pointer.pointer_id,
+        active_pointer_revision=snapshot.active_pointer.revision,
+        active_promoted_model_id=current.promoted_model_id,
+        current_contract_id=current_contract.contract_id,
+        status="rollback_candidate",
+        selected_target_promoted_model_id=earlier.promoted_model_id,
+        selected_assessment_id=assessment.assessment_id,
+        assessed_candidates=(assessment,),
+        rationale="supported drift with compatible historical candidate",
+    )
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+    governance = SqlitePerceptionGovernanceLedgerStore(tmp_path / "governance.sqlite3")
+    governance.append_recommendation(recommendation)
+    governance.append_disposition(disposition)
+    return (
+        lifecycle,
+        governance,
+        earlier,
+        current,
+        other,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    )
+
+
+def test_executes_and_persists_one_receipt(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        earlier,
+        _,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path)
+    try:
+        receipt = execute_or_reconcile_approved_rollback(
+            lifecycle,
+            governance,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        repeated = execute_or_reconcile_approved_rollback(
+            lifecycle,
+            governance,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        assert repeated == receipt
+        assert lifecycle.get_active_pointer().active_promoted_model_id == earlier.promoted_model_id
+        assert governance.list_execution_receipts() == (receipt,)
+    finally:
+        governance.close()
+
+
+def test_recovers_receipt_after_crash_between_mutation_and_persistence(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        earlier,
+        _,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path)
+    database = tmp_path / "governance.sqlite3"
+    try:
+        _, transition, pointer = execute_approved_rollback(
+            lifecycle,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        assert pointer.active_promoted_model_id == earlier.promoted_model_id
+        assert governance.list_execution_receipts() == ()
+        governance.close()
+
+        with SqlitePerceptionGovernanceLedgerStore(database) as restarted:
+            receipt = execute_or_reconcile_approved_rollback(
+                lifecycle,
+                restarted,
+                recommendation,
+                disposition,
+                current_contract=current_contract,
+                target_contract=target_contract,
+            )
+            assert receipt.transition_id == transition.transition_id
+            assert receipt.pointer_revision == pointer.revision
+            assert restarted.list_execution_receipts() == (receipt,)
+    finally:
+        try:
+            governance.close()
+        except Exception:
+            pass
+
+
+def test_unrelated_pointer_movement_is_not_misread_as_recovery(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        _,
+        _,
+        other,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path)
+    try:
+        supersede_active_model(
+            lifecycle,
+            other.promoted_model_id,
+            actor="different-operator",
+            reason="unrelated deployment",
+        )
+        with pytest.raises(
+            PerceptionGovernedExecutionError,
+            match="neither reviewed pre-state nor exact rollback post-state",
+        ):
+            execute_or_reconcile_approved_rollback(
+                lifecycle,
+                governance,
+                recommendation,
+                disposition,
+                current_contract=current_contract,
+                target_contract=target_contract,
+            )
+        assert governance.list_execution_receipts() == ()
+    finally:
+        governance.close()
+
+
+def test_execution_requires_exact_persisted_chain(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        _,
+        _,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path)
+    try:
+        unpersisted = OperationalRecommendationDTO(
+            **{
+                **recommendation.__dict__,
+                "recommendation_id": "sha256:different-recommendation",
+            }
+        )
+        with pytest.raises(PerceptionGovernedExecutionError, match="exact persisted recommendation"):
+            execute_or_reconcile_approved_rollback(
+                lifecycle,
+                governance,
+                unpersisted,
+                disposition,
+                current_contract=current_contract,
+                target_contract=target_contract,
+            )
+    finally:
+        governance.close()


### PR DESCRIPTION
## Summary

Implements P17D: a restart-safe governed rollback orchestrator that closes the crash window between lifecycle mutation and governance receipt persistence.

## Governed states

- existing receipt: return idempotently with no lifecycle mutation;
- reviewed pre-state still active: execute the approved compatible rollback and persist its receipt;
- exact next rollback post-state exists without a receipt: prove the transition and materialize the missing receipt;
- any unrelated lifecycle movement: reject as stale or conflicting evidence.

## Reconciliation proof

Recovery requires the exact next pointer revision, approved target model, rollback transition kind, previous and next model identities, transition sequence, operator identity, and operator reason.

The resulting pointer is content-addressed and therefore has a new identity after rollback; reconciliation correctly validates the transition and revision rather than incorrectly requiring the old pointer identity.

## Authority boundary

The lifecycle store remains the sole active-model authority. The governance store records evidence, review, and receipts only. P17D does not claim a distributed transaction across arbitrary databases; it deterministically repairs the single known crash window.

## Validation

The branch is based directly on merged P17C commit `2ab1133544c3a363fbf63c7425f52f657371be49`.

Tests cover normal execution, idempotent replay after receipt persistence, process interruption after lifecycle mutation, restart reconciliation, unrelated pointer movement rejection, and exact persisted-chain enforcement.

Audit-Exempt: adds internal execution recovery and stale-state safety; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains authoritative; no green result is claimed until it completes.