### PR TITLE
fix(inventory): satisfy Ruff static analysis

### DIFF
--- a/scripts/analyze_package_inventory.py
+++ b/scripts/analyze_package_inventory.py
@@ -23,7 +23,7 @@ for _name in dir(_implementation):
     if not _name.startswith("_"):
         globals()[_name] = getattr(_implementation, _name)
 
-CLASSIFICATIONS.add("perception")
+_implementation.CLASSIFICATIONS.add("perception")
 
 if __name__ == "__main__":
     _implementation.main()


### PR DESCRIPTION
## Summary

Fixes the new Ruff offender introduced by the inventory compatibility wrapper.

## Root cause

The wrapper re-exported implementation symbols dynamically through `globals()`, then referenced `CLASSIFICATIONS` as a bare name. Runtime behavior was valid, but Ruff correctly reported the name as statically undefined because dynamic global injection is not analyzable.

## Change

Replace:

```python
CLASSIFICATIONS.add("perception")
```

with:

```python
_implementation.CLASSIFICATIONS.add("perception")
```

This keeps the shared set mutation identical while making the dependency explicit and statically valid.

## Scope

This PR addresses only the reported `test_ruff_scope_claims.py` failure. The script is not added to the known-offender exemption.

Audit-Exempt: fixes internal tooling lint compliance; no public evidence-status claim changed.

GitHub Actions remains authoritative. No green result is claimed until completion.