### PR TITLE
fix(tests): repair validator loading and benchmark isolation

### DIFF
--- a/scripts/validate_release_candidate.py
+++ b/scripts/validate_release_candidate.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 _IMPLEMENTATION_PATH = Path(__file__).with_name("_validate_release_candidate_impl.py")
 _ORIGINAL_MODULE_NAME = __name__
+_IMPLEMENTATION_MODULE_NAME = "_zeromodel_validate_release_candidate_impl"
 
-globals()["__name__"] = "_zeromodel_validate_release_candidate_impl"
+_CURRENT_MODULE = sys.modules[_ORIGINAL_MODULE_NAME]
+sys.modules[_IMPLEMENTATION_MODULE_NAME] = _CURRENT_MODULE
+globals()["__name__"] = _IMPLEMENTATION_MODULE_NAME
 try:
     exec(
         compile(
@@ -18,6 +22,7 @@ try:
     )
 finally:
     globals()["__name__"] = _ORIGINAL_MODULE_NAME
+    sys.modules.pop(_IMPLEMENTATION_MODULE_NAME, None)
 
 _VERSION = globals()["VERSION"]
 globals()["PACKAGES"]["perception"] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,45 @@ def cache_stage6_materialization_plans(request: pytest.FixtureRequest):
         benchmark._episode_plans_for_split = original
 
 
+@pytest.fixture(autouse=True)
+def isolate_video_action_set_manifest_test(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Keep the manifest unit test outside the durable SQL ownership boundary."""
+    if request.node.name != "test_build_split_writes_overlap_and_observation_manifests":
+        yield
+        return
+
+    import research.benchmarks.video_action_set_benchmark as benchmark
+
+    stored_records: list[dict[str, Any]] = []
+
+    class FakeVideoActionSetRuntime:
+        def load_identity(self, repo_root: Any) -> Any:
+            return benchmark.load_identity(repo_root)
+
+        def save_episode_plans(self, plans: Any) -> Any:
+            return plans
+
+        def save_observation_records(self, records: Any) -> Any:
+            stored_records[:] = list(records)
+            return tuple(records)
+
+        def list_observation_records(self, **_kwargs: Any) -> tuple[dict[str, Any], ...]:
+            return tuple(stored_records)
+
+    class FakeRuntime:
+        video_action_set = FakeVideoActionSetRuntime()
+
+    monkeypatch.setattr(
+        benchmark._build_orchestration,
+        "_build_durable_runtime",
+        lambda _output_dir: FakeRuntime(),
+    )
+    yield
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("zeromodel test tiers")
     group.addoption(


### PR DESCRIPTION
## Summary

Repairs the two failures reported after PR #119.

## Release-validator dataclass failure

The compatibility wrapper temporarily changed `__name__` before executing the preserved implementation. Dataclasses record that temporary module name and look it up in `sys.modules` while processing annotations. Because the temporary name was not registered, collection failed with:

```text
AttributeError: 'NoneType' object has no attribute '__dict__'
```

The wrapper now registers the current module under the temporary implementation name for the duration of execution, then removes the alias and restores the original name. This preserves the complete private/public surface and monkeypatch semantics while making dataclass construction valid.

## Benchmark manifest test failure

`test_build_split_writes_overlap_and_observation_manifests` is an orchestration/manifest unit test using deliberately synthetic observation identities. It accidentally entered the durable SQL store, where the ownership invariant correctly rejected the invented benchmark seed and episode-plan identities.

The test is now isolated with a small in-memory runtime double that implements only the methods required by `build_split`:

- load benchmark identity;
- accept generated episode plans;
- save synthetic observation records;
- list those records for manifest generation.

The SQL store invariant is unchanged and remains covered by its dedicated integration tests.

## Focused verification

```powershell
pytest tests/test_release_report_test_layers.py -q
pytest tests/test_video_action_set_benchmark.py::test_build_split_writes_overlap_and_observation_manifests -q
```

Then rerun the broader suite.

Audit-Exempt: fixes internal test and release-tool compatibility; no public evidence-status claim changed.

GitHub Actions is authoritative. No green result is claimed until completion.