### PR TITLE
feat(perception): add P17E execution attempt journal

### DIFF
--- a/packages/perception/docs/stage-p17e-execution-attempt-journal.md
+++ b/packages/perception/docs/stage-p17e-execution-attempt-journal.md
@@ -1,0 +1,61 @@
+# Stage P17E — Governed Execution Attempt Journal
+
+## Objective
+
+Make every governed rollback attempt durably visible before lifecycle mutation begins and preserve one append-only terminal outcome after execution, reconciliation, idempotent linkage, or governed failure.
+
+P17D repairs the specific crash window where lifecycle rollback committed but its governance receipt did not. P17E adds the missing operational record that an attempt was started and whether it eventually terminated.
+
+## Event model
+
+```text
+GovernedExecutionAttemptDTO
+    ↓
+prepared
+    ↓
+completed | reconciled | idempotent | failed
+```
+
+The attempt identity binds:
+
+- recommendation identity;
+- approved disposition identity;
+- reviewed pointer identity and revision;
+- reviewed active model;
+- approved target model;
+- current compatibility contract;
+- target compatibility contract.
+
+## Terminal meanings
+
+- `completed`: the reviewed pre-state was still active, so this invocation executed the rollback.
+- `reconciled`: a prepared-only attempt resumed after lifecycle rollback had committed without its terminal journal event.
+- `idempotent`: the execution receipt already existed before this attempt was linked to it.
+- `failed`: governed validation rejected the operation before a receipt could be established.
+
+A failed attempt is terminal. Retrying requires a new recommendation and operator disposition rather than silently reopening rejected evidence.
+
+## Storage boundary
+
+`SqliteGovernedExecutionAttemptStore` is a separate append-only SQLite contract. This avoids silently changing the P17C governance-ledger schema in place.
+
+The stores retain distinct authority:
+
+- lifecycle store: active-model truth and transitions;
+- governance ledger: recommendation, disposition, and receipt evidence;
+- attempt journal: operational execution intent and terminal attempt outcome.
+
+The attempt journal never changes lifecycle state directly.
+
+## Restart rule
+
+A process crash after `prepared` leaves a visible incomplete attempt. The next invocation resumes through P17D:
+
+1. execute if the reviewed pre-state remains current;
+2. reconcile if the exact approved rollback post-state already exists;
+3. reject any unrelated lifecycle movement;
+4. append exactly one terminal attempt event.
+
+## Deliberate boundary
+
+P17E does not add automatic retries, background workers, leases, timeouts, or multi-party approval. Those require explicit scheduling and concurrency contracts rather than inference from an unfinished attempt.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -27,6 +27,14 @@ from .evidence import (
     FIELD_RELEVANCE_VERSION, EvidenceVPMDTO, FieldRelevanceDTO,
     PerceptionEvidenceError, estimate_field_relevance,
 )
+from .execution_journal import (
+    EXECUTION_ATTEMPT_EVENT_KINDS, EXECUTION_ATTEMPT_EVENT_VERSION,
+    EXECUTION_ATTEMPT_TERMINAL_KINDS, EXECUTION_ATTEMPT_VERSION,
+    SQL_EXECUTION_JOURNAL_SCHEMA_VERSION, GovernedExecutionAttemptDTO,
+    GovernedExecutionAttemptEventDTO, PerceptionExecutionJournalError,
+    SqliteGovernedExecutionAttemptStore, build_governed_execution_attempt,
+    execute_journaled_approved_rollback,
+)
 from .expectations import (
     ANNOTATION_VERSION, CONFORMANCE_REPORT_VERSION, CONFORMANCE_STATUSES,
     EXPECTATION_VERSION, OBSERVED_REGISTRATION_VERSION,
@@ -43,6 +51,14 @@ from .fields import (
     build_grid_field_schema, extract_source_fields, mask_source_fields,
     reconstruct_source_array, validate_source_for_schema,
 )
+from .gated_health import (
+    OPERATIONAL_DRIFT_POLICY_VERSION, OPERATIONAL_EVIDENCE_SEMANTICS,
+    OperationalDriftPolicyDTO, diagnose_operational_health,
+)
+from .governed_execution import (
+    GOVERNED_EXECUTION_SEMANTICS, PerceptionGovernedExecutionError,
+    execute_or_reconcile_approved_rollback,
+)
 from .health import (
     OPERATIONAL_HEALTH_FINDING_VERSION, OPERATIONAL_HEALTH_METRICS,
     OPERATIONAL_HEALTH_REPORT_VERSION, OPERATIONAL_HEALTH_SEMANTICS,
@@ -51,10 +67,6 @@ from .health import (
     OperationalHealthFindingDTO, OperationalHealthReportDTO,
     OperationalReferenceProfileDTO, PerceptionOperationalHealthError,
     build_operational_reference_profile,
-)
-from .gated_health import (
-    OPERATIONAL_DRIFT_POLICY_VERSION, OPERATIONAL_EVIDENCE_SEMANTICS,
-    OperationalDriftPolicyDTO, diagnose_operational_health,
 )
 from .inference import (
     BASELINE_MODEL_VERSION, CONFIDENCE_SEMANTICS, DISTANCE_SEMANTICS,
@@ -76,11 +88,6 @@ from .lifecycle import (
     register_promoted_model, resolve_active_promoted_model,
     rollback_active_model, supersede_active_model,
 )
-from .partitions import (
-    DATASET_PARTITION_SEMANTICS, DATASET_PARTITION_VERSION,
-    DatasetPartitionDTO, PerceptionDatasetPartitionError,
-    build_dataset_partition,
-)
 from .partitioned_governance import (
     PARTITION_GOVERNANCE_SEMANTICS,
     PARTITION_OWNED_COMPARISON_VERSION,
@@ -92,6 +99,11 @@ from .partitioned_governance import (
     calibrate_partition_owned_candidates,
     evaluate_partition_owned_model_on_test,
     promote_partition_owned_model,
+)
+from .partitions import (
+    DATASET_PARTITION_SEMANTICS, DATASET_PARTITION_VERSION,
+    DatasetPartitionDTO, PerceptionDatasetPartitionError,
+    build_dataset_partition,
 )
 from .production import (
     PRODUCTION_INFERENCE_RECORD_VERSION, PRODUCTION_INFERENCE_SEMANTICS,
@@ -128,6 +140,11 @@ from .representation import (
     SourceImageEncoderSpecDTO, SourceVPMDTO, TargetVPMDTO,
     decode_discrete_action, encode_discrete_action, encode_source_array,
     encode_source_image_bytes,
+)
+from .sql_governance import (
+    GOVERNANCE_EXECUTION_RECEIPT_VERSION, SQL_GOVERNANCE_SCHEMA_VERSION,
+    SQL_GOVERNANCE_STORE_VERSION, GovernanceExecutionReceiptDTO,
+    PerceptionSqlGovernanceError, SqlitePerceptionGovernanceLedgerStore,
 )
 from .sql_lifecycle import (
     SQL_LIFECYCLE_SCHEMA_VERSION, SQL_LIFECYCLE_SEMANTICS,
@@ -183,6 +200,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P17B"
+PERCEPTION_STAGE = "P17E"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/execution_journal.py
+++ b/packages/perception/src/zeromodel/perception/execution_journal.py
@@ -1,0 +1,413 @@
+"""Append-only governed execution attempt journal for Stage P17E.
+
+P17D makes rollback execution restart-recoverable. P17E makes the attempt itself durable and
+observable: an approved disposition receives one deterministic attempt identity, a prepared
+event before execution, and exactly one terminal event after completion, reconciliation,
+idempotent replay, or governed failure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final, Mapping
+
+from .compatibility import ModelCompatibilityContractDTO
+from .disposition import OperationalRecommendationDispositionDTO
+from .governed_execution import (
+    PerceptionGovernedExecutionError,
+    execute_or_reconcile_approved_rollback,
+)
+from .lifecycle import PerceptionModelLifecycleStore
+from .recommendation import OperationalRecommendationDTO
+from .sql_governance import (
+    GovernanceExecutionReceiptDTO,
+    SqlitePerceptionGovernanceLedgerStore,
+)
+
+EXECUTION_ATTEMPT_VERSION: Final = "perception-governed-execution-attempt/1"
+EXECUTION_ATTEMPT_EVENT_VERSION: Final = "perception-governed-execution-attempt-event/1"
+SQL_EXECUTION_JOURNAL_SCHEMA_VERSION: Final = "perception-sql-execution-journal-schema/1"
+EXECUTION_ATTEMPT_EVENT_KINDS: Final = {
+    "prepared",
+    "completed",
+    "reconciled",
+    "idempotent",
+    "failed",
+}
+EXECUTION_ATTEMPT_TERMINAL_KINDS: Final = EXECUTION_ATTEMPT_EVENT_KINDS - {"prepared"}
+
+
+class PerceptionExecutionJournalError(ValueError):
+    """Raised when execution-attempt journal contracts are violated."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class GovernedExecutionAttemptDTO:
+    attempt_id: str
+    recommendation_id: str
+    disposition_id: str
+    reviewed_pointer_id: str
+    reviewed_pointer_revision: int
+    reviewed_active_promoted_model_id: str
+    target_promoted_model_id: str
+    current_contract_id: str
+    target_contract_id: str
+    version: str = EXECUTION_ATTEMPT_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.attempt_id,
+                self.recommendation_id,
+                self.disposition_id,
+                self.reviewed_pointer_id,
+                self.reviewed_active_promoted_model_id,
+                self.target_promoted_model_id,
+                self.current_contract_id,
+                self.target_contract_id,
+            )
+        ):
+            raise PerceptionExecutionJournalError("execution attempt identities must be non-empty")
+        if self.reviewed_pointer_revision <= 0:
+            raise PerceptionExecutionJournalError(
+                "execution attempt requires a positive reviewed pointer revision"
+            )
+        if self.version != EXECUTION_ATTEMPT_VERSION:
+            raise PerceptionExecutionJournalError("unsupported execution attempt version")
+
+
+@dataclass(frozen=True)
+class GovernedExecutionAttemptEventDTO:
+    event_id: str
+    attempt_id: str
+    sequence_number: int
+    event_kind: str
+    receipt_id: str | None
+    pointer_revision: int | None
+    failure_type: str | None
+    failure_message: str | None
+    version: str = EXECUTION_ATTEMPT_EVENT_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.event_id or not self.attempt_id:
+            raise PerceptionExecutionJournalError("attempt event identities must be non-empty")
+        if self.sequence_number not in {1, 2}:
+            raise PerceptionExecutionJournalError("attempt event sequence must be one or two")
+        if self.event_kind not in EXECUTION_ATTEMPT_EVENT_KINDS:
+            raise PerceptionExecutionJournalError("unsupported attempt event kind")
+        if self.event_kind == "prepared":
+            if self.sequence_number != 1 or any(
+                value is not None
+                for value in (
+                    self.receipt_id,
+                    self.pointer_revision,
+                    self.failure_type,
+                    self.failure_message,
+                )
+            ):
+                raise PerceptionExecutionJournalError("prepared event cannot contain terminal data")
+        elif self.event_kind == "failed":
+            if self.sequence_number != 2 or not self.failure_type or not self.failure_message:
+                raise PerceptionExecutionJournalError("failed event requires failure details")
+            if self.receipt_id is not None or self.pointer_revision is not None:
+                raise PerceptionExecutionJournalError("failed event cannot contain receipt data")
+        else:
+            if self.sequence_number != 2 or not self.receipt_id or self.pointer_revision is None:
+                raise PerceptionExecutionJournalError("successful terminal event requires receipt data")
+            if self.pointer_revision <= 0:
+                raise PerceptionExecutionJournalError("terminal pointer revision must be positive")
+            if self.failure_type is not None or self.failure_message is not None:
+                raise PerceptionExecutionJournalError("successful terminal event cannot contain failure data")
+        if self.version != EXECUTION_ATTEMPT_EVENT_VERSION:
+            raise PerceptionExecutionJournalError("unsupported attempt event version")
+
+
+def build_governed_execution_attempt(
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+) -> GovernedExecutionAttemptDTO:
+    target_id = disposition.selected_target_promoted_model_id
+    if disposition.status != "approved" or target_id is None:
+        raise PerceptionExecutionJournalError("execution attempt requires an approved rollback target")
+    if disposition.recommendation_id != recommendation.recommendation_id:
+        raise PerceptionExecutionJournalError("disposition does not belong to recommendation")
+    if current_contract.contract_id != recommendation.current_contract_id:
+        raise PerceptionExecutionJournalError("current contract does not match recommendation")
+    if target_contract.promoted_model_id != target_id:
+        raise PerceptionExecutionJournalError("target contract does not describe approved target")
+    payload: Mapping[str, object] = {
+        "current_contract_id": current_contract.contract_id,
+        "disposition_id": disposition.disposition_id,
+        "recommendation_id": recommendation.recommendation_id,
+        "reviewed_active_promoted_model_id": recommendation.active_promoted_model_id,
+        "reviewed_pointer_id": recommendation.active_pointer_id,
+        "reviewed_pointer_revision": recommendation.active_pointer_revision,
+        "target_contract_id": target_contract.contract_id,
+        "target_promoted_model_id": target_id,
+        "version": EXECUTION_ATTEMPT_VERSION,
+    }
+    return GovernedExecutionAttemptDTO(attempt_id=_digest(payload), **payload)
+
+
+def _event(
+    attempt: GovernedExecutionAttemptDTO,
+    *,
+    sequence_number: int,
+    event_kind: str,
+    receipt_id: str | None = None,
+    pointer_revision: int | None = None,
+    failure_type: str | None = None,
+    failure_message: str | None = None,
+) -> GovernedExecutionAttemptEventDTO:
+    payload: Mapping[str, object] = {
+        "attempt_id": attempt.attempt_id,
+        "event_kind": event_kind,
+        "failure_message": failure_message,
+        "failure_type": failure_type,
+        "pointer_revision": pointer_revision,
+        "receipt_id": receipt_id,
+        "sequence_number": sequence_number,
+        "version": EXECUTION_ATTEMPT_EVENT_VERSION,
+    }
+    return GovernedExecutionAttemptEventDTO(event_id=_digest(payload), **payload)
+
+
+class SqliteGovernedExecutionAttemptStore:
+    """Append-only SQLite journal for governed execution attempts and events."""
+
+    def __init__(self, database: str | Path) -> None:
+        self._connection = sqlite3.connect(str(database))
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA foreign_keys = ON")
+        self._initialize()
+
+    def __enter__(self) -> "SqliteGovernedExecutionAttemptStore":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        self.close()
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def _initialize(self) -> None:
+        self._connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS perception_execution_journal_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS perception_governed_execution_attempts (
+                attempt_id TEXT PRIMARY KEY,
+                disposition_id TEXT NOT NULL UNIQUE,
+                payload_json TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS perception_governed_execution_attempt_events (
+                event_id TEXT PRIMARY KEY,
+                attempt_id TEXT NOT NULL,
+                sequence_number INTEGER NOT NULL,
+                event_kind TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                UNIQUE(attempt_id, sequence_number),
+                FOREIGN KEY(attempt_id)
+                    REFERENCES perception_governed_execution_attempts(attempt_id)
+            );
+            """
+        )
+        row = self._connection.execute(
+            "SELECT value FROM perception_execution_journal_metadata WHERE key='schema_version'"
+        ).fetchone()
+        if row is None:
+            self._connection.execute(
+                "INSERT INTO perception_execution_journal_metadata(key, value) "
+                "VALUES('schema_version', ?)",
+                (SQL_EXECUTION_JOURNAL_SCHEMA_VERSION,),
+            )
+            self._connection.commit()
+        elif row["value"] != SQL_EXECUTION_JOURNAL_SCHEMA_VERSION:
+            raise PerceptionExecutionJournalError("unsupported execution journal schema version")
+
+    def append_attempt(self, attempt: GovernedExecutionAttemptDTO) -> None:
+        encoded = json.dumps(asdict(attempt), sort_keys=True, separators=(",", ":"))
+        row = self._connection.execute(
+            "SELECT attempt_id, payload_json FROM perception_governed_execution_attempts "
+            "WHERE disposition_id = ?",
+            (attempt.disposition_id,),
+        ).fetchone()
+        if row is not None:
+            if row["attempt_id"] != attempt.attempt_id or row["payload_json"] != encoded:
+                raise PerceptionExecutionJournalError(
+                    "disposition already has a conflicting execution attempt"
+                )
+            return
+        self._connection.execute(
+            "INSERT INTO perception_governed_execution_attempts"
+            "(attempt_id, disposition_id, payload_json) VALUES(?, ?, ?)",
+            (attempt.attempt_id, attempt.disposition_id, encoded),
+        )
+        self._connection.commit()
+
+    def append_event(self, event: GovernedExecutionAttemptEventDTO) -> None:
+        if self.get_attempt(event.attempt_id) is None:
+            raise PerceptionExecutionJournalError("attempt event requires persisted attempt")
+        existing = self._connection.execute(
+            "SELECT event_id, payload_json FROM perception_governed_execution_attempt_events "
+            "WHERE attempt_id = ? AND sequence_number = ?",
+            (event.attempt_id, event.sequence_number),
+        ).fetchone()
+        encoded = json.dumps(asdict(event), sort_keys=True, separators=(",", ":"))
+        if existing is not None:
+            if existing["event_id"] != event.event_id or existing["payload_json"] != encoded:
+                raise PerceptionExecutionJournalError("attempt sequence already has another event")
+            return
+        events = self.list_events(event.attempt_id)
+        expected_sequence = len(events) + 1
+        if event.sequence_number != expected_sequence:
+            raise PerceptionExecutionJournalError("attempt event sequence is not contiguous")
+        if events and events[-1].event_kind in EXECUTION_ATTEMPT_TERMINAL_KINDS:
+            raise PerceptionExecutionJournalError("terminal execution attempt cannot be extended")
+        self._connection.execute(
+            "INSERT INTO perception_governed_execution_attempt_events"
+            "(event_id, attempt_id, sequence_number, event_kind, payload_json) "
+            "VALUES(?, ?, ?, ?, ?)",
+            (
+                event.event_id,
+                event.attempt_id,
+                event.sequence_number,
+                event.event_kind,
+                encoded,
+            ),
+        )
+        self._connection.commit()
+
+    def get_attempt(self, attempt_id: str) -> GovernedExecutionAttemptDTO | None:
+        row = self._connection.execute(
+            "SELECT payload_json FROM perception_governed_execution_attempts WHERE attempt_id = ?",
+            (attempt_id,),
+        ).fetchone()
+        return None if row is None else GovernedExecutionAttemptDTO(**json.loads(row["payload_json"]))
+
+    def list_events(self, attempt_id: str) -> tuple[GovernedExecutionAttemptEventDTO, ...]:
+        rows = self._connection.execute(
+            "SELECT payload_json FROM perception_governed_execution_attempt_events "
+            "WHERE attempt_id = ? ORDER BY sequence_number",
+            (attempt_id,),
+        ).fetchall()
+        return tuple(
+            GovernedExecutionAttemptEventDTO(**json.loads(row["payload_json"])) for row in rows
+        )
+
+
+def execute_journaled_approved_rollback(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    attempt_store: SqliteGovernedExecutionAttemptStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+) -> tuple[GovernedExecutionAttemptDTO, GovernanceExecutionReceiptDTO]:
+    """Journal preparation, execute or reconcile once, and append one terminal event."""
+
+    attempt = build_governed_execution_attempt(
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    attempt_store.append_attempt(attempt)
+    events = attempt_store.list_events(attempt.attempt_id)
+    if events and events[-1].event_kind in EXECUTION_ATTEMPT_TERMINAL_KINDS:
+        terminal = events[-1]
+        if terminal.event_kind == "failed":
+            raise PerceptionExecutionJournalError(
+                f"execution attempt is terminally failed: {terminal.failure_message}"
+            )
+        receipts = tuple(
+            item
+            for item in governance_store.list_execution_receipts()
+            if item.receipt_id == terminal.receipt_id
+        )
+        if len(receipts) != 1:
+            raise PerceptionExecutionJournalError(
+                "terminal attempt references missing or ambiguous execution receipt"
+            )
+        return attempt, receipts[0]
+    if not events:
+        attempt_store.append_event(_event(attempt, sequence_number=1, event_kind="prepared"))
+
+    existing_receipt = next(
+        (
+            item
+            for item in governance_store.list_execution_receipts()
+            if item.disposition_id == disposition.disposition_id
+        ),
+        None,
+    )
+    pointer_before = lifecycle_store.get_active_pointer()
+    reviewed_pre_state = all(
+        (
+            pointer_before.pointer_id == recommendation.active_pointer_id,
+            pointer_before.revision == recommendation.active_pointer_revision,
+            pointer_before.active_promoted_model_id == recommendation.active_promoted_model_id,
+        )
+    )
+    try:
+        receipt = execute_or_reconcile_approved_rollback(
+            lifecycle_store,
+            governance_store,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+    except (PerceptionGovernedExecutionError, ValueError) as error:
+        attempt_store.append_event(
+            _event(
+                attempt,
+                sequence_number=2,
+                event_kind="failed",
+                failure_type=type(error).__name__,
+                failure_message=str(error),
+            )
+        )
+        raise PerceptionExecutionJournalError(str(error)) from error
+
+    if existing_receipt is not None:
+        event_kind = "idempotent"
+    elif reviewed_pre_state:
+        event_kind = "completed"
+    else:
+        event_kind = "reconciled"
+    attempt_store.append_event(
+        _event(
+            attempt,
+            sequence_number=2,
+            event_kind=event_kind,
+            receipt_id=receipt.receipt_id,
+            pointer_revision=receipt.pointer_revision,
+        )
+    )
+    return attempt, receipt

--- a/packages/perception/tests/test_execution_journal_p17e.py
+++ b/packages/perception/tests/test_execution_journal_p17e.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception.compatibility import (
+    build_model_compatibility_contract,
+)
+from zeromodel.perception.disposition import disposition_operational_recommendation
+from zeromodel.perception.execution_journal import (
+    PerceptionExecutionJournalError,
+    SqliteGovernedExecutionAttemptStore,
+    build_governed_execution_attempt,
+    execute_journaled_approved_rollback,
+)
+from zeromodel.perception.governed_execution import execute_or_reconcile_approved_rollback
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+from zeromodel.perception.recommendation import OperationalRecommendationDTO
+from zeromodel.perception.sql_governance import SqlitePerceptionGovernanceLedgerStore
+
+
+def _promoted(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"model-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _contract(model: PromotedPerceptionModelDTO):
+    return build_model_compatibility_contract(
+        model,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+
+
+def _fixture(governance_database):
+    lifecycle = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    for model in (earlier, current):
+        register_promoted_model(
+            lifecycle,
+            model,
+            registered_by="test",
+            registration_reason="candidate",
+        )
+    activate_promoted_model(lifecycle, earlier.promoted_model_id, actor="test", reason="activate")
+    supersede_active_model(lifecycle, current.promoted_model_id, actor="test", reason="supersede")
+    snapshot = build_model_lifecycle_snapshot(lifecycle)
+    current_contract = _contract(current)
+    target_contract = _contract(earlier)
+    from zeromodel.perception.compatibility import assess_rollback_compatibility
+
+    assessment = assess_rollback_compatibility(current_contract, target_contract)
+    recommendation = OperationalRecommendationDTO(
+        recommendation_id="sha256:recommendation",
+        health_report_id="sha256:health",
+        lifecycle_snapshot_id=snapshot.snapshot_id,
+        active_pointer_id=snapshot.active_pointer.pointer_id,
+        active_pointer_revision=snapshot.active_pointer.revision,
+        active_promoted_model_id=current.promoted_model_id,
+        current_contract_id=current_contract.contract_id,
+        status="rollback_candidate",
+        selected_target_promoted_model_id=earlier.promoted_model_id,
+        selected_assessment_id=assessment.assessment_id,
+        assessed_candidates=(assessment,),
+        rationale="supported drift and compatible historical target",
+    )
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+    governance = SqlitePerceptionGovernanceLedgerStore(governance_database)
+    governance.append_recommendation(recommendation)
+    governance.append_disposition(disposition)
+    return (
+        lifecycle,
+        governance,
+        earlier,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    )
+
+
+def test_normal_execution_records_prepared_and_completed(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        earlier,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts:
+        attempt, receipt = execute_journaled_approved_rollback(
+            lifecycle,
+            governance,
+            attempts,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        events = attempts.list_events(attempt.attempt_id)
+
+    assert tuple(item.event_kind for item in events) == ("prepared", "completed")
+    assert receipt.resulting_promoted_model_id == earlier.promoted_model_id
+    assert lifecycle.get_active_pointer().revision == recommendation.active_pointer_revision + 1
+
+
+def test_prepared_only_attempt_is_reconciled_after_crash(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    attempts_database = tmp_path / "attempts.sqlite3"
+    attempt = build_governed_execution_attempt(
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    from zeromodel.perception.execution_journal import _event
+
+    with SqliteGovernedExecutionAttemptStore(attempts_database) as attempts:
+        attempts.append_attempt(attempt)
+        attempts.append_event(_event(attempt, sequence_number=1, event_kind="prepared"))
+    execute_or_reconcile_approved_rollback(
+        lifecycle,
+        governance,
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    governance.close()
+
+    with SqlitePerceptionGovernanceLedgerStore(
+        tmp_path / "governance.sqlite3"
+    ) as reopened_governance, SqliteGovernedExecutionAttemptStore(attempts_database) as attempts:
+        resumed, receipt = execute_journaled_approved_rollback(
+            lifecycle,
+            reopened_governance,
+            attempts,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        events = attempts.list_events(resumed.attempt_id)
+
+    assert tuple(item.event_kind for item in events) == ("prepared", "reconciled")
+    assert receipt.pointer_revision == recommendation.active_pointer_revision + 1
+
+
+def test_existing_receipt_with_new_attempt_is_idempotently_linked(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    expected = execute_or_reconcile_approved_rollback(
+        lifecycle,
+        governance,
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts:
+        attempt, receipt = execute_journaled_approved_rollback(
+            lifecycle,
+            governance,
+            attempts,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        events = attempts.list_events(attempt.attempt_id)
+
+    assert receipt == expected
+    assert tuple(item.event_kind for item in events) == ("prepared", "idempotent")
+
+
+def test_failure_is_terminal_and_does_not_retry(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    supersede_target = _promoted("third")
+    register_promoted_model(
+        lifecycle,
+        supersede_target,
+        registered_by="test",
+        registration_reason="unrelated",
+    )
+    supersede_active_model(
+        lifecycle,
+        supersede_target.promoted_model_id,
+        actor="other",
+        reason="unrelated change",
+    )
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts:
+        with pytest.raises(PerceptionExecutionJournalError):
+            execute_journaled_approved_rollback(
+                lifecycle,
+                governance,
+                attempts,
+                recommendation,
+                disposition,
+                current_contract=current_contract,
+                target_contract=target_contract,
+            )
+        attempt = build_governed_execution_attempt(
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        events = attempts.list_events(attempt.attempt_id)
+        with pytest.raises(PerceptionExecutionJournalError, match="terminally failed"):
+            execute_journaled_approved_rollback(
+                lifecycle,
+                governance,
+                attempts,
+                recommendation,
+                disposition,
+                current_contract=current_contract,
+                target_contract=target_contract,
+            )
+
+    assert tuple(item.event_kind for item in events) == ("prepared", "failed")
+
+
+def test_attempt_and_events_survive_restart(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    database = tmp_path / "attempts.sqlite3"
+    with governance, SqliteGovernedExecutionAttemptStore(database) as attempts:
+        attempt, _ = execute_journaled_approved_rollback(
+            lifecycle,
+            governance,
+            attempts,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+    with SqliteGovernedExecutionAttemptStore(database) as reopened:
+        assert reopened.get_attempt(attempt.attempt_id) == attempt
+        assert tuple(item.event_kind for item in reopened.list_events(attempt.attempt_id)) == (
+            "prepared",
+            "completed",
+        )

--- a/packages/perception/tests/test_execution_journal_public_api_p17e.py
+++ b/packages/perception/tests/test_execution_journal_public_api_p17e.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import zeromodel.perception as perception
+
+
+def test_p17e_execution_governance_is_public() -> None:
+    expected = {
+        "GovernanceExecutionReceiptDTO",
+        "GovernedExecutionAttemptDTO",
+        "GovernedExecutionAttemptEventDTO",
+        "PerceptionExecutionJournalError",
+        "PerceptionGovernedExecutionError",
+        "SqliteGovernedExecutionAttemptStore",
+        "SqlitePerceptionGovernanceLedgerStore",
+        "build_governed_execution_attempt",
+        "execute_journaled_approved_rollback",
+        "execute_or_reconcile_approved_rollback",
+    }
+
+    assert perception.PERCEPTION_STAGE == "P17E"
+    assert expected <= set(perception.__all__)
+    for name in expected:
+        assert getattr(perception, name) is not None


### PR DESCRIPTION
## Summary

Implements P17E: an append-only governed execution-attempt journal around the P17D crash-recoverable rollback path.

## Durable attempt chain

```text
GovernedExecutionAttemptDTO
    ↓
prepared
    ↓
completed | reconciled | idempotent | failed
```

## Guarantees

- one deterministic execution attempt per approved disposition;
- `prepared` is persisted before lifecycle execution begins;
- one terminal event per attempt;
- prepared-only attempts can resume safely after restart through P17D;
- exact lifecycle post-state is classified as `reconciled`;
- pre-existing receipts are linked as `idempotent` without another rollback;
- governed validation failures become terminal `failed` attempts;
- terminal successful attempts must resolve to exactly one governance receipt;
- attempts and events survive process restart;
- the existing P17C governance schema is not silently migrated in place.

## Authority boundary

The lifecycle store remains the sole active-model authority. The governance ledger remains the recommendation/disposition/receipt evidence store. The new attempt journal records operational intent and outcome only.

## Public integration

This PR also exports the P17C governance ledger, P17D recovery orchestrator, and P17E attempt journal from `zeromodel.perception`, and advances `PERCEPTION_STAGE` to `P17E`.

## Validation

The branch is based directly on merged P17D commit `6544f63e81566f54232a96bcf9032a80a623a634`.

Tests cover normal completion, prepared-only crash recovery, restart reconciliation, pre-existing receipt linkage, terminal failure, restart persistence, and the public package contract.

Audit-Exempt: adds internal governance execution journaling and public packaging; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains authoritative; no green result is claimed until it completes.