### PR TITLE
feat(perception): add P17I certification integrity audit

### DIFF
--- a/packages/perception/docs/stage-p17i-certification-integrity-audit.md
+++ b/packages/perception/docs/stage-p17i-certification-integrity-audit.md
@@ -1,0 +1,50 @@
+# Stage P17I — Certification Integrity Audit
+
+## Objective
+
+Extend the P17F read-only governance reconciliation across the P17H certification ledger.
+
+```text
+lifecycle store
+    + governance ledger
+    + execution attempt journal
+    + certification ledger
+        ↓
+CertificationIntegrityAuditReportDTO
+```
+
+## Composition
+
+P17I first runs the existing three-store `audit_governance_integrity(...)`. It then validates every durable certification against the recommendation, disposition, attempt, receipt, and resulting pointer revision it claims to certify.
+
+## Status model
+
+- `valid`: the underlying governance audit is valid and certification ownership is complete;
+- `attention_required`: no contradiction is proven, but a warning exists;
+- `invalid`: the underlying governance audit is invalid or a certification has a missing or contradictory ownership link.
+
+## Checks
+
+The audit detects:
+
+- certifications whose recommendation, disposition, attempt, or receipt is missing;
+- attempt ownership that differs from the certification;
+- disposition ownership that differs from the certification;
+- receipt ownership that differs from the certification;
+- receipt result revisions that differ from the certified revision;
+- successful journaled attempts without a durable P17H certification;
+- invalid or attention-required three-store governance history.
+
+## Historical certification semantics
+
+A certification is evidence about a specific historical transition. It does not become stale merely because later valid lifecycle transitions occur.
+
+The auditor therefore compares a certification with its own receipt and ownership chain. It does not require the certified pointer revision to remain the current active revision.
+
+## Missing certification classification
+
+A successful attempt without a P17H bundle is reported as `successful_attempt_uncertified` with warning severity. This preserves compatibility with executions completed before certification persistence existed while making the evidence gap visible.
+
+## Determinism and authority
+
+Findings and reports are content-addressed and canonically ordered. The audit is read-only and cannot repair, certify, execute, approve, reject, or mutate lifecycle state.

--- a/packages/perception/src/zeromodel/perception/certification_audit.py
+++ b/packages/perception/src/zeromodel/perception/certification_audit.py
@@ -1,0 +1,177 @@
+"""Read-only four-store certification integrity audit for Stage P17I."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .execution_journal import SqliteGovernedExecutionAttemptStore
+from .governance_audit import audit_governance_integrity
+from .lifecycle import PerceptionModelLifecycleStore
+from .sql_certification import SqliteGovernanceCertificationStore
+from .sql_governance import SqlitePerceptionGovernanceLedgerStore
+
+CERTIFICATION_AUDIT_VERSION: Final = "perception-certification-integrity-audit/1"
+CERTIFICATION_AUDIT_FINDING_VERSION: Final = "perception-certification-integrity-finding/1"
+CERTIFICATION_AUDIT_SEMANTICS: Final = (
+    "read_only_reconciliation_of_lifecycle_governance_attempt_and_certification_history"
+)
+CERTIFICATION_AUDIT_STATUSES: Final = {"valid", "attention_required", "invalid"}
+CERTIFICATION_AUDIT_SEVERITIES: Final = {"info", "warning", "error"}
+
+
+class PerceptionCertificationAuditError(ValueError):
+    """Raised when certification audit contracts are violated."""
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class CertificationIntegrityFindingDTO:
+    finding_id: str
+    severity: str
+    code: str
+    subject_kind: str
+    subject_id: str
+    related_ids: tuple[str, ...]
+    message: str
+    version: str = CERTIFICATION_AUDIT_FINDING_VERSION
+
+    def __post_init__(self) -> None:
+        if not all((self.finding_id, self.severity, self.code, self.subject_kind, self.subject_id, self.message)):
+            raise PerceptionCertificationAuditError("finding fields must be non-empty")
+        if self.severity not in CERTIFICATION_AUDIT_SEVERITIES:
+            raise PerceptionCertificationAuditError("unsupported finding severity")
+        if self.related_ids != tuple(sorted(set(self.related_ids))):
+            raise PerceptionCertificationAuditError("related identities must be sorted and unique")
+        if self.version != CERTIFICATION_AUDIT_FINDING_VERSION:
+            raise PerceptionCertificationAuditError("unsupported finding version")
+
+
+@dataclass(frozen=True)
+class CertificationIntegrityAuditReportDTO:
+    report_id: str
+    status: str
+    governance_audit_report_id: str
+    governance_audit_status: str
+    certification_count: int
+    successful_attempt_count: int
+    finding_count: int
+    findings: tuple[CertificationIntegrityFindingDTO, ...]
+    semantics: str = CERTIFICATION_AUDIT_SEMANTICS
+    version: str = CERTIFICATION_AUDIT_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.report_id or not self.governance_audit_report_id:
+            raise PerceptionCertificationAuditError("report identities must be non-empty")
+        if self.status not in CERTIFICATION_AUDIT_STATUSES:
+            raise PerceptionCertificationAuditError("unsupported report status")
+        if min(self.certification_count, self.successful_attempt_count, self.finding_count) < 0:
+            raise PerceptionCertificationAuditError("report counts cannot be negative")
+        if self.finding_count != len(self.findings):
+            raise PerceptionCertificationAuditError("finding count mismatch")
+        expected = tuple(sorted(self.findings, key=lambda item: (item.severity, item.code, item.subject_kind, item.subject_id, item.finding_id)))
+        if self.findings != expected:
+            raise PerceptionCertificationAuditError("findings must be canonically sorted")
+        if self.semantics != CERTIFICATION_AUDIT_SEMANTICS or self.version != CERTIFICATION_AUDIT_VERSION:
+            raise PerceptionCertificationAuditError("unsupported report contract")
+
+
+def _finding(severity: str, code: str, subject_kind: str, subject_id: str, message: str, *related_ids: str) -> CertificationIntegrityFindingDTO:
+    related = tuple(sorted(set(related_ids)))
+    payload: Mapping[str, object] = {
+        "severity": severity,
+        "code": code,
+        "subject_kind": subject_kind,
+        "subject_id": subject_id,
+        "related_ids": related,
+        "message": message,
+        "version": CERTIFICATION_AUDIT_FINDING_VERSION,
+    }
+    return CertificationIntegrityFindingDTO(finding_id=_digest(payload), **payload)
+
+
+def audit_certification_integrity(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    attempt_store: SqliteGovernedExecutionAttemptStore,
+    certification_store: SqliteGovernanceCertificationStore,
+) -> CertificationIntegrityAuditReportDTO:
+    """Reconcile certifications with lifecycle, governance, and attempt history."""
+
+    base = audit_governance_integrity(lifecycle_store, governance_store, attempt_store)
+    recommendations = {item.recommendation_id: item for item in governance_store.list_recommendations()}
+    dispositions = {item.disposition_id: item for item in governance_store.list_dispositions()}
+    receipts = {item.receipt_id: item for item in governance_store.list_execution_receipts()}
+    attempts = {item.attempt_id: item for item in attempt_store.list_attempts()}
+    bundles = certification_store.list_certifications()
+    certified_attempts = {item.certification.attempt_id for item in bundles}
+    findings: list[CertificationIntegrityFindingDTO] = []
+
+    if base.status != "valid":
+        severity = "error" if base.status == "invalid" else "warning"
+        findings.append(_finding(severity, f"underlying_governance_{base.status}", "governance_audit", base.report_id, "three-store governance integrity is not valid"))
+
+    for bundle in bundles:
+        item = bundle.certification
+        attempt = attempts.get(item.attempt_id)
+        disposition = dispositions.get(item.disposition_id)
+        recommendation = recommendations.get(item.recommendation_id)
+        receipt = receipts.get(item.receipt_id)
+        for owned, code, related in (
+            (attempt, "certification_missing_attempt", item.attempt_id),
+            (disposition, "certification_missing_disposition", item.disposition_id),
+            (recommendation, "certification_missing_recommendation", item.recommendation_id),
+            (receipt, "certification_missing_receipt", item.receipt_id),
+        ):
+            if owned is None:
+                findings.append(_finding("error", code, "certification", item.certification_id, "certification references a missing artifact", related))
+        if attempt is not None and (attempt.disposition_id != item.disposition_id or attempt.recommendation_id != item.recommendation_id):
+            findings.append(_finding("error", "certification_attempt_ownership_mismatch", "certification", item.certification_id, "attempt ownership differs from certification", attempt.attempt_id))
+        if disposition is not None and disposition.recommendation_id != item.recommendation_id:
+            findings.append(_finding("error", "certification_disposition_ownership_mismatch", "certification", item.certification_id, "disposition ownership differs from certification", disposition.disposition_id))
+        if receipt is not None:
+            if receipt.disposition_id != item.disposition_id or receipt.recommendation_id != item.recommendation_id:
+                findings.append(_finding("error", "certification_receipt_ownership_mismatch", "certification", item.certification_id, "receipt ownership differs from certification", receipt.receipt_id))
+            if receipt.pointer_revision != item.resulting_pointer_revision:
+                findings.append(_finding("error", "certification_receipt_revision_mismatch", "certification", item.certification_id, "receipt revision differs from certification", receipt.receipt_id))
+
+    successful = 0
+    for attempt in attempts.values():
+        events = attempt_store.list_events(attempt.attempt_id)
+        terminal = events[-1] if events else None
+        if terminal is None or terminal.event_kind not in {"completed", "reconciled", "idempotent"}:
+            continue
+        successful += 1
+        if attempt.attempt_id not in certified_attempts:
+            findings.append(_finding("warning", "successful_attempt_uncertified", "attempt", attempt.attempt_id, "successful execution has no durable certification", attempt.disposition_id))
+
+    canonical = tuple(sorted(findings, key=lambda item: (item.severity, item.code, item.subject_kind, item.subject_id, item.finding_id)))
+    status = "invalid" if any(item.severity == "error" for item in canonical) else "attention_required" if any(item.severity == "warning" for item in canonical) else "valid"
+    payload: Mapping[str, object] = {
+        "status": status,
+        "governance_audit_report_id": base.report_id,
+        "governance_audit_status": base.status,
+        "certification_count": len(bundles),
+        "successful_attempt_count": successful,
+        "finding_ids": tuple(item.finding_id for item in canonical),
+        "semantics": CERTIFICATION_AUDIT_SEMANTICS,
+        "version": CERTIFICATION_AUDIT_VERSION,
+    }
+    return CertificationIntegrityAuditReportDTO(
+        report_id=_digest(payload),
+        status=status,
+        governance_audit_report_id=base.report_id,
+        governance_audit_status=base.status,
+        certification_count=len(bundles),
+        successful_attempt_count=successful,
+        finding_count=len(canonical),
+        findings=canonical,
+    )

--- a/packages/perception/tests/test_certification_audit_p17i.py
+++ b/packages/perception/tests/test_certification_audit_p17i.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from zeromodel.perception.certification_audit import audit_certification_integrity
+from zeromodel.perception.governance_audit import GovernanceIntegrityAuditReportDTO
+from zeromodel.perception.governance_gate import GovernanceExecutionGateDTO
+from zeromodel.perception.sql_certification import (
+    GovernanceExecutionCertificationBundleDTO,
+    GovernanceExecutionCertificationDTO,
+)
+
+
+class _Lifecycle:
+    def get_active_pointer(self):
+        return SimpleNamespace(pointer_id="sha256:pointer", revision=0)
+
+    def list_transitions(self):
+        return ()
+
+
+class _Governance:
+    def __init__(self, *, receipts=()):
+        self._receipts = receipts
+
+    def list_recommendations(self):
+        return ()
+
+    def list_dispositions(self):
+        return ()
+
+    def list_execution_receipts(self):
+        return self._receipts
+
+
+class _Attempts:
+    def list_attempts(self):
+        return ()
+
+    def list_events(self, attempt_id):
+        del attempt_id
+        return ()
+
+
+class _Certifications:
+    def __init__(self, bundles=()):
+        self._bundles = bundles
+
+    def list_certifications(self):
+        return self._bundles
+
+
+def _audit(report_id: str, revision: int) -> GovernanceIntegrityAuditReportDTO:
+    return GovernanceIntegrityAuditReportDTO(
+        report_id=report_id,
+        status="valid",
+        active_pointer_id="sha256:pointer",
+        active_pointer_revision=revision,
+        recommendation_count=0,
+        disposition_count=0,
+        receipt_count=0,
+        attempt_count=0,
+        finding_count=0,
+        findings=(),
+    )
+
+
+def _orphan_bundle() -> GovernanceExecutionCertificationBundleDTO:
+    gate = GovernanceExecutionGateDTO(
+        gate_id="sha256:gate",
+        recommendation_id="sha256:recommendation",
+        disposition_id="sha256:disposition",
+        attempt_id="sha256:attempt",
+        receipt_id="sha256:receipt",
+        pre_audit_report_id="sha256:pre",
+        post_audit_report_id="sha256:post",
+        authorization_mode="clean",
+        resulting_pointer_revision=1,
+    )
+    certification = GovernanceExecutionCertificationDTO(
+        certification_id="sha256:certification",
+        gate_id=gate.gate_id,
+        recommendation_id=gate.recommendation_id,
+        disposition_id=gate.disposition_id,
+        attempt_id=gate.attempt_id,
+        receipt_id=gate.receipt_id,
+        pre_audit_report_id=gate.pre_audit_report_id,
+        post_audit_report_id=gate.post_audit_report_id,
+        resulting_pointer_revision=1,
+    )
+    return GovernanceExecutionCertificationBundleDTO(
+        certification=certification,
+        gate=gate,
+        pre_audit=_audit("sha256:pre", 0),
+        post_audit=_audit("sha256:post", 1),
+    )
+
+
+def test_empty_four_store_history_is_valid_and_deterministic() -> None:
+    first = audit_certification_integrity(
+        _Lifecycle(), _Governance(), _Attempts(), _Certifications()
+    )
+    second = audit_certification_integrity(
+        _Lifecycle(), _Governance(), _Attempts(), _Certifications()
+    )
+
+    assert first == second
+    assert first.status == "valid"
+    assert first.certification_count == 0
+    assert first.findings == ()
+
+
+def test_orphan_certification_is_invalid() -> None:
+    report = audit_certification_integrity(
+        _Lifecycle(),
+        _Governance(),
+        _Attempts(),
+        _Certifications((_orphan_bundle(),)),
+    )
+
+    assert report.status == "invalid"
+    assert tuple(item.code for item in report.findings) == (
+        "certification_missing_attempt",
+        "certification_missing_disposition",
+        "certification_missing_receipt",
+        "certification_missing_recommendation",
+    )
+
+
+def test_invalid_three_store_history_propagates_to_certification_audit() -> None:
+    orphan_receipt = SimpleNamespace(
+        receipt_id="sha256:receipt",
+        disposition_id="sha256:missing-disposition",
+        recommendation_id="sha256:missing-recommendation",
+        transition_id="sha256:missing-transition",
+        pointer_revision=1,
+        resulting_promoted_model_id="promoted-earlier",
+    )
+    report = audit_certification_integrity(
+        _Lifecycle(),
+        _Governance(receipts=(orphan_receipt,)),
+        _Attempts(),
+        _Certifications(),
+    )
+
+    assert report.status == "invalid"
+    assert report.governance_audit_status == "invalid"
+    assert "underlying_governance_invalid" in tuple(
+        item.code for item in report.findings
+    )

--- a/packages/perception/tests/test_certification_audit_public_api_p17i.py
+++ b/packages/perception/tests/test_certification_audit_public_api_p17i.py
@@ -1,0 +1,27 @@
+from zeromodel.perception.certification_audit import (
+    CERTIFICATION_AUDIT_FINDING_VERSION,
+    CERTIFICATION_AUDIT_SEMANTICS,
+    CERTIFICATION_AUDIT_SEVERITIES,
+    CERTIFICATION_AUDIT_STATUSES,
+    CERTIFICATION_AUDIT_VERSION,
+    CertificationIntegrityAuditReportDTO,
+    CertificationIntegrityFindingDTO,
+    PerceptionCertificationAuditError,
+    audit_certification_integrity,
+)
+
+
+def test_p17i_certification_audit_public_contract() -> None:
+    assert CERTIFICATION_AUDIT_VERSION == "perception-certification-integrity-audit/1"
+    assert CERTIFICATION_AUDIT_FINDING_VERSION.endswith("/1")
+    assert CERTIFICATION_AUDIT_SEMANTICS
+    assert CERTIFICATION_AUDIT_STATUSES == {
+        "valid",
+        "attention_required",
+        "invalid",
+    }
+    assert CERTIFICATION_AUDIT_SEVERITIES == {"info", "warning", "error"}
+    assert CertificationIntegrityAuditReportDTO
+    assert CertificationIntegrityFindingDTO
+    assert PerceptionCertificationAuditError
+    assert callable(audit_certification_integrity)


### PR DESCRIPTION
## Summary

Implements P17I: deterministic, read-only four-store reconciliation across lifecycle state, the governance ledger, the execution-attempt journal, and the durable certification ledger.

## Audit chain

```text
P17F lifecycle + governance + attempt audit
    +
P17H certification ledger
        ↓
CertificationIntegrityAuditReportDTO
```

## Checks

- propagates invalid or attention-required three-store governance state;
- rejects certifications whose recommendation, disposition, attempt, or receipt is missing;
- validates attempt, disposition, and receipt ownership against the certification;
- validates receipt pointer revision against the certified result revision;
- reports successful journaled executions without a P17H certification as warnings;
- preserves historical certifications after later valid lifecycle transitions.

## Status model

- `valid`: all four stores compose without warnings or contradictions;
- `attention_required`: an evidence gap exists, such as a successful pre-P17H execution without certification;
- `invalid`: underlying governance is invalid or a certification ownership/revision contradiction exists.

## Determinism and authority

Findings and reports are content-addressed and canonically sorted. The audit is strictly read-only and does not certify, execute, repair, approve, reject, or mutate lifecycle state.

## Validation

Tests cover deterministic empty-history auditing, orphan certification detection, invalid three-store state propagation, and the public `certification_audit` module contract.

Audit-Exempt: adds internal certification-integrity reporting; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains authoritative; no green result is claimed until it completes.