### PR TITLE
fix(tests): prevent action-set monkeypatch leakage

### DIFF
--- a/docs/reviews/action-set-test-isolation-note.md
+++ b/docs/reviews/action-set-test-isolation-note.md
@@ -1,0 +1,9 @@
+# Action-set test isolation note
+
+This stabilization change does not alter action-set production behavior.
+
+The research instrument test patches the legacy benchmark facade with synthetic materialization and provider functions. Those patches must be scoped with `pytest.MonkeyPatch.context()` so they are restored even when an intermediate build or verification step raises.
+
+Without exception-safe cleanup, later family-semantics and reference-verification tests observe the synthetic one-record universe and fail with misleading symptoms such as missing splice/control/temporal rows, absent provider mutation targets, and leaked lambda aliases.
+
+The production materialization, family validation, reference verification, DTO, and SQL ownership contracts remain unchanged.

--- a/tests/test_video_action_set_instrument.py
+++ b/tests/test_video_action_set_instrument.py
@@ -59,10 +59,12 @@ def _fake_provider_rows() -> list[dict[str, object]]:
     ]
 
 
-def test_instrument_audits_and_verification(tmp_path: Path) -> None:
+def test_instrument_audits_and_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     benchmark.freeze_benchmark(tmp_path, REPO_ROOT)
     fake_provider_rows = _fake_provider_rows()
-    monkeypatch = pytest.MonkeyPatch()
     fake_records = [
         {
             "split": "development",
@@ -97,47 +99,50 @@ def test_instrument_audits_and_verification(tmp_path: Path) -> None:
         {**record, "split": "selection", "frame_id": "selection:episode-001:frame-00"}
         for record in fake_records
     ]
-    monkeypatch.setattr(
-        benchmark,
-        "_materialize_records",
-        lambda split, repo_root: {
-            "development": fake_records,
-            "calibration": fake_records_calibration,
-            "selection": fake_records_selection,
-        }[split],
-    )
-    monkeypatch.setattr(
-        benchmark,
-        "measure_record_collection",
-        lambda records, prototypes, policy_artifact_id, **_kwargs: fake_provider_rows,
-    )
-    monkeypatch.setattr(benchmark, "canonical_prototypes", lambda: {})
-    benchmark.build_split("development", tmp_path, REPO_ROOT)
-    benchmark.build_split("calibration", tmp_path, REPO_ROOT)
-    benchmark.build_split("selection", tmp_path, REPO_ROOT)
-    monkeypatch.undo()
+
+    with monkeypatch.context() as build_patch:
+        build_patch.setattr(
+            benchmark,
+            "_materialize_records",
+            lambda split, repo_root: {
+                "development": fake_records,
+                "calibration": fake_records_calibration,
+                "selection": fake_records_selection,
+            }[split],
+        )
+        build_patch.setattr(
+            benchmark,
+            "measure_record_collection",
+            lambda records, prototypes, policy_artifact_id, **_kwargs: fake_provider_rows,
+        )
+        build_patch.setattr(benchmark, "canonical_prototypes", lambda: {})
+        benchmark.build_split("development", tmp_path, REPO_ROOT)
+        benchmark.build_split("calibration", tmp_path, REPO_ROOT)
+        benchmark.build_split("selection", tmp_path, REPO_ROOT)
+
     evidence = benchmark.audit_evidence_completeness(tmp_path)
-    monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(
-        benchmark,
-        "audit_canonical_providers",
-        lambda output_dir: {
-            "P1": {"exact_top1_count": 112},
-            "P2": {"exact_top1_count": 112},
-            "P3": {"exact_top1_count": 112},
-        },
-    )
-    monkeypatch.setattr(
-        benchmark,
-        "verify_instrument",
-        lambda output_dir, repo_root: {
-            "verified": True,
-            "final_materialization_count": 0,
-        },
-    )
-    canonical = benchmark.audit_canonical_providers(tmp_path)
-    verification = benchmark.verify_instrument(tmp_path, REPO_ROOT)
-    monkeypatch.undo()
+
+    with monkeypatch.context() as audit_patch:
+        audit_patch.setattr(
+            benchmark,
+            "audit_canonical_providers",
+            lambda output_dir: {
+                "P1": {"exact_top1_count": 112},
+                "P2": {"exact_top1_count": 112},
+                "P3": {"exact_top1_count": 112},
+            },
+        )
+        audit_patch.setattr(
+            benchmark,
+            "verify_instrument",
+            lambda output_dir, repo_root: {
+                "verified": True,
+                "final_materialization_count": 0,
+            },
+        )
+        canonical = benchmark.audit_canonical_providers(tmp_path)
+        verification = benchmark.verify_instrument(tmp_path, REPO_ROOT)
+
     assert evidence["complete_score_evidence"] is True
     assert canonical["P3"]["exact_top1_count"] == 112
     assert verification["verified"] is True


### PR DESCRIPTION
## Summary

Fixes a cross-test contamination bug in `test_video_action_set_instrument.py` that caused a large cluster of misleading family-semantics and reference-verification failures.

## Root cause

The instrument test created manual `pytest.MonkeyPatch()` objects and called `undo()` only after several build and verification operations. If any intermediate call raised, the patched benchmark facade remained globally mutated for the rest of the test session.

The leaked patches replaced the real action-set universe with a synthetic one-record dataset and lambda providers. Later tests then failed with symptoms including:

- zero conflicting-splice records instead of 112;
- missing stale/impossible/control records and `StopIteration`;
- mutation fixtures unable to find provider or frame rows;
- missing `executed_action` and `final` plan entries;
- the observation-universe compatibility alias resolving to the instrument test lambda.

## Change

- use the pytest-managed `monkeypatch` fixture;
- scope build-time patches with `monkeypatch.context()`;
- scope audit/verification patches with a separate `monkeypatch.context()`;
- guarantee restoration even when build, audit, or verification raises;
- document the test isolation boundary.

## Production impact

None. Materialization, family validation, reference verification, DTO validation, and SQL ownership behavior are unchanged.

## Focused verification

```powershell
pytest tests/test_video_action_set_instrument.py -q
pytest tests/test_video_action_set_family_semantics.py -q
pytest tests/test_video_action_set_reference_verification.py -q
pytest tests/test_video_observation_universe_kernel.py -q
```

Then rerun the complete suite from current `main` plus this branch.

Audit-Exempt: fixes internal research-test isolation; no public evidence-status claim changed.

GitHub Actions is authoritative. No green result is claimed until completion.