### PR TITLE
feat(perception): add P17F governance integrity audit

### DIFF
--- a/packages/perception/docs/stage-p17f-governance-integrity-audit.md
+++ b/packages/perception/docs/stage-p17f-governance-integrity-audit.md
@@ -1,0 +1,64 @@
+# Stage P17F — Governance Integrity Audit
+
+## Objective
+
+Provide one deterministic, read-only reconciliation pass across the three operational authorities introduced through P17:
+
+```text
+lifecycle store
+    +
+governance ledger
+    +
+execution attempt journal
+        ↓
+GovernanceIntegrityAuditReportDTO
+```
+
+The auditor does not repair, delete, retry, approve, reject, activate, or roll back anything.
+
+## Status model
+
+- `valid`: no warning or error finding exists;
+- `attention_required`: at least one recoverable or historical warning exists, but no contradiction is proven;
+- `invalid`: at least one cross-store contradiction, orphan, or impossible success chain exists.
+
+Informational findings do not downgrade a valid report.
+
+## Findings
+
+The audit checks:
+
+- dispositions reference existing recommendations and preserve recommendation status;
+- receipts belong to approved dispositions and the same recommendation;
+- receipts reference real rollback transitions;
+- receipt pointer revisions match transition sequence numbers;
+- receipt target models match lifecycle rollback targets;
+- attempts reference the exact recommendation and approved disposition;
+- attempts begin with `prepared`;
+- prepared-only attempts are surfaced as recoverable incomplete work;
+- failed attempts do not also possess success receipts;
+- successful terminal events resolve to exactly matching receipts;
+- terminal pointer revisions and rollback targets match their receipts;
+- receipts without P17E attempt records are identified as legacy, not automatically corrupt.
+
+## Determinism
+
+Every finding and report is content-addressed. Findings are canonically sorted, and the report identity includes:
+
+- current pointer identity and revision;
+- artifact counts;
+- report status;
+- ordered finding identities;
+- audit semantics and version.
+
+Repeating the audit over unchanged stores yields an identical report.
+
+## Authority boundary
+
+The audit reads DTOs from each store through public methods. `SqliteGovernedExecutionAttemptStore.list_attempts()` is added as a canonical read surface so the auditor does not reach into private SQLite state.
+
+The lifecycle store remains the sole active-model authority. The audit report is evidence about integrity, not operational state.
+
+## Deliberate boundary
+
+P17F does not automatically resume prepared attempts, repair missing receipts, or quarantine invalid records. Those actions must remain explicit and separately governed.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -55,6 +55,13 @@ from .gated_health import (
     OPERATIONAL_DRIFT_POLICY_VERSION, OPERATIONAL_EVIDENCE_SEMANTICS,
     OperationalDriftPolicyDTO, diagnose_operational_health,
 )
+from .governance_audit import (
+    GOVERNANCE_AUDIT_FINDING_VERSION, GOVERNANCE_AUDIT_SEMANTICS,
+    GOVERNANCE_AUDIT_SEVERITIES, GOVERNANCE_AUDIT_STATUSES,
+    GOVERNANCE_AUDIT_VERSION, GovernanceIntegrityAuditReportDTO,
+    GovernanceIntegrityFindingDTO, PerceptionGovernanceAuditError,
+    audit_governance_integrity,
+)
 from .governed_execution import (
     GOVERNED_EXECUTION_SEMANTICS, PerceptionGovernedExecutionError,
     execute_or_reconcile_approved_rollback,
@@ -200,6 +207,6 @@ from .weighted import (
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P17E"
+PERCEPTION_STAGE = "P17F"
 
 __all__ = [name for name in globals() if not name.startswith("_") and name not in {"annotations"}]

--- a/packages/perception/src/zeromodel/perception/execution_journal.py
+++ b/packages/perception/src/zeromodel/perception/execution_journal.py
@@ -308,6 +308,14 @@ class SqliteGovernedExecutionAttemptStore:
         ).fetchone()
         return None if row is None else GovernedExecutionAttemptDTO(**json.loads(row["payload_json"]))
 
+    def list_attempts(self) -> tuple[GovernedExecutionAttemptDTO, ...]:
+        rows = self._connection.execute(
+            "SELECT payload_json FROM perception_governed_execution_attempts ORDER BY attempt_id"
+        ).fetchall()
+        return tuple(
+            GovernedExecutionAttemptDTO(**json.loads(row["payload_json"])) for row in rows
+        )
+
     def list_events(self, attempt_id: str) -> tuple[GovernedExecutionAttemptEventDTO, ...]:
         rows = self._connection.execute(
             "SELECT payload_json FROM perception_governed_execution_attempt_events "

--- a/packages/perception/src/zeromodel/perception/governance_audit.py
+++ b/packages/perception/src/zeromodel/perception/governance_audit.py
@@ -1,0 +1,535 @@
+"""Read-only cross-store governance integrity audit for Stage P17F.
+
+The lifecycle store remains authoritative for active-model history. The governance ledger owns
+recommendations, dispositions, and receipts. The execution journal owns attempt intent and
+terminal outcomes. This module reconciles those immutable records into one deterministic audit
+report without mutating any store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .execution_journal import (
+    EXECUTION_ATTEMPT_TERMINAL_KINDS,
+    GovernedExecutionAttemptDTO,
+    GovernedExecutionAttemptEventDTO,
+    SqliteGovernedExecutionAttemptStore,
+)
+from .lifecycle import PerceptionModelLifecycleStore
+from .sql_governance import SqlitePerceptionGovernanceLedgerStore
+
+GOVERNANCE_AUDIT_VERSION: Final = "perception-governance-integrity-audit/1"
+GOVERNANCE_AUDIT_FINDING_VERSION: Final = "perception-governance-integrity-finding/1"
+GOVERNANCE_AUDIT_SEMANTICS: Final = (
+    "read_only_cross_store_reconciliation_of_lifecycle_governance_and_execution_history"
+)
+GOVERNANCE_AUDIT_SEVERITIES: Final = {"info", "warning", "error"}
+GOVERNANCE_AUDIT_STATUSES: Final = {"valid", "attention_required", "invalid"}
+
+
+class PerceptionGovernanceAuditError(ValueError):
+    """Raised when governance audit DTO contracts are violated."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class GovernanceIntegrityFindingDTO:
+    finding_id: str
+    severity: str
+    code: str
+    subject_kind: str
+    subject_id: str
+    related_ids: tuple[str, ...]
+    message: str
+    version: str = GOVERNANCE_AUDIT_FINDING_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.finding_id,
+                self.severity,
+                self.code,
+                self.subject_kind,
+                self.subject_id,
+                self.message,
+            )
+        ):
+            raise PerceptionGovernanceAuditError("audit finding fields must be non-empty")
+        if self.severity not in GOVERNANCE_AUDIT_SEVERITIES:
+            raise PerceptionGovernanceAuditError("unsupported audit finding severity")
+        if self.related_ids != tuple(sorted(set(self.related_ids))):
+            raise PerceptionGovernanceAuditError("audit related identities must be sorted and unique")
+        if self.version != GOVERNANCE_AUDIT_FINDING_VERSION:
+            raise PerceptionGovernanceAuditError("unsupported audit finding version")
+
+
+@dataclass(frozen=True)
+class GovernanceIntegrityAuditReportDTO:
+    report_id: str
+    status: str
+    active_pointer_id: str
+    active_pointer_revision: int
+    recommendation_count: int
+    disposition_count: int
+    receipt_count: int
+    attempt_count: int
+    finding_count: int
+    findings: tuple[GovernanceIntegrityFindingDTO, ...]
+    semantics: str = GOVERNANCE_AUDIT_SEMANTICS
+    version: str = GOVERNANCE_AUDIT_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.report_id or not self.active_pointer_id:
+            raise PerceptionGovernanceAuditError("audit report identities must be non-empty")
+        if self.status not in GOVERNANCE_AUDIT_STATUSES:
+            raise PerceptionGovernanceAuditError("unsupported audit report status")
+        if self.active_pointer_revision < 0:
+            raise PerceptionGovernanceAuditError("audit pointer revision cannot be negative")
+        counts = (
+            self.recommendation_count,
+            self.disposition_count,
+            self.receipt_count,
+            self.attempt_count,
+            self.finding_count,
+        )
+        if any(value < 0 for value in counts):
+            raise PerceptionGovernanceAuditError("audit counts cannot be negative")
+        if self.finding_count != len(self.findings):
+            raise PerceptionGovernanceAuditError("audit finding count does not match findings")
+        expected = tuple(
+            sorted(
+                self.findings,
+                key=lambda item: (
+                    item.severity,
+                    item.code,
+                    item.subject_kind,
+                    item.subject_id,
+                    item.finding_id,
+                ),
+            )
+        )
+        if self.findings != expected:
+            raise PerceptionGovernanceAuditError("audit findings must be canonically sorted")
+        if self.semantics != GOVERNANCE_AUDIT_SEMANTICS:
+            raise PerceptionGovernanceAuditError("unsupported audit semantics")
+        if self.version != GOVERNANCE_AUDIT_VERSION:
+            raise PerceptionGovernanceAuditError("unsupported audit version")
+
+
+def _finding(
+    *,
+    severity: str,
+    code: str,
+    subject_kind: str,
+    subject_id: str,
+    message: str,
+    related_ids: tuple[str, ...] = (),
+) -> GovernanceIntegrityFindingDTO:
+    related = tuple(sorted(set(related_ids)))
+    payload: Mapping[str, object] = {
+        "code": code,
+        "message": message,
+        "related_ids": related,
+        "severity": severity,
+        "subject_id": subject_id,
+        "subject_kind": subject_kind,
+        "version": GOVERNANCE_AUDIT_FINDING_VERSION,
+    }
+    return GovernanceIntegrityFindingDTO(finding_id=_digest(payload), **payload)
+
+
+def _terminal_event(
+    events: tuple[GovernedExecutionAttemptEventDTO, ...],
+) -> GovernedExecutionAttemptEventDTO | None:
+    if not events:
+        return None
+    terminal = events[-1]
+    return terminal if terminal.event_kind in EXECUTION_ATTEMPT_TERMINAL_KINDS else None
+
+
+def _audit_attempt(
+    attempt: GovernedExecutionAttemptDTO,
+    events: tuple[GovernedExecutionAttemptEventDTO, ...],
+    *,
+    recommendations_by_id: Mapping[str, object],
+    dispositions_by_id: Mapping[str, object],
+    receipts_by_disposition: Mapping[str, object],
+) -> tuple[GovernanceIntegrityFindingDTO, ...]:
+    findings: list[GovernanceIntegrityFindingDTO] = []
+    recommendation = recommendations_by_id.get(attempt.recommendation_id)
+    disposition = dispositions_by_id.get(attempt.disposition_id)
+    receipt = receipts_by_disposition.get(attempt.disposition_id)
+
+    if recommendation is None:
+        findings.append(
+            _finding(
+                severity="error",
+                code="attempt_missing_recommendation",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                related_ids=(attempt.recommendation_id,),
+                message="execution attempt references a missing recommendation",
+            )
+        )
+    if disposition is None:
+        findings.append(
+            _finding(
+                severity="error",
+                code="attempt_missing_disposition",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                related_ids=(attempt.disposition_id,),
+                message="execution attempt references a missing disposition",
+            )
+        )
+    else:
+        if disposition.recommendation_id != attempt.recommendation_id:  # type: ignore[attr-defined]
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="attempt_disposition_recommendation_mismatch",
+                    subject_kind="attempt",
+                    subject_id=attempt.attempt_id,
+                    related_ids=(attempt.disposition_id, attempt.recommendation_id),
+                    message="attempt and disposition do not reference the same recommendation",
+                )
+            )
+        if disposition.status != "approved":  # type: ignore[attr-defined]
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="attempt_without_approval",
+                    subject_kind="attempt",
+                    subject_id=attempt.attempt_id,
+                    related_ids=(attempt.disposition_id,),
+                    message="execution attempt does not belong to an approved disposition",
+                )
+            )
+
+    if not events:
+        findings.append(
+            _finding(
+                severity="error",
+                code="attempt_without_prepared_event",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                message="persisted execution attempt has no prepared event",
+            )
+        )
+        return tuple(findings)
+
+    if events[0].event_kind != "prepared" or events[0].sequence_number != 1:
+        findings.append(
+            _finding(
+                severity="error",
+                code="attempt_invalid_first_event",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                related_ids=(events[0].event_id,),
+                message="execution attempt does not begin with the canonical prepared event",
+            )
+        )
+
+    terminal = _terminal_event(events)
+    if terminal is None:
+        findings.append(
+            _finding(
+                severity="warning",
+                code="attempt_prepared_incomplete",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                related_ids=(events[0].event_id,),
+                message="prepared execution attempt has no terminal event and may require recovery",
+            )
+        )
+        return tuple(findings)
+
+    if terminal.event_kind == "failed":
+        if receipt is not None:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="failed_attempt_has_receipt",
+                    subject_kind="attempt",
+                    subject_id=attempt.attempt_id,
+                    related_ids=(receipt.receipt_id, terminal.event_id),  # type: ignore[attr-defined]
+                    message="terminally failed attempt also has a success receipt",
+                )
+            )
+        return tuple(findings)
+
+    if receipt is None:
+        findings.append(
+            _finding(
+                severity="error",
+                code="successful_attempt_missing_receipt",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                related_ids=(terminal.event_id,),
+                message="successful terminal attempt does not resolve to a governance receipt",
+            )
+        )
+        return tuple(findings)
+
+    if terminal.receipt_id != receipt.receipt_id:  # type: ignore[attr-defined]
+        findings.append(
+            _finding(
+                severity="error",
+                code="attempt_receipt_identity_mismatch",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                related_ids=(terminal.event_id, receipt.receipt_id),  # type: ignore[attr-defined]
+                message="terminal event references a different receipt identity",
+            )
+        )
+    if terminal.pointer_revision != receipt.pointer_revision:  # type: ignore[attr-defined]
+        findings.append(
+            _finding(
+                severity="error",
+                code="attempt_receipt_revision_mismatch",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                related_ids=(terminal.event_id, receipt.receipt_id),  # type: ignore[attr-defined]
+                message="terminal event and receipt disagree on resulting pointer revision",
+            )
+        )
+    if receipt.resulting_promoted_model_id != attempt.target_promoted_model_id:  # type: ignore[attr-defined]
+        findings.append(
+            _finding(
+                severity="error",
+                code="attempt_receipt_target_mismatch",
+                subject_kind="attempt",
+                subject_id=attempt.attempt_id,
+                related_ids=(receipt.receipt_id,),  # type: ignore[attr-defined]
+                message="execution receipt does not activate the attempt target model",
+            )
+        )
+    return tuple(findings)
+
+
+def audit_governance_integrity(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    attempt_store: SqliteGovernedExecutionAttemptStore,
+) -> GovernanceIntegrityAuditReportDTO:
+    """Reconcile all durable governance records without mutating any store."""
+
+    pointer = lifecycle_store.get_active_pointer()
+    transitions = lifecycle_store.list_transitions()
+    transitions_by_id = {item.transition_id: item for item in transitions}
+    recommendations = governance_store.list_recommendations()
+    dispositions = governance_store.list_dispositions()
+    receipts = governance_store.list_execution_receipts()
+    attempts = attempt_store.list_attempts()
+
+    recommendations_by_id = {item.recommendation_id: item for item in recommendations}
+    dispositions_by_id = {item.disposition_id: item for item in dispositions}
+    dispositions_by_recommendation = {item.recommendation_id: item for item in dispositions}
+    receipts_by_disposition = {item.disposition_id: item for item in receipts}
+    attempts_by_disposition = {item.disposition_id: item for item in attempts}
+
+    findings: list[GovernanceIntegrityFindingDTO] = []
+
+    for disposition in dispositions:
+        recommendation = recommendations_by_id.get(disposition.recommendation_id)
+        if recommendation is None:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="disposition_missing_recommendation",
+                    subject_kind="disposition",
+                    subject_id=disposition.disposition_id,
+                    related_ids=(disposition.recommendation_id,),
+                    message="operator disposition references a missing recommendation",
+                )
+            )
+        elif disposition.recommendation_status != recommendation.status:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="disposition_recommendation_status_mismatch",
+                    subject_kind="disposition",
+                    subject_id=disposition.disposition_id,
+                    related_ids=(recommendation.recommendation_id,),
+                    message="disposition records a different recommendation status",
+                )
+            )
+
+    for recommendation in recommendations:
+        if recommendation.recommendation_id not in dispositions_by_recommendation:
+            findings.append(
+                _finding(
+                    severity="info",
+                    code="recommendation_awaiting_disposition",
+                    subject_kind="recommendation",
+                    subject_id=recommendation.recommendation_id,
+                    message="recommendation has not received a final operator disposition",
+                )
+            )
+
+    for receipt in receipts:
+        disposition = dispositions_by_id.get(receipt.disposition_id)
+        if disposition is None:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="receipt_missing_disposition",
+                    subject_kind="receipt",
+                    subject_id=receipt.receipt_id,
+                    related_ids=(receipt.disposition_id,),
+                    message="execution receipt references a missing disposition",
+                )
+            )
+        else:
+            if disposition.status != "approved":
+                findings.append(
+                    _finding(
+                        severity="error",
+                        code="receipt_without_approval",
+                        subject_kind="receipt",
+                        subject_id=receipt.receipt_id,
+                        related_ids=(disposition.disposition_id,),
+                        message="execution receipt belongs to a non-approved disposition",
+                    )
+                )
+            if disposition.recommendation_id != receipt.recommendation_id:
+                findings.append(
+                    _finding(
+                        severity="error",
+                        code="receipt_recommendation_mismatch",
+                        subject_kind="receipt",
+                        subject_id=receipt.receipt_id,
+                        related_ids=(disposition.disposition_id, receipt.recommendation_id),
+                        message="receipt and disposition reference different recommendations",
+                    )
+                )
+        transition = transitions_by_id.get(receipt.transition_id)
+        if transition is None:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="receipt_missing_transition",
+                    subject_kind="receipt",
+                    subject_id=receipt.receipt_id,
+                    related_ids=(receipt.transition_id,),
+                    message="execution receipt references a missing lifecycle transition",
+                )
+            )
+        else:
+            if transition.transition_kind != "rollback":
+                findings.append(
+                    _finding(
+                        severity="error",
+                        code="receipt_transition_not_rollback",
+                        subject_kind="receipt",
+                        subject_id=receipt.receipt_id,
+                        related_ids=(transition.transition_id,),
+                        message="execution receipt references a non-rollback transition",
+                    )
+                )
+            if transition.sequence_number != receipt.pointer_revision:
+                findings.append(
+                    _finding(
+                        severity="error",
+                        code="receipt_transition_revision_mismatch",
+                        subject_kind="receipt",
+                        subject_id=receipt.receipt_id,
+                        related_ids=(transition.transition_id,),
+                        message="receipt pointer revision differs from transition sequence",
+                    )
+                )
+            if transition.next_promoted_model_id != receipt.resulting_promoted_model_id:
+                findings.append(
+                    _finding(
+                        severity="error",
+                        code="receipt_transition_target_mismatch",
+                        subject_kind="receipt",
+                        subject_id=receipt.receipt_id,
+                        related_ids=(transition.transition_id,),
+                        message="receipt result differs from lifecycle rollback target",
+                    )
+                )
+        if receipt.disposition_id not in attempts_by_disposition:
+            findings.append(
+                _finding(
+                    severity="warning",
+                    code="legacy_unjournaled_receipt",
+                    subject_kind="receipt",
+                    subject_id=receipt.receipt_id,
+                    related_ids=(receipt.disposition_id,),
+                    message="receipt has no P17E attempt record and may predate execution journaling",
+                )
+            )
+
+    for attempt in attempts:
+        findings.extend(
+            _audit_attempt(
+                attempt,
+                attempt_store.list_events(attempt.attempt_id),
+                recommendations_by_id=recommendations_by_id,
+                dispositions_by_id=dispositions_by_id,
+                receipts_by_disposition=receipts_by_disposition,
+            )
+        )
+
+    canonical_findings = tuple(
+        sorted(
+            findings,
+            key=lambda item: (
+                item.severity,
+                item.code,
+                item.subject_kind,
+                item.subject_id,
+                item.finding_id,
+            ),
+        )
+    )
+    if any(item.severity == "error" for item in canonical_findings):
+        status = "invalid"
+    elif any(item.severity == "warning" for item in canonical_findings):
+        status = "attention_required"
+    else:
+        status = "valid"
+
+    payload: Mapping[str, object] = {
+        "active_pointer_id": pointer.pointer_id,
+        "active_pointer_revision": pointer.revision,
+        "attempt_count": len(attempts),
+        "disposition_count": len(dispositions),
+        "finding_count": len(canonical_findings),
+        "finding_ids": tuple(item.finding_id for item in canonical_findings),
+        "receipt_count": len(receipts),
+        "recommendation_count": len(recommendations),
+        "semantics": GOVERNANCE_AUDIT_SEMANTICS,
+        "status": status,
+        "version": GOVERNANCE_AUDIT_VERSION,
+    }
+    return GovernanceIntegrityAuditReportDTO(
+        report_id=_digest(payload),
+        status=status,
+        active_pointer_id=pointer.pointer_id,
+        active_pointer_revision=pointer.revision,
+        recommendation_count=len(recommendations),
+        disposition_count=len(dispositions),
+        receipt_count=len(receipts),
+        attempt_count=len(attempts),
+        finding_count=len(canonical_findings),
+        findings=canonical_findings,
+    )

--- a/packages/perception/tests/test_governance_audit_p17f.py
+++ b/packages/perception/tests/test_governance_audit_p17f.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from zeromodel.perception.compatibility import (
+    assess_rollback_compatibility,
+    build_model_compatibility_contract,
+)
+from zeromodel.perception.disposition import disposition_operational_recommendation
+from zeromodel.perception.execution_journal import (
+    SqliteGovernedExecutionAttemptStore,
+    _event,
+    build_governed_execution_attempt,
+    execute_journaled_approved_rollback,
+)
+from zeromodel.perception.governance_audit import audit_governance_integrity
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+from zeromodel.perception.recommendation import OperationalRecommendationDTO
+from zeromodel.perception.sql_governance import (
+    GovernanceExecutionReceiptDTO,
+    SqlitePerceptionGovernanceLedgerStore,
+)
+
+
+def _promoted(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"model-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _contract(model: PromotedPerceptionModelDTO):
+    return build_model_compatibility_contract(
+        model,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+
+
+def _fixture(governance_database):
+    lifecycle = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    for model in (earlier, current):
+        register_promoted_model(
+            lifecycle,
+            model,
+            registered_by="test",
+            registration_reason="candidate",
+        )
+    activate_promoted_model(lifecycle, earlier.promoted_model_id, actor="test", reason="activate")
+    supersede_active_model(lifecycle, current.promoted_model_id, actor="test", reason="supersede")
+    snapshot = build_model_lifecycle_snapshot(lifecycle)
+    current_contract = _contract(current)
+    target_contract = _contract(earlier)
+    assessment = assess_rollback_compatibility(current_contract, target_contract)
+    recommendation = OperationalRecommendationDTO(
+        recommendation_id="sha256:recommendation",
+        health_report_id="sha256:health",
+        lifecycle_snapshot_id=snapshot.snapshot_id,
+        active_pointer_id=snapshot.active_pointer.pointer_id,
+        active_pointer_revision=snapshot.active_pointer.revision,
+        active_promoted_model_id=current.promoted_model_id,
+        current_contract_id=current_contract.contract_id,
+        status="rollback_candidate",
+        selected_target_promoted_model_id=earlier.promoted_model_id,
+        selected_assessment_id=assessment.assessment_id,
+        assessed_candidates=(assessment,),
+        rationale="supported drift and compatible historical target",
+    )
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+    governance = SqlitePerceptionGovernanceLedgerStore(governance_database)
+    governance.append_recommendation(recommendation)
+    governance.append_disposition(disposition)
+    return (
+        lifecycle,
+        governance,
+        earlier,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    )
+
+
+def test_complete_governance_chain_is_valid_and_deterministic(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts:
+        execute_journaled_approved_rollback(
+            lifecycle,
+            governance,
+            attempts,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        first = audit_governance_integrity(lifecycle, governance, attempts)
+        second = audit_governance_integrity(lifecycle, governance, attempts)
+
+    assert first == second
+    assert first.status == "valid"
+    assert first.findings == ()
+    assert first.recommendation_count == 1
+    assert first.disposition_count == 1
+    assert first.receipt_count == 1
+    assert first.attempt_count == 1
+
+
+def test_prepared_only_attempt_requires_attention_not_corruption(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        _,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts:
+        attempt = build_governed_execution_attempt(
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        attempts.append_attempt(attempt)
+        attempts.append_event(_event(attempt, sequence_number=1, event_kind="prepared"))
+        report = audit_governance_integrity(lifecycle, governance, attempts)
+
+    assert report.status == "attention_required"
+    assert tuple(item.code for item in report.findings) == ("attempt_prepared_incomplete",)
+    assert report.findings[0].severity == "warning"
+
+
+def test_receipt_with_missing_lifecycle_transition_is_invalid(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        earlier,
+        _,
+        _,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    receipt = GovernanceExecutionReceiptDTO(
+        receipt_id="sha256:receipt",
+        disposition_id=disposition.disposition_id,
+        recommendation_id=recommendation.recommendation_id,
+        assessment_id=disposition.selected_assessment_id or "",
+        transition_id="sha256:missing-transition",
+        pointer_id="sha256:pointer-after",
+        pointer_revision=recommendation.active_pointer_revision + 1,
+        resulting_promoted_model_id=earlier.promoted_model_id,
+    )
+    governance.append_execution_receipt(receipt)
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts:
+        report = audit_governance_integrity(lifecycle, governance, attempts)
+
+    assert report.status == "invalid"
+    assert "receipt_missing_transition" in tuple(item.code for item in report.findings)
+    assert "legacy_unjournaled_receipt" in tuple(item.code for item in report.findings)
+
+
+def test_undisposed_recommendation_is_informational_and_valid(tmp_path) -> None:
+    lifecycle = InMemoryPerceptionModelLifecycleStore()
+    governance = SqlitePerceptionGovernanceLedgerStore(tmp_path / "governance.sqlite3")
+    recommendation = OperationalRecommendationDTO(
+        recommendation_id="sha256:recommendation-only",
+        health_report_id="sha256:health",
+        lifecycle_snapshot_id="sha256:snapshot",
+        active_pointer_id=lifecycle.get_active_pointer().pointer_id,
+        active_pointer_revision=0,
+        active_promoted_model_id="promoted-current",
+        current_contract_id="sha256:contract",
+        status="investigate",
+        selected_target_promoted_model_id=None,
+        selected_assessment_id=None,
+        assessed_candidates=(),
+        rationale="investigation required",
+    )
+    governance.append_recommendation(recommendation)
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts:
+        report = audit_governance_integrity(lifecycle, governance, attempts)
+
+    assert report.status == "valid"
+    assert tuple(item.code for item in report.findings) == (
+        "recommendation_awaiting_disposition",
+    )
+    assert report.findings[0].severity == "info"

--- a/packages/perception/tests/test_governance_audit_p17f.py
+++ b/packages/perception/tests/test_governance_audit_p17f.py
@@ -198,14 +198,28 @@ def test_receipt_with_missing_lifecycle_transition_is_invalid(tmp_path) -> None:
 
 def test_undisposed_recommendation_is_informational_and_valid(tmp_path) -> None:
     lifecycle = InMemoryPerceptionModelLifecycleStore()
+    current = _promoted("current-only")
+    register_promoted_model(
+        lifecycle,
+        current,
+        registered_by="test",
+        registration_reason="candidate",
+    )
+    activate_promoted_model(
+        lifecycle,
+        current.promoted_model_id,
+        actor="test",
+        reason="activate",
+    )
+    pointer = lifecycle.get_active_pointer()
     governance = SqlitePerceptionGovernanceLedgerStore(tmp_path / "governance.sqlite3")
     recommendation = OperationalRecommendationDTO(
         recommendation_id="sha256:recommendation-only",
         health_report_id="sha256:health",
         lifecycle_snapshot_id="sha256:snapshot",
-        active_pointer_id=lifecycle.get_active_pointer().pointer_id,
-        active_pointer_revision=0,
-        active_promoted_model_id="promoted-current",
+        active_pointer_id=pointer.pointer_id,
+        active_pointer_revision=pointer.revision,
+        active_promoted_model_id=current.promoted_model_id,
         current_contract_id="sha256:contract",
         status="investigate",
         selected_target_promoted_model_id=None,

--- a/packages/perception/tests/test_governance_audit_public_api_p17f.py
+++ b/packages/perception/tests/test_governance_audit_public_api_p17f.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import zeromodel.perception as perception
+
+
+def test_p17f_governance_audit_is_public() -> None:
+    expected = {
+        "GOVERNANCE_AUDIT_FINDING_VERSION",
+        "GOVERNANCE_AUDIT_SEMANTICS",
+        "GOVERNANCE_AUDIT_SEVERITIES",
+        "GOVERNANCE_AUDIT_STATUSES",
+        "GOVERNANCE_AUDIT_VERSION",
+        "GovernanceIntegrityAuditReportDTO",
+        "GovernanceIntegrityFindingDTO",
+        "PerceptionGovernanceAuditError",
+        "audit_governance_integrity",
+    }
+
+    assert perception.PERCEPTION_STAGE == "P17F"
+    assert expected <= set(perception.__all__)
+    assert hasattr(perception.SqliteGovernedExecutionAttemptStore, "list_attempts")


### PR DESCRIPTION
## Summary

Implements P17F: a deterministic, read-only integrity audit across lifecycle state, the durable governance ledger, and the governed execution-attempt journal.

## Audit surface

```text
lifecycle store
    +
governance ledger
    +
execution attempt journal
        ↓
GovernanceIntegrityAuditReportDTO
```

## Status model

- `valid`: no warning or error finding;
- `attention_required`: recoverable or historical warnings exist, but no contradiction is proven;
- `invalid`: at least one orphan, contradiction, or impossible success chain exists.

Informational findings do not downgrade a valid report.

## Checks

- disposition-to-recommendation ownership and status consistency;
- receipt-to-approved-disposition and recommendation ownership;
- receipt-to-lifecycle rollback transition existence;
- transition sequence, pointer revision, and rollback target agreement;
- attempt-to-recommendation and approved disposition ownership;
- canonical prepared-first attempt history;
- prepared-only attempts surfaced as recoverable incomplete work;
- failed attempts cannot also possess success receipts;
- successful terminal events must resolve to matching receipts;
- terminal pointer revision and target agreement;
- pre-P17E unjournaled receipts classified as legacy warnings rather than automatic corruption.

## Determinism and authority

Findings and reports are content-addressed and canonically sorted. The audit is strictly read-only and does not retry, repair, approve, reject, activate, or roll back anything.

`SqliteGovernedExecutionAttemptStore.list_attempts()` is added as a DTO-only public read surface so the auditor never reaches into private SQLite state.

## Validation

The branch is based directly on merged P17E commit `be8263bb3004bd1c3eb5efb596d15f5b8743c5a5`.

Tests cover a complete valid chain, deterministic identity, a prepared-only recoverable attempt, a receipt referencing a missing lifecycle transition, an undisposed informational recommendation, canonical attempt enumeration, and the public package contract.

Audit-Exempt: adds internal governance-integrity reporting and public packaging; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains authoritative; no green result is claimed until it completes.