### PR TITLE
feat(perception): add P17H durable gate certification

### DIFF
--- a/packages/perception/docs/stage-p17h-durable-gate-certification.md
+++ b/packages/perception/docs/stage-p17h-durable-gate-certification.md
@@ -1,0 +1,75 @@
+# Stage P17H — Durable Audit-Gate Certification
+
+## Objective
+
+Persist the complete P17G execution certification so it survives process restart and can be inspected without reconstructing historical pre-execution state.
+
+```text
+P17F pre-audit
+    ↓
+P17G audit-gated rollback or recovery
+    ↓
+P17F valid post-audit
+    ↓
+GovernanceExecutionGateDTO
+    + exact pre-audit report
+    + exact post-audit report
+        ↓
+GovernanceExecutionCertificationBundleDTO
+        ↓
+SqliteGovernanceCertificationStore
+```
+
+## Why the bundle is necessary
+
+P17G content-addresses the identities of the pre- and post-audit reports, but its return value is process-local. After restart, the resulting gate identity alone cannot reproduce the exact pre-execution report because lifecycle state has already changed.
+
+P17H therefore stores all four immutable artifacts together:
+
+- `GovernanceExecutionCertificationDTO`;
+- `GovernanceExecutionGateDTO`;
+- exact `GovernanceIntegrityAuditReportDTO` before execution;
+- exact valid `GovernanceIntegrityAuditReportDTO` after execution.
+
+## Certification invariants
+
+A certification bundle is accepted only when:
+
+- the certification references the supplied gate;
+- recommendation, disposition, attempt, receipt, and audit identities agree;
+- the gate references the supplied pre- and post-audits;
+- the post-audit status is `valid`;
+- the post-audit active pointer revision equals the gate result revision.
+
+## Append-only storage
+
+`SqliteGovernanceCertificationStore` permits one certification per:
+
+- gate;
+- attempt;
+- operator disposition.
+
+An identical re-append is idempotent. A conflicting certification for an already certified attempt or disposition is rejected rather than overwritten.
+
+The store persists the full JSON payloads and reconstructs nested audit findings and related identities after restart.
+
+## Execution entry point
+
+`execute_and_certify_audit_gated_rollback(...)`:
+
+1. captures the deterministic pre-audit;
+2. delegates execution and recovery to P17G;
+3. verifies that the gate references the same pre-audit;
+4. builds the certification bundle;
+5. appends the bundle to the certification store;
+6. returns the durable bundle, attempt, and receipt.
+
+## Authority boundary
+
+The certification database is evidence, not lifecycle state. It cannot register, activate, supersede, deactivate, or roll back a model.
+
+The lifecycle store remains the sole active-model authority. The governance ledger remains the authority for recommendations, dispositions, and receipts. The attempt journal remains the authority for execution intent and terminal attempt outcome.
+
+## Deliberate boundary
+
+P17H does not yet make certifications an input to the P17F cross-store integrity audit. That is a separate integration step because it changes the auditor from three-store reconciliation to four-store reconciliation and requires explicit legacy behavior for gates created before certification persistence existed.

--- a/packages/perception/src/zeromodel/perception/sql_certification.py
+++ b/packages/perception/src/zeromodel/perception/sql_certification.py
@@ -1,0 +1,324 @@
+"""Durable audit-gate certification ledger for Stage P17H.
+
+P17G returns a content-addressed gate after a governed rollback, but the gate and the audit
+reports it references are otherwise process-local. P17H persists the complete certification
+bundle without becoming another lifecycle authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final, Mapping
+
+from .compatibility import ModelCompatibilityContractDTO
+from .disposition import OperationalRecommendationDispositionDTO
+from .execution_journal import GovernedExecutionAttemptDTO, SqliteGovernedExecutionAttemptStore
+from .governance_audit import (
+    GovernanceIntegrityAuditReportDTO,
+    GovernanceIntegrityFindingDTO,
+    audit_governance_integrity,
+)
+from .governance_gate import GovernanceExecutionGateDTO, execute_audit_gated_approved_rollback
+from .lifecycle import PerceptionModelLifecycleStore
+from .recommendation import OperationalRecommendationDTO
+from .sql_governance import GovernanceExecutionReceiptDTO, SqlitePerceptionGovernanceLedgerStore
+
+GOVERNANCE_CERTIFICATION_VERSION: Final = "perception-governance-certification/1"
+SQL_CERTIFICATION_SCHEMA_VERSION: Final = "perception-sql-certification-schema/1"
+SQL_CERTIFICATION_STORE_VERSION: Final = "perception-sql-certification-store/1"
+GOVERNANCE_CERTIFICATION_SEMANTICS: Final = (
+    "durable_bundle_of_execution_gate_and_exact_pre_and_post_integrity_audits"
+)
+
+
+class PerceptionSqlCertificationError(ValueError):
+    """Raised when durable governance certification contracts are violated."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    return f"sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class GovernanceExecutionCertificationDTO:
+    certification_id: str
+    gate_id: str
+    recommendation_id: str
+    disposition_id: str
+    attempt_id: str
+    receipt_id: str
+    pre_audit_report_id: str
+    post_audit_report_id: str
+    resulting_pointer_revision: int
+    semantics: str = GOVERNANCE_CERTIFICATION_SEMANTICS
+    version: str = GOVERNANCE_CERTIFICATION_VERSION
+
+    def __post_init__(self) -> None:
+        identities = (
+            self.certification_id,
+            self.gate_id,
+            self.recommendation_id,
+            self.disposition_id,
+            self.attempt_id,
+            self.receipt_id,
+            self.pre_audit_report_id,
+            self.post_audit_report_id,
+        )
+        if not all(identities):
+            raise PerceptionSqlCertificationError("certification identities must be non-empty")
+        if self.resulting_pointer_revision <= 0:
+            raise PerceptionSqlCertificationError(
+                "certification requires a positive resulting pointer revision"
+            )
+        if self.semantics != GOVERNANCE_CERTIFICATION_SEMANTICS:
+            raise PerceptionSqlCertificationError("unsupported certification semantics")
+        if self.version != GOVERNANCE_CERTIFICATION_VERSION:
+            raise PerceptionSqlCertificationError("unsupported certification version")
+
+
+@dataclass(frozen=True)
+class GovernanceExecutionCertificationBundleDTO:
+    certification: GovernanceExecutionCertificationDTO
+    gate: GovernanceExecutionGateDTO
+    pre_audit: GovernanceIntegrityAuditReportDTO
+    post_audit: GovernanceIntegrityAuditReportDTO
+
+    def __post_init__(self) -> None:
+        certification = self.certification
+        gate = self.gate
+        if certification.gate_id != gate.gate_id:
+            raise PerceptionSqlCertificationError("certification does not reference supplied gate")
+        for field in (
+            "recommendation_id",
+            "disposition_id",
+            "attempt_id",
+            "receipt_id",
+            "pre_audit_report_id",
+            "post_audit_report_id",
+            "resulting_pointer_revision",
+        ):
+            if getattr(certification, field) != getattr(gate, field):
+                raise PerceptionSqlCertificationError(
+                    f"certification and gate disagree on {field}"
+                )
+        if gate.pre_audit_report_id != self.pre_audit.report_id:
+            raise PerceptionSqlCertificationError("gate does not reference supplied pre-audit")
+        if gate.post_audit_report_id != self.post_audit.report_id:
+            raise PerceptionSqlCertificationError("gate does not reference supplied post-audit")
+        if self.post_audit.status != "valid":
+            raise PerceptionSqlCertificationError("certification requires a valid post-audit")
+        if self.post_audit.active_pointer_revision != gate.resulting_pointer_revision:
+            raise PerceptionSqlCertificationError(
+                "post-audit pointer revision does not match certified result"
+            )
+
+
+def build_governance_execution_certification(
+    gate: GovernanceExecutionGateDTO,
+    pre_audit: GovernanceIntegrityAuditReportDTO,
+    post_audit: GovernanceIntegrityAuditReportDTO,
+) -> GovernanceExecutionCertificationBundleDTO:
+    payload: Mapping[str, object] = {
+        "attempt_id": gate.attempt_id,
+        "disposition_id": gate.disposition_id,
+        "gate_id": gate.gate_id,
+        "post_audit_report_id": post_audit.report_id,
+        "pre_audit_report_id": pre_audit.report_id,
+        "receipt_id": gate.receipt_id,
+        "recommendation_id": gate.recommendation_id,
+        "resulting_pointer_revision": gate.resulting_pointer_revision,
+        "semantics": GOVERNANCE_CERTIFICATION_SEMANTICS,
+        "version": GOVERNANCE_CERTIFICATION_VERSION,
+    }
+    certification = GovernanceExecutionCertificationDTO(
+        certification_id=_digest(payload), **payload
+    )
+    return GovernanceExecutionCertificationBundleDTO(
+        certification=certification,
+        gate=gate,
+        pre_audit=pre_audit,
+        post_audit=post_audit,
+    )
+
+
+def _decode_audit(payload: Mapping[str, object]) -> GovernanceIntegrityAuditReportDTO:
+    data = dict(payload)
+    data["findings"] = tuple(
+        GovernanceIntegrityFindingDTO(
+            **{**item, "related_ids": tuple(item["related_ids"])}
+        )
+        for item in data["findings"]
+    )
+    return GovernanceIntegrityAuditReportDTO(**data)
+
+
+class SqliteGovernanceCertificationStore:
+    """Append-only SQLite store for complete execution certification bundles."""
+
+    def __init__(self, database: str | Path) -> None:
+        self._connection = sqlite3.connect(str(database))
+        self._connection.row_factory = sqlite3.Row
+        self._initialize()
+
+    def __enter__(self) -> "SqliteGovernanceCertificationStore":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        self.close()
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def _initialize(self) -> None:
+        self._connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS perception_certification_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS perception_governance_certifications (
+                certification_id TEXT PRIMARY KEY,
+                gate_id TEXT NOT NULL UNIQUE,
+                attempt_id TEXT NOT NULL UNIQUE,
+                disposition_id TEXT NOT NULL UNIQUE,
+                payload_json TEXT NOT NULL,
+                gate_json TEXT NOT NULL,
+                pre_audit_json TEXT NOT NULL,
+                post_audit_json TEXT NOT NULL
+            );
+            """
+        )
+        row = self._connection.execute(
+            "SELECT value FROM perception_certification_metadata WHERE key='schema_version'"
+        ).fetchone()
+        if row is None:
+            self._connection.execute(
+                "INSERT INTO perception_certification_metadata(key, value) VALUES('schema_version', ?)",
+                (SQL_CERTIFICATION_SCHEMA_VERSION,),
+            )
+            self._connection.commit()
+        elif row["value"] != SQL_CERTIFICATION_SCHEMA_VERSION:
+            raise PerceptionSqlCertificationError("unsupported certification schema version")
+
+    def append_certification(
+        self, bundle: GovernanceExecutionCertificationBundleDTO
+    ) -> None:
+        certification = bundle.certification
+        encoded = (
+            json.dumps(asdict(certification), sort_keys=True, separators=(",", ":")),
+            json.dumps(asdict(bundle.gate), sort_keys=True, separators=(",", ":")),
+            json.dumps(asdict(bundle.pre_audit), sort_keys=True, separators=(",", ":")),
+            json.dumps(asdict(bundle.post_audit), sort_keys=True, separators=(",", ":")),
+        )
+        row = self._connection.execute(
+            "SELECT certification_id, payload_json, gate_json, pre_audit_json, post_audit_json "
+            "FROM perception_governance_certifications WHERE attempt_id = ? OR disposition_id = ?",
+            (certification.attempt_id, certification.disposition_id),
+        ).fetchone()
+        if row is not None:
+            existing = (
+                row["payload_json"],
+                row["gate_json"],
+                row["pre_audit_json"],
+                row["post_audit_json"],
+            )
+            if row["certification_id"] != certification.certification_id or existing != encoded:
+                raise PerceptionSqlCertificationError(
+                    "attempt or disposition already has a conflicting certification"
+                )
+            return
+        self._connection.execute(
+            "INSERT INTO perception_governance_certifications"
+            "(certification_id, gate_id, attempt_id, disposition_id, payload_json, gate_json, "
+            "pre_audit_json, post_audit_json) VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                certification.certification_id,
+                certification.gate_id,
+                certification.attempt_id,
+                certification.disposition_id,
+                *encoded,
+            ),
+        )
+        self._connection.commit()
+
+    def get_certification(
+        self, certification_id: str
+    ) -> GovernanceExecutionCertificationBundleDTO | None:
+        row = self._connection.execute(
+            "SELECT payload_json, gate_json, pre_audit_json, post_audit_json "
+            "FROM perception_governance_certifications WHERE certification_id = ?",
+            (certification_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return GovernanceExecutionCertificationBundleDTO(
+            certification=GovernanceExecutionCertificationDTO(
+                **json.loads(row["payload_json"])
+            ),
+            gate=GovernanceExecutionGateDTO(**json.loads(row["gate_json"])),
+            pre_audit=_decode_audit(json.loads(row["pre_audit_json"])),
+            post_audit=_decode_audit(json.loads(row["post_audit_json"])),
+        )
+
+    def list_certifications(self) -> tuple[GovernanceExecutionCertificationBundleDTO, ...]:
+        rows = self._connection.execute(
+            "SELECT certification_id FROM perception_governance_certifications "
+            "ORDER BY certification_id"
+        ).fetchall()
+        return tuple(
+            bundle
+            for row in rows
+            if (bundle := self.get_certification(row["certification_id"])) is not None
+        )
+
+
+def execute_and_certify_audit_gated_rollback(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    attempt_store: SqliteGovernedExecutionAttemptStore,
+    certification_store: SqliteGovernanceCertificationStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+) -> tuple[
+    GovernanceExecutionCertificationBundleDTO,
+    GovernedExecutionAttemptDTO,
+    GovernanceExecutionReceiptDTO,
+]:
+    """Execute through P17G and durably persist the exact surrounding audit evidence."""
+
+    pre_audit = audit_governance_integrity(
+        lifecycle_store, governance_store, attempt_store
+    )
+    gate, attempt, receipt, post_audit = execute_audit_gated_approved_rollback(
+        lifecycle_store,
+        governance_store,
+        attempt_store,
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    if gate.pre_audit_report_id != pre_audit.report_id:
+        raise PerceptionSqlCertificationError(
+            "execution gate pre-audit differs from certification pre-audit"
+        )
+    bundle = build_governance_execution_certification(gate, pre_audit, post_audit)
+    certification_store.append_certification(bundle)
+    return bundle, attempt, receipt

--- a/packages/perception/tests/test_sql_certification_p17h.py
+++ b/packages/perception/tests/test_sql_certification_p17h.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from zeromodel.perception.compatibility import (
+    assess_rollback_compatibility,
+    build_model_compatibility_contract,
+)
+from zeromodel.perception.disposition import disposition_operational_recommendation
+from zeromodel.perception.execution_journal import SqliteGovernedExecutionAttemptStore
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+from zeromodel.perception.recommendation import OperationalRecommendationDTO
+from zeromodel.perception.sql_certification import (
+    PerceptionSqlCertificationError,
+    SqliteGovernanceCertificationStore,
+    execute_and_certify_audit_gated_rollback,
+)
+from zeromodel.perception.sql_governance import SqlitePerceptionGovernanceLedgerStore
+
+
+def _promoted(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"model-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _fixture(governance_database):
+    lifecycle = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    for model in (earlier, current):
+        register_promoted_model(
+            lifecycle,
+            model,
+            registered_by="test",
+            registration_reason="candidate",
+        )
+    activate_promoted_model(
+        lifecycle, earlier.promoted_model_id, actor="test", reason="activate"
+    )
+    supersede_active_model(
+        lifecycle, current.promoted_model_id, actor="test", reason="supersede"
+    )
+    snapshot = build_model_lifecycle_snapshot(lifecycle)
+    current_contract = build_model_compatibility_contract(
+        current,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+    target_contract = build_model_compatibility_contract(
+        earlier,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+    assessment = assess_rollback_compatibility(current_contract, target_contract)
+    recommendation = OperationalRecommendationDTO(
+        recommendation_id="sha256:recommendation",
+        health_report_id="sha256:health",
+        lifecycle_snapshot_id=snapshot.snapshot_id,
+        active_pointer_id=snapshot.active_pointer.pointer_id,
+        active_pointer_revision=snapshot.active_pointer.revision,
+        active_promoted_model_id=current.promoted_model_id,
+        current_contract_id=current_contract.contract_id,
+        status="rollback_candidate",
+        selected_target_promoted_model_id=earlier.promoted_model_id,
+        selected_assessment_id=assessment.assessment_id,
+        assessed_candidates=(assessment,),
+        rationale="supported drift and compatible historical target",
+    )
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+    governance = SqlitePerceptionGovernanceLedgerStore(governance_database)
+    governance.append_recommendation(recommendation)
+    governance.append_disposition(disposition)
+    return (
+        lifecycle,
+        governance,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    )
+
+
+def test_certification_survives_restart_with_exact_audits(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    certification_database = tmp_path / "certifications.sqlite3"
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts, SqliteGovernanceCertificationStore(certification_database) as certifications:
+        bundle, attempt, receipt = execute_and_certify_audit_gated_rollback(
+            lifecycle,
+            governance,
+            attempts,
+            certifications,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        certifications.append_certification(bundle)
+
+    with SqliteGovernanceCertificationStore(certification_database) as reopened:
+        restored = reopened.get_certification(bundle.certification.certification_id)
+        listed = reopened.list_certifications()
+
+    assert restored == bundle
+    assert listed == (bundle,)
+    assert bundle.certification.attempt_id == attempt.attempt_id
+    assert bundle.certification.receipt_id == receipt.receipt_id
+    assert bundle.pre_audit.report_id == bundle.gate.pre_audit_report_id
+    assert bundle.post_audit.status == "valid"
+    assert bundle.post_audit.active_pointer_revision == receipt.pointer_revision
+
+
+def test_conflicting_certification_for_same_attempt_is_rejected(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts, SqliteGovernanceCertificationStore(
+        tmp_path / "certifications.sqlite3"
+    ) as certifications:
+        bundle, _, _ = execute_and_certify_audit_gated_rollback(
+            lifecycle,
+            governance,
+            attempts,
+            certifications,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+        conflicting = replace(
+            bundle,
+            certification=replace(
+                bundle.certification,
+                certification_id="sha256:conflicting-certification",
+            ),
+        )
+        with pytest.raises(
+            PerceptionSqlCertificationError,
+            match="conflicting certification",
+        ):
+            certifications.append_certification(conflicting)
+
+
+def test_bundle_rejects_non_valid_post_audit(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts, SqliteGovernanceCertificationStore(
+        tmp_path / "certifications.sqlite3"
+    ) as certifications:
+        bundle, _, _ = execute_and_certify_audit_gated_rollback(
+            lifecycle,
+            governance,
+            attempts,
+            certifications,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+
+    with pytest.raises(PerceptionSqlCertificationError, match="valid post-audit"):
+        replace(bundle, post_audit=replace(bundle.post_audit, status="attention_required"))

--- a/packages/perception/tests/test_sql_certification_public_api_p17h.py
+++ b/packages/perception/tests/test_sql_certification_public_api_p17h.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from zeromodel.perception.sql_certification import (
+    GOVERNANCE_CERTIFICATION_SEMANTICS,
+    GOVERNANCE_CERTIFICATION_VERSION,
+    SQL_CERTIFICATION_SCHEMA_VERSION,
+    SQL_CERTIFICATION_STORE_VERSION,
+    GovernanceExecutionCertificationBundleDTO,
+    GovernanceExecutionCertificationDTO,
+    PerceptionSqlCertificationError,
+    SqliteGovernanceCertificationStore,
+    build_governance_execution_certification,
+    execute_and_certify_audit_gated_rollback,
+)
+
+
+def test_p17h_certification_module_is_public() -> None:
+    assert GOVERNANCE_CERTIFICATION_VERSION.endswith("/1")
+    assert SQL_CERTIFICATION_SCHEMA_VERSION.endswith("/1")
+    assert SQL_CERTIFICATION_STORE_VERSION.endswith("/1")
+    assert "durable_bundle" in GOVERNANCE_CERTIFICATION_SEMANTICS
+    assert GovernanceExecutionCertificationDTO is not None
+    assert GovernanceExecutionCertificationBundleDTO is not None
+    assert PerceptionSqlCertificationError is not None
+    assert SqliteGovernanceCertificationStore is not None
+    assert callable(build_governance_execution_certification)
+    assert callable(execute_and_certify_audit_gated_rollback)


### PR DESCRIPTION
## Summary

Implements P17H: durable, append-only persistence for the complete P17G execution certification bundle.

## Certification chain

```text
P17F pre-audit
    ↓
P17G audit-gated rollback / recovery
    ↓
P17F valid post-audit
    ↓
GovernanceExecutionGateDTO
    + exact pre-audit report
    + exact post-audit report
        ↓
GovernanceExecutionCertificationBundleDTO
        ↓
SqliteGovernanceCertificationStore
```

## Why this is necessary

P17G returns a content-addressed gate, but the gate and the exact audit reports it references are otherwise process-local. After lifecycle mutation, the original pre-execution audit cannot be reconstructed from current state alone.

P17H persists the gate, the exact pre-audit, the exact valid post-audit, and a content-addressed certification DTO as one immutable bundle.

## Invariants

- certification and gate identities must agree;
- recommendation, disposition, attempt, receipt, and result revision must agree;
- the gate must reference the supplied pre- and post-audits;
- the post-audit must be valid;
- the post-audit pointer revision must equal the certified result revision;
- one certification is allowed per gate, attempt, and disposition;
- identical re-appends are idempotent;
- conflicting rewrites are rejected.

## Execution entry point

`execute_and_certify_audit_gated_rollback(...)` captures the deterministic pre-audit, delegates execution/recovery to P17G, verifies the gate references that same pre-audit, persists the complete bundle, and returns the bundle, attempt, and receipt.

## Authority boundary

The certification store records evidence only. It cannot mutate lifecycle state. Lifecycle, governance-ledger, and attempt-journal authorities remain unchanged.

## Validation

Tests cover restart restoration of nested audit evidence, exact idempotent re-append, conflicting certification rejection, invalid post-audit rejection, and the public `sql_certification` module contract.

Audit-Exempt: adds internal durable governance certification evidence; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains authoritative; no green result is claimed until it completes.