### PR TITLE
feat(perception): add P17G audit-gated governed execution

### DIFF
--- a/packages/perception/docs/stage-p17g-audit-gated-governed-execution.md
+++ b/packages/perception/docs/stage-p17g-audit-gated-governed-execution.md
@@ -1,0 +1,83 @@
+# Stage P17G — Audit-Gated Governed Execution
+
+## Objective
+
+Make the P17F cross-store integrity audit an explicit precondition and postcondition of governed rollback execution.
+
+```text
+lifecycle + governance + attempt journal
+    ↓
+pre-execution integrity audit
+    ↓
+audit authorization gate
+    ↓
+P17E journaled execution / P17D recovery
+    ↓
+post-execution integrity audit
+    ↓
+GovernanceExecutionGateDTO
+```
+
+## Accepted pre-states
+
+P17G accepts only:
+
+- `clean`: the complete governance audit is `valid`;
+- `recover_prepared_attempt`: the only non-informational finding is one `attempt_prepared_incomplete` warning for the exact deterministic attempt being resumed.
+
+An `invalid` audit always blocks execution. An `attention_required` audit concerning another attempt, a legacy receipt, or any unrelated warning also blocks execution.
+
+This narrow exception prevents the integrity gate from deadlocking the crash-recovery path introduced in P17D and journaled in P17E.
+
+## Postcondition
+
+After execution or recovery, P17G reruns the full P17F audit. The operation is certified only when the resulting report is `valid`.
+
+A lifecycle function returning successfully is therefore not sufficient evidence on its own. The lifecycle transition, governance receipt, attempt history, terminal event, target model, and pointer revision must compose into one valid chain.
+
+## Gate artifact
+
+`GovernanceExecutionGateDTO` content-addresses:
+
+- recommendation and disposition identities;
+- deterministic attempt identity;
+- receipt identity;
+- pre- and post-audit report identities;
+- authorization mode;
+- resulting pointer revision;
+- gate semantics and version.
+
+The gate artifact records why execution was permitted and which integrity reports surrounded it. It is not a second lifecycle authority.
+
+## Safety boundary
+
+P17G does not:
+
+- repair invalid governance history;
+- waive unrelated warnings;
+- retry terminally failed attempts;
+- infer that an old unjournaled receipt is safe to reuse;
+- replace explicit operator approval;
+- change lifecycle state outside the existing P17D/P17E path.
+
+## Completion of P17
+
+P17G closes the operational recommendation loop:
+
+```text
+health evidence
+    ↓
+recommendation
+    ↓
+operator disposition
+    ↓
+durable governance ledger
+    ↓
+crash-recoverable execution
+    ↓
+append-only attempt journal
+    ↓
+cross-store integrity audit
+    ↓
+audit-gated execution certification
+```

--- a/packages/perception/src/zeromodel/perception/governance_gate.py
+++ b/packages/perception/src/zeromodel/perception/governance_gate.py
@@ -1,0 +1,228 @@
+"""Audit-gated governed rollback execution for Stage P17G.
+
+P17F can prove whether lifecycle, governance, and execution-journal history agree. P17G
+uses that report as an explicit execution precondition and verifies the resulting chain again
+after execution. The only non-valid pre-state accepted is one recoverable prepared-only
+warning for the exact deterministic attempt being resumed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .compatibility import ModelCompatibilityContractDTO
+from .disposition import OperationalRecommendationDispositionDTO
+from .execution_journal import (
+    GovernedExecutionAttemptDTO,
+    SqliteGovernedExecutionAttemptStore,
+    build_governed_execution_attempt,
+    execute_journaled_approved_rollback,
+)
+from .governance_audit import (
+    GovernanceIntegrityAuditReportDTO,
+    audit_governance_integrity,
+)
+from .lifecycle import PerceptionModelLifecycleStore
+from .recommendation import OperationalRecommendationDTO
+from .sql_governance import (
+    GovernanceExecutionReceiptDTO,
+    SqlitePerceptionGovernanceLedgerStore,
+)
+
+GOVERNANCE_EXECUTION_GATE_VERSION: Final = "perception-governance-execution-gate/1"
+GOVERNANCE_EXECUTION_GATE_SEMANTICS: Final = (
+    "pre_and_post_integrity_audit_gated_governed_rollback_execution"
+)
+GOVERNANCE_EXECUTION_GATE_MODES: Final = {"clean", "recover_prepared_attempt"}
+
+
+class PerceptionGovernanceExecutionGateError(ValueError):
+    """Raised when cross-store integrity does not authorize governed execution."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class GovernanceExecutionGateDTO:
+    gate_id: str
+    recommendation_id: str
+    disposition_id: str
+    attempt_id: str
+    receipt_id: str
+    pre_audit_report_id: str
+    post_audit_report_id: str
+    authorization_mode: str
+    resulting_pointer_revision: int
+    semantics: str = GOVERNANCE_EXECUTION_GATE_SEMANTICS
+    version: str = GOVERNANCE_EXECUTION_GATE_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.gate_id,
+                self.recommendation_id,
+                self.disposition_id,
+                self.attempt_id,
+                self.receipt_id,
+                self.pre_audit_report_id,
+                self.post_audit_report_id,
+            )
+        ):
+            raise PerceptionGovernanceExecutionGateError(
+                "governance execution gate identities must be non-empty"
+            )
+        if self.authorization_mode not in GOVERNANCE_EXECUTION_GATE_MODES:
+            raise PerceptionGovernanceExecutionGateError(
+                "unsupported governance execution authorization mode"
+            )
+        if self.resulting_pointer_revision <= 0:
+            raise PerceptionGovernanceExecutionGateError(
+                "governance execution gate requires a positive resulting pointer revision"
+            )
+        if self.semantics != GOVERNANCE_EXECUTION_GATE_SEMANTICS:
+            raise PerceptionGovernanceExecutionGateError(
+                "unsupported governance execution gate semantics"
+            )
+        if self.version != GOVERNANCE_EXECUTION_GATE_VERSION:
+            raise PerceptionGovernanceExecutionGateError(
+                "unsupported governance execution gate version"
+            )
+
+
+def authorize_governance_execution(
+    report: GovernanceIntegrityAuditReportDTO,
+    attempt: GovernedExecutionAttemptDTO,
+) -> str:
+    """Return the permitted gate mode or reject the audited pre-state.
+
+    A valid report authorizes a clean execution. An attention-required report authorizes
+    only recovery of one prepared-only warning belonging to this exact attempt. Informational
+    findings may coexist with either accepted state because they do not downgrade integrity.
+    """
+
+    if report.status == "valid":
+        return "clean"
+    if report.status == "invalid":
+        raise PerceptionGovernanceExecutionGateError(
+            "governance integrity audit is invalid; execution is blocked"
+        )
+
+    non_info = tuple(item for item in report.findings if item.severity != "info")
+    exact_recovery = (
+        len(non_info) == 1
+        and non_info[0].severity == "warning"
+        and non_info[0].code == "attempt_prepared_incomplete"
+        and non_info[0].subject_kind == "attempt"
+        and non_info[0].subject_id == attempt.attempt_id
+    )
+    if exact_recovery:
+        return "recover_prepared_attempt"
+    raise PerceptionGovernanceExecutionGateError(
+        "governance integrity requires attention unrelated to this recoverable attempt"
+    )
+
+
+def _build_gate(
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    attempt: GovernedExecutionAttemptDTO,
+    receipt: GovernanceExecutionReceiptDTO,
+    pre_audit: GovernanceIntegrityAuditReportDTO,
+    post_audit: GovernanceIntegrityAuditReportDTO,
+    *,
+    authorization_mode: str,
+) -> GovernanceExecutionGateDTO:
+    payload: Mapping[str, object] = {
+        "attempt_id": attempt.attempt_id,
+        "authorization_mode": authorization_mode,
+        "disposition_id": disposition.disposition_id,
+        "post_audit_report_id": post_audit.report_id,
+        "pre_audit_report_id": pre_audit.report_id,
+        "receipt_id": receipt.receipt_id,
+        "recommendation_id": recommendation.recommendation_id,
+        "resulting_pointer_revision": receipt.pointer_revision,
+        "semantics": GOVERNANCE_EXECUTION_GATE_SEMANTICS,
+        "version": GOVERNANCE_EXECUTION_GATE_VERSION,
+    }
+    return GovernanceExecutionGateDTO(gate_id=_digest(payload), **payload)
+
+
+def execute_audit_gated_approved_rollback(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    attempt_store: SqliteGovernedExecutionAttemptStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+) -> tuple[
+    GovernanceExecutionGateDTO,
+    GovernedExecutionAttemptDTO,
+    GovernanceExecutionReceiptDTO,
+    GovernanceIntegrityAuditReportDTO,
+]:
+    """Audit, execute or recover once, and prove the resulting governance chain is valid."""
+
+    attempt = build_governed_execution_attempt(
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    pre_audit = audit_governance_integrity(
+        lifecycle_store,
+        governance_store,
+        attempt_store,
+    )
+    authorization_mode = authorize_governance_execution(pre_audit, attempt)
+
+    executed_attempt, receipt = execute_journaled_approved_rollback(
+        lifecycle_store,
+        governance_store,
+        attempt_store,
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    if executed_attempt.attempt_id != attempt.attempt_id:
+        raise PerceptionGovernanceExecutionGateError(
+            "executed attempt identity differs from audited attempt"
+        )
+
+    post_audit = audit_governance_integrity(
+        lifecycle_store,
+        governance_store,
+        attempt_store,
+    )
+    if post_audit.status != "valid":
+        raise PerceptionGovernanceExecutionGateError(
+            "governed execution completed but the resulting integrity audit is not valid"
+        )
+
+    gate = _build_gate(
+        recommendation,
+        disposition,
+        attempt,
+        receipt,
+        pre_audit,
+        post_audit,
+        authorization_mode=authorization_mode,
+    )
+    return gate, attempt, receipt, post_audit

--- a/packages/perception/tests/test_governance_gate_p17g.py
+++ b/packages/perception/tests/test_governance_gate_p17g.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.perception.compatibility import (
+    assess_rollback_compatibility,
+    build_model_compatibility_contract,
+)
+from zeromodel.perception.disposition import disposition_operational_recommendation
+from zeromodel.perception.execution_journal import (
+    GovernedExecutionAttemptDTO,
+    GovernedExecutionAttemptEventDTO,
+    SqliteGovernedExecutionAttemptStore,
+    build_governed_execution_attempt,
+)
+from zeromodel.perception.governance_audit import (
+    GOVERNANCE_AUDIT_FINDING_VERSION,
+    GOVERNANCE_AUDIT_SEMANTICS,
+    GOVERNANCE_AUDIT_VERSION,
+    GovernanceIntegrityAuditReportDTO,
+    GovernanceIntegrityFindingDTO,
+    audit_governance_integrity,
+)
+from zeromodel.perception.governance_gate import (
+    PerceptionGovernanceExecutionGateError,
+    authorize_governance_execution,
+    execute_audit_gated_approved_rollback,
+)
+from zeromodel.perception.governed_execution import execute_or_reconcile_approved_rollback
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+from zeromodel.perception.recommendation import OperationalRecommendationDTO
+from zeromodel.perception.sql_governance import SqlitePerceptionGovernanceLedgerStore
+
+
+def _promoted(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"model-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _fixture(database):
+    lifecycle = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    for model in (earlier, current):
+        register_promoted_model(
+            lifecycle,
+            model,
+            registered_by="test",
+            registration_reason="candidate",
+        )
+    activate_promoted_model(
+        lifecycle,
+        earlier.promoted_model_id,
+        actor="test",
+        reason="activate",
+    )
+    supersede_active_model(
+        lifecycle,
+        current.promoted_model_id,
+        actor="test",
+        reason="supersede",
+    )
+    snapshot = build_model_lifecycle_snapshot(lifecycle)
+    current_contract = build_model_compatibility_contract(
+        current,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+    target_contract = build_model_compatibility_contract(
+        earlier,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+    assessment = assess_rollback_compatibility(current_contract, target_contract)
+    recommendation = OperationalRecommendationDTO(
+        recommendation_id="sha256:recommendation",
+        health_report_id="sha256:health",
+        lifecycle_snapshot_id=snapshot.snapshot_id,
+        active_pointer_id=snapshot.active_pointer.pointer_id,
+        active_pointer_revision=snapshot.active_pointer.revision,
+        active_promoted_model_id=current.promoted_model_id,
+        current_contract_id=current_contract.contract_id,
+        status="rollback_candidate",
+        selected_target_promoted_model_id=earlier.promoted_model_id,
+        selected_assessment_id=assessment.assessment_id,
+        assessed_candidates=(assessment,),
+        rationale="supported drift and compatible historical target",
+    )
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+    governance = SqlitePerceptionGovernanceLedgerStore(database)
+    governance.append_recommendation(recommendation)
+    governance.append_disposition(disposition)
+    return lifecycle, governance, current_contract, target_contract, recommendation, disposition
+
+
+def test_clean_execution_finishes_with_valid_audit(tmp_path) -> None:
+    lifecycle, governance, current_contract, target_contract, recommendation, disposition = (
+        _fixture(tmp_path / "governance.sqlite3")
+    )
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts:
+        gate, attempt, receipt, report = execute_audit_gated_approved_rollback(
+            lifecycle,
+            governance,
+            attempts,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+
+    assert gate.authorization_mode == "clean"
+    assert gate.attempt_id == attempt.attempt_id
+    assert gate.receipt_id == receipt.receipt_id
+    assert report.status == "valid"
+    assert report.findings == ()
+
+
+def test_exact_prepared_attempt_can_recover(tmp_path) -> None:
+    lifecycle, governance, current_contract, target_contract, recommendation, disposition = (
+        _fixture(tmp_path / "governance.sqlite3")
+    )
+    attempts_path = tmp_path / "attempts.sqlite3"
+    attempt = build_governed_execution_attempt(
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    with SqliteGovernedExecutionAttemptStore(attempts_path) as attempts:
+        attempts.append_attempt(attempt)
+        attempts.append_event(
+            GovernedExecutionAttemptEventDTO(
+                event_id="sha256:prepared",
+                attempt_id=attempt.attempt_id,
+                sequence_number=1,
+                event_kind="prepared",
+                receipt_id=None,
+                pointer_revision=None,
+                failure_type=None,
+                failure_message=None,
+            )
+        )
+    execute_or_reconcile_approved_rollback(
+        lifecycle,
+        governance,
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    governance.close()
+
+    with SqlitePerceptionGovernanceLedgerStore(
+        tmp_path / "governance.sqlite3"
+    ) as reopened, SqliteGovernedExecutionAttemptStore(attempts_path) as attempts:
+        pre = audit_governance_integrity(lifecycle, reopened, attempts)
+        gate, _, _, post = execute_audit_gated_approved_rollback(
+            lifecycle,
+            reopened,
+            attempts,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+
+    assert pre.status == "attention_required"
+    assert gate.authorization_mode == "recover_prepared_attempt"
+    assert post.status == "valid"
+
+
+def test_unrelated_warning_does_not_authorize_recovery() -> None:
+    finding = GovernanceIntegrityFindingDTO(
+        finding_id="sha256:finding",
+        severity="warning",
+        code="legacy_unjournaled_receipt",
+        subject_kind="receipt",
+        subject_id="sha256:receipt",
+        related_ids=(),
+        message="historical receipt has no attempt journal",
+        version=GOVERNANCE_AUDIT_FINDING_VERSION,
+    )
+    report = GovernanceIntegrityAuditReportDTO(
+        report_id="sha256:report",
+        status="attention_required",
+        active_pointer_id="sha256:pointer",
+        active_pointer_revision=2,
+        recommendation_count=1,
+        disposition_count=1,
+        receipt_count=1,
+        attempt_count=0,
+        finding_count=1,
+        findings=(finding,),
+        semantics=GOVERNANCE_AUDIT_SEMANTICS,
+        version=GOVERNANCE_AUDIT_VERSION,
+    )
+    attempt = GovernedExecutionAttemptDTO(
+        attempt_id="sha256:attempt",
+        recommendation_id="sha256:recommendation",
+        disposition_id="sha256:disposition",
+        reviewed_pointer_id="sha256:pointer",
+        reviewed_pointer_revision=2,
+        reviewed_active_promoted_model_id="promoted-current",
+        target_promoted_model_id="promoted-earlier",
+        current_contract_id="sha256:current-contract",
+        target_contract_id="sha256:target-contract",
+    )
+
+    with pytest.raises(
+        PerceptionGovernanceExecutionGateError,
+        match="attention unrelated",
+    ):
+        authorize_governance_execution(report, attempt)

--- a/packages/perception/tests/test_governance_gate_public_api_p17g.py
+++ b/packages/perception/tests/test_governance_gate_public_api_p17g.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from zeromodel.perception.governance_gate import (
+    GOVERNANCE_EXECUTION_GATE_MODES,
+    GOVERNANCE_EXECUTION_GATE_SEMANTICS,
+    GOVERNANCE_EXECUTION_GATE_VERSION,
+    GovernanceExecutionGateDTO,
+    PerceptionGovernanceExecutionGateError,
+    authorize_governance_execution,
+    execute_audit_gated_approved_rollback,
+)
+
+
+def test_p17g_governance_gate_public_contract() -> None:
+    assert GOVERNANCE_EXECUTION_GATE_VERSION.endswith("/1")
+    assert "integrity_audit" in GOVERNANCE_EXECUTION_GATE_SEMANTICS
+    assert GOVERNANCE_EXECUTION_GATE_MODES == {
+        "clean",
+        "recover_prepared_attempt",
+    }
+    assert GovernanceExecutionGateDTO.__name__ == "GovernanceExecutionGateDTO"
+    assert issubclass(PerceptionGovernanceExecutionGateError, ValueError)
+    assert callable(authorize_governance_execution)
+    assert callable(execute_audit_gated_approved_rollback)


### PR DESCRIPTION
## Summary

Implements P17G: audit-gated governed rollback execution on top of the P17F integrity auditor and P17D/P17E recovery path.

## Execution contract

```text
lifecycle + governance + attempt journal
    ↓
pre-execution P17F audit
    ↓
authorization gate
    ↓
P17E journaled execution / P17D recovery
    ↓
post-execution P17F audit
    ↓
GovernanceExecutionGateDTO
```

## Accepted pre-states

- `clean`: the complete governance audit is valid;
- `recover_prepared_attempt`: the only non-informational finding is one `attempt_prepared_incomplete` warning for the exact deterministic attempt being resumed.

Invalid audits, unrelated warnings, and legacy unjournaled-receipt warnings block execution.

## Postcondition

After execution or recovery, the complete cross-store audit must be valid. A lifecycle call returning successfully is not sufficient certification by itself.

## Gate artifact

The content-addressed `GovernanceExecutionGateDTO` binds recommendation, disposition, attempt, receipt, pre-audit, post-audit, authorization mode, and resulting pointer revision.

## Validation

Tests cover clean execution, exact prepared-attempt recovery, unrelated-warning rejection, and the dedicated public module contract.

This branch is based directly on current main commit `2ed263c10c0b723e3b0ebe6af7c8b22a56147d0f`, including the repository Ruff fixes merged after P17F.

Audit-Exempt: adds internal governance execution gating and certification; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains authoritative; no green result is claimed until it completes.