### PR TITLE
fix(inventory): support direct file imports

### DIFF
--- a/scripts/analyze_package_inventory.py
+++ b/scripts/analyze_package_inventory.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
-try:
-    from . import _analyze_package_inventory_impl as _implementation
-    from ._analyze_package_inventory_impl import *  # noqa: F401,F403
-except ImportError:  # pragma: no cover - direct script execution
-    import _analyze_package_inventory_impl as _implementation
-    from _analyze_package_inventory_impl import *  # type: ignore[no-redef]  # noqa: F401,F403
+import importlib.util
+import sys
+from pathlib import Path
+
+_IMPLEMENTATION_NAME = "_zeromodel_analyze_package_inventory_impl"
+_IMPLEMENTATION_PATH = Path(__file__).with_name("_analyze_package_inventory_impl.py")
+_IMPLEMENTATION_SPEC = importlib.util.spec_from_file_location(
+    _IMPLEMENTATION_NAME,
+    _IMPLEMENTATION_PATH,
+)
+if _IMPLEMENTATION_SPEC is None or _IMPLEMENTATION_SPEC.loader is None:
+    raise ImportError(f"cannot load inventory implementation from {_IMPLEMENTATION_PATH}")
+
+_implementation = importlib.util.module_from_spec(_IMPLEMENTATION_SPEC)
+sys.modules[_IMPLEMENTATION_NAME] = _implementation
+_IMPLEMENTATION_SPEC.loader.exec_module(_implementation)
+
+for _name in dir(_implementation):
+    if not _name.startswith("_"):
+        globals()[_name] = getattr(_implementation, _name)
 
 CLASSIFICATIONS.add("perception")
 

--- a/tests/test_analyze_package_inventory.py
+++ b/tests/test_analyze_package_inventory.py
@@ -19,6 +19,7 @@ PRODUCTION_PACKAGE_KEYS = {
     "analysis",
     "observation",
     "vision",
+    "perception",
     "video",
     "sqlalchemy",
     "artifacts",
@@ -47,7 +48,7 @@ def test_inventory_rows_cover_unique_modules_and_allowed_classifications() -> No
     )
 
 
-def test_all_nine_production_source_roots_are_discovered() -> None:
+def test_all_ten_production_source_roots_are_discovered() -> None:
     """No production package may be silently omitted from discovery: every
     key configured in package-boundaries.toml must contribute at least one
     classified row."""
@@ -57,7 +58,7 @@ def test_all_nine_production_source_roots_are_discovered() -> None:
     assert discovered == PRODUCTION_PACKAGE_KEYS
 
 
-def test_all_nine_package_test_roots_are_discovered() -> None:
+def test_all_ten_package_test_roots_are_discovered() -> None:
     boundaries = inventory.load_package_boundaries()
     data = inventory.make_inventory("2026-01-01T00:00:00Z")
     paths = {row["path"] for row in data["rows"]}


### PR DESCRIPTION
## Summary

Fixes `tests/test_analyze_package_inventory.py` collection when the inventory script is loaded directly with `importlib.util.spec_from_file_location`.

## Root cause

`scripts/analyze_package_inventory.py` was split into a wrapper and implementation module. The wrapper first attempted a package-relative import, then a top-level import. Under direct file loading, neither a package context nor the `scripts/` directory was available on `sys.path`, so collection failed before any tests ran.

## Changes

- loads `_analyze_package_inventory_impl.py` explicitly from the wrapper's sibling path;
- registers the implementation module before execution so dataclass/module metadata remains stable;
- re-exports the implementation's public names;
- keeps direct CLI execution working;
- adds `perception` to the inventory test's production package authority;
- renames the stale nine-package test descriptions to ten-package descriptions.

## Reproduction

The reported failure was:

```text
ImportError: attempted relative import with no known parent package
ModuleNotFoundError: No module named '_analyze_package_inventory_impl'
```

## Scope

This PR addresses only the first local collection failure. Subsequent failures should be handled separately after this test collects and runs.

Audit-Exempt: fixes internal test/tool loading and package inventory metadata; no public evidence-status claim changed.

GitHub Actions remains authoritative. No green result is claimed until completion.