### PR TITLE
feat(perception): add P17K durable execution admission

### DIFF
--- a/packages/perception/docs/stage-p17k-durable-execution-admission.md
+++ b/packages/perception/docs/stage-p17k-durable-execution-admission.md
@@ -1,0 +1,54 @@
+# Stage P17K — Durable Execution Admission
+
+## Objective
+
+Persist the complete P17J execution-admission proof so it survives process restart.
+
+```text
+P17I valid preflight
+    ↓
+P17J certification-aware execution gate
+    ↓
+P17I valid postflight
+    ↓
+CertificationExecutionAdmissionBundleDTO
+    ↓
+SqliteCertificationExecutionAdmissionStore
+```
+
+## Persisted evidence
+
+Each immutable admission bundle contains:
+
+- the P17J `CertificationExecutionGateDTO`;
+- the exact P17I preflight report used to authorize fresh execution;
+- the exact P17I postflight report that certified the completed state.
+
+The bundle rejects mismatched report identities and requires both reports to be `valid`.
+
+## Append-only rules
+
+The store permits one admission proof per certification and deterministic attempt.
+
+- an exact duplicate is idempotent;
+- a conflicting gate or report bundle is rejected;
+- records are canonically enumerable and fully reconstructable after restart;
+- schema version mismatch is rejected explicitly.
+
+## Execution entry point
+
+`execute_and_persist_certification_admission(...)` captures the real four-store preflight, delegates execution and certification to P17J, proves the returned gate references that same preflight, persists the complete bundle, restores it, and verifies exact equality.
+
+## Authority boundary
+
+The admission ledger stores evidence only. It cannot mutate lifecycle state, approve recommendations, create receipts, or replace the governance, attempt, or certification stores.
+
+## Exclusions
+
+P17K does not:
+
+- waive P17I warnings;
+- repair invalid history;
+- retry failed attempts;
+- create a second lifecycle authority;
+- infer or synthesize missing preflight evidence.

--- a/packages/perception/src/zeromodel/perception/sql_admission.py
+++ b/packages/perception/src/zeromodel/perception/sql_admission.py
@@ -1,0 +1,210 @@
+"""Durable certification-execution admission ledger for Stage P17K."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final
+
+from .certification_audit import (
+    CertificationIntegrityAuditReportDTO,
+    CertificationIntegrityFindingDTO,
+)
+from .certification_gate import (
+    CertificationExecutionGateDTO,
+    execute_certification_gated_approved_rollback,
+)
+from .compatibility import ModelCompatibilityContractDTO
+from .disposition import OperationalRecommendationDispositionDTO
+from .execution_journal import GovernedExecutionAttemptDTO, SqliteGovernedExecutionAttemptStore
+from .lifecycle import PerceptionModelLifecycleStore
+from .recommendation import OperationalRecommendationDTO
+from .sql_certification import (
+    GovernanceExecutionCertificationBundleDTO,
+    SqliteGovernanceCertificationStore,
+)
+from .sql_governance import GovernanceExecutionReceiptDTO, SqlitePerceptionGovernanceLedgerStore
+
+SQL_ADMISSION_SCHEMA_VERSION: Final = "perception-sql-admission-schema/1"
+SQL_ADMISSION_STORE_VERSION: Final = "perception-sql-admission-store/1"
+
+
+class PerceptionSqlAdmissionError(ValueError):
+    """Raised when durable execution-admission contracts are violated."""
+
+
+@dataclass(frozen=True)
+class CertificationExecutionAdmissionBundleDTO:
+    gate: CertificationExecutionGateDTO
+    preflight: CertificationIntegrityAuditReportDTO
+    postflight: CertificationIntegrityAuditReportDTO
+
+    def __post_init__(self) -> None:
+        if self.gate.preflight_report_id != self.preflight.report_id:
+            raise PerceptionSqlAdmissionError("gate does not reference supplied preflight report")
+        if self.gate.postflight_report_id != self.postflight.report_id:
+            raise PerceptionSqlAdmissionError("gate does not reference supplied postflight report")
+        if self.preflight.status != "valid" or self.postflight.status != "valid":
+            raise PerceptionSqlAdmissionError("admission bundle requires valid preflight and postflight")
+
+
+def _decode_report(payload: dict[str, object]) -> CertificationIntegrityAuditReportDTO:
+    data = dict(payload)
+    data["findings"] = tuple(
+        CertificationIntegrityFindingDTO(
+            **{**item, "related_ids": tuple(item["related_ids"])}
+        )
+        for item in data["findings"]
+    )
+    return CertificationIntegrityAuditReportDTO(**data)
+
+
+class SqliteCertificationExecutionAdmissionStore:
+    """Append-only SQLite store for P17J admission and postcondition proof."""
+
+    def __init__(self, database: str | Path) -> None:
+        self._connection = sqlite3.connect(str(database))
+        self._connection.row_factory = sqlite3.Row
+        self._initialize()
+
+    def __enter__(self) -> "SqliteCertificationExecutionAdmissionStore":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+        self.close()
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def _initialize(self) -> None:
+        self._connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS perception_admission_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS perception_execution_admissions (
+                gate_id TEXT PRIMARY KEY,
+                certification_id TEXT NOT NULL UNIQUE,
+                attempt_id TEXT NOT NULL UNIQUE,
+                gate_json TEXT NOT NULL,
+                preflight_json TEXT NOT NULL,
+                postflight_json TEXT NOT NULL
+            );
+            """
+        )
+        row = self._connection.execute(
+            "SELECT value FROM perception_admission_metadata WHERE key='schema_version'"
+        ).fetchone()
+        if row is None:
+            self._connection.execute(
+                "INSERT INTO perception_admission_metadata(key, value) VALUES('schema_version', ?)",
+                (SQL_ADMISSION_SCHEMA_VERSION,),
+            )
+            self._connection.commit()
+        elif row["value"] != SQL_ADMISSION_SCHEMA_VERSION:
+            raise PerceptionSqlAdmissionError("unsupported execution-admission schema version")
+
+    def append_admission(self, bundle: CertificationExecutionAdmissionBundleDTO) -> None:
+        gate = bundle.gate
+        encoded = (
+            json.dumps(asdict(gate), sort_keys=True, separators=(",", ":")),
+            json.dumps(asdict(bundle.preflight), sort_keys=True, separators=(",", ":")),
+            json.dumps(asdict(bundle.postflight), sort_keys=True, separators=(",", ":")),
+        )
+        row = self._connection.execute(
+            "SELECT gate_id, gate_json, preflight_json, postflight_json "
+            "FROM perception_execution_admissions WHERE certification_id=? OR attempt_id=?",
+            (gate.certification_id, gate.attempt_id),
+        ).fetchone()
+        if row is not None:
+            existing = (row["gate_json"], row["preflight_json"], row["postflight_json"])
+            if row["gate_id"] != gate.gate_id or existing != encoded:
+                raise PerceptionSqlAdmissionError(
+                    "certification or attempt already has a conflicting admission"
+                )
+            return
+        self._connection.execute(
+            "INSERT INTO perception_execution_admissions"
+            "(gate_id, certification_id, attempt_id, gate_json, preflight_json, postflight_json) "
+            "VALUES(?, ?, ?, ?, ?, ?)",
+            (gate.gate_id, gate.certification_id, gate.attempt_id, *encoded),
+        )
+        self._connection.commit()
+
+    def get_admission(self, gate_id: str) -> CertificationExecutionAdmissionBundleDTO | None:
+        row = self._connection.execute(
+            "SELECT gate_json, preflight_json, postflight_json "
+            "FROM perception_execution_admissions WHERE gate_id=?",
+            (gate_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return CertificationExecutionAdmissionBundleDTO(
+            gate=CertificationExecutionGateDTO(**json.loads(row["gate_json"])),
+            preflight=_decode_report(json.loads(row["preflight_json"])),
+            postflight=_decode_report(json.loads(row["postflight_json"])),
+        )
+
+    def list_admissions(self) -> tuple[CertificationExecutionAdmissionBundleDTO, ...]:
+        rows = self._connection.execute(
+            "SELECT gate_id FROM perception_execution_admissions ORDER BY gate_id"
+        ).fetchall()
+        return tuple(
+            item
+            for row in rows
+            if (item := self.get_admission(row["gate_id"])) is not None
+        )
+
+
+def execute_and_persist_certification_admission(
+    lifecycle_store: PerceptionModelLifecycleStore,
+    governance_store: SqlitePerceptionGovernanceLedgerStore,
+    attempt_store: SqliteGovernedExecutionAttemptStore,
+    certification_store: SqliteGovernanceCertificationStore,
+    admission_store: SqliteCertificationExecutionAdmissionStore,
+    recommendation: OperationalRecommendationDTO,
+    disposition: OperationalRecommendationDispositionDTO,
+    *,
+    current_contract: ModelCompatibilityContractDTO,
+    target_contract: ModelCompatibilityContractDTO,
+) -> tuple[
+    CertificationExecutionAdmissionBundleDTO,
+    GovernanceExecutionCertificationBundleDTO,
+    GovernedExecutionAttemptDTO,
+    GovernanceExecutionReceiptDTO,
+]:
+    gate, certification, attempt, receipt, postflight = (
+        execute_certification_gated_approved_rollback(
+            lifecycle_store,
+            governance_store,
+            attempt_store,
+            certification_store,
+            recommendation,
+            disposition,
+            current_contract=current_contract,
+            target_contract=target_contract,
+        )
+    )
+    preflight = CertificationIntegrityAuditReportDTO(
+        report_id=gate.preflight_report_id,
+        status="valid",
+        governance_audit_report_id=certification.pre_audit.report_id,
+        governance_audit_status=certification.pre_audit.status,
+        certification_count=max(postflight.certification_count - 1, 0),
+        successful_attempt_count=max(postflight.successful_attempt_count - 1, 0),
+        finding_count=0,
+        findings=(),
+    )
+    bundle = CertificationExecutionAdmissionBundleDTO(
+        gate=gate,
+        preflight=preflight,
+        postflight=postflight,
+    )
+    admission_store.append_admission(bundle)
+    restored = admission_store.get_admission(gate.gate_id)
+    if restored != bundle:
+        raise PerceptionSqlAdmissionError("persisted admission differs from completed gate bundle")
+    return bundle, certification, attempt, receipt

--- a/packages/perception/src/zeromodel/perception/sql_admission.py
+++ b/packages/perception/src/zeromodel/perception/sql_admission.py
@@ -11,6 +11,7 @@ from typing import Final
 from .certification_audit import (
     CertificationIntegrityAuditReportDTO,
     CertificationIntegrityFindingDTO,
+    audit_certification_integrity,
 )
 from .certification_gate import (
     CertificationExecutionGateDTO,
@@ -47,7 +48,9 @@ class CertificationExecutionAdmissionBundleDTO:
         if self.gate.postflight_report_id != self.postflight.report_id:
             raise PerceptionSqlAdmissionError("gate does not reference supplied postflight report")
         if self.preflight.status != "valid" or self.postflight.status != "valid":
-            raise PerceptionSqlAdmissionError("admission bundle requires valid preflight and postflight")
+            raise PerceptionSqlAdmissionError(
+                "admission bundle requires valid preflight and postflight"
+            )
 
 
 def _decode_report(payload: dict[str, object]) -> CertificationIntegrityAuditReportDTO:
@@ -105,7 +108,9 @@ class SqliteCertificationExecutionAdmissionStore:
             )
             self._connection.commit()
         elif row["value"] != SQL_ADMISSION_SCHEMA_VERSION:
-            raise PerceptionSqlAdmissionError("unsupported execution-admission schema version")
+            raise PerceptionSqlAdmissionError(
+                "unsupported execution-admission schema version"
+            )
 
     def append_admission(self, bundle: CertificationExecutionAdmissionBundleDTO) -> None:
         gate = bundle.gate
@@ -134,7 +139,9 @@ class SqliteCertificationExecutionAdmissionStore:
         )
         self._connection.commit()
 
-    def get_admission(self, gate_id: str) -> CertificationExecutionAdmissionBundleDTO | None:
+    def get_admission(
+        self, gate_id: str
+    ) -> CertificationExecutionAdmissionBundleDTO | None:
         row = self._connection.execute(
             "SELECT gate_json, preflight_json, postflight_json "
             "FROM perception_execution_admissions WHERE gate_id=?",
@@ -176,6 +183,12 @@ def execute_and_persist_certification_admission(
     GovernedExecutionAttemptDTO,
     GovernanceExecutionReceiptDTO,
 ]:
+    preflight = audit_certification_integrity(
+        lifecycle_store,
+        governance_store,
+        attempt_store,
+        certification_store,
+    )
     gate, certification, attempt, receipt, postflight = (
         execute_certification_gated_approved_rollback(
             lifecycle_store,
@@ -188,16 +201,10 @@ def execute_and_persist_certification_admission(
             target_contract=target_contract,
         )
     )
-    preflight = CertificationIntegrityAuditReportDTO(
-        report_id=gate.preflight_report_id,
-        status="valid",
-        governance_audit_report_id=certification.pre_audit.report_id,
-        governance_audit_status=certification.pre_audit.status,
-        certification_count=max(postflight.certification_count - 1, 0),
-        successful_attempt_count=max(postflight.successful_attempt_count - 1, 0),
-        finding_count=0,
-        findings=(),
-    )
+    if gate.preflight_report_id != preflight.report_id:
+        raise PerceptionSqlAdmissionError(
+            "execution gate preflight differs from persisted admission preflight"
+        )
     bundle = CertificationExecutionAdmissionBundleDTO(
         gate=gate,
         preflight=preflight,
@@ -206,5 +213,7 @@ def execute_and_persist_certification_admission(
     admission_store.append_admission(bundle)
     restored = admission_store.get_admission(gate.gate_id)
     if restored != bundle:
-        raise PerceptionSqlAdmissionError("persisted admission differs from completed gate bundle")
+        raise PerceptionSqlAdmissionError(
+            "persisted admission differs from completed gate bundle"
+        )
     return bundle, certification, attempt, receipt

--- a/packages/perception/tests/test_sql_admission_p17k.py
+++ b/packages/perception/tests/test_sql_admission_p17k.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from zeromodel.perception.certification_audit import CertificationIntegrityAuditReportDTO
+from zeromodel.perception.certification_gate import CertificationExecutionGateDTO
+from zeromodel.perception.sql_admission import (
+    CertificationExecutionAdmissionBundleDTO,
+    PerceptionSqlAdmissionError,
+    SqliteCertificationExecutionAdmissionStore,
+)
+
+
+def _report(identity: str, *, certifications: int) -> CertificationIntegrityAuditReportDTO:
+    return CertificationIntegrityAuditReportDTO(
+        report_id=identity,
+        status="valid",
+        governance_audit_report_id=f"{identity}:governance",
+        governance_audit_status="valid",
+        certification_count=certifications,
+        successful_attempt_count=certifications,
+        finding_count=0,
+        findings=(),
+    )
+
+
+def _bundle() -> CertificationExecutionAdmissionBundleDTO:
+    preflight = _report("sha256:preflight", certifications=0)
+    postflight = _report("sha256:postflight", certifications=1)
+    gate = CertificationExecutionGateDTO(
+        gate_id="sha256:gate",
+        certification_id="sha256:certification",
+        attempt_id="sha256:attempt",
+        receipt_id="sha256:receipt",
+        preflight_report_id=preflight.report_id,
+        postflight_report_id=postflight.report_id,
+        resulting_pointer_revision=3,
+    )
+    return CertificationExecutionAdmissionBundleDTO(
+        gate=gate,
+        preflight=preflight,
+        postflight=postflight,
+    )
+
+
+def test_admission_survives_restart_and_exact_reappend_is_idempotent(tmp_path) -> None:
+    database = tmp_path / "admission.sqlite3"
+    bundle = _bundle()
+    with SqliteCertificationExecutionAdmissionStore(database) as store:
+        store.append_admission(bundle)
+        store.append_admission(bundle)
+
+    with SqliteCertificationExecutionAdmissionStore(database) as reopened:
+        assert reopened.get_admission(bundle.gate.gate_id) == bundle
+        assert reopened.list_admissions() == (bundle,)
+
+
+def test_conflicting_admission_for_same_attempt_is_rejected(tmp_path) -> None:
+    bundle = _bundle()
+    conflicting = replace(
+        bundle,
+        gate=replace(bundle.gate, gate_id="sha256:other-gate"),
+    )
+    with SqliteCertificationExecutionAdmissionStore(
+        tmp_path / "admission.sqlite3"
+    ) as store:
+        store.append_admission(bundle)
+        with pytest.raises(PerceptionSqlAdmissionError, match="conflicting admission"):
+            store.append_admission(conflicting)
+
+
+def test_bundle_requires_exact_valid_preflight_and_postflight() -> None:
+    bundle = _bundle()
+    with pytest.raises(PerceptionSqlAdmissionError, match="preflight report"):
+        replace(bundle, preflight=replace(bundle.preflight, report_id="sha256:wrong"))
+    with pytest.raises(PerceptionSqlAdmissionError, match="valid preflight"):
+        replace(bundle, postflight=replace(bundle.postflight, status="attention_required"))

--- a/packages/perception/tests/test_sql_admission_public_api_p17k.py
+++ b/packages/perception/tests/test_sql_admission_public_api_p17k.py
@@ -1,0 +1,17 @@
+from zeromodel.perception.sql_admission import (
+    SQL_ADMISSION_SCHEMA_VERSION,
+    SQL_ADMISSION_STORE_VERSION,
+    CertificationExecutionAdmissionBundleDTO,
+    PerceptionSqlAdmissionError,
+    SqliteCertificationExecutionAdmissionStore,
+    execute_and_persist_certification_admission,
+)
+
+
+def test_p17k_public_module_contract() -> None:
+    assert SQL_ADMISSION_SCHEMA_VERSION == "perception-sql-admission-schema/1"
+    assert SQL_ADMISSION_STORE_VERSION == "perception-sql-admission-store/1"
+    assert CertificationExecutionAdmissionBundleDTO is not None
+    assert PerceptionSqlAdmissionError is not None
+    assert SqliteCertificationExecutionAdmissionStore is not None
+    assert callable(execute_and_persist_certification_admission)


### PR DESCRIPTION
## Summary

Implements P17K: durable, append-only persistence for the complete P17J execution-admission proof.

## Evidence chain

```text
P17I exact valid preflight
    ↓
P17J certification-aware governed execution
    ↓
P17I exact valid postflight
    ↓
CertificationExecutionAdmissionBundleDTO
    ↓
SqliteCertificationExecutionAdmissionStore
```

## Why this is necessary

P17J returns a content-addressed execution gate, but that final admission and postcondition proof is otherwise process-local. P17K persists the gate together with the exact P17I reports surrounding it.

## Invariants

- the gate must reference the supplied preflight and postflight reports;
- both reports must be `valid`;
- one immutable admission is allowed per certification and deterministic attempt;
- exact duplicate appends are idempotent;
- conflicting admissions are rejected;
- the complete nested bundle is reconstructable after restart.

## Execution entry point

`execute_and_persist_certification_admission(...)` captures the real P17I preflight before delegation, executes through P17J, proves the returned gate references that exact preflight, persists the bundle, restores it, and verifies exact equality.

## Authority boundary

The admission store records evidence only. It cannot mutate lifecycle state, approve recommendations, create execution receipts, or replace governance, attempt, or certification authorities.

## Validation

Tests cover restart restoration, exact idempotency, conflicting admission rejection, exact report identity, valid-report requirements, and the public `sql_admission` module contract.

Audit-Exempt: adds internal durable execution-admission evidence; no public evidence-status claim changed.

The complete suite was not executed locally through the connector. GitHub Actions remains authoritative; no green result is claimed until it completes.