### PR TITLE
fix(release): preserve validator private surface

### DIFF
--- a/scripts/validate_release_candidate.py
+++ b/scripts/validate_release_candidate.py
@@ -2,9 +2,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts._validate_release_candidate_impl import *  # noqa: F403
+_IMPLEMENTATION_PATH = Path(__file__).with_name("_validate_release_candidate_impl.py")
+_ORIGINAL_MODULE_NAME = __name__
 
-PACKAGES["perception"] = {  # noqa: F405
+globals()["__name__"] = "_zeromodel_validate_release_candidate_impl"
+try:
+    exec(
+        compile(
+            _IMPLEMENTATION_PATH.read_text(encoding="utf-8"),
+            str(_IMPLEMENTATION_PATH),
+            "exec",
+        ),
+        globals(),
+        globals(),
+    )
+finally:
+    globals()["__name__"] = _ORIGINAL_MODULE_NAME
+
+_VERSION = globals()["VERSION"]
+globals()["PACKAGES"]["perception"] = {
     "path": Path("packages/perception"),
     "distribution": "zeromodel-perception",
     "wheel_stem": "zeromodel_perception",
@@ -12,12 +28,11 @@ PACKAGES["perception"] = {  # noqa: F405
     "requires": {
         "numpy>=1.23",
         "pillow>=9.0",
-        f"zeromodel=={VERSION}",  # noqa: F405
-        f"zeromodel-observation=={VERSION}",  # noqa: F405
+        f"zeromodel=={_VERSION}",
+        f"zeromodel-observation=={_VERSION}",
     },
     "depends_on": ("core", "observation"),
 }
 
-
-if __name__ == "__main__":
-    main()  # noqa: F405
+if _ORIGINAL_MODULE_NAME == "__main__":
+    raise SystemExit(globals()["main"]())


### PR DESCRIPTION
## Summary

Restores the complete module surface of `scripts/validate_release_candidate.py` after the implementation was split into a compatibility wrapper.

## Root cause

The wrapper used `from ... import *`, which intentionally excludes underscore-prefixed names. Repository tests directly exercise and monkeypatch private helpers such as `_pytest_count`, so the wrapper no longer behaved like the original single module.

Simply copying private function objects from the implementation module would still be insufficient because their globals would remain bound to that separate module. Monkeypatches applied to the wrapper would not be observed by release-report functions.

## Change

- executes the preserved implementation source inside the wrapper module namespace;
- temporarily changes `__name__` so the implementation's CLI block does not run during loading;
- restores the wrapper's original module name afterward;
- preserves all public and private functions, constants, classes, and mutable globals;
- adds the perception package to the restored shared `PACKAGES` authority;
- invokes `main()` only when the wrapper itself is executed as a script.

## Reported failure

```text
AttributeError: module 'validate_release_candidate' has no attribute '_pytest_count'
```

## Scope

This PR addresses this compatibility failure only. Further test failures should be handled from the next complete local run.

Audit-Exempt: fixes internal release tooling compatibility; no public evidence-status claim changed.

GitHub Actions remains authoritative. No green result is claimed until completion.