### PR TITLE
feat(perception): add P18B annotated transition conformance

### DIFF
--- a/packages/perception/docs/p18-roadmap.md
+++ b/packages/perception/docs/p18-roadmap.md
@@ -2,17 +2,17 @@
 
 P18 returns the perception package to its visual research spine after the P17 governance sequence.
 
-## P18A — Observed transition evidence
+## P18A — Observed transition evidence — complete
 
 Materialize a deterministic fieldwise VPM describing what changed between an exact source observation and its exact result observation. Optional region annotations bind known object identities to the measurements without changing them.
 
-## P18B — Annotated transition conformance
+## P18B — Annotated transition conformance — current
 
-Declare expected state changes for marked objects, relations, and control regions, then compare those declarations with P18A measurements. Findings must preserve missing, unexpected, excessive, insufficient, and directionally wrong changes rather than collapsing them into one boolean.
+Declare expected state changes for marked objects, relations, and control regions, then compare those declarations with immutable P18A measurements. Findings preserve confirmed, missing, unexpected, excessive, insufficient, directionally wrong, inconclusive, and unexplained changes rather than collapsing them into one boolean.
 
-## P18C — Unexplained recurrent transition discovery
+## P18C — Unexplained recurrent transition discovery — next
 
-Aggregate transition evidence across interactions to identify unmarked fields or relations that repeatedly change with a result. This stage should generate candidate missing components and test hypotheses, not causal conclusions.
+Aggregate transition evidence and conformance findings across interactions to identify unmarked fields or relations that repeatedly change with a result. This stage should generate candidate missing components and test hypotheses, not causal conclusions.
 
 ## Boundary
 

--- a/packages/perception/docs/stage-p18b-annotated-transition-conformance.md
+++ b/packages/perception/docs/stage-p18b-annotated-transition-conformance.md
@@ -1,0 +1,73 @@
+# Stage P18B — Annotated Transition Conformance
+
+## Objective
+
+Compare declared state-change expectations for marked objects, relations, and control regions with one immutable P18A transition artifact.
+
+```text
+P18A TransitionEvidenceVPMDTO
+    +
+PerceptionRegionAnnotationDTO / RelationAnnotationDTO
+    +
+TransitionExpectationDTO
+    ↓
+TransitionConformanceReportDTO
+```
+
+P18B does not recalculate or rewrite the P18A measurements. It resolves each declaration to exact field identities and evaluates the weighted field evidence already present in the transition artifact.
+
+## Declarations
+
+A `TransitionExpectationDTO` targets one or more annotation or relation identities and declares one of four behaviours:
+
+- `stable` — change must remain within maximum tolerances;
+- `change` — non-directional change must satisfy minimum and maximum tolerances;
+- `increase` — change must satisfy the magnitude thresholds and have positive signed direction;
+- `decrease` — change must satisfy the magnitude thresholds and have negative signed direction.
+
+Thresholds cover:
+
+- mean absolute change;
+- changed-value fraction;
+- signed change magnitude for directional expectations.
+
+## Findings
+
+P18B preserves distinct outcomes rather than reducing the test to one boolean:
+
+- `confirmed`;
+- `missing_expected_change`;
+- `unexpected_change`;
+- `excessive_change`;
+- `insufficient_change`;
+- `wrong_change_direction`;
+- `inconclusive`;
+- `unexplained_change`.
+
+Report status is:
+
+- `conformant` when all declarations are confirmed and no unexplained fields qualify;
+- `attention_required` for inconclusive or unexplained evidence without a declared failure;
+- `nonconformant` when a declared expectation fails.
+
+## Relation fields
+
+A relation expectation uses `derived_field_ids` when they are declared. Otherwise it resolves to the union of its member annotation fields. This keeps relation testing explicit and addressable without inventing a second spatial representation.
+
+## Integrity boundary
+
+P18B verifies that:
+
+- supplied annotation identities exactly match the P18A artifact;
+- each annotation's field bindings exactly match the bindings persisted by P18A;
+- expectations and annotations use the same field schema as the transition;
+- relation members and derived fields exist;
+- identities, thresholds, findings, report status, and unexplained-evidence thresholds are content-addressed.
+
+## Non-claims
+
+A confirmed expectation means only that the declared visual transition matched the measured transition under the chosen thresholds. It does not prove that the marked object caused the action or result.
+
+## Next stage
+
+P18C aggregates P18A and P18B evidence across interactions to identify recurrent, unmarked transition fields and propose candidate missing components for testing. It must preserve recurrence and association as evidence without converting them into causal conclusions.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -1,4 +1,4 @@
-"""ZeroModel perception public API through Stage P18A."""
+"""ZeroModel perception public API through Stage P18B."""
 
 from __future__ import annotations
 
@@ -51,6 +51,20 @@ from .sql_certification import (  # noqa: F401
     build_governance_execution_certification,
     execute_and_certify_audit_gated_rollback,
 )
+from .transition_conformance import (  # noqa: F401
+    TRANSITION_CONFORMANCE_FINDING_VERSION,
+    TRANSITION_CONFORMANCE_REPORT_STATUSES,
+    TRANSITION_CONFORMANCE_REPORT_VERSION,
+    TRANSITION_CONFORMANCE_SEMANTICS,
+    TRANSITION_CONFORMANCE_STATUSES,
+    TRANSITION_EXPECTATION_VERSION,
+    TRANSITION_EXPECTED_CHANGE_KINDS,
+    PerceptionTransitionConformanceError,
+    TransitionConformanceFindingDTO,
+    TransitionConformanceReportDTO,
+    TransitionExpectationDTO,
+    evaluate_transition_conformance,
+)
 from .transition_evidence import (  # noqa: F401
     TRANSITION_CHANGED_FRACTION_SEMANTICS,
     TRANSITION_CHANGE_SEMANTICS,
@@ -65,7 +79,7 @@ from .transition_evidence import (  # noqa: F401
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P18A"
+PERCEPTION_STAGE = "P18B"
 
 __all__ = [
     name

--- a/packages/perception/src/zeromodel/perception/transition_conformance.py
+++ b/packages/perception/src/zeromodel/perception/transition_conformance.py
@@ -1,0 +1,621 @@
+"""Annotation-aware transition conformance for Stage P18B.
+
+P18B compares declarations about marked objects, relations, and stable controls
+with one immutable P18A transition artifact. Findings are deterministic tests of
+the declarations, not causal conclusions and not edits to the observed evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Final, Mapping
+
+from .expectations import PerceptionRegionAnnotationDTO, RelationAnnotationDTO
+from .transition_evidence import TransitionEvidenceVPMDTO, TransitionFieldEvidenceDTO
+
+TRANSITION_EXPECTATION_VERSION: Final = "perception-transition-expectation/1"
+TRANSITION_CONFORMANCE_FINDING_VERSION: Final = (
+    "perception-transition-conformance-finding/1"
+)
+TRANSITION_CONFORMANCE_REPORT_VERSION: Final = (
+    "perception-transition-conformance-report/1"
+)
+TRANSITION_CONFORMANCE_SEMANTICS: Final = (
+    "weighted_field_transition_measurements_compared_with_declared_annotation_or_relation_thresholds"
+)
+TRANSITION_EXPECTED_CHANGE_KINDS: Final = {
+    "stable",
+    "change",
+    "increase",
+    "decrease",
+}
+TRANSITION_CONFORMANCE_STATUSES: Final = {
+    "confirmed",
+    "missing_expected_change",
+    "unexpected_change",
+    "excessive_change",
+    "insufficient_change",
+    "wrong_change_direction",
+    "unexplained_change",
+    "inconclusive",
+}
+TRANSITION_CONFORMANCE_REPORT_STATUSES: Final = {
+    "conformant",
+    "attention_required",
+    "nonconformant",
+}
+_NONCONFORMANT: Final = {
+    "missing_expected_change",
+    "unexpected_change",
+    "excessive_change",
+    "insufficient_change",
+    "wrong_change_direction",
+}
+_ATTENTION: Final = {"unexplained_change", "inconclusive"}
+
+
+class PerceptionTransitionConformanceError(ValueError):
+    """Raised when transition-conformance contracts are invalid."""
+
+
+def _json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    value = _json(payload)
+    hasher = hashlib.sha256()
+    hasher.update(len(value).to_bytes(8, "big"))
+    hasher.update(value)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def _payload(value: object, identity_field: str) -> dict[str, object]:
+    payload = asdict(value)  # type: ignore[arg-type]
+    payload.pop(identity_field)
+    return payload
+
+
+def _unit(name: str, value: float) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise PerceptionTransitionConformanceError(f"{name} must be in [0, 1]")
+
+
+def _ordered(name: str, values: tuple[str, ...]) -> None:
+    if values != tuple(sorted(set(values))):
+        raise PerceptionTransitionConformanceError(f"{name} must be unique and sorted")
+
+
+@dataclass(frozen=True)
+class TransitionExpectationDTO:
+    """Declared transition behaviour for annotation or relation identities."""
+
+    expectation_id: str
+    field_schema_id: str
+    annotation_ids: tuple[str, ...]
+    relation_ids: tuple[str, ...]
+    expected_change: str
+    minimum_mean_absolute_change: float = 0.0
+    maximum_mean_absolute_change: float = 1.0
+    minimum_changed_fraction: float = 0.0
+    maximum_changed_fraction: float = 1.0
+    minimum_signed_change_magnitude: float = 0.0
+    version: str = TRANSITION_EXPECTATION_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.expectation_id or not self.field_schema_id:
+            raise PerceptionTransitionConformanceError(
+                "transition expectation identities must be non-empty"
+            )
+        if not self.annotation_ids and not self.relation_ids:
+            raise PerceptionTransitionConformanceError(
+                "transition expectation requires annotations or relations"
+            )
+        _ordered("annotation_ids", self.annotation_ids)
+        _ordered("relation_ids", self.relation_ids)
+        if self.expected_change not in TRANSITION_EXPECTED_CHANGE_KINDS:
+            raise PerceptionTransitionConformanceError(
+                f"unsupported expected_change: {self.expected_change}"
+            )
+        for name in (
+            "minimum_mean_absolute_change",
+            "maximum_mean_absolute_change",
+            "minimum_changed_fraction",
+            "maximum_changed_fraction",
+            "minimum_signed_change_magnitude",
+        ):
+            _unit(name, getattr(self, name))
+        if self.minimum_mean_absolute_change > self.maximum_mean_absolute_change:
+            raise PerceptionTransitionConformanceError(
+                "minimum_mean_absolute_change exceeds maximum"
+            )
+        if self.minimum_changed_fraction > self.maximum_changed_fraction:
+            raise PerceptionTransitionConformanceError(
+                "minimum_changed_fraction exceeds maximum"
+            )
+        if (
+            self.expected_change not in {"increase", "decrease"}
+            and self.minimum_signed_change_magnitude != 0.0
+        ):
+            raise PerceptionTransitionConformanceError(
+                "minimum_signed_change_magnitude requires increase or decrease"
+            )
+        if self.expected_change == "stable" and (
+            self.minimum_mean_absolute_change != 0.0
+            or self.minimum_changed_fraction != 0.0
+        ):
+            raise PerceptionTransitionConformanceError(
+                "stable expectations use maximum tolerances"
+            )
+        if self.version != TRANSITION_EXPECTATION_VERSION:
+            raise PerceptionTransitionConformanceError(
+                "unsupported transition expectation version"
+            )
+        if self.expectation_id != _digest(_payload(self, "expectation_id")):
+            raise PerceptionTransitionConformanceError(
+                "transition expectation identity disagrees with canonical payload"
+            )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        field_schema_id: str,
+        annotation_ids: tuple[str, ...] = (),
+        relation_ids: tuple[str, ...] = (),
+        expected_change: str,
+        minimum_mean_absolute_change: float = 0.0,
+        maximum_mean_absolute_change: float = 1.0,
+        minimum_changed_fraction: float = 0.0,
+        maximum_changed_fraction: float = 1.0,
+        minimum_signed_change_magnitude: float = 0.0,
+    ) -> "TransitionExpectationDTO":
+        values: dict[str, object] = {
+            "field_schema_id": field_schema_id,
+            "annotation_ids": tuple(sorted(set(annotation_ids))),
+            "relation_ids": tuple(sorted(set(relation_ids))),
+            "expected_change": expected_change,
+            "minimum_mean_absolute_change": minimum_mean_absolute_change,
+            "maximum_mean_absolute_change": maximum_mean_absolute_change,
+            "minimum_changed_fraction": minimum_changed_fraction,
+            "maximum_changed_fraction": maximum_changed_fraction,
+            "minimum_signed_change_magnitude": minimum_signed_change_magnitude,
+            "version": TRANSITION_EXPECTATION_VERSION,
+        }
+        return cls(expectation_id=_digest(values), **values)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class TransitionConformanceFindingDTO:
+    finding_id: str
+    status: str
+    expectation_id: str | None
+    annotation_ids: tuple[str, ...]
+    relation_ids: tuple[str, ...]
+    field_ids: tuple[str, ...]
+    observed_mean_absolute_change: float
+    observed_mean_signed_change: float
+    observed_changed_fraction: float
+    detail: str
+    version: str = TRANSITION_CONFORMANCE_FINDING_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.finding_id or not self.detail:
+            raise PerceptionTransitionConformanceError(
+                "transition finding identity and detail must be non-empty"
+            )
+        if self.status not in TRANSITION_CONFORMANCE_STATUSES:
+            raise PerceptionTransitionConformanceError(
+                f"unsupported transition finding status: {self.status}"
+            )
+        for name in ("annotation_ids", "relation_ids", "field_ids"):
+            _ordered(name, getattr(self, name))
+        if not self.field_ids:
+            raise PerceptionTransitionConformanceError(
+                "transition finding requires at least one field"
+            )
+        _unit("observed_mean_absolute_change", self.observed_mean_absolute_change)
+        _unit("observed_changed_fraction", self.observed_changed_fraction)
+        if not -1.0 <= self.observed_mean_signed_change <= 1.0:
+            raise PerceptionTransitionConformanceError(
+                "observed_mean_signed_change must be in [-1, 1]"
+            )
+        if self.status == "unexplained_change":
+            if self.expectation_id is not None or self.annotation_ids or self.relation_ids:
+                raise PerceptionTransitionConformanceError(
+                    "unexplained findings cannot reference declared targets"
+                )
+        elif self.expectation_id is None:
+            raise PerceptionTransitionConformanceError(
+                "declared findings require expectation_id"
+            )
+        if self.version != TRANSITION_CONFORMANCE_FINDING_VERSION:
+            raise PerceptionTransitionConformanceError(
+                "unsupported transition finding version"
+            )
+        if self.finding_id != _digest(_payload(self, "finding_id")):
+            raise PerceptionTransitionConformanceError(
+                "transition finding identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class TransitionConformanceReportDTO:
+    report_id: str
+    status: str
+    transition_evidence_id: str
+    field_schema_id: str
+    expectation_ids: tuple[str, ...]
+    annotation_ids: tuple[str, ...]
+    relation_ids: tuple[str, ...]
+    minimum_unexplained_mean_absolute_change: float
+    minimum_unexplained_changed_fraction: float
+    findings: tuple[TransitionConformanceFindingDTO, ...]
+    semantics: str = TRANSITION_CONFORMANCE_SEMANTICS
+    version: str = TRANSITION_CONFORMANCE_REPORT_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.report_id or not self.transition_evidence_id or not self.field_schema_id:
+            raise PerceptionTransitionConformanceError(
+                "transition report identities must be non-empty"
+            )
+        if not self.expectation_ids:
+            raise PerceptionTransitionConformanceError(
+                "transition report requires at least one expectation"
+            )
+        if self.status not in TRANSITION_CONFORMANCE_REPORT_STATUSES:
+            raise PerceptionTransitionConformanceError(
+                f"unsupported transition report status: {self.status}"
+            )
+        for name in ("expectation_ids", "annotation_ids", "relation_ids"):
+            _ordered(name, getattr(self, name))
+        finding_ids = tuple(item.finding_id for item in self.findings)
+        _ordered("transition finding identities", finding_ids)
+        _unit(
+            "minimum_unexplained_mean_absolute_change",
+            self.minimum_unexplained_mean_absolute_change,
+        )
+        _unit(
+            "minimum_unexplained_changed_fraction",
+            self.minimum_unexplained_changed_fraction,
+        )
+        declared = {
+            item.expectation_id for item in self.findings if item.expectation_id is not None
+        }
+        if declared != set(self.expectation_ids):
+            raise PerceptionTransitionConformanceError(
+                "report expectation identities must match declared findings"
+            )
+        if self.status != _report_status(self.findings):
+            raise PerceptionTransitionConformanceError(
+                "transition report status disagrees with findings"
+            )
+        if self.semantics != TRANSITION_CONFORMANCE_SEMANTICS:
+            raise PerceptionTransitionConformanceError(
+                "unsupported transition conformance semantics"
+            )
+        if self.version != TRANSITION_CONFORMANCE_REPORT_VERSION:
+            raise PerceptionTransitionConformanceError(
+                "unsupported transition conformance report version"
+            )
+        if self.report_id != _digest(_payload(self, "report_id")):
+            raise PerceptionTransitionConformanceError(
+                "transition report identity disagrees with canonical payload"
+            )
+
+    def findings_for_status(
+        self, status: str
+    ) -> tuple[TransitionConformanceFindingDTO, ...]:
+        if status not in TRANSITION_CONFORMANCE_STATUSES:
+            raise PerceptionTransitionConformanceError(
+                f"unsupported transition finding status: {status}"
+            )
+        return tuple(item for item in self.findings if item.status == status)
+
+
+def _report_status(findings: tuple[TransitionConformanceFindingDTO, ...]) -> str:
+    statuses = {item.status for item in findings}
+    if statuses & _NONCONFORMANT:
+        return "nonconformant"
+    if statuses & _ATTENTION:
+        return "attention_required"
+    return "conformant"
+
+
+def _finding(
+    *,
+    status: str,
+    expectation: TransitionExpectationDTO | None,
+    field_ids: tuple[str, ...],
+    mean_absolute: float,
+    mean_signed: float,
+    changed_fraction: float,
+    detail: str,
+) -> TransitionConformanceFindingDTO:
+    values: dict[str, object] = {
+        "status": status,
+        "expectation_id": None if expectation is None else expectation.expectation_id,
+        "annotation_ids": () if expectation is None else expectation.annotation_ids,
+        "relation_ids": () if expectation is None else expectation.relation_ids,
+        "field_ids": field_ids,
+        "observed_mean_absolute_change": mean_absolute,
+        "observed_mean_signed_change": mean_signed,
+        "observed_changed_fraction": changed_fraction,
+        "detail": detail,
+        "version": TRANSITION_CONFORMANCE_FINDING_VERSION,
+    }
+    return TransitionConformanceFindingDTO(
+        finding_id=_digest(values), **values  # type: ignore[arg-type]
+    )
+
+
+def _aggregate(
+    fields: tuple[TransitionFieldEvidenceDTO, ...],
+) -> tuple[float, float, float, int]:
+    total = sum(item.total_value_count for item in fields)
+    if total <= 0:
+        raise PerceptionTransitionConformanceError(
+            "transition target has no measurable values"
+        )
+    absolute = sum(
+        item.mean_absolute_change * item.total_value_count for item in fields
+    ) / total
+    signed = sum(item.mean_signed_change * item.total_value_count for item in fields) / total
+    changed = sum(item.changed_value_count for item in fields)
+    return absolute, signed, changed / total, changed
+
+
+def _classify(
+    expectation: TransitionExpectationDTO,
+    fields: tuple[TransitionFieldEvidenceDTO, ...],
+) -> TransitionConformanceFindingDTO:
+    absolute, signed, fraction, changed = _aggregate(fields)
+    field_ids = tuple(sorted(item.field_id for item in fields))
+
+    if expectation.expected_change == "stable":
+        if (
+            absolute > expectation.maximum_mean_absolute_change
+            or fraction > expectation.maximum_changed_fraction
+        ):
+            status = "unexpected_change"
+            detail = "declared stable target exceeded its change tolerance"
+        else:
+            status = "confirmed"
+            detail = "declared stable target remained within tolerance"
+    elif changed == 0:
+        status = "missing_expected_change"
+        detail = "declared changing target had no P18A threshold crossings"
+    elif (
+        absolute < expectation.minimum_mean_absolute_change
+        or fraction < expectation.minimum_changed_fraction
+    ):
+        status = "insufficient_change"
+        detail = "observed transition did not reach the declared minimum"
+    elif expectation.expected_change in {"increase", "decrease"}:
+        required = expectation.minimum_signed_change_magnitude
+        wrong = signed < -required if expectation.expected_change == "increase" else signed > required
+        inconclusive = (
+            signed <= required
+            if expectation.expected_change == "increase"
+            else signed >= -required
+        )
+        if wrong:
+            status = "wrong_change_direction"
+            detail = "observed signed change was opposite the declaration"
+        elif inconclusive:
+            status = "inconclusive"
+            detail = "absolute change was present but net direction was too small"
+        elif (
+            absolute > expectation.maximum_mean_absolute_change
+            or fraction > expectation.maximum_changed_fraction
+        ):
+            status = "excessive_change"
+            detail = "observed directional change exceeded the declared maximum"
+        else:
+            status = "confirmed"
+            detail = f"observed transition confirmed the declared {expectation.expected_change}"
+    elif (
+        absolute > expectation.maximum_mean_absolute_change
+        or fraction > expectation.maximum_changed_fraction
+    ):
+        status = "excessive_change"
+        detail = "observed change exceeded the declared maximum"
+    else:
+        status = "confirmed"
+        detail = "observed transition confirmed the declared change"
+
+    return _finding(
+        status=status,
+        expectation=expectation,
+        field_ids=field_ids,
+        mean_absolute=absolute,
+        mean_signed=signed,
+        changed_fraction=fraction,
+        detail=detail,
+    )
+
+
+def _relation_fields(
+    relation: RelationAnnotationDTO,
+    annotations: Mapping[str, PerceptionRegionAnnotationDTO],
+    known_fields: set[str],
+) -> tuple[str, ...]:
+    unknown_members = set(relation.member_annotation_ids) - set(annotations)
+    if unknown_members:
+        raise PerceptionTransitionConformanceError(
+            f"relation references unknown annotations: {sorted(unknown_members)}"
+        )
+    if relation.derived_field_ids:
+        unknown = set(relation.derived_field_ids) - known_fields
+        if unknown:
+            raise PerceptionTransitionConformanceError(
+                f"relation references unknown derived fields: {sorted(unknown)}"
+            )
+        return relation.derived_field_ids
+    return tuple(
+        sorted(
+            {
+                field_id
+                for annotation_id in relation.member_annotation_ids
+                for field_id in annotations[annotation_id].field_ids
+            }
+        )
+    )
+
+
+def evaluate_transition_conformance(
+    transition: TransitionEvidenceVPMDTO,
+    expectations: tuple[TransitionExpectationDTO, ...],
+    annotations: tuple[PerceptionRegionAnnotationDTO, ...],
+    relations: tuple[RelationAnnotationDTO, ...] = (),
+    *,
+    minimum_unexplained_mean_absolute_change: float = 0.0,
+    minimum_unexplained_changed_fraction: float = 0.0,
+) -> TransitionConformanceReportDTO:
+    """Evaluate declarations while preserving the exact P18A measurements."""
+
+    if not expectations:
+        raise PerceptionTransitionConformanceError(
+            "transition conformance requires at least one expectation"
+        )
+    _unit(
+        "minimum_unexplained_mean_absolute_change",
+        minimum_unexplained_mean_absolute_change,
+    )
+    _unit(
+        "minimum_unexplained_changed_fraction",
+        minimum_unexplained_changed_fraction,
+    )
+    expectation_map = {item.expectation_id: item for item in expectations}
+    annotation_map = {item.annotation_id: item for item in annotations}
+    relation_map = {item.relation_id: item for item in relations}
+    if len(expectation_map) != len(expectations):
+        raise PerceptionTransitionConformanceError(
+            "transition expectations must have unique identities"
+        )
+    if len(annotation_map) != len(annotations):
+        raise PerceptionTransitionConformanceError(
+            "transition annotations must have unique identities"
+        )
+    if len(relation_map) != len(relations):
+        raise PerceptionTransitionConformanceError(
+            "transition relations must have unique identities"
+        )
+    if tuple(sorted(annotation_map)) != transition.annotation_ids:
+        raise PerceptionTransitionConformanceError(
+            "supplied annotations must exactly match P18A annotation identities"
+        )
+
+    field_map = {item.field_id: item for item in transition.fields}
+    known_fields = set(field_map)
+    expected_bindings: dict[str, list[str]] = {field_id: [] for field_id in known_fields}
+    for annotation in annotations:
+        if annotation.field_schema_id != transition.field_schema_id:
+            raise PerceptionTransitionConformanceError(
+                "annotation field schema does not match transition evidence"
+            )
+        unknown = set(annotation.field_ids) - known_fields
+        if unknown:
+            raise PerceptionTransitionConformanceError(
+                f"annotation references unknown fields: {sorted(unknown)}"
+            )
+        for field_id in annotation.field_ids:
+            expected_bindings[field_id].append(annotation.annotation_id)
+    for field_id, field in field_map.items():
+        if field.annotation_ids != tuple(sorted(expected_bindings[field_id])):
+            raise PerceptionTransitionConformanceError(
+                "supplied annotations disagree with P18A field bindings"
+            )
+
+    relation_field_map = {
+        identity: _relation_fields(relation, annotation_map, known_fields)
+        for identity, relation in relation_map.items()
+    }
+    findings: list[TransitionConformanceFindingDTO] = []
+    covered: set[str] = set()
+    for expectation in sorted(expectations, key=lambda item: item.expectation_id):
+        if expectation.field_schema_id != transition.field_schema_id:
+            raise PerceptionTransitionConformanceError(
+                "expectation field schema does not match transition evidence"
+            )
+        unknown_annotations = set(expectation.annotation_ids) - set(annotation_map)
+        unknown_relations = set(expectation.relation_ids) - set(relation_map)
+        if unknown_annotations:
+            raise PerceptionTransitionConformanceError(
+                f"expectation references unknown annotations: {sorted(unknown_annotations)}"
+            )
+        if unknown_relations:
+            raise PerceptionTransitionConformanceError(
+                f"expectation references unknown relations: {sorted(unknown_relations)}"
+            )
+        target_fields = {
+            field_id
+            for annotation_id in expectation.annotation_ids
+            for field_id in annotation_map[annotation_id].field_ids
+        }
+        for relation_id in expectation.relation_ids:
+            target_fields.update(relation_field_map[relation_id])
+        if not target_fields:
+            raise PerceptionTransitionConformanceError(
+                "transition expectation resolves to no fields"
+            )
+        covered.update(target_fields)
+        findings.append(
+            _classify(
+                expectation,
+                tuple(field_map[field_id] for field_id in sorted(target_fields)),
+            )
+        )
+
+    for field_id in sorted(known_fields - covered):
+        field = field_map[field_id]
+        if (
+            field.changed_value_count > 0
+            and field.mean_absolute_change
+            >= minimum_unexplained_mean_absolute_change
+            and field.changed_fraction >= minimum_unexplained_changed_fraction
+        ):
+            findings.append(
+                _finding(
+                    status="unexplained_change",
+                    expectation=None,
+                    field_ids=(field_id,),
+                    mean_absolute=field.mean_absolute_change,
+                    mean_signed=field.mean_signed_change,
+                    changed_fraction=field.changed_fraction,
+                    detail=(
+                        "field changed above the unexplained thresholds without "
+                        "a declared transition expectation"
+                    ),
+                )
+            )
+
+    ordered_findings = tuple(sorted(findings, key=lambda item: item.finding_id))
+    values: dict[str, object] = {
+        "status": _report_status(ordered_findings),
+        "transition_evidence_id": transition.transition_evidence_id,
+        "field_schema_id": transition.field_schema_id,
+        "expectation_ids": tuple(sorted(expectation_map)),
+        "annotation_ids": tuple(sorted(annotation_map)),
+        "relation_ids": tuple(sorted(relation_map)),
+        "minimum_unexplained_mean_absolute_change": (
+            minimum_unexplained_mean_absolute_change
+        ),
+        "minimum_unexplained_changed_fraction": minimum_unexplained_changed_fraction,
+        "findings": ordered_findings,
+        "semantics": TRANSITION_CONFORMANCE_SEMANTICS,
+        "version": TRANSITION_CONFORMANCE_REPORT_VERSION,
+    }
+    identity_values = dict(values)
+    identity_values["findings"] = tuple(asdict(item) for item in ordered_findings)
+    return TransitionConformanceReportDTO(
+        report_id=_digest(identity_values), **values  # type: ignore[arg-type]
+    )

--- a/packages/perception/tests/test_transition_conformance_p18b.py
+++ b/packages/perception/tests/test_transition_conformance_p18b.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    PerceptionRegionAnnotationDTO,
+    RelationAnnotationDTO,
+    SourceImageEncoderSpecDTO,
+    build_grid_field_schema,
+    build_transition_evidence_vpm,
+    encode_source_array,
+)
+from zeromodel.perception.transition_conformance import (
+    PerceptionTransitionConformanceError,
+    TransitionExpectationDTO,
+    evaluate_transition_conformance,
+)
+
+
+def _source(values: list[int]):
+    encoder = SourceImageEncoderSpecDTO(color_space="L")
+    return encode_source_array(np.array([values], dtype=np.uint8), encoder)
+
+
+def _annotations(schema, labels: tuple[str, ...]):
+    fields = tuple(sorted(schema.fields, key=lambda item: item.x0))
+    annotations = tuple(
+        PerceptionRegionAnnotationDTO.create(
+            schema,
+            (field.field_id,),
+            label=label,
+            role="component",
+        )
+        for field, label in zip(fields, labels, strict=True)
+    )
+    return fields, annotations
+
+
+def test_conformance_distinguishes_confirmed_missing_and_unexplained() -> None:
+    before = _source([0, 0, 0, 0, 0, 0])
+    after = _source([255, 255, 0, 0, 128, 128])
+    schema = build_grid_field_schema(before, tile_width=2, tile_height=1)
+    fields = tuple(sorted(schema.fields, key=lambda item: item.x0))
+    tank = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[0].field_id,),
+        label="tank",
+        role="actor",
+    )
+    alien = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[1].field_id,),
+        label="alien",
+        role="target",
+    )
+    transition = build_transition_evidence_vpm(
+        before,
+        after,
+        schema,
+        annotations=(tank, alien),
+    )
+    tank_expectation = TransitionExpectationDTO.create(
+        field_schema_id=schema.field_schema_id,
+        annotation_ids=(tank.annotation_id,),
+        expected_change="increase",
+        minimum_mean_absolute_change=0.5,
+        minimum_changed_fraction=1.0,
+        minimum_signed_change_magnitude=0.5,
+    )
+    alien_expectation = TransitionExpectationDTO.create(
+        field_schema_id=schema.field_schema_id,
+        annotation_ids=(alien.annotation_id,),
+        expected_change="change",
+        minimum_mean_absolute_change=0.1,
+    )
+
+    first = evaluate_transition_conformance(
+        transition,
+        (tank_expectation, alien_expectation),
+        (tank, alien),
+        minimum_unexplained_mean_absolute_change=0.1,
+    )
+    second = evaluate_transition_conformance(
+        transition,
+        (alien_expectation, tank_expectation),
+        (alien, tank),
+        minimum_unexplained_mean_absolute_change=0.1,
+    )
+
+    assert first == second
+    assert first.status == "nonconformant"
+    assert {item.status for item in first.findings} == {
+        "confirmed",
+        "missing_expected_change",
+        "unexplained_change",
+    }
+    unexplained = first.findings_for_status("unexplained_change")
+    assert len(unexplained) == 1
+    assert unexplained[0].field_ids == (fields[2].field_id,)
+    assert transition.fields == transition.fields
+
+
+def test_conformance_preserves_distinct_failure_modes() -> None:
+    before = _source([0, 0, 0, 0, 255, 255, 0, 255])
+    after = _source([102, 102, 204, 204, 102, 102, 153, 102])
+    schema = build_grid_field_schema(before, tile_width=2, tile_height=1)
+    _, annotations = _annotations(schema, ("control", "projectile", "tank", "mixed"))
+    transition = build_transition_evidence_vpm(
+        before,
+        after,
+        schema,
+        annotations=annotations,
+    )
+    control, projectile, tank, mixed = annotations
+    expectations = (
+        TransitionExpectationDTO.create(
+            field_schema_id=schema.field_schema_id,
+            annotation_ids=(control.annotation_id,),
+            expected_change="stable",
+            maximum_mean_absolute_change=0.1,
+            maximum_changed_fraction=0.1,
+        ),
+        TransitionExpectationDTO.create(
+            field_schema_id=schema.field_schema_id,
+            annotation_ids=(projectile.annotation_id,),
+            expected_change="change",
+            maximum_mean_absolute_change=0.5,
+        ),
+        TransitionExpectationDTO.create(
+            field_schema_id=schema.field_schema_id,
+            annotation_ids=(tank.annotation_id,),
+            expected_change="increase",
+            minimum_mean_absolute_change=0.2,
+            minimum_signed_change_magnitude=0.1,
+        ),
+        TransitionExpectationDTO.create(
+            field_schema_id=schema.field_schema_id,
+            annotation_ids=(mixed.annotation_id,),
+            expected_change="increase",
+            minimum_mean_absolute_change=0.2,
+            minimum_signed_change_magnitude=0.1,
+        ),
+    )
+
+    report = evaluate_transition_conformance(
+        transition,
+        expectations,
+        annotations,
+    )
+
+    assert report.status == "nonconformant"
+    assert {item.status for item in report.findings} == {
+        "unexpected_change",
+        "excessive_change",
+        "wrong_change_direction",
+        "inconclusive",
+    }
+
+
+def test_relation_expectation_uses_explicit_derived_fields() -> None:
+    before = _source([0, 0, 0, 0, 0, 0])
+    after = _source([0, 0, 0, 0, 102, 102])
+    schema = build_grid_field_schema(before, tile_width=2, tile_height=1)
+    fields = tuple(sorted(schema.fields, key=lambda item: item.x0))
+    tank = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[0].field_id,),
+        label="tank",
+    )
+    alien = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[1].field_id,),
+        label="alien",
+    )
+    relation = RelationAnnotationDTO(
+        relation_id="sha256:tank-alien-distance",
+        relation_type="relative_distance",
+        member_annotation_ids=tuple(sorted((tank.annotation_id, alien.annotation_id))),
+        derived_field_ids=(fields[2].field_id,),
+    )
+    transition = build_transition_evidence_vpm(
+        before,
+        after,
+        schema,
+        annotations=(tank, alien),
+    )
+    expectation = TransitionExpectationDTO.create(
+        field_schema_id=schema.field_schema_id,
+        relation_ids=(relation.relation_id,),
+        expected_change="change",
+        minimum_mean_absolute_change=0.2,
+    )
+
+    report = evaluate_transition_conformance(
+        transition,
+        (expectation,),
+        (tank, alien),
+        (relation,),
+    )
+
+    assert report.status == "conformant"
+    assert report.findings[0].status == "confirmed"
+    assert report.findings[0].field_ids == (fields[2].field_id,)
+    assert report.findings[0].relation_ids == (relation.relation_id,)
+
+
+def test_conformance_rejects_binding_mismatch_and_identity_tampering() -> None:
+    before = _source([0, 0, 0, 0])
+    after = _source([255, 255, 0, 0])
+    schema = build_grid_field_schema(before, tile_width=2, tile_height=1)
+    fields = tuple(sorted(schema.fields, key=lambda item: item.x0))
+    tank = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[0].field_id,),
+        label="tank",
+    )
+    transition = build_transition_evidence_vpm(
+        before,
+        after,
+        schema,
+        annotations=(tank,),
+    )
+    expectation = TransitionExpectationDTO.create(
+        field_schema_id=schema.field_schema_id,
+        annotation_ids=(tank.annotation_id,),
+        expected_change="change",
+    )
+    report = evaluate_transition_conformance(
+        transition,
+        (expectation,),
+        (tank,),
+    )
+
+    with pytest.raises(
+        PerceptionTransitionConformanceError,
+        match="field bindings",
+    ):
+        evaluate_transition_conformance(
+            transition,
+            (expectation,),
+            (replace(tank, field_ids=(fields[1].field_id,)),),
+        )
+    with pytest.raises(
+        PerceptionTransitionConformanceError,
+        match="at least one expectation",
+    ):
+        evaluate_transition_conformance(transition, (), (tank,))
+    with pytest.raises(
+        PerceptionTransitionConformanceError,
+        match="expectation identity",
+    ):
+        replace(expectation, expectation_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionTransitionConformanceError,
+        match="report identity",
+    ):
+        replace(report, report_id="sha256:tampered")

--- a/packages/perception/tests/test_transition_conformance_p18b_public_surface.py
+++ b/packages/perception/tests/test_transition_conformance_p18b_public_surface.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import zeromodel.perception as perception
+
+
+def test_p18b_is_exposed_from_package_root() -> None:
+    expected = {
+        "PerceptionTransitionConformanceError",
+        "TransitionConformanceFindingDTO",
+        "TransitionConformanceReportDTO",
+        "TransitionExpectationDTO",
+        "evaluate_transition_conformance",
+        "TRANSITION_CONFORMANCE_REPORT_VERSION",
+        "TRANSITION_EXPECTATION_VERSION",
+    }
+
+    assert expected <= set(perception.__all__)
+    for name in expected:
+        assert getattr(perception, name) is not None


### PR DESCRIPTION
Audit-Exempt: adds an internal deterministic transition-testing layer over existing P18A evidence; no public capability claim status changes.

## Objective

Implement P18B: compare declared visual state-change expectations for marked objects, relations, and controls with one immutable P18A transition artifact.

```text
P18A TransitionEvidenceVPMDTO
    + annotations / relations
    + TransitionExpectationDTO
    ↓
TransitionConformanceReportDTO
```

## What changed

- Add content-addressed `TransitionExpectationDTO` declarations for:
  - stable regions;
  - non-directional change;
  - increase;
  - decrease.
- Add explicit minimum/maximum thresholds for mean absolute change and changed-value fraction.
- Add minimum signed-change magnitude for directional expectations.
- Add deterministic findings that preserve:
  - `confirmed`;
  - `missing_expected_change`;
  - `unexpected_change`;
  - `excessive_change`;
  - `insufficient_change`;
  - `wrong_change_direction`;
  - `inconclusive`;
  - `unexplained_change`.
- Add report status: `conformant`, `attention_required`, or `nonconformant`.
- Support relation expectations through explicit `derived_field_ids`, falling back to the union of member annotation fields.
- Detect changed fields that are not covered by any declared expectation.
- Verify supplied annotation identities and exact field bindings against the P18A artifact rather than trusting matching IDs alone.
- Advance the package surface and P18 roadmap to P18B while retaining all earlier contracts.

## Epistemic boundary

P18B tests whether a declared visual transition matches measured P18A evidence. It does not infer labels, rewrite observations, or prove that a marked component caused an action or result.

## Validation

Local contract harness:

```text
4 passed
```

It covers deterministic ordering, confirmed/missing/unexplained evidence, stable/excessive/directional/inconclusive distinctions, relation-owned derived fields, binding mismatch rejection, and identity tampering.

The clean wheel-installed `perception-package` workflow is authoritative for the complete package suite.

## Next stage

P18C will aggregate transition and conformance evidence across interactions to identify recurrent unmarked fields and propose candidate missing components for further testing without converting association into causality.