### PR TITLE
feat(perception): add P17J certification-aware execution gate

### DIFF
--- a/packages/perception/docs/stage-p17j-certification-aware-execution-gate.md
+++ b/packages/perception/docs/stage-p17j-certification-aware-execution-gate.md
@@ -1,0 +1,43 @@
+# Stage P17J — Certification-Aware Execution Gate
+
+## Objective
+
+Use the P17I four-store certification audit before and after a fresh governed rollback.
+
+```text
+lifecycle + governance + attempt journal + certification ledger
+    ↓
+P17I preflight audit
+    ↓
+P17H governed rollback and certification
+    ↓
+P17I postflight audit
+    ↓
+CertificationExecutionGateDTO
+```
+
+## Preflight rule
+
+Fresh work starts only when the four-store report is `valid`.
+
+Both `attention_required` and `invalid` block the operation. Warning-level evidence gaps are not silently waived.
+
+## Recovery boundary
+
+The existing P17G and P17H paths remain responsible for the exact deterministic operation already in progress. P17J governs entry into fresh work and does not treat unrelated certification warnings as recovery authorization.
+
+## Postflight rule
+
+After certification, P17J requires:
+
+- the exact certification bundle to be readable from the certification ledger;
+- the restored bundle to equal the completed bundle;
+- the new four-store report to be `valid`.
+
+## Gate artifact
+
+`CertificationExecutionGateDTO` binds the certification, attempt, receipt, preflight report, postflight report, and resulting pointer revision.
+
+## Authority boundary
+
+P17J adds no new model-state authority. The lifecycle store remains authoritative for the active model, while the other stores retain their existing evidence ownership.

--- a/packages/perception/src/zeromodel/perception/certification_gate.py
+++ b/packages/perception/src/zeromodel/perception/certification_gate.py
@@ -1,0 +1,159 @@
+"""Certification-aware governed rollback execution for Stage P17J."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from .certification_audit import (
+    CertificationIntegrityAuditReportDTO,
+    audit_certification_integrity,
+)
+from .compatibility import ModelCompatibilityContractDTO
+from .disposition import OperationalRecommendationDispositionDTO
+from .execution_journal import GovernedExecutionAttemptDTO, SqliteGovernedExecutionAttemptStore
+from .lifecycle import PerceptionModelLifecycleStore
+from .recommendation import OperationalRecommendationDTO
+from .sql_certification import (
+    GovernanceExecutionCertificationBundleDTO,
+    SqliteGovernanceCertificationStore,
+    execute_and_certify_audit_gated_rollback,
+)
+from .sql_governance import GovernanceExecutionReceiptDTO, SqlitePerceptionGovernanceLedgerStore
+
+CERTIFICATION_EXECUTION_GATE_VERSION: Final = "perception-certification-execution-gate/1"
+CERTIFICATION_EXECUTION_GATE_SEMANTICS: Final = (
+    "four_store_preflight_and_postflight_gated_governed_execution"
+)
+
+
+class PerceptionCertificationExecutionGateError(ValueError):
+    """Raised when certification integrity does not authorize or certify execution."""
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class CertificationExecutionGateDTO:
+    gate_id: str
+    certification_id: str
+    attempt_id: str
+    receipt_id: str
+    preflight_report_id: str
+    postflight_report_id: str
+    resulting_pointer_revision: int
+    semantics: str = CERTIFICATION_EXECUTION_GATE_SEMANTICS
+    version: str = CERTIFICATION_EXECUTION_GATE_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.gate_id,
+                self.certification_id,
+                self.attempt_id,
+                self.receipt_id,
+                self.preflight_report_id,
+                self.postflight_report_id,
+            )
+        ):
+            raise PerceptionCertificationExecutionGateError(
+                "certification execution gate identities must be non-empty"
+            )
+        if self.resulting_pointer_revision <= 0:
+            raise PerceptionCertificationExecutionGateError(
+                "certification execution gate requires a positive pointer revision"
+            )
+        if self.semantics != CERTIFICATION_EXECUTION_GATE_SEMANTICS:
+            raise PerceptionCertificationExecutionGateError("unsupported gate semantics")
+        if self.version != CERTIFICATION_EXECUTION_GATE_VERSION:
+            raise PerceptionCertificationExecutionGateError("unsupported gate version")
+
+
+def authorize_certification_execution(report: CertificationIntegrityAuditReportDTO) -> None:
+    """Require a completely valid four-store state before starting fresh execution."""
+
+    if report.status != "valid":
+        raise PerceptionCertificationExecutionGateError(
+            "certification integrity is not valid; fresh execution is blocked"
+        )
+
+
+def execute_certification_gated_approved_rollback(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    attempt_store: SqliteGovernedExecutionAttemptStore,
+    certification_store: SqliteGovernanceCertificationStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+) -> tuple[
+    CertificationExecutionGateDTO,
+    GovernanceExecutionCertificationBundleDTO,
+    GovernedExecutionAttemptDTO,
+    GovernanceExecutionReceiptDTO,
+    CertificationIntegrityAuditReportDTO,
+]:
+    """Preflight four stores, execute and certify, then prove all four stores are valid."""
+
+    preflight = audit_certification_integrity(
+        lifecycle_store,
+        governance_store,
+        attempt_store,
+        certification_store,
+    )
+    authorize_certification_execution(preflight)
+
+    bundle, attempt, receipt = execute_and_certify_audit_gated_rollback(
+        lifecycle_store,
+        governance_store,
+        attempt_store,
+        certification_store,
+        recommendation,
+        disposition,
+        current_contract=current_contract,
+        target_contract=target_contract,
+    )
+    restored = certification_store.get_certification(
+        bundle.certification.certification_id
+    )
+    if restored != bundle:
+        raise PerceptionCertificationExecutionGateError(
+            "persisted certification differs from completed execution bundle"
+        )
+
+    postflight = audit_certification_integrity(
+        lifecycle_store,
+        governance_store,
+        attempt_store,
+        certification_store,
+    )
+    if postflight.status != "valid":
+        raise PerceptionCertificationExecutionGateError(
+            "certified execution completed but four-store integrity is not valid"
+        )
+
+    payload: Mapping[str, object] = {
+        "attempt_id": attempt.attempt_id,
+        "certification_id": bundle.certification.certification_id,
+        "postflight_report_id": postflight.report_id,
+        "preflight_report_id": preflight.report_id,
+        "receipt_id": receipt.receipt_id,
+        "resulting_pointer_revision": receipt.pointer_revision,
+        "semantics": CERTIFICATION_EXECUTION_GATE_SEMANTICS,
+        "version": CERTIFICATION_EXECUTION_GATE_VERSION,
+    }
+    gate = CertificationExecutionGateDTO(gate_id=_digest(payload), **payload)
+    return gate, bundle, attempt, receipt, postflight

--- a/packages/perception/tests/test_certification_gate_p17j.py
+++ b/packages/perception/tests/test_certification_gate_p17j.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from zeromodel.perception.certification_audit import (
+    CertificationIntegrityAuditReportDTO,
+    audit_certification_integrity,
+)
+from zeromodel.perception.certification_gate import (
+    PerceptionCertificationExecutionGateError,
+    authorize_certification_execution,
+    execute_certification_gated_approved_rollback,
+)
+from zeromodel.perception.compatibility import (
+    assess_rollback_compatibility,
+    build_model_compatibility_contract,
+)
+from zeromodel.perception.disposition import disposition_operational_recommendation
+from zeromodel.perception.execution_journal import SqliteGovernedExecutionAttemptStore
+from zeromodel.perception.lifecycle import (
+    InMemoryPerceptionModelLifecycleStore,
+    activate_promoted_model,
+    build_model_lifecycle_snapshot,
+    register_promoted_model,
+    supersede_active_model,
+)
+from zeromodel.perception.promotion import PromotedPerceptionModelDTO
+from zeromodel.perception.recommendation import OperationalRecommendationDTO
+from zeromodel.perception.sql_certification import SqliteGovernanceCertificationStore
+from zeromodel.perception.sql_governance import SqlitePerceptionGovernanceLedgerStore
+
+
+def _promoted(name: str) -> PromotedPerceptionModelDTO:
+    return PromotedPerceptionModelDTO(
+        promoted_model_id=f"promoted-{name}",
+        model_kind="single_frame",
+        model_id=f"model-{name}",
+        rejection_threshold=0.25,
+        calibration_id=f"calibration-{name}",
+        promotion_decision_id=f"decision-{name}",
+        validation_comparison_report_id=f"validation-{name}",
+        training_split="train",
+        evaluation_split="validation",
+    )
+
+
+def _fixture(database):
+    lifecycle = InMemoryPerceptionModelLifecycleStore()
+    earlier = _promoted("earlier")
+    current = _promoted("current")
+    for model in (earlier, current):
+        register_promoted_model(
+            lifecycle,
+            model,
+            registered_by="test",
+            registration_reason="candidate",
+        )
+    activate_promoted_model(
+        lifecycle,
+        earlier.promoted_model_id,
+        actor="test",
+        reason="activate",
+    )
+    supersede_active_model(
+        lifecycle,
+        current.promoted_model_id,
+        actor="test",
+        reason="supersede",
+    )
+    snapshot = build_model_lifecycle_snapshot(lifecycle)
+    current_contract = build_model_compatibility_contract(
+        current,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+    target_contract = build_model_compatibility_contract(
+        earlier,
+        action_schema_id="actions-v1",
+        source_encoder_spec_id="encoder-v1",
+        field_schema_id="fields-v1",
+        inference_semantics_version="runtime-v1",
+        deployment_slot="primary",
+    )
+    assessment = assess_rollback_compatibility(current_contract, target_contract)
+    recommendation = OperationalRecommendationDTO(
+        recommendation_id="sha256:recommendation",
+        health_report_id="sha256:health",
+        lifecycle_snapshot_id=snapshot.snapshot_id,
+        active_pointer_id=snapshot.active_pointer.pointer_id,
+        active_pointer_revision=snapshot.active_pointer.revision,
+        active_promoted_model_id=current.promoted_model_id,
+        current_contract_id=current_contract.contract_id,
+        status="rollback_candidate",
+        selected_target_promoted_model_id=earlier.promoted_model_id,
+        selected_assessment_id=assessment.assessment_id,
+        assessed_candidates=(assessment,),
+        rationale="supported drift and compatible historical target",
+    )
+    disposition = disposition_operational_recommendation(
+        recommendation,
+        status="approved",
+        reviewed_by="operator",
+        reason="restore prior compatible model",
+    )
+    governance = SqlitePerceptionGovernanceLedgerStore(database)
+    governance.append_recommendation(recommendation)
+    governance.append_disposition(disposition)
+    return (
+        lifecycle,
+        governance,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    )
+
+
+def test_valid_four_store_state_executes_and_finishes_valid(tmp_path) -> None:
+    (
+        lifecycle,
+        governance,
+        current_contract,
+        target_contract,
+        recommendation,
+        disposition,
+    ) = _fixture(tmp_path / "governance.sqlite3")
+    with governance, SqliteGovernedExecutionAttemptStore(
+        tmp_path / "attempts.sqlite3"
+    ) as attempts, SqliteGovernanceCertificationStore(
+        tmp_path / "certifications.sqlite3"
+    ) as certifications:
+        preflight = audit_certification_integrity(
+            lifecycle,
+            governance,
+            attempts,
+            certifications,
+        )
+        gate, bundle, attempt, receipt, postflight = (
+            execute_certification_gated_approved_rollback(
+                lifecycle,
+                governance,
+                attempts,
+                certifications,
+                recommendation,
+                disposition,
+                current_contract=current_contract,
+                target_contract=target_contract,
+            )
+        )
+
+    assert preflight.status == "valid"
+    assert postflight.status == "valid"
+    assert gate.certification_id == bundle.certification.certification_id
+    assert gate.attempt_id == attempt.attempt_id
+    assert gate.receipt_id == receipt.receipt_id
+    assert gate.resulting_pointer_revision == receipt.pointer_revision
+    assert postflight.certification_count == 1
+
+
+def test_attention_required_preflight_blocks_fresh_execution() -> None:
+    report = CertificationIntegrityAuditReportDTO(
+        report_id="sha256:report",
+        status="valid",
+        governance_audit_report_id="sha256:governance",
+        governance_audit_status="valid",
+        certification_count=0,
+        successful_attempt_count=0,
+        finding_count=0,
+        findings=(),
+    )
+    blocked = replace(report, status="attention_required")
+
+    with pytest.raises(
+        PerceptionCertificationExecutionGateError,
+        match="fresh execution is blocked",
+    ):
+        authorize_certification_execution(blocked)

--- a/packages/perception/tests/test_certification_gate_public_api_p17j.py
+++ b/packages/perception/tests/test_certification_gate_public_api_p17j.py
@@ -1,0 +1,19 @@
+from zeromodel.perception.certification_gate import (
+    CERTIFICATION_EXECUTION_GATE_SEMANTICS,
+    CERTIFICATION_EXECUTION_GATE_VERSION,
+    CertificationExecutionGateDTO,
+    PerceptionCertificationExecutionGateError,
+    authorize_certification_execution,
+    execute_certification_gated_approved_rollback,
+)
+
+
+def test_p17j_certification_gate_public_contract() -> None:
+    assert CERTIFICATION_EXECUTION_GATE_VERSION == (
+        "perception-certification-execution-gate/1"
+    )
+    assert CERTIFICATION_EXECUTION_GATE_SEMANTICS
+    assert CertificationExecutionGateDTO
+    assert PerceptionCertificationExecutionGateError
+    assert callable(authorize_certification_execution)
+    assert callable(execute_certification_gated_approved_rollback)


### PR DESCRIPTION
## Summary

Implements P17J: certification-aware preflight and postflight gating for fresh governed rollback execution.

## Execution chain

```text
lifecycle + governance + attempts + certifications
    ↓
P17I preflight audit
    ↓
P17H execute and certify
    ↓
P17I postflight audit
    ↓
CertificationExecutionGateDTO
```

## Fresh-execution rule

Fresh execution is authorized only when the four-store certification audit is `valid`.

Both `attention_required` and `invalid` block the operation. Warning-level evidence gaps are not silently waived.

## Postcondition

After P17H completes, P17J verifies that:

- the exact certification bundle can be restored from the certification ledger;
- the restored bundle equals the completed bundle;
- the new four-store certification audit is `valid`.

## Gate artifact

`CertificationExecutionGateDTO` binds the certification, attempt, receipt, preflight report, postflight report, resulting pointer revision, semantics, and version.

## Recovery boundary

P17G and P17H retain responsibility for the exact deterministic operation already in progress. P17J governs entry into fresh work and does not reinterpret unrelated certification warnings as recovery authorization.

## Validation

Tests cover a complete valid execution-and-certification path, valid postflight integrity, persisted certification identity, and rejection of warning-level preflight state.

Audit-Exempt: adds internal certification-aware execution gating; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains authoritative; no green result is claimed until it completes.