### PR TITLE
feat(perception): add P18C recurrent unexplained transition discovery

### DIFF
--- a/packages/perception/docs/p18-roadmap.md
+++ b/packages/perception/docs/p18-roadmap.md
@@ -6,13 +6,19 @@ P18 returns the perception package to its visual research spine after the P17 go
 
 Materialize a deterministic fieldwise VPM describing what changed between an exact source observation and its exact result observation. Optional region annotations bind known object identities to the measurements without changing them.
 
-## P18B — Annotated transition conformance — current
+## P18B — Annotated transition conformance — complete
 
 Declare expected state changes for marked objects, relations, and control regions, then compare those declarations with immutable P18A measurements. Findings preserve confirmed, missing, unexpected, excessive, insufficient, directionally wrong, inconclusive, and unexplained changes rather than collapsing them into one boolean.
 
-## P18C — Unexplained recurrent transition discovery — next
+## P18C — Recurrent unexplained transition discovery — current
 
-Aggregate transition evidence and conformance findings across interactions to identify unmarked fields or relations that repeatedly change with a result. This stage should generate candidate missing components and test hypotheses, not causal conclusions.
+Aggregate P18A evidence and P18B findings across an explicit discovery cohort. Preserve complete recurrence statistics for individual unexplained fields and exact co-occurrence signatures, then emit thresholded `candidate_unvalidated` missing-component hypotheses.
+
+Observations without unexplained findings remain in the denominator. Repeated deterministic transition artifacts from distinct interactions remain valid evidence. Discovery never doubles as validation.
+
+## P18D — Held-out candidate validation — next
+
+Translate P18C candidates into explicit transition expectations and evaluate them against a separately identified validation cohort. Promotion must require held-out support, preserve rejected and inconclusive candidates, and prevent discovery-cohort evidence from entering validation denominators.
 
 ## Boundary
 

--- a/packages/perception/docs/stage-p18c-recurrent-unexplained-transition-discovery.md
+++ b/packages/perception/docs/stage-p18c-recurrent-unexplained-transition-discovery.md
@@ -1,0 +1,91 @@
+# Stage P18C — Recurrent Unexplained Transition Discovery
+
+## Objective
+
+Aggregate immutable P18A transition evidence and P18B conformance findings across a declared discovery cohort to identify recurrent unmarked fields and exact co-occurrence signatures.
+
+```text
+interaction identity
+    + P18A TransitionEvidenceVPMDTO
+    + P18B TransitionConformanceReportDTO
+    ↓
+TransitionDiscoveryObservationDTO
+    ↓ many observations from one cohort
+field recurrence + exact unexplained signatures
+    ↓
+TransitionDiscoveryReportDTO
+    ├── complete recurrence statistics
+    └── MissingComponentCandidateDTO hypotheses
+```
+
+P18C does not assign a semantic label to a field. It identifies spatial evidence that repeatedly escaped the current annotation and expectation model.
+
+## Discovery observations
+
+`TransitionDiscoveryObservationDTO.create(...)` verifies that the P18B report references the supplied P18A artifact and that every unexplained finding reproduces the exact P18A field measurements.
+
+Observations with no unexplained findings remain in the cohort. They are required for an honest recurrence denominator.
+
+Distinct interactions may reference identical transition or conformance artifacts. P18C counts interactions through their unique interaction and observation identities rather than rejecting repeated deterministic evidence.
+
+## Recurrence statistics
+
+P18C records two kinds of statistics:
+
+- `field` — how often one exact unmarked field is unexplained;
+- `cooccurrence_signature` — how often the same complete set of two or more unexplained fields appears together.
+
+Each statistic preserves:
+
+- observation and occurrence counts;
+- recurrence fraction across the complete cohort;
+- weighted mean absolute, signed, and changed-fraction measurements;
+- positive, negative, and neutral direction counts;
+- dominant direction and direction consistency;
+- supporting interaction, observation, transition, conformance, and finding identities.
+
+Exact signatures are intentionally conservative. An observation containing extra unexplained fields belongs to a different signature.
+
+## Candidate policy
+
+`TransitionDiscoveryPolicyDTO` separates overall evidence sufficiency from candidate thresholds:
+
+- minimum cohort observation count;
+- minimum field occurrence count and recurrence fraction;
+- minimum signature occurrence count and recurrence fraction;
+- minimum directional consistency;
+- signed-change epsilon.
+
+The report can therefore distinguish:
+
+- `insufficient_evidence` — the cohort is too small to propose candidates;
+- `no_candidates` — the cohort is sufficient but no statistic crosses policy;
+- `candidates_found` — one or more statistics cross policy.
+
+## Candidate hypotheses
+
+A `MissingComponentCandidateDTO` is always marked `candidate_unvalidated`.
+
+Where signed evidence is sufficiently consistent, the candidate proposes a future expectation of `increase` or `decrease`. Otherwise it proposes the non-directional expectation `change`.
+
+The proposal is intended for a later, separate validation cohort. P18C does not validate its own discoveries on the same interactions that generated them.
+
+## Integrity boundary
+
+The observation, policy, recurrence statistics, candidates, and complete discovery report are content-addressed. P18C rejects mixed cohorts, mixed field schemas, duplicate interaction identities, lineage mismatches, metric mismatches, invalid thresholds, and identity tampering.
+
+## Non-claims
+
+P18C does not claim that:
+
+- a recurrent field is an object;
+- a co-occurrence signature is a relation;
+- a candidate caused the action or state transition;
+- recurrence in the discovery cohort generalizes;
+- a proposed expectation is confirmed.
+
+Its claim is narrower: the declared cohort contains recurrent, addressable unexplained transition evidence that is suitable for a new falsifiable hypothesis.
+
+## Next stage
+
+The next slice should validate P18C candidates against a separately identified evaluation cohort. Candidate promotion must require held-out evidence and preserve failed candidates rather than silently discarding them.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -1,4 +1,4 @@
-"""ZeroModel perception public API through Stage P18B."""
+"""ZeroModel perception public API through Stage P18C."""
 
 from __future__ import annotations
 
@@ -65,6 +65,28 @@ from .transition_conformance import (  # noqa: F401
     TransitionExpectationDTO,
     evaluate_transition_conformance,
 )
+from .transition_discovery import (  # noqa: F401
+    DIRECTION_LABELS,
+    MISSING_COMPONENT_CANDIDATE_VERSION,
+    MISSING_COMPONENT_HYPOTHESIS_STATUS,
+    PROPOSED_CHANGE_KINDS,
+    RECURRENT_UNEXPLAINED_STATISTIC_KINDS,
+    RECURRENT_UNEXPLAINED_STATISTIC_VERSION,
+    TRANSITION_DISCOVERY_OBSERVATION_VERSION,
+    TRANSITION_DISCOVERY_POLICY_VERSION,
+    TRANSITION_DISCOVERY_REPORT_STATUSES,
+    TRANSITION_DISCOVERY_REPORT_VERSION,
+    TRANSITION_DISCOVERY_SEMANTICS,
+    UNEXPLAINED_FIELD_OCCURRENCE_VERSION,
+    MissingComponentCandidateDTO,
+    PerceptionTransitionDiscoveryError,
+    RecurrentUnexplainedStatisticDTO,
+    TransitionDiscoveryObservationDTO,
+    TransitionDiscoveryPolicyDTO,
+    TransitionDiscoveryReportDTO,
+    UnexplainedFieldOccurrenceDTO,
+    discover_recurrent_unexplained_transitions,
+)
 from .transition_evidence import (  # noqa: F401
     TRANSITION_CHANGED_FRACTION_SEMANTICS,
     TRANSITION_CHANGE_SEMANTICS,
@@ -79,7 +101,7 @@ from .transition_evidence import (  # noqa: F401
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P18B"
+PERCEPTION_STAGE = "P18C"
 
 __all__ = [
     name

--- a/packages/perception/src/zeromodel/perception/transition_discovery.py
+++ b/packages/perception/src/zeromodel/perception/transition_discovery.py
@@ -1,0 +1,1090 @@
+"""Recurrent unexplained transition discovery for Stage P18C.
+
+P18C materializes a declared discovery cohort from immutable P18A transition
+artifacts and P18B conformance reports. It measures recurrence and exact
+co-occurrence of unexplained fields, then emits unvalidated candidate components
+and falsifiable change hypotheses. Recurrence is association evidence, not
+semantic detection, validation, or causal proof.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Final, Mapping
+
+from .transition_conformance import TransitionConformanceReportDTO
+from .transition_evidence import TransitionEvidenceVPMDTO, TransitionFieldEvidenceDTO
+
+UNEXPLAINED_FIELD_OCCURRENCE_VERSION: Final = (
+    "perception-unexplained-field-occurrence/1"
+)
+TRANSITION_DISCOVERY_OBSERVATION_VERSION: Final = (
+    "perception-transition-discovery-observation/1"
+)
+TRANSITION_DISCOVERY_POLICY_VERSION: Final = (
+    "perception-transition-discovery-policy/1"
+)
+UNEXPLAINED_FIELD_RECURRENCE_VERSION: Final = (
+    "perception-unexplained-field-recurrence/1"
+)
+UNEXPLAINED_SIGNATURE_RECURRENCE_VERSION: Final = (
+    "perception-unexplained-signature-recurrence/1"
+)
+MISSING_COMPONENT_CANDIDATE_VERSION: Final = (
+    "perception-missing-component-candidate/1"
+)
+TRANSITION_DISCOVERY_REPORT_VERSION: Final = (
+    "perception-transition-discovery-report/1"
+)
+TRANSITION_DISCOVERY_SEMANTICS: Final = (
+    "recurrence_of_p18b_unexplained_fields_within_one_declared_discovery_cohort"
+)
+TRANSITION_DISCOVERY_REPORT_STATUSES: Final = {
+    "insufficient_evidence",
+    "no_candidates",
+    "candidates_found",
+}
+MISSING_COMPONENT_CANDIDATE_KINDS: Final = {
+    "field",
+    "cooccurrence_signature",
+}
+MISSING_COMPONENT_HYPOTHESIS_STATUS: Final = "candidate_unvalidated"
+PROPOSED_CHANGE_KINDS: Final = {"change", "increase", "decrease"}
+DIRECTION_LABELS: Final = {"positive", "negative", "mixed", "neutral"}
+
+
+class PerceptionTransitionDiscoveryError(ValueError):
+    """Raised when recurrent-transition discovery contracts are invalid."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    value = _canonical_json(payload)
+    hasher = hashlib.sha256()
+    hasher.update(len(value).to_bytes(8, "big"))
+    hasher.update(value)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def _payload(value: object, identity_field: str) -> dict[str, object]:
+    payload = asdict(value)  # type: ignore[arg-type]
+    payload.pop(identity_field)
+    return payload
+
+
+def _ordered(name: str, values: tuple[str, ...], *, allow_empty: bool = True) -> None:
+    if not allow_empty and not values:
+        raise PerceptionTransitionDiscoveryError(f"{name} must be non-empty")
+    if values != tuple(sorted(set(values))):
+        raise PerceptionTransitionDiscoveryError(
+            f"{name} must be unique and sorted"
+        )
+
+
+def _unit(name: str, value: float) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise PerceptionTransitionDiscoveryError(f"{name} must be in [0, 1]")
+
+
+def _positive_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise PerceptionTransitionDiscoveryError(f"{name} must be a positive integer")
+
+
+def _same_float(left: float, right: float) -> bool:
+    return abs(left - right) <= 1e-12
+
+
+@dataclass(frozen=True)
+class UnexplainedFieldOccurrenceDTO:
+    """Exact P18A field evidence referenced by one P18B unexplained finding."""
+
+    occurrence_id: str
+    field_id: str
+    finding_id: str
+    mean_absolute_change: float
+    mean_signed_change: float
+    changed_fraction: float
+    changed_value_count: int
+    total_value_count: int
+    version: str = UNEXPLAINED_FIELD_OCCURRENCE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.occurrence_id or not self.field_id or not self.finding_id:
+            raise PerceptionTransitionDiscoveryError(
+                "unexplained occurrence identities must be non-empty"
+            )
+        _unit("mean_absolute_change", self.mean_absolute_change)
+        _unit("changed_fraction", self.changed_fraction)
+        if not -1.0 <= self.mean_signed_change <= 1.0:
+            raise PerceptionTransitionDiscoveryError(
+                "mean_signed_change must be in [-1, 1]"
+            )
+        _positive_int("total_value_count", self.total_value_count)
+        if (
+            isinstance(self.changed_value_count, bool)
+            or not isinstance(self.changed_value_count, int)
+            or not 0 <= self.changed_value_count <= self.total_value_count
+        ):
+            raise PerceptionTransitionDiscoveryError(
+                "changed_value_count must be within total_value_count"
+            )
+        if not _same_float(
+            self.changed_fraction,
+            self.changed_value_count / self.total_value_count,
+        ):
+            raise PerceptionTransitionDiscoveryError(
+                "changed_fraction disagrees with occurrence counts"
+            )
+        if self.version != UNEXPLAINED_FIELD_OCCURRENCE_VERSION:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported unexplained occurrence version"
+            )
+        if self.occurrence_id != _digest(_payload(self, "occurrence_id")):
+            raise PerceptionTransitionDiscoveryError(
+                "unexplained occurrence identity disagrees with canonical payload"
+            )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        finding_id: str,
+        field: TransitionFieldEvidenceDTO,
+    ) -> "UnexplainedFieldOccurrenceDTO":
+        values: dict[str, object] = {
+            "field_id": field.field_id,
+            "finding_id": finding_id,
+            "mean_absolute_change": field.mean_absolute_change,
+            "mean_signed_change": field.mean_signed_change,
+            "changed_fraction": field.changed_fraction,
+            "changed_value_count": field.changed_value_count,
+            "total_value_count": field.total_value_count,
+            "version": UNEXPLAINED_FIELD_OCCURRENCE_VERSION,
+        }
+        return cls(occurrence_id=_digest(values), **values)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class TransitionDiscoveryObservationDTO:
+    """One interaction in an explicit discovery cohort, including empty evidence."""
+
+    observation_id: str
+    interaction_id: str
+    cohort_id: str
+    field_schema_id: str
+    transition_evidence_id: str
+    conformance_report_id: str
+    unexplained_fields: tuple[UnexplainedFieldOccurrenceDTO, ...]
+    version: str = TRANSITION_DISCOVERY_OBSERVATION_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.observation_id,
+                self.interaction_id,
+                self.cohort_id,
+                self.field_schema_id,
+                self.transition_evidence_id,
+                self.conformance_report_id,
+            )
+        ):
+            raise PerceptionTransitionDiscoveryError(
+                "discovery observation identities must be non-empty"
+            )
+        field_ids = tuple(item.field_id for item in self.unexplained_fields)
+        if field_ids != tuple(sorted(set(field_ids))):
+            raise PerceptionTransitionDiscoveryError(
+                "unexplained fields must be unique and sorted by field_id"
+            )
+        occurrence_ids = tuple(item.occurrence_id for item in self.unexplained_fields)
+        _ordered("unexplained occurrence identities", occurrence_ids)
+        if self.version != TRANSITION_DISCOVERY_OBSERVATION_VERSION:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported discovery observation version"
+            )
+        if self.observation_id != _digest(_payload(self, "observation_id")):
+            raise PerceptionTransitionDiscoveryError(
+                "discovery observation identity disagrees with canonical payload"
+            )
+
+    @property
+    def unexplained_field_ids(self) -> tuple[str, ...]:
+        return tuple(item.field_id for item in self.unexplained_fields)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        interaction_id: str,
+        cohort_id: str,
+        transition: TransitionEvidenceVPMDTO,
+        conformance: TransitionConformanceReportDTO,
+    ) -> "TransitionDiscoveryObservationDTO":
+        if not interaction_id or not cohort_id:
+            raise PerceptionTransitionDiscoveryError(
+                "interaction_id and cohort_id must be non-empty"
+            )
+        if conformance.transition_evidence_id != transition.transition_evidence_id:
+            raise PerceptionTransitionDiscoveryError(
+                "conformance report does not reference the supplied transition"
+            )
+        if conformance.field_schema_id != transition.field_schema_id:
+            raise PerceptionTransitionDiscoveryError(
+                "conformance report field schema does not match transition"
+            )
+        field_map = {item.field_id: item for item in transition.fields}
+        occurrences: list[UnexplainedFieldOccurrenceDTO] = []
+        seen_fields: set[str] = set()
+        for finding in conformance.findings:
+            if finding.status != "unexplained_change":
+                continue
+            if len(finding.field_ids) != 1:
+                raise PerceptionTransitionDiscoveryError(
+                    "P18C requires field-addressable unexplained findings"
+                )
+            field_id = finding.field_ids[0]
+            if field_id in seen_fields:
+                raise PerceptionTransitionDiscoveryError(
+                    "conformance report repeats an unexplained field"
+                )
+            try:
+                field = field_map[field_id]
+            except KeyError as exc:
+                raise PerceptionTransitionDiscoveryError(
+                    f"unexplained finding references unknown field: {field_id}"
+                ) from exc
+            if not (
+                _same_float(
+                    finding.observed_mean_absolute_change,
+                    field.mean_absolute_change,
+                )
+                and _same_float(
+                    finding.observed_mean_signed_change,
+                    field.mean_signed_change,
+                )
+                and _same_float(
+                    finding.observed_changed_fraction,
+                    field.changed_fraction,
+                )
+            ):
+                raise PerceptionTransitionDiscoveryError(
+                    "unexplained finding metrics disagree with P18A field evidence"
+                )
+            seen_fields.add(field_id)
+            occurrences.append(
+                UnexplainedFieldOccurrenceDTO.create(
+                    finding_id=finding.finding_id,
+                    field=field,
+                )
+            )
+        ordered = tuple(sorted(occurrences, key=lambda item: item.field_id))
+        values: dict[str, object] = {
+            "interaction_id": interaction_id,
+            "cohort_id": cohort_id,
+            "field_schema_id": transition.field_schema_id,
+            "transition_evidence_id": transition.transition_evidence_id,
+            "conformance_report_id": conformance.report_id,
+            "unexplained_fields": ordered,
+            "version": TRANSITION_DISCOVERY_OBSERVATION_VERSION,
+        }
+        identity_values = dict(values)
+        identity_values["unexplained_fields"] = tuple(asdict(item) for item in ordered)
+        return cls(
+            observation_id=_digest(identity_values),
+            **values,  # type: ignore[arg-type]
+        )
+
+
+@dataclass(frozen=True)
+class TransitionDiscoveryPolicyDTO:
+    policy_id: str
+    minimum_observation_count: int = 3
+    minimum_field_occurrence_count: int = 2
+    minimum_field_recurrence_fraction: float = 0.5
+    minimum_signature_occurrence_count: int = 2
+    minimum_signature_recurrence_fraction: float = 0.5
+    minimum_direction_consistency: float = 0.75
+    direction_epsilon: float = 0.01
+    version: str = TRANSITION_DISCOVERY_POLICY_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.policy_id:
+            raise PerceptionTransitionDiscoveryError("policy_id must be non-empty")
+        for name in (
+            "minimum_observation_count",
+            "minimum_field_occurrence_count",
+            "minimum_signature_occurrence_count",
+        ):
+            _positive_int(name, getattr(self, name))
+        for name in (
+            "minimum_field_recurrence_fraction",
+            "minimum_signature_recurrence_fraction",
+            "minimum_direction_consistency",
+            "direction_epsilon",
+        ):
+            _unit(name, getattr(self, name))
+        if self.version != TRANSITION_DISCOVERY_POLICY_VERSION:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported transition discovery policy version"
+            )
+        if self.policy_id != _digest(_payload(self, "policy_id")):
+            raise PerceptionTransitionDiscoveryError(
+                "transition discovery policy identity disagrees with canonical payload"
+            )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        minimum_observation_count: int = 3,
+        minimum_field_occurrence_count: int = 2,
+        minimum_field_recurrence_fraction: float = 0.5,
+        minimum_signature_occurrence_count: int = 2,
+        minimum_signature_recurrence_fraction: float = 0.5,
+        minimum_direction_consistency: float = 0.75,
+        direction_epsilon: float = 0.01,
+    ) -> "TransitionDiscoveryPolicyDTO":
+        values: dict[str, object] = {
+            "minimum_observation_count": minimum_observation_count,
+            "minimum_field_occurrence_count": minimum_field_occurrence_count,
+            "minimum_field_recurrence_fraction": minimum_field_recurrence_fraction,
+            "minimum_signature_occurrence_count": minimum_signature_occurrence_count,
+            "minimum_signature_recurrence_fraction": (
+                minimum_signature_recurrence_fraction
+            ),
+            "minimum_direction_consistency": minimum_direction_consistency,
+            "direction_epsilon": direction_epsilon,
+            "version": TRANSITION_DISCOVERY_POLICY_VERSION,
+        }
+        return cls(policy_id=_digest(values), **values)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class UnexplainedFieldRecurrenceDTO:
+    statistic_id: str
+    field_id: str
+    observation_count: int
+    occurrence_count: int
+    recurrence_fraction: float
+    mean_absolute_change: float
+    mean_signed_change: float
+    mean_changed_fraction: float
+    positive_count: int
+    negative_count: int
+    neutral_count: int
+    dominant_direction: str
+    direction_consistency: float
+    supporting_observation_ids: tuple[str, ...]
+    supporting_interaction_ids: tuple[str, ...]
+    supporting_transition_evidence_ids: tuple[str, ...]
+    supporting_conformance_report_ids: tuple[str, ...]
+    supporting_finding_ids: tuple[str, ...]
+    version: str = UNEXPLAINED_FIELD_RECURRENCE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.statistic_id or not self.field_id:
+            raise PerceptionTransitionDiscoveryError(
+                "field recurrence identities must be non-empty"
+            )
+        _positive_int("observation_count", self.observation_count)
+        _positive_int("occurrence_count", self.occurrence_count)
+        if self.occurrence_count > self.observation_count:
+            raise PerceptionTransitionDiscoveryError(
+                "field occurrence_count exceeds observation_count"
+            )
+        _unit("recurrence_fraction", self.recurrence_fraction)
+        _unit("mean_absolute_change", self.mean_absolute_change)
+        _unit("mean_changed_fraction", self.mean_changed_fraction)
+        _unit("direction_consistency", self.direction_consistency)
+        if not -1.0 <= self.mean_signed_change <= 1.0:
+            raise PerceptionTransitionDiscoveryError(
+                "mean_signed_change must be in [-1, 1]"
+            )
+        if not _same_float(
+            self.recurrence_fraction,
+            self.occurrence_count / self.observation_count,
+        ):
+            raise PerceptionTransitionDiscoveryError(
+                "field recurrence_fraction disagrees with counts"
+            )
+        if self.positive_count + self.negative_count + self.neutral_count != self.occurrence_count:
+            raise PerceptionTransitionDiscoveryError(
+                "field direction counts disagree with occurrence_count"
+            )
+        if self.dominant_direction not in DIRECTION_LABELS:
+            raise PerceptionTransitionDiscoveryError(
+                f"unsupported dominant_direction: {self.dominant_direction}"
+            )
+        for name in (
+            "supporting_observation_ids",
+            "supporting_interaction_ids",
+            "supporting_transition_evidence_ids",
+            "supporting_conformance_report_ids",
+            "supporting_finding_ids",
+        ):
+            _ordered(name, getattr(self, name), allow_empty=False)
+        if len(self.supporting_observation_ids) != self.occurrence_count:
+            raise PerceptionTransitionDiscoveryError(
+                "field supporting observation count disagrees with occurrence_count"
+            )
+        if self.version != UNEXPLAINED_FIELD_RECURRENCE_VERSION:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported field recurrence version"
+            )
+        if self.statistic_id != _digest(_payload(self, "statistic_id")):
+            raise PerceptionTransitionDiscoveryError(
+                "field recurrence identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class UnexplainedSignatureRecurrenceDTO:
+    statistic_id: str
+    field_ids: tuple[str, ...]
+    observation_count: int
+    occurrence_count: int
+    recurrence_fraction: float
+    mean_absolute_change: float
+    mean_signed_change: float
+    mean_changed_fraction: float
+    positive_count: int
+    negative_count: int
+    neutral_count: int
+    dominant_direction: str
+    direction_consistency: float
+    supporting_observation_ids: tuple[str, ...]
+    supporting_interaction_ids: tuple[str, ...]
+    supporting_transition_evidence_ids: tuple[str, ...]
+    supporting_conformance_report_ids: tuple[str, ...]
+    supporting_finding_ids: tuple[str, ...]
+    version: str = UNEXPLAINED_SIGNATURE_RECURRENCE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.statistic_id:
+            raise PerceptionTransitionDiscoveryError(
+                "signature recurrence identity must be non-empty"
+            )
+        _ordered("signature field_ids", self.field_ids, allow_empty=False)
+        if len(self.field_ids) < 2:
+            raise PerceptionTransitionDiscoveryError(
+                "signature recurrence requires at least two fields"
+            )
+        _positive_int("observation_count", self.observation_count)
+        _positive_int("occurrence_count", self.occurrence_count)
+        if self.occurrence_count > self.observation_count:
+            raise PerceptionTransitionDiscoveryError(
+                "signature occurrence_count exceeds observation_count"
+            )
+        _unit("recurrence_fraction", self.recurrence_fraction)
+        _unit("mean_absolute_change", self.mean_absolute_change)
+        _unit("mean_changed_fraction", self.mean_changed_fraction)
+        _unit("direction_consistency", self.direction_consistency)
+        if not -1.0 <= self.mean_signed_change <= 1.0:
+            raise PerceptionTransitionDiscoveryError(
+                "mean_signed_change must be in [-1, 1]"
+            )
+        if not _same_float(
+            self.recurrence_fraction,
+            self.occurrence_count / self.observation_count,
+        ):
+            raise PerceptionTransitionDiscoveryError(
+                "signature recurrence_fraction disagrees with counts"
+            )
+        if self.positive_count + self.negative_count + self.neutral_count != self.occurrence_count:
+            raise PerceptionTransitionDiscoveryError(
+                "signature direction counts disagree with occurrence_count"
+            )
+        if self.dominant_direction not in DIRECTION_LABELS:
+            raise PerceptionTransitionDiscoveryError(
+                f"unsupported dominant_direction: {self.dominant_direction}"
+            )
+        for name in (
+            "supporting_observation_ids",
+            "supporting_interaction_ids",
+            "supporting_transition_evidence_ids",
+            "supporting_conformance_report_ids",
+            "supporting_finding_ids",
+        ):
+            _ordered(name, getattr(self, name), allow_empty=False)
+        if len(self.supporting_observation_ids) != self.occurrence_count:
+            raise PerceptionTransitionDiscoveryError(
+                "signature supporting observation count disagrees with occurrence_count"
+            )
+        if self.version != UNEXPLAINED_SIGNATURE_RECURRENCE_VERSION:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported signature recurrence version"
+            )
+        if self.statistic_id != _digest(_payload(self, "statistic_id")):
+            raise PerceptionTransitionDiscoveryError(
+                "signature recurrence identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class MissingComponentCandidateDTO:
+    candidate_id: str
+    candidate_kind: str
+    source_statistic_id: str
+    field_ids: tuple[str, ...]
+    occurrence_count: int
+    observation_count: int
+    recurrence_fraction: float
+    proposed_expected_change: str
+    dominant_direction: str
+    direction_consistency: float
+    supporting_observation_ids: tuple[str, ...]
+    hypothesis_status: str = MISSING_COMPONENT_HYPOTHESIS_STATUS
+    version: str = MISSING_COMPONENT_CANDIDATE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.candidate_id or not self.source_statistic_id:
+            raise PerceptionTransitionDiscoveryError(
+                "missing-component candidate identities must be non-empty"
+            )
+        if self.candidate_kind not in MISSING_COMPONENT_CANDIDATE_KINDS:
+            raise PerceptionTransitionDiscoveryError(
+                f"unsupported candidate_kind: {self.candidate_kind}"
+            )
+        _ordered("candidate field_ids", self.field_ids, allow_empty=False)
+        if self.candidate_kind == "field" and len(self.field_ids) != 1:
+            raise PerceptionTransitionDiscoveryError(
+                "field candidates require exactly one field"
+            )
+        if self.candidate_kind == "cooccurrence_signature" and len(self.field_ids) < 2:
+            raise PerceptionTransitionDiscoveryError(
+                "cooccurrence candidates require at least two fields"
+            )
+        _positive_int("occurrence_count", self.occurrence_count)
+        _positive_int("observation_count", self.observation_count)
+        if self.occurrence_count > self.observation_count:
+            raise PerceptionTransitionDiscoveryError(
+                "candidate occurrence_count exceeds observation_count"
+            )
+        _unit("recurrence_fraction", self.recurrence_fraction)
+        _unit("direction_consistency", self.direction_consistency)
+        if self.proposed_expected_change not in PROPOSED_CHANGE_KINDS:
+            raise PerceptionTransitionDiscoveryError(
+                f"unsupported proposed_expected_change: {self.proposed_expected_change}"
+            )
+        if self.dominant_direction not in DIRECTION_LABELS:
+            raise PerceptionTransitionDiscoveryError(
+                f"unsupported dominant_direction: {self.dominant_direction}"
+            )
+        _ordered(
+            "candidate supporting_observation_ids",
+            self.supporting_observation_ids,
+            allow_empty=False,
+        )
+        if len(self.supporting_observation_ids) != self.occurrence_count:
+            raise PerceptionTransitionDiscoveryError(
+                "candidate supporting observations disagree with occurrence_count"
+            )
+        if self.hypothesis_status != MISSING_COMPONENT_HYPOTHESIS_STATUS:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported missing-component hypothesis status"
+            )
+        if self.version != MISSING_COMPONENT_CANDIDATE_VERSION:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported missing-component candidate version"
+            )
+        if self.candidate_id != _digest(_payload(self, "candidate_id")):
+            raise PerceptionTransitionDiscoveryError(
+                "missing-component candidate identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class TransitionDiscoveryReportDTO:
+    report_id: str
+    status: str
+    cohort_id: str
+    field_schema_id: str
+    policy_id: str
+    observation_ids: tuple[str, ...]
+    interaction_ids: tuple[str, ...]
+    transition_evidence_ids: tuple[str, ...]
+    conformance_report_ids: tuple[str, ...]
+    field_statistics: tuple[UnexplainedFieldRecurrenceDTO, ...]
+    signature_statistics: tuple[UnexplainedSignatureRecurrenceDTO, ...]
+    candidates: tuple[MissingComponentCandidateDTO, ...]
+    semantics: str = TRANSITION_DISCOVERY_SEMANTICS
+    version: str = TRANSITION_DISCOVERY_REPORT_VERSION
+
+    def __post_init__(self) -> None:
+        if not all((self.report_id, self.cohort_id, self.field_schema_id, self.policy_id)):
+            raise PerceptionTransitionDiscoveryError(
+                "transition discovery report identities must be non-empty"
+            )
+        if self.status not in TRANSITION_DISCOVERY_REPORT_STATUSES:
+            raise PerceptionTransitionDiscoveryError(
+                f"unsupported discovery report status: {self.status}"
+            )
+        for name in (
+            "observation_ids",
+            "interaction_ids",
+            "transition_evidence_ids",
+            "conformance_report_ids",
+        ):
+            _ordered(name, getattr(self, name), allow_empty=False)
+        count = len(self.observation_ids)
+        if not (
+            len(self.interaction_ids)
+            == len(self.transition_evidence_ids)
+            == len(self.conformance_report_ids)
+            == count
+        ):
+            raise PerceptionTransitionDiscoveryError(
+                "report evidence identity counts must match observations"
+            )
+        field_statistic_ids = tuple(item.statistic_id for item in self.field_statistics)
+        signature_statistic_ids = tuple(
+            item.statistic_id for item in self.signature_statistics
+        )
+        candidate_ids = tuple(item.candidate_id for item in self.candidates)
+        _ordered("field statistic identities", field_statistic_ids)
+        _ordered("signature statistic identities", signature_statistic_ids)
+        _ordered("candidate identities", candidate_ids)
+        expected_status = (
+            "candidates_found" if self.candidates else "no_candidates"
+        )
+        if self.status != "insufficient_evidence" and self.status != expected_status:
+            raise PerceptionTransitionDiscoveryError(
+                "discovery report status disagrees with candidates"
+            )
+        if self.status == "insufficient_evidence" and self.candidates:
+            raise PerceptionTransitionDiscoveryError(
+                "insufficient-evidence reports cannot contain candidates"
+            )
+        known_statistics = set(field_statistic_ids) | set(signature_statistic_ids)
+        if any(item.source_statistic_id not in known_statistics for item in self.candidates):
+            raise PerceptionTransitionDiscoveryError(
+                "candidate references unknown recurrence statistic"
+            )
+        if self.semantics != TRANSITION_DISCOVERY_SEMANTICS:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported transition discovery semantics"
+            )
+        if self.version != TRANSITION_DISCOVERY_REPORT_VERSION:
+            raise PerceptionTransitionDiscoveryError(
+                "unsupported transition discovery report version"
+            )
+        if self.report_id != _digest(_payload(self, "report_id")):
+            raise PerceptionTransitionDiscoveryError(
+                "transition discovery report identity disagrees with canonical payload"
+            )
+
+    def candidates_for_kind(
+        self,
+        candidate_kind: str,
+    ) -> tuple[MissingComponentCandidateDTO, ...]:
+        if candidate_kind not in MISSING_COMPONENT_CANDIDATE_KINDS:
+            raise PerceptionTransitionDiscoveryError(
+                f"unsupported candidate_kind: {candidate_kind}"
+            )
+        return tuple(
+            item for item in self.candidates if item.candidate_kind == candidate_kind
+        )
+
+
+def _direction_counts(
+    signed_values: tuple[float, ...],
+    epsilon: float,
+) -> tuple[int, int, int, str, float]:
+    positive = sum(value > epsilon for value in signed_values)
+    negative = sum(value < -epsilon for value in signed_values)
+    neutral = len(signed_values) - positive - negative
+    counts = {"positive": positive, "negative": negative, "neutral": neutral}
+    maximum = max(counts.values())
+    leaders = tuple(sorted(name for name, count in counts.items() if count == maximum))
+    dominant = leaders[0] if len(leaders) == 1 else "mixed"
+    return positive, negative, neutral, dominant, maximum / len(signed_values)
+
+
+def _aggregate_occurrence_groups(
+    groups: tuple[tuple[UnexplainedFieldOccurrenceDTO, ...], ...],
+    epsilon: float,
+) -> tuple[float, float, float, int, int, int, str, float]:
+    total_values = 0
+    absolute_total = 0.0
+    signed_total = 0.0
+    changed_values = 0
+    per_observation_signed: list[float] = []
+    for group in groups:
+        group_total = sum(item.total_value_count for item in group)
+        if group_total <= 0:
+            raise PerceptionTransitionDiscoveryError(
+                "recurrence evidence group has no measurable values"
+            )
+        total_values += group_total
+        absolute_total += sum(
+            item.mean_absolute_change * item.total_value_count for item in group
+        )
+        signed_value = sum(
+            item.mean_signed_change * item.total_value_count for item in group
+        ) / group_total
+        signed_total += signed_value * group_total
+        changed_values += sum(item.changed_value_count for item in group)
+        per_observation_signed.append(signed_value)
+    positive, negative, neutral, dominant, consistency = _direction_counts(
+        tuple(per_observation_signed),
+        epsilon,
+    )
+    return (
+        absolute_total / total_values,
+        signed_total / total_values,
+        changed_values / total_values,
+        positive,
+        negative,
+        neutral,
+        dominant,
+        consistency,
+    )
+
+
+def _support_values(
+    observations: tuple[TransitionDiscoveryObservationDTO, ...],
+    field_ids: tuple[str, ...],
+) -> tuple[
+    tuple[tuple[UnexplainedFieldOccurrenceDTO, ...], ...],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+]:
+    field_set = set(field_ids)
+    groups: list[tuple[UnexplainedFieldOccurrenceDTO, ...]] = []
+    selected: list[TransitionDiscoveryObservationDTO] = []
+    finding_ids: set[str] = set()
+    for observation in observations:
+        matches = tuple(
+            item for item in observation.unexplained_fields if item.field_id in field_set
+        )
+        if len(matches) != len(field_ids):
+            continue
+        groups.append(matches)
+        selected.append(observation)
+        finding_ids.update(item.finding_id for item in matches)
+    return (
+        tuple(groups),
+        tuple(sorted(item.observation_id for item in selected)),
+        tuple(sorted(item.interaction_id for item in selected)),
+        tuple(sorted(item.transition_evidence_id for item in selected)),
+        tuple(sorted(item.conformance_report_id for item in selected)),
+        tuple(sorted(finding_ids)),
+    )
+
+
+def _field_statistic(
+    field_id: str,
+    observations: tuple[TransitionDiscoveryObservationDTO, ...],
+    policy: TransitionDiscoveryPolicyDTO,
+) -> UnexplainedFieldRecurrenceDTO:
+    groups, observation_ids, interaction_ids, transition_ids, report_ids, finding_ids = (
+        _support_values(observations, (field_id,))
+    )
+    metrics = _aggregate_occurrence_groups(groups, policy.direction_epsilon)
+    values: dict[str, object] = {
+        "field_id": field_id,
+        "observation_count": len(observations),
+        "occurrence_count": len(groups),
+        "recurrence_fraction": len(groups) / len(observations),
+        "mean_absolute_change": metrics[0],
+        "mean_signed_change": metrics[1],
+        "mean_changed_fraction": metrics[2],
+        "positive_count": metrics[3],
+        "negative_count": metrics[4],
+        "neutral_count": metrics[5],
+        "dominant_direction": metrics[6],
+        "direction_consistency": metrics[7],
+        "supporting_observation_ids": observation_ids,
+        "supporting_interaction_ids": interaction_ids,
+        "supporting_transition_evidence_ids": transition_ids,
+        "supporting_conformance_report_ids": report_ids,
+        "supporting_finding_ids": finding_ids,
+        "version": UNEXPLAINED_FIELD_RECURRENCE_VERSION,
+    }
+    return UnexplainedFieldRecurrenceDTO(
+        statistic_id=_digest(values), **values  # type: ignore[arg-type]
+    )
+
+
+def _signature_statistic(
+    field_ids: tuple[str, ...],
+    supporting: tuple[TransitionDiscoveryObservationDTO, ...],
+    observation_count: int,
+    policy: TransitionDiscoveryPolicyDTO,
+) -> UnexplainedSignatureRecurrenceDTO:
+    groups = tuple(item.unexplained_fields for item in supporting)
+    metrics = _aggregate_occurrence_groups(groups, policy.direction_epsilon)
+    finding_ids = tuple(
+        sorted(
+            {
+                occurrence.finding_id
+                for observation in supporting
+                for occurrence in observation.unexplained_fields
+            }
+        )
+    )
+    values: dict[str, object] = {
+        "field_ids": field_ids,
+        "observation_count": observation_count,
+        "occurrence_count": len(supporting),
+        "recurrence_fraction": len(supporting) / observation_count,
+        "mean_absolute_change": metrics[0],
+        "mean_signed_change": metrics[1],
+        "mean_changed_fraction": metrics[2],
+        "positive_count": metrics[3],
+        "negative_count": metrics[4],
+        "neutral_count": metrics[5],
+        "dominant_direction": metrics[6],
+        "direction_consistency": metrics[7],
+        "supporting_observation_ids": tuple(
+            sorted(item.observation_id for item in supporting)
+        ),
+        "supporting_interaction_ids": tuple(
+            sorted(item.interaction_id for item in supporting)
+        ),
+        "supporting_transition_evidence_ids": tuple(
+            sorted(item.transition_evidence_id for item in supporting)
+        ),
+        "supporting_conformance_report_ids": tuple(
+            sorted(item.conformance_report_id for item in supporting)
+        ),
+        "supporting_finding_ids": finding_ids,
+        "version": UNEXPLAINED_SIGNATURE_RECURRENCE_VERSION,
+    }
+    return UnexplainedSignatureRecurrenceDTO(
+        statistic_id=_digest(values), **values  # type: ignore[arg-type]
+    )
+
+
+def _proposed_change(
+    dominant_direction: str,
+    direction_consistency: float,
+    policy: TransitionDiscoveryPolicyDTO,
+) -> str:
+    if direction_consistency < policy.minimum_direction_consistency:
+        return "change"
+    if dominant_direction == "positive":
+        return "increase"
+    if dominant_direction == "negative":
+        return "decrease"
+    return "change"
+
+
+def _candidate(
+    *,
+    candidate_kind: str,
+    source_statistic_id: str,
+    field_ids: tuple[str, ...],
+    occurrence_count: int,
+    observation_count: int,
+    recurrence_fraction: float,
+    dominant_direction: str,
+    direction_consistency: float,
+    supporting_observation_ids: tuple[str, ...],
+    policy: TransitionDiscoveryPolicyDTO,
+) -> MissingComponentCandidateDTO:
+    values: dict[str, object] = {
+        "candidate_kind": candidate_kind,
+        "source_statistic_id": source_statistic_id,
+        "field_ids": field_ids,
+        "occurrence_count": occurrence_count,
+        "observation_count": observation_count,
+        "recurrence_fraction": recurrence_fraction,
+        "proposed_expected_change": _proposed_change(
+            dominant_direction,
+            direction_consistency,
+            policy,
+        ),
+        "dominant_direction": dominant_direction,
+        "direction_consistency": direction_consistency,
+        "supporting_observation_ids": supporting_observation_ids,
+        "hypothesis_status": MISSING_COMPONENT_HYPOTHESIS_STATUS,
+        "version": MISSING_COMPONENT_CANDIDATE_VERSION,
+    }
+    return MissingComponentCandidateDTO(
+        candidate_id=_digest(values), **values  # type: ignore[arg-type]
+    )
+
+
+def discover_recurrent_unexplained_transitions(
+    observations: tuple[TransitionDiscoveryObservationDTO, ...],
+    policy: TransitionDiscoveryPolicyDTO | None = None,
+) -> TransitionDiscoveryReportDTO:
+    """Discover recurrent unexplained field hypotheses within one cohort."""
+
+    if not observations:
+        raise PerceptionTransitionDiscoveryError(
+            "transition discovery requires at least one observation"
+        )
+    resolved = policy or TransitionDiscoveryPolicyDTO.create()
+    observation_map = {item.observation_id: item for item in observations}
+    interaction_map = {item.interaction_id: item for item in observations}
+    transition_map = {item.transition_evidence_id: item for item in observations}
+    report_map = {item.conformance_report_id: item for item in observations}
+    if len(observation_map) != len(observations):
+        raise PerceptionTransitionDiscoveryError(
+            "discovery observations must have unique identities"
+        )
+    if len(interaction_map) != len(observations):
+        raise PerceptionTransitionDiscoveryError(
+            "discovery interactions must have unique identities"
+        )
+    if len(transition_map) != len(observations):
+        raise PerceptionTransitionDiscoveryError(
+            "discovery transitions must have unique identities"
+        )
+    if len(report_map) != len(observations):
+        raise PerceptionTransitionDiscoveryError(
+            "discovery conformance reports must have unique identities"
+        )
+    cohort_ids = {item.cohort_id for item in observations}
+    schema_ids = {item.field_schema_id for item in observations}
+    if len(cohort_ids) != 1:
+        raise PerceptionTransitionDiscoveryError(
+            "discovery observations must belong to one cohort"
+        )
+    if len(schema_ids) != 1:
+        raise PerceptionTransitionDiscoveryError(
+            "discovery observations must use one field schema"
+        )
+    ordered_observations = tuple(
+        sorted(observations, key=lambda item: item.observation_id)
+    )
+    all_field_ids = tuple(
+        sorted(
+            {
+                occurrence.field_id
+                for observation in ordered_observations
+                for occurrence in observation.unexplained_fields
+            }
+        )
+    )
+    field_statistics = tuple(
+        sorted(
+            (
+                _field_statistic(field_id, ordered_observations, resolved)
+                for field_id in all_field_ids
+            ),
+            key=lambda item: item.statistic_id,
+        )
+    )
+    signature_support: dict[
+        tuple[str, ...], list[TransitionDiscoveryObservationDTO]
+    ] = {}
+    for observation in ordered_observations:
+        signature = observation.unexplained_field_ids
+        if len(signature) >= 2:
+            signature_support.setdefault(signature, []).append(observation)
+    signature_statistics = tuple(
+        sorted(
+            (
+                _signature_statistic(
+                    signature,
+                    tuple(supporting),
+                    len(ordered_observations),
+                    resolved,
+                )
+                for signature, supporting in signature_support.items()
+            ),
+            key=lambda item: item.statistic_id,
+        )
+    )
+
+    candidates: list[MissingComponentCandidateDTO] = []
+    evidence_ready = len(ordered_observations) >= resolved.minimum_observation_count
+    if evidence_ready:
+        for statistic in field_statistics:
+            if (
+                statistic.occurrence_count
+                >= resolved.minimum_field_occurrence_count
+                and statistic.recurrence_fraction
+                >= resolved.minimum_field_recurrence_fraction
+            ):
+                candidates.append(
+                    _candidate(
+                        candidate_kind="field",
+                        source_statistic_id=statistic.statistic_id,
+                        field_ids=(statistic.field_id,),
+                        occurrence_count=statistic.occurrence_count,
+                        observation_count=statistic.observation_count,
+                        recurrence_fraction=statistic.recurrence_fraction,
+                        dominant_direction=statistic.dominant_direction,
+                        direction_consistency=statistic.direction_consistency,
+                        supporting_observation_ids=(
+                            statistic.supporting_observation_ids
+                        ),
+                        policy=resolved,
+                    )
+                )
+        for statistic in signature_statistics:
+            if (
+                statistic.occurrence_count
+                >= resolved.minimum_signature_occurrence_count
+                and statistic.recurrence_fraction
+                >= resolved.minimum_signature_recurrence_fraction
+            ):
+                candidates.append(
+                    _candidate(
+                        candidate_kind="cooccurrence_signature",
+                        source_statistic_id=statistic.statistic_id,
+                        field_ids=statistic.field_ids,
+                        occurrence_count=statistic.occurrence_count,
+                        observation_count=statistic.observation_count,
+                        recurrence_fraction=statistic.recurrence_fraction,
+                        dominant_direction=statistic.dominant_direction,
+                        direction_consistency=statistic.direction_consistency,
+                        supporting_observation_ids=(
+                            statistic.supporting_observation_ids
+                        ),
+                        policy=resolved,
+                    )
+                )
+    ordered_candidates = tuple(sorted(candidates, key=lambda item: item.candidate_id))
+    if not evidence_ready:
+        status = "insufficient_evidence"
+    elif ordered_candidates:
+        status = "candidates_found"
+    else:
+        status = "no_candidates"
+    values: dict[str, object] = {
+        "status": status,
+        "cohort_id": next(iter(cohort_ids)),
+        "field_schema_id": next(iter(schema_ids)),
+        "policy_id": resolved.policy_id,
+        "observation_ids": tuple(sorted(observation_map)),
+        "interaction_ids": tuple(sorted(interaction_map)),
+        "transition_evidence_ids": tuple(sorted(transition_map)),
+        "conformance_report_ids": tuple(sorted(report_map)),
+        "field_statistics": field_statistics,
+        "signature_statistics": signature_statistics,
+        "candidates": ordered_candidates,
+        "semantics": TRANSITION_DISCOVERY_SEMANTICS,
+        "version": TRANSITION_DISCOVERY_REPORT_VERSION,
+    }
+    identity_values = dict(values)
+    identity_values["field_statistics"] = tuple(
+        asdict(item) for item in field_statistics
+    )
+    identity_values["signature_statistics"] = tuple(
+        asdict(item) for item in signature_statistics
+    )
+    identity_values["candidates"] = tuple(asdict(item) for item in ordered_candidates)
+    return TransitionDiscoveryReportDTO(
+        report_id=_digest(identity_values),
+        **values,  # type: ignore[arg-type]
+    )

--- a/packages/perception/src/zeromodel/perception/transition_discovery.py
+++ b/packages/perception/src/zeromodel/perception/transition_discovery.py
@@ -1,10 +1,9 @@
 """Recurrent unexplained transition discovery for Stage P18C.
 
-P18C materializes a declared discovery cohort from immutable P18A transition
-artifacts and P18B conformance reports. It measures recurrence and exact
-co-occurrence of unexplained fields, then emits unvalidated candidate components
-and falsifiable change hypotheses. Recurrence is association evidence, not
-semantic detection, validation, or causal proof.
+P18C aggregates immutable P18A evidence and P18B unexplained findings inside one
+explicit discovery cohort. It produces thresholded, content-addressed candidate
+components and falsifiable change hypotheses. Candidates remain unvalidated
+associations; they are not semantic detections or causal conclusions.
 """
 
 from __future__ import annotations
@@ -26,11 +25,8 @@ TRANSITION_DISCOVERY_OBSERVATION_VERSION: Final = (
 TRANSITION_DISCOVERY_POLICY_VERSION: Final = (
     "perception-transition-discovery-policy/1"
 )
-UNEXPLAINED_FIELD_RECURRENCE_VERSION: Final = (
-    "perception-unexplained-field-recurrence/1"
-)
-UNEXPLAINED_SIGNATURE_RECURRENCE_VERSION: Final = (
-    "perception-unexplained-signature-recurrence/1"
+RECURRENT_UNEXPLAINED_STATISTIC_VERSION: Final = (
+    "perception-recurrent-unexplained-statistic/1"
 )
 MISSING_COMPONENT_CANDIDATE_VERSION: Final = (
     "perception-missing-component-candidate/1"
@@ -46,7 +42,7 @@ TRANSITION_DISCOVERY_REPORT_STATUSES: Final = {
     "no_candidates",
     "candidates_found",
 }
-MISSING_COMPONENT_CANDIDATE_KINDS: Final = {
+RECURRENT_UNEXPLAINED_STATISTIC_KINDS: Final = {
     "field",
     "cooccurrence_signature",
 }
@@ -83,13 +79,30 @@ def _payload(value: object, identity_field: str) -> dict[str, object]:
     return payload
 
 
-def _ordered(name: str, values: tuple[str, ...], *, allow_empty: bool = True) -> None:
+def _ordered_unique(
+    name: str,
+    values: tuple[str, ...],
+    *,
+    allow_empty: bool = True,
+) -> None:
     if not allow_empty and not values:
         raise PerceptionTransitionDiscoveryError(f"{name} must be non-empty")
     if values != tuple(sorted(set(values))):
         raise PerceptionTransitionDiscoveryError(
             f"{name} must be unique and sorted"
         )
+
+
+def _ordered_with_repetition(
+    name: str,
+    values: tuple[str, ...],
+    *,
+    allow_empty: bool = True,
+) -> None:
+    if not allow_empty and not values:
+        raise PerceptionTransitionDiscoveryError(f"{name} must be non-empty")
+    if values != tuple(sorted(values)):
+        raise PerceptionTransitionDiscoveryError(f"{name} must be sorted")
 
 
 def _unit(name: str, value: float) -> None:
@@ -99,7 +112,9 @@ def _unit(name: str, value: float) -> None:
 
 def _positive_int(name: str, value: int) -> None:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        raise PerceptionTransitionDiscoveryError(f"{name} must be a positive integer")
+        raise PerceptionTransitionDiscoveryError(
+            f"{name} must be a positive integer"
+        )
 
 
 def _same_float(left: float, right: float) -> bool:
@@ -178,7 +193,7 @@ class UnexplainedFieldOccurrenceDTO:
 
 @dataclass(frozen=True)
 class TransitionDiscoveryObservationDTO:
-    """One interaction in an explicit discovery cohort, including empty evidence."""
+    """One interaction in a discovery cohort, including zero-finding controls."""
 
     observation_id: str
     interaction_id: str
@@ -209,7 +224,10 @@ class TransitionDiscoveryObservationDTO:
                 "unexplained fields must be unique and sorted by field_id"
             )
         occurrence_ids = tuple(item.occurrence_id for item in self.unexplained_fields)
-        _ordered("unexplained occurrence identities", occurrence_ids)
+        if len(occurrence_ids) != len(set(occurrence_ids)):
+            raise PerceptionTransitionDiscoveryError(
+                "unexplained occurrence identities must be unique"
+            )
         if self.version != TRANSITION_DISCOVERY_OBSERVATION_VERSION:
             raise PerceptionTransitionDiscoveryError(
                 "unsupported discovery observation version"
@@ -300,7 +318,9 @@ class TransitionDiscoveryObservationDTO:
             "version": TRANSITION_DISCOVERY_OBSERVATION_VERSION,
         }
         identity_values = dict(values)
-        identity_values["unexplained_fields"] = tuple(asdict(item) for item in ordered)
+        identity_values["unexplained_fields"] = tuple(
+            asdict(item) for item in ordered
+        )
         return cls(
             observation_id=_digest(identity_values),
             **values,  # type: ignore[arg-type]
@@ -372,86 +392,9 @@ class TransitionDiscoveryPolicyDTO:
 
 
 @dataclass(frozen=True)
-class UnexplainedFieldRecurrenceDTO:
+class RecurrentUnexplainedStatisticDTO:
     statistic_id: str
-    field_id: str
-    observation_count: int
-    occurrence_count: int
-    recurrence_fraction: float
-    mean_absolute_change: float
-    mean_signed_change: float
-    mean_changed_fraction: float
-    positive_count: int
-    negative_count: int
-    neutral_count: int
-    dominant_direction: str
-    direction_consistency: float
-    supporting_observation_ids: tuple[str, ...]
-    supporting_interaction_ids: tuple[str, ...]
-    supporting_transition_evidence_ids: tuple[str, ...]
-    supporting_conformance_report_ids: tuple[str, ...]
-    supporting_finding_ids: tuple[str, ...]
-    version: str = UNEXPLAINED_FIELD_RECURRENCE_VERSION
-
-    def __post_init__(self) -> None:
-        if not self.statistic_id or not self.field_id:
-            raise PerceptionTransitionDiscoveryError(
-                "field recurrence identities must be non-empty"
-            )
-        _positive_int("observation_count", self.observation_count)
-        _positive_int("occurrence_count", self.occurrence_count)
-        if self.occurrence_count > self.observation_count:
-            raise PerceptionTransitionDiscoveryError(
-                "field occurrence_count exceeds observation_count"
-            )
-        _unit("recurrence_fraction", self.recurrence_fraction)
-        _unit("mean_absolute_change", self.mean_absolute_change)
-        _unit("mean_changed_fraction", self.mean_changed_fraction)
-        _unit("direction_consistency", self.direction_consistency)
-        if not -1.0 <= self.mean_signed_change <= 1.0:
-            raise PerceptionTransitionDiscoveryError(
-                "mean_signed_change must be in [-1, 1]"
-            )
-        if not _same_float(
-            self.recurrence_fraction,
-            self.occurrence_count / self.observation_count,
-        ):
-            raise PerceptionTransitionDiscoveryError(
-                "field recurrence_fraction disagrees with counts"
-            )
-        if self.positive_count + self.negative_count + self.neutral_count != self.occurrence_count:
-            raise PerceptionTransitionDiscoveryError(
-                "field direction counts disagree with occurrence_count"
-            )
-        if self.dominant_direction not in DIRECTION_LABELS:
-            raise PerceptionTransitionDiscoveryError(
-                f"unsupported dominant_direction: {self.dominant_direction}"
-            )
-        for name in (
-            "supporting_observation_ids",
-            "supporting_interaction_ids",
-            "supporting_transition_evidence_ids",
-            "supporting_conformance_report_ids",
-            "supporting_finding_ids",
-        ):
-            _ordered(name, getattr(self, name), allow_empty=False)
-        if len(self.supporting_observation_ids) != self.occurrence_count:
-            raise PerceptionTransitionDiscoveryError(
-                "field supporting observation count disagrees with occurrence_count"
-            )
-        if self.version != UNEXPLAINED_FIELD_RECURRENCE_VERSION:
-            raise PerceptionTransitionDiscoveryError(
-                "unsupported field recurrence version"
-            )
-        if self.statistic_id != _digest(_payload(self, "statistic_id")):
-            raise PerceptionTransitionDiscoveryError(
-                "field recurrence identity disagrees with canonical payload"
-            )
-
-
-@dataclass(frozen=True)
-class UnexplainedSignatureRecurrenceDTO:
-    statistic_id: str
+    statistic_kind: str
     field_ids: tuple[str, ...]
     observation_count: int
     occurrence_count: int
@@ -469,23 +412,31 @@ class UnexplainedSignatureRecurrenceDTO:
     supporting_transition_evidence_ids: tuple[str, ...]
     supporting_conformance_report_ids: tuple[str, ...]
     supporting_finding_ids: tuple[str, ...]
-    version: str = UNEXPLAINED_SIGNATURE_RECURRENCE_VERSION
+    version: str = RECURRENT_UNEXPLAINED_STATISTIC_VERSION
 
     def __post_init__(self) -> None:
         if not self.statistic_id:
             raise PerceptionTransitionDiscoveryError(
-                "signature recurrence identity must be non-empty"
+                "recurrence statistic identity must be non-empty"
             )
-        _ordered("signature field_ids", self.field_ids, allow_empty=False)
-        if len(self.field_ids) < 2:
+        if self.statistic_kind not in RECURRENT_UNEXPLAINED_STATISTIC_KINDS:
             raise PerceptionTransitionDiscoveryError(
-                "signature recurrence requires at least two fields"
+                f"unsupported statistic_kind: {self.statistic_kind}"
+            )
+        _ordered_unique("statistic field_ids", self.field_ids, allow_empty=False)
+        if self.statistic_kind == "field" and len(self.field_ids) != 1:
+            raise PerceptionTransitionDiscoveryError(
+                "field statistics require exactly one field"
+            )
+        if self.statistic_kind == "cooccurrence_signature" and len(self.field_ids) < 2:
+            raise PerceptionTransitionDiscoveryError(
+                "cooccurrence statistics require at least two fields"
             )
         _positive_int("observation_count", self.observation_count)
         _positive_int("occurrence_count", self.occurrence_count)
         if self.occurrence_count > self.observation_count:
             raise PerceptionTransitionDiscoveryError(
-                "signature occurrence_count exceeds observation_count"
+                "occurrence_count exceeds observation_count"
             )
         _unit("recurrence_fraction", self.recurrence_fraction)
         _unit("mean_absolute_change", self.mean_absolute_change)
@@ -500,43 +451,69 @@ class UnexplainedSignatureRecurrenceDTO:
             self.occurrence_count / self.observation_count,
         ):
             raise PerceptionTransitionDiscoveryError(
-                "signature recurrence_fraction disagrees with counts"
+                "recurrence_fraction disagrees with counts"
             )
-        if self.positive_count + self.negative_count + self.neutral_count != self.occurrence_count:
+        if (
+            self.positive_count + self.negative_count + self.neutral_count
+            != self.occurrence_count
+        ):
             raise PerceptionTransitionDiscoveryError(
-                "signature direction counts disagree with occurrence_count"
+                "direction counts disagree with occurrence_count"
             )
         if self.dominant_direction not in DIRECTION_LABELS:
             raise PerceptionTransitionDiscoveryError(
                 f"unsupported dominant_direction: {self.dominant_direction}"
             )
-        for name in (
+        _ordered_unique(
             "supporting_observation_ids",
+            self.supporting_observation_ids,
+            allow_empty=False,
+        )
+        _ordered_unique(
             "supporting_interaction_ids",
+            self.supporting_interaction_ids,
+            allow_empty=False,
+        )
+        _ordered_with_repetition(
             "supporting_transition_evidence_ids",
+            self.supporting_transition_evidence_ids,
+            allow_empty=False,
+        )
+        _ordered_with_repetition(
             "supporting_conformance_report_ids",
+            self.supporting_conformance_report_ids,
+            allow_empty=False,
+        )
+        _ordered_unique(
             "supporting_finding_ids",
+            self.supporting_finding_ids,
+            allow_empty=False,
+        )
+        if not (
+            len(self.supporting_observation_ids)
+            == len(self.supporting_interaction_ids)
+            == len(self.supporting_transition_evidence_ids)
+            == len(self.supporting_conformance_report_ids)
+            == self.occurrence_count
         ):
-            _ordered(name, getattr(self, name), allow_empty=False)
-        if len(self.supporting_observation_ids) != self.occurrence_count:
             raise PerceptionTransitionDiscoveryError(
-                "signature supporting observation count disagrees with occurrence_count"
+                "supporting evidence counts disagree with occurrence_count"
             )
-        if self.version != UNEXPLAINED_SIGNATURE_RECURRENCE_VERSION:
+        if self.version != RECURRENT_UNEXPLAINED_STATISTIC_VERSION:
             raise PerceptionTransitionDiscoveryError(
-                "unsupported signature recurrence version"
+                "unsupported recurrence statistic version"
             )
         if self.statistic_id != _digest(_payload(self, "statistic_id")):
             raise PerceptionTransitionDiscoveryError(
-                "signature recurrence identity disagrees with canonical payload"
+                "recurrence statistic identity disagrees with canonical payload"
             )
 
 
 @dataclass(frozen=True)
 class MissingComponentCandidateDTO:
     candidate_id: str
-    candidate_kind: str
     source_statistic_id: str
+    candidate_kind: str
     field_ids: tuple[str, ...]
     occurrence_count: int
     observation_count: int
@@ -551,13 +528,13 @@ class MissingComponentCandidateDTO:
     def __post_init__(self) -> None:
         if not self.candidate_id or not self.source_statistic_id:
             raise PerceptionTransitionDiscoveryError(
-                "missing-component candidate identities must be non-empty"
+                "candidate identities must be non-empty"
             )
-        if self.candidate_kind not in MISSING_COMPONENT_CANDIDATE_KINDS:
+        if self.candidate_kind not in RECURRENT_UNEXPLAINED_STATISTIC_KINDS:
             raise PerceptionTransitionDiscoveryError(
                 f"unsupported candidate_kind: {self.candidate_kind}"
             )
-        _ordered("candidate field_ids", self.field_ids, allow_empty=False)
+        _ordered_unique("candidate field_ids", self.field_ids, allow_empty=False)
         if self.candidate_kind == "field" and len(self.field_ids) != 1:
             raise PerceptionTransitionDiscoveryError(
                 "field candidates require exactly one field"
@@ -582,18 +559,18 @@ class MissingComponentCandidateDTO:
             raise PerceptionTransitionDiscoveryError(
                 f"unsupported dominant_direction: {self.dominant_direction}"
             )
-        _ordered(
+        _ordered_unique(
             "candidate supporting_observation_ids",
             self.supporting_observation_ids,
             allow_empty=False,
         )
         if len(self.supporting_observation_ids) != self.occurrence_count:
             raise PerceptionTransitionDiscoveryError(
-                "candidate supporting observations disagree with occurrence_count"
+                "candidate support count disagrees with occurrence_count"
             )
         if self.hypothesis_status != MISSING_COMPONENT_HYPOTHESIS_STATUS:
             raise PerceptionTransitionDiscoveryError(
-                "unsupported missing-component hypothesis status"
+                "unsupported candidate hypothesis status"
             )
         if self.version != MISSING_COMPONENT_CANDIDATE_VERSION:
             raise PerceptionTransitionDiscoveryError(
@@ -601,7 +578,7 @@ class MissingComponentCandidateDTO:
             )
         if self.candidate_id != _digest(_payload(self, "candidate_id")):
             raise PerceptionTransitionDiscoveryError(
-                "missing-component candidate identity disagrees with canonical payload"
+                "candidate identity disagrees with canonical payload"
             )
 
 
@@ -616,8 +593,7 @@ class TransitionDiscoveryReportDTO:
     interaction_ids: tuple[str, ...]
     transition_evidence_ids: tuple[str, ...]
     conformance_report_ids: tuple[str, ...]
-    field_statistics: tuple[UnexplainedFieldRecurrenceDTO, ...]
-    signature_statistics: tuple[UnexplainedSignatureRecurrenceDTO, ...]
+    statistics: tuple[RecurrentUnexplainedStatisticDTO, ...]
     candidates: tuple[MissingComponentCandidateDTO, ...]
     semantics: str = TRANSITION_DISCOVERY_SEMANTICS
     version: str = TRANSITION_DISCOVERY_REPORT_VERSION
@@ -625,19 +601,24 @@ class TransitionDiscoveryReportDTO:
     def __post_init__(self) -> None:
         if not all((self.report_id, self.cohort_id, self.field_schema_id, self.policy_id)):
             raise PerceptionTransitionDiscoveryError(
-                "transition discovery report identities must be non-empty"
+                "discovery report identities must be non-empty"
             )
         if self.status not in TRANSITION_DISCOVERY_REPORT_STATUSES:
             raise PerceptionTransitionDiscoveryError(
                 f"unsupported discovery report status: {self.status}"
             )
-        for name in (
-            "observation_ids",
-            "interaction_ids",
+        _ordered_unique("observation_ids", self.observation_ids, allow_empty=False)
+        _ordered_unique("interaction_ids", self.interaction_ids, allow_empty=False)
+        _ordered_with_repetition(
             "transition_evidence_ids",
+            self.transition_evidence_ids,
+            allow_empty=False,
+        )
+        _ordered_with_repetition(
             "conformance_report_ids",
-        ):
-            _ordered(name, getattr(self, name), allow_empty=False)
+            self.conformance_report_ids,
+            allow_empty=False,
+        )
         count = len(self.observation_ids)
         if not (
             len(self.interaction_ids)
@@ -646,31 +627,31 @@ class TransitionDiscoveryReportDTO:
             == count
         ):
             raise PerceptionTransitionDiscoveryError(
-                "report evidence identity counts must match observations"
+                "report evidence counts must match observations"
             )
-        field_statistic_ids = tuple(item.statistic_id for item in self.field_statistics)
-        signature_statistic_ids = tuple(
-            item.statistic_id for item in self.signature_statistics
-        )
+        statistic_ids = tuple(item.statistic_id for item in self.statistics)
         candidate_ids = tuple(item.candidate_id for item in self.candidates)
-        _ordered("field statistic identities", field_statistic_ids)
-        _ordered("signature statistic identities", signature_statistic_ids)
-        _ordered("candidate identities", candidate_ids)
-        expected_status = (
-            "candidates_found" if self.candidates else "no_candidates"
-        )
-        if self.status != "insufficient_evidence" and self.status != expected_status:
-            raise PerceptionTransitionDiscoveryError(
-                "discovery report status disagrees with candidates"
-            )
+        _ordered_unique("statistic identities", statistic_ids)
+        _ordered_unique("candidate identities", candidate_ids)
         if self.status == "insufficient_evidence" and self.candidates:
             raise PerceptionTransitionDiscoveryError(
                 "insufficient-evidence reports cannot contain candidates"
             )
-        known_statistics = set(field_statistic_ids) | set(signature_statistic_ids)
-        if any(item.source_statistic_id not in known_statistics for item in self.candidates):
+        if self.status == "candidates_found" and not self.candidates:
             raise PerceptionTransitionDiscoveryError(
-                "candidate references unknown recurrence statistic"
+                "candidates_found reports require candidates"
+            )
+        if self.status == "no_candidates" and self.candidates:
+            raise PerceptionTransitionDiscoveryError(
+                "no_candidates reports cannot contain candidates"
+            )
+        known_statistics = set(statistic_ids)
+        if any(
+            item.source_statistic_id not in known_statistics
+            for item in self.candidates
+        ):
+            raise PerceptionTransitionDiscoveryError(
+                "candidate references an unknown recurrence statistic"
             )
         if self.semantics != TRANSITION_DISCOVERY_SEMANTICS:
             raise PerceptionTransitionDiscoveryError(
@@ -682,14 +663,14 @@ class TransitionDiscoveryReportDTO:
             )
         if self.report_id != _digest(_payload(self, "report_id")):
             raise PerceptionTransitionDiscoveryError(
-                "transition discovery report identity disagrees with canonical payload"
+                "discovery report identity disagrees with canonical payload"
             )
 
     def candidates_for_kind(
         self,
         candidate_kind: str,
     ) -> tuple[MissingComponentCandidateDTO, ...]:
-        if candidate_kind not in MISSING_COMPONENT_CANDIDATE_KINDS:
+        if candidate_kind not in RECURRENT_UNEXPLAINED_STATISTIC_KINDS:
             raise PerceptionTransitionDiscoveryError(
                 f"unsupported candidate_kind: {candidate_kind}"
             )
@@ -698,159 +679,72 @@ class TransitionDiscoveryReportDTO:
         )
 
 
-def _direction_counts(
-    signed_values: tuple[float, ...],
+def _direction_summary(
+    values: tuple[float, ...],
     epsilon: float,
 ) -> tuple[int, int, int, str, float]:
-    positive = sum(value > epsilon for value in signed_values)
-    negative = sum(value < -epsilon for value in signed_values)
-    neutral = len(signed_values) - positive - negative
+    positive = sum(item > epsilon for item in values)
+    negative = sum(item < -epsilon for item in values)
+    neutral = len(values) - positive - negative
     counts = {"positive": positive, "negative": negative, "neutral": neutral}
     maximum = max(counts.values())
     leaders = tuple(sorted(name for name, count in counts.items() if count == maximum))
     dominant = leaders[0] if len(leaders) == 1 else "mixed"
-    return positive, negative, neutral, dominant, maximum / len(signed_values)
+    return positive, negative, neutral, dominant, maximum / len(values)
 
 
-def _aggregate_occurrence_groups(
-    groups: tuple[tuple[UnexplainedFieldOccurrenceDTO, ...], ...],
-    epsilon: float,
-) -> tuple[float, float, float, int, int, int, str, float]:
-    total_values = 0
-    absolute_total = 0.0
-    signed_total = 0.0
-    changed_values = 0
-    per_observation_signed: list[float] = []
-    for group in groups:
-        group_total = sum(item.total_value_count for item in group)
-        if group_total <= 0:
-            raise PerceptionTransitionDiscoveryError(
-                "recurrence evidence group has no measurable values"
-            )
-        total_values += group_total
-        absolute_total += sum(
-            item.mean_absolute_change * item.total_value_count for item in group
-        )
-        signed_value = sum(
-            item.mean_signed_change * item.total_value_count for item in group
-        ) / group_total
-        signed_total += signed_value * group_total
-        changed_values += sum(item.changed_value_count for item in group)
-        per_observation_signed.append(signed_value)
-    positive, negative, neutral, dominant, consistency = _direction_counts(
-        tuple(per_observation_signed),
-        epsilon,
-    )
-    return (
-        absolute_total / total_values,
-        signed_total / total_values,
-        changed_values / total_values,
-        positive,
-        negative,
-        neutral,
-        dominant,
-        consistency,
-    )
-
-
-def _support_values(
-    observations: tuple[TransitionDiscoveryObservationDTO, ...],
-    field_ids: tuple[str, ...],
-) -> tuple[
-    tuple[tuple[UnexplainedFieldOccurrenceDTO, ...], ...],
-    tuple[str, ...],
-    tuple[str, ...],
-    tuple[str, ...],
-    tuple[str, ...],
-    tuple[str, ...],
-]:
-    field_set = set(field_ids)
-    groups: list[tuple[UnexplainedFieldOccurrenceDTO, ...]] = []
-    selected: list[TransitionDiscoveryObservationDTO] = []
-    finding_ids: set[str] = set()
-    for observation in observations:
-        matches = tuple(
-            item for item in observation.unexplained_fields if item.field_id in field_set
-        )
-        if len(matches) != len(field_ids):
-            continue
-        groups.append(matches)
-        selected.append(observation)
-        finding_ids.update(item.finding_id for item in matches)
-    return (
-        tuple(groups),
-        tuple(sorted(item.observation_id for item in selected)),
-        tuple(sorted(item.interaction_id for item in selected)),
-        tuple(sorted(item.transition_evidence_id for item in selected)),
-        tuple(sorted(item.conformance_report_id for item in selected)),
-        tuple(sorted(finding_ids)),
-    )
-
-
-def _field_statistic(
-    field_id: str,
-    observations: tuple[TransitionDiscoveryObservationDTO, ...],
-    policy: TransitionDiscoveryPolicyDTO,
-) -> UnexplainedFieldRecurrenceDTO:
-    groups, observation_ids, interaction_ids, transition_ids, report_ids, finding_ids = (
-        _support_values(observations, (field_id,))
-    )
-    metrics = _aggregate_occurrence_groups(groups, policy.direction_epsilon)
-    values: dict[str, object] = {
-        "field_id": field_id,
-        "observation_count": len(observations),
-        "occurrence_count": len(groups),
-        "recurrence_fraction": len(groups) / len(observations),
-        "mean_absolute_change": metrics[0],
-        "mean_signed_change": metrics[1],
-        "mean_changed_fraction": metrics[2],
-        "positive_count": metrics[3],
-        "negative_count": metrics[4],
-        "neutral_count": metrics[5],
-        "dominant_direction": metrics[6],
-        "direction_consistency": metrics[7],
-        "supporting_observation_ids": observation_ids,
-        "supporting_interaction_ids": interaction_ids,
-        "supporting_transition_evidence_ids": transition_ids,
-        "supporting_conformance_report_ids": report_ids,
-        "supporting_finding_ids": finding_ids,
-        "version": UNEXPLAINED_FIELD_RECURRENCE_VERSION,
-    }
-    return UnexplainedFieldRecurrenceDTO(
-        statistic_id=_digest(values), **values  # type: ignore[arg-type]
-    )
-
-
-def _signature_statistic(
+def _build_statistic(
+    *,
+    statistic_kind: str,
     field_ids: tuple[str, ...],
     supporting: tuple[TransitionDiscoveryObservationDTO, ...],
     observation_count: int,
     policy: TransitionDiscoveryPolicyDTO,
-) -> UnexplainedSignatureRecurrenceDTO:
-    groups = tuple(item.unexplained_fields for item in supporting)
-    metrics = _aggregate_occurrence_groups(groups, policy.direction_epsilon)
-    finding_ids = tuple(
-        sorted(
-            {
-                occurrence.finding_id
-                for observation in supporting
-                for occurrence in observation.unexplained_fields
-            }
+) -> RecurrentUnexplainedStatisticDTO:
+    field_set = set(field_ids)
+    total_values = 0
+    absolute_total = 0.0
+    signed_total = 0.0
+    changed_values = 0
+    observation_signed: list[float] = []
+    finding_ids: set[str] = set()
+    for observation in supporting:
+        occurrences = tuple(
+            item for item in observation.unexplained_fields if item.field_id in field_set
         )
-    )
+        if len(occurrences) != len(field_ids):
+            raise PerceptionTransitionDiscoveryError(
+                "supporting observation does not contain every statistic field"
+            )
+        group_values = sum(item.total_value_count for item in occurrences)
+        group_signed = sum(
+            item.mean_signed_change * item.total_value_count
+            for item in occurrences
+        ) / group_values
+        total_values += group_values
+        absolute_total += sum(
+            item.mean_absolute_change * item.total_value_count
+            for item in occurrences
+        )
+        signed_total += group_signed * group_values
+        changed_values += sum(item.changed_value_count for item in occurrences)
+        observation_signed.append(group_signed)
+        finding_ids.update(item.finding_id for item in occurrences)
+    direction = _direction_summary(tuple(observation_signed), policy.direction_epsilon)
     values: dict[str, object] = {
+        "statistic_kind": statistic_kind,
         "field_ids": field_ids,
         "observation_count": observation_count,
         "occurrence_count": len(supporting),
         "recurrence_fraction": len(supporting) / observation_count,
-        "mean_absolute_change": metrics[0],
-        "mean_signed_change": metrics[1],
-        "mean_changed_fraction": metrics[2],
-        "positive_count": metrics[3],
-        "negative_count": metrics[4],
-        "neutral_count": metrics[5],
-        "dominant_direction": metrics[6],
-        "direction_consistency": metrics[7],
+        "mean_absolute_change": absolute_total / total_values,
+        "mean_signed_change": signed_total / total_values,
+        "mean_changed_fraction": changed_values / total_values,
+        "positive_count": direction[0],
+        "negative_count": direction[1],
+        "neutral_count": direction[2],
+        "dominant_direction": direction[3],
+        "direction_consistency": direction[4],
         "supporting_observation_ids": tuple(
             sorted(item.observation_id for item in supporting)
         ),
@@ -863,61 +757,49 @@ def _signature_statistic(
         "supporting_conformance_report_ids": tuple(
             sorted(item.conformance_report_id for item in supporting)
         ),
-        "supporting_finding_ids": finding_ids,
-        "version": UNEXPLAINED_SIGNATURE_RECURRENCE_VERSION,
+        "supporting_finding_ids": tuple(sorted(finding_ids)),
+        "version": RECURRENT_UNEXPLAINED_STATISTIC_VERSION,
     }
-    return UnexplainedSignatureRecurrenceDTO(
-        statistic_id=_digest(values), **values  # type: ignore[arg-type]
+    return RecurrentUnexplainedStatisticDTO(
+        statistic_id=_digest(values),
+        **values,  # type: ignore[arg-type]
     )
 
 
 def _proposed_change(
-    dominant_direction: str,
-    direction_consistency: float,
+    statistic: RecurrentUnexplainedStatisticDTO,
     policy: TransitionDiscoveryPolicyDTO,
 ) -> str:
-    if direction_consistency < policy.minimum_direction_consistency:
+    if statistic.direction_consistency < policy.minimum_direction_consistency:
         return "change"
-    if dominant_direction == "positive":
+    if statistic.dominant_direction == "positive":
         return "increase"
-    if dominant_direction == "negative":
+    if statistic.dominant_direction == "negative":
         return "decrease"
     return "change"
 
 
 def _candidate(
-    *,
-    candidate_kind: str,
-    source_statistic_id: str,
-    field_ids: tuple[str, ...],
-    occurrence_count: int,
-    observation_count: int,
-    recurrence_fraction: float,
-    dominant_direction: str,
-    direction_consistency: float,
-    supporting_observation_ids: tuple[str, ...],
+    statistic: RecurrentUnexplainedStatisticDTO,
     policy: TransitionDiscoveryPolicyDTO,
 ) -> MissingComponentCandidateDTO:
     values: dict[str, object] = {
-        "candidate_kind": candidate_kind,
-        "source_statistic_id": source_statistic_id,
-        "field_ids": field_ids,
-        "occurrence_count": occurrence_count,
-        "observation_count": observation_count,
-        "recurrence_fraction": recurrence_fraction,
-        "proposed_expected_change": _proposed_change(
-            dominant_direction,
-            direction_consistency,
-            policy,
-        ),
-        "dominant_direction": dominant_direction,
-        "direction_consistency": direction_consistency,
-        "supporting_observation_ids": supporting_observation_ids,
+        "source_statistic_id": statistic.statistic_id,
+        "candidate_kind": statistic.statistic_kind,
+        "field_ids": statistic.field_ids,
+        "occurrence_count": statistic.occurrence_count,
+        "observation_count": statistic.observation_count,
+        "recurrence_fraction": statistic.recurrence_fraction,
+        "proposed_expected_change": _proposed_change(statistic, policy),
+        "dominant_direction": statistic.dominant_direction,
+        "direction_consistency": statistic.direction_consistency,
+        "supporting_observation_ids": statistic.supporting_observation_ids,
         "hypothesis_status": MISSING_COMPONENT_HYPOTHESIS_STATUS,
         "version": MISSING_COMPONENT_CANDIDATE_VERSION,
     }
     return MissingComponentCandidateDTO(
-        candidate_id=_digest(values), **values  # type: ignore[arg-type]
+        candidate_id=_digest(values),
+        **values,  # type: ignore[arg-type]
     )
 
 
@@ -932,25 +814,13 @@ def discover_recurrent_unexplained_transitions(
             "transition discovery requires at least one observation"
         )
     resolved = policy or TransitionDiscoveryPolicyDTO.create()
-    observation_map = {item.observation_id: item for item in observations}
-    interaction_map = {item.interaction_id: item for item in observations}
-    transition_map = {item.transition_evidence_id: item for item in observations}
-    report_map = {item.conformance_report_id: item for item in observations}
-    if len(observation_map) != len(observations):
+    if len({item.observation_id for item in observations}) != len(observations):
         raise PerceptionTransitionDiscoveryError(
             "discovery observations must have unique identities"
         )
-    if len(interaction_map) != len(observations):
+    if len({item.interaction_id for item in observations}) != len(observations):
         raise PerceptionTransitionDiscoveryError(
             "discovery interactions must have unique identities"
-        )
-    if len(transition_map) != len(observations):
-        raise PerceptionTransitionDiscoveryError(
-            "discovery transitions must have unique identities"
-        )
-    if len(report_map) != len(observations):
-        raise PerceptionTransitionDiscoveryError(
-            "discovery conformance reports must have unique identities"
         )
     cohort_ids = {item.cohort_id for item in observations}
     schema_ids = {item.field_schema_id for item in observations}
@@ -962,98 +832,75 @@ def discover_recurrent_unexplained_transitions(
         raise PerceptionTransitionDiscoveryError(
             "discovery observations must use one field schema"
         )
-    ordered_observations = tuple(
-        sorted(observations, key=lambda item: item.observation_id)
-    )
+    ordered = tuple(sorted(observations, key=lambda item: item.observation_id))
     all_field_ids = tuple(
         sorted(
             {
                 occurrence.field_id
-                for observation in ordered_observations
+                for observation in ordered
                 for occurrence in observation.unexplained_fields
             }
         )
     )
-    field_statistics = tuple(
+    statistics: list[RecurrentUnexplainedStatisticDTO] = []
+    for field_id in all_field_ids:
+        supporting = tuple(
+            item for item in ordered if field_id in item.unexplained_field_ids
+        )
+        statistics.append(
+            _build_statistic(
+                statistic_kind="field",
+                field_ids=(field_id,),
+                supporting=supporting,
+                observation_count=len(ordered),
+                policy=resolved,
+            )
+        )
+    signatures = tuple(
         sorted(
-            (
-                _field_statistic(field_id, ordered_observations, resolved)
-                for field_id in all_field_ids
-            ),
-            key=lambda item: item.statistic_id,
+            {
+                item.unexplained_field_ids
+                for item in ordered
+                if len(item.unexplained_field_ids) >= 2
+            }
         )
     )
-    signature_support: dict[
-        tuple[str, ...], list[TransitionDiscoveryObservationDTO]
-    ] = {}
-    for observation in ordered_observations:
-        signature = observation.unexplained_field_ids
-        if len(signature) >= 2:
-            signature_support.setdefault(signature, []).append(observation)
-    signature_statistics = tuple(
-        sorted(
-            (
-                _signature_statistic(
-                    signature,
-                    tuple(supporting),
-                    len(ordered_observations),
-                    resolved,
-                )
-                for signature, supporting in signature_support.items()
-            ),
-            key=lambda item: item.statistic_id,
+    for signature in signatures:
+        supporting = tuple(
+            item for item in ordered if item.unexplained_field_ids == signature
         )
+        statistics.append(
+            _build_statistic(
+                statistic_kind="cooccurrence_signature",
+                field_ids=signature,
+                supporting=supporting,
+                observation_count=len(ordered),
+                policy=resolved,
+            )
+        )
+    ordered_statistics = tuple(
+        sorted(statistics, key=lambda item: item.statistic_id)
     )
-
+    evidence_ready = len(ordered) >= resolved.minimum_observation_count
     candidates: list[MissingComponentCandidateDTO] = []
-    evidence_ready = len(ordered_observations) >= resolved.minimum_observation_count
     if evidence_ready:
-        for statistic in field_statistics:
-            if (
-                statistic.occurrence_count
-                >= resolved.minimum_field_occurrence_count
-                and statistic.recurrence_fraction
-                >= resolved.minimum_field_recurrence_fraction
-            ):
-                candidates.append(
-                    _candidate(
-                        candidate_kind="field",
-                        source_statistic_id=statistic.statistic_id,
-                        field_ids=(statistic.field_id,),
-                        occurrence_count=statistic.occurrence_count,
-                        observation_count=statistic.observation_count,
-                        recurrence_fraction=statistic.recurrence_fraction,
-                        dominant_direction=statistic.dominant_direction,
-                        direction_consistency=statistic.direction_consistency,
-                        supporting_observation_ids=(
-                            statistic.supporting_observation_ids
-                        ),
-                        policy=resolved,
-                    )
+        for statistic in ordered_statistics:
+            if statistic.statistic_kind == "field":
+                qualifies = (
+                    statistic.occurrence_count
+                    >= resolved.minimum_field_occurrence_count
+                    and statistic.recurrence_fraction
+                    >= resolved.minimum_field_recurrence_fraction
                 )
-        for statistic in signature_statistics:
-            if (
-                statistic.occurrence_count
-                >= resolved.minimum_signature_occurrence_count
-                and statistic.recurrence_fraction
-                >= resolved.minimum_signature_recurrence_fraction
-            ):
-                candidates.append(
-                    _candidate(
-                        candidate_kind="cooccurrence_signature",
-                        source_statistic_id=statistic.statistic_id,
-                        field_ids=statistic.field_ids,
-                        occurrence_count=statistic.occurrence_count,
-                        observation_count=statistic.observation_count,
-                        recurrence_fraction=statistic.recurrence_fraction,
-                        dominant_direction=statistic.dominant_direction,
-                        direction_consistency=statistic.direction_consistency,
-                        supporting_observation_ids=(
-                            statistic.supporting_observation_ids
-                        ),
-                        policy=resolved,
-                    )
+            else:
+                qualifies = (
+                    statistic.occurrence_count
+                    >= resolved.minimum_signature_occurrence_count
+                    and statistic.recurrence_fraction
+                    >= resolved.minimum_signature_recurrence_fraction
                 )
+            if qualifies:
+                candidates.append(_candidate(statistic, resolved))
     ordered_candidates = tuple(sorted(candidates, key=lambda item: item.candidate_id))
     if not evidence_ready:
         status = "insufficient_evidence"
@@ -1066,24 +913,26 @@ def discover_recurrent_unexplained_transitions(
         "cohort_id": next(iter(cohort_ids)),
         "field_schema_id": next(iter(schema_ids)),
         "policy_id": resolved.policy_id,
-        "observation_ids": tuple(sorted(observation_map)),
-        "interaction_ids": tuple(sorted(interaction_map)),
-        "transition_evidence_ids": tuple(sorted(transition_map)),
-        "conformance_report_ids": tuple(sorted(report_map)),
-        "field_statistics": field_statistics,
-        "signature_statistics": signature_statistics,
+        "observation_ids": tuple(sorted(item.observation_id for item in ordered)),
+        "interaction_ids": tuple(sorted(item.interaction_id for item in ordered)),
+        "transition_evidence_ids": tuple(
+            sorted(item.transition_evidence_id for item in ordered)
+        ),
+        "conformance_report_ids": tuple(
+            sorted(item.conformance_report_id for item in ordered)
+        ),
+        "statistics": ordered_statistics,
         "candidates": ordered_candidates,
         "semantics": TRANSITION_DISCOVERY_SEMANTICS,
         "version": TRANSITION_DISCOVERY_REPORT_VERSION,
     }
     identity_values = dict(values)
-    identity_values["field_statistics"] = tuple(
-        asdict(item) for item in field_statistics
+    identity_values["statistics"] = tuple(
+        asdict(item) for item in ordered_statistics
     )
-    identity_values["signature_statistics"] = tuple(
-        asdict(item) for item in signature_statistics
+    identity_values["candidates"] = tuple(
+        asdict(item) for item in ordered_candidates
     )
-    identity_values["candidates"] = tuple(asdict(item) for item in ordered_candidates)
     return TransitionDiscoveryReportDTO(
         report_id=_digest(identity_values),
         **values,  # type: ignore[arg-type]

--- a/packages/perception/tests/test_transition_discovery_p18c.py
+++ b/packages/perception/tests/test_transition_discovery_p18c.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    PerceptionRegionAnnotationDTO,
+    SourceImageEncoderSpecDTO,
+    TransitionExpectationDTO,
+    build_grid_field_schema,
+    build_transition_evidence_vpm,
+    encode_source_array,
+    evaluate_transition_conformance,
+)
+from zeromodel.perception.transition_discovery import (
+    PerceptionTransitionDiscoveryError,
+    TransitionDiscoveryObservationDTO,
+    TransitionDiscoveryPolicyDTO,
+    discover_recurrent_unexplained_transitions,
+)
+
+
+def _fixture():
+    encoder = SourceImageEncoderSpecDTO(color_space="L")
+    source = encode_source_array(np.zeros((1, 6), dtype=np.uint8), encoder)
+    schema = build_grid_field_schema(source, tile_width=2, tile_height=1)
+    fields = tuple(sorted(schema.fields, key=lambda item: item.x0))
+    control = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[0].field_id,),
+        label="control",
+        role="stable_control",
+    )
+    expectation = TransitionExpectationDTO.create(
+        field_schema_id=schema.field_schema_id,
+        annotation_ids=(control.annotation_id,),
+        expected_change="stable",
+        maximum_mean_absolute_change=0.0,
+        maximum_changed_fraction=0.0,
+    )
+    return encoder, schema, fields, control, expectation
+
+
+def _observation(
+    *,
+    interaction_id: str,
+    before_values: list[int],
+    after_values: list[int],
+    cohort_id: str = "discovery/train",
+):
+    encoder, schema, fields, control, expectation = _fixture()
+    before = encode_source_array(
+        np.array([before_values], dtype=np.uint8),
+        encoder,
+    )
+    after = encode_source_array(
+        np.array([after_values], dtype=np.uint8),
+        encoder,
+    )
+    transition = build_transition_evidence_vpm(
+        before,
+        after,
+        schema,
+        annotations=(control,),
+    )
+    conformance = evaluate_transition_conformance(
+        transition,
+        (expectation,),
+        (control,),
+        minimum_unexplained_mean_absolute_change=0.05,
+        minimum_unexplained_changed_fraction=0.5,
+    )
+    observation = TransitionDiscoveryObservationDTO.create(
+        interaction_id=interaction_id,
+        cohort_id=cohort_id,
+        transition=transition,
+        conformance=conformance,
+    )
+    return observation, transition, conformance, fields
+
+
+def _cohort():
+    first = _observation(
+        interaction_id="interaction-1",
+        before_values=[0, 0, 0, 0, 0, 0],
+        after_values=[0, 0, 255, 255, 128, 128],
+    )
+    second = _observation(
+        interaction_id="interaction-2",
+        before_values=[0, 0, 0, 0, 0, 0],
+        after_values=[0, 0, 255, 255, 128, 128],
+    )
+    third = _observation(
+        interaction_id="interaction-3",
+        before_values=[0, 0, 0, 0, 0, 0],
+        after_values=[0, 0, 200, 200, 0, 0],
+    )
+    fourth = _observation(
+        interaction_id="interaction-4",
+        before_values=[0, 0, 0, 0, 0, 0],
+        after_values=[0, 0, 0, 0, 0, 0],
+    )
+    return first, second, third, fourth
+
+
+def _policy(**changes: object) -> TransitionDiscoveryPolicyDTO:
+    values: dict[str, object] = {
+        "minimum_observation_count": 4,
+        "minimum_field_occurrence_count": 2,
+        "minimum_field_recurrence_fraction": 0.5,
+        "minimum_signature_occurrence_count": 2,
+        "minimum_signature_recurrence_fraction": 0.5,
+        "minimum_direction_consistency": 0.75,
+        "direction_epsilon": 0.01,
+    }
+    values.update(changes)
+    return TransitionDiscoveryPolicyDTO.create(**values)  # type: ignore[arg-type]
+
+
+def test_discovers_recurrent_fields_and_exact_cooccurrence_signatures() -> None:
+    cohort = _cohort()
+    observations = tuple(item[0] for item in cohort)
+    fields = cohort[0][3]
+
+    first = discover_recurrent_unexplained_transitions(
+        observations,
+        _policy(),
+    )
+    second = discover_recurrent_unexplained_transitions(
+        tuple(reversed(observations)),
+        _policy(),
+    )
+
+    assert first == second
+    assert first.status == "candidates_found"
+    assert len(first.statistics) == 3
+    assert len(first.candidates_for_kind("field")) == 2
+    assert len(first.candidates_for_kind("cooccurrence_signature")) == 1
+
+    by_fields = {item.field_ids: item for item in first.statistics}
+    primary = by_fields[(fields[1].field_id,)]
+    secondary = by_fields[(fields[2].field_id,)]
+    signature = by_fields[(fields[1].field_id, fields[2].field_id)]
+    assert primary.occurrence_count == 3
+    assert primary.recurrence_fraction == 0.75
+    assert secondary.occurrence_count == 2
+    assert secondary.recurrence_fraction == 0.5
+    assert signature.occurrence_count == 2
+    assert signature.recurrence_fraction == 0.5
+
+    assert {item.proposed_expected_change for item in first.candidates} == {
+        "increase"
+    }
+    assert {item.hypothesis_status for item in first.candidates} == {
+        "candidate_unvalidated"
+    }
+    assert observations[3].unexplained_fields == ()
+
+    repeated_transition_id = cohort[0][1].transition_evidence_id
+    assert first.transition_evidence_ids.count(repeated_transition_id) == 2
+    repeated_report_id = cohort[0][2].report_id
+    assert first.conformance_report_ids.count(repeated_report_id) == 2
+
+
+def test_evidence_gate_and_candidate_thresholds_are_separate() -> None:
+    observations = tuple(item[0] for item in _cohort())
+
+    insufficient = discover_recurrent_unexplained_transitions(
+        observations[:3],
+        _policy(minimum_observation_count=4),
+    )
+    assert insufficient.status == "insufficient_evidence"
+    assert insufficient.statistics
+    assert insufficient.candidates == ()
+
+    no_candidates = discover_recurrent_unexplained_transitions(
+        observations,
+        _policy(
+            minimum_field_occurrence_count=4,
+            minimum_field_recurrence_fraction=1.0,
+            minimum_signature_occurrence_count=4,
+            minimum_signature_recurrence_fraction=1.0,
+        ),
+    )
+    assert no_candidates.status == "no_candidates"
+    assert no_candidates.statistics
+    assert no_candidates.candidates == ()
+
+
+def test_direction_proposal_remains_nondirectional_when_evidence_is_mixed() -> None:
+    observations = (
+        _observation(
+            interaction_id="positive-1",
+            before_values=[0, 0, 0, 0, 0, 0],
+            after_values=[0, 0, 200, 200, 0, 0],
+        )[0],
+        _observation(
+            interaction_id="positive-2",
+            before_values=[0, 0, 0, 0, 0, 0],
+            after_values=[0, 0, 180, 180, 0, 0],
+        )[0],
+        _observation(
+            interaction_id="negative-1",
+            before_values=[0, 0, 255, 255, 0, 0],
+            after_values=[0, 0, 0, 0, 0, 0],
+        )[0],
+        _observation(
+            interaction_id="negative-2",
+            before_values=[0, 0, 220, 220, 0, 0],
+            after_values=[0, 0, 0, 0, 0, 0],
+        )[0],
+    )
+
+    report = discover_recurrent_unexplained_transitions(
+        observations,
+        _policy(
+            minimum_field_occurrence_count=4,
+            minimum_field_recurrence_fraction=1.0,
+        ),
+    )
+
+    candidate = report.candidates_for_kind("field")[0]
+    assert candidate.dominant_direction == "mixed"
+    assert candidate.direction_consistency == 0.5
+    assert candidate.proposed_expected_change == "change"
+
+
+def test_discovery_rejects_lineage_cohort_and_identity_tampering() -> None:
+    first, second, third, _ = _cohort()
+
+    with pytest.raises(
+        PerceptionTransitionDiscoveryError,
+        match="does not reference",
+    ):
+        TransitionDiscoveryObservationDTO.create(
+            interaction_id="mismatch",
+            cohort_id="discovery/train",
+            transition=first[1],
+            conformance=third[2],
+        )
+
+    other_cohort = TransitionDiscoveryObservationDTO.create(
+        interaction_id="other-cohort",
+        cohort_id="discovery/other",
+        transition=third[1],
+        conformance=third[2],
+    )
+    with pytest.raises(
+        PerceptionTransitionDiscoveryError,
+        match="one cohort",
+    ):
+        discover_recurrent_unexplained_transitions(
+            (first[0], other_cohort),
+            _policy(minimum_observation_count=2),
+        )
+
+    duplicate_interaction = TransitionDiscoveryObservationDTO.create(
+        interaction_id=first[0].interaction_id,
+        cohort_id="discovery/train",
+        transition=second[1],
+        conformance=second[2],
+    )
+    with pytest.raises(
+        PerceptionTransitionDiscoveryError,
+        match="unique identities",
+    ):
+        discover_recurrent_unexplained_transitions(
+            (first[0], duplicate_interaction),
+            _policy(minimum_observation_count=2),
+        )
+
+    policy = _policy()
+    with pytest.raises(
+        PerceptionTransitionDiscoveryError,
+        match="policy identity",
+    ):
+        replace(policy, policy_id="sha256:tampered")
+
+    report = discover_recurrent_unexplained_transitions(
+        tuple(item[0] for item in _cohort()),
+        policy,
+    )
+    with pytest.raises(
+        PerceptionTransitionDiscoveryError,
+        match="report identity",
+    ):
+        replace(report, report_id="sha256:tampered")

--- a/packages/perception/tests/test_transition_discovery_p18c_public_surface.py
+++ b/packages/perception/tests/test_transition_discovery_p18c_public_surface.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import zeromodel.perception as perception
+
+
+def test_p18c_is_exposed_from_package_root() -> None:
+    expected = {
+        "PerceptionTransitionDiscoveryError",
+        "UnexplainedFieldOccurrenceDTO",
+        "TransitionDiscoveryObservationDTO",
+        "TransitionDiscoveryPolicyDTO",
+        "RecurrentUnexplainedStatisticDTO",
+        "MissingComponentCandidateDTO",
+        "TransitionDiscoveryReportDTO",
+        "discover_recurrent_unexplained_transitions",
+        "TRANSITION_DISCOVERY_REPORT_VERSION",
+        "TRANSITION_DISCOVERY_POLICY_VERSION",
+    }
+
+    assert expected <= set(perception.__all__)
+    for name in expected:
+        assert getattr(perception, name) is not None


### PR DESCRIPTION
Audit-Exempt: adds an internal hypothesis-discovery layer over existing P18A/P18B evidence; no public capability claim status changes.

## Objective

Implement P18C: aggregate unexplained transition evidence across one explicit discovery cohort and emit thresholded, unvalidated missing-component hypotheses.

```text
interaction identity
    + P18A TransitionEvidenceVPMDTO
    + P18B TransitionConformanceReportDTO
    ↓
TransitionDiscoveryObservationDTO
    ↓ cohort aggregation
field recurrence + exact co-occurrence signatures
    ↓
TransitionDiscoveryReportDTO
```

## What changed

- Add content-addressed `TransitionDiscoveryObservationDTO` that:
  - binds interaction, cohort, P18A, and P18B identities;
  - verifies the P18B report references the supplied transition;
  - verifies unexplained finding metrics against exact P18A field evidence;
  - retains observations with zero unexplained findings for the denominator.
- Add `TransitionDiscoveryPolicyDTO` with separate thresholds for:
  - overall cohort evidence sufficiency;
  - individual-field occurrence and recurrence;
  - exact multi-field signature occurrence and recurrence;
  - directional consistency and signed-change epsilon.
- Add complete `RecurrentUnexplainedStatisticDTO` evidence for:
  - individual exact fields;
  - exact co-occurrence signatures.
- Preserve weighted absolute, signed, and changed-fraction measurements; direction counts; recurrence fractions; and complete supporting lineage.
- Allow distinct interactions to reference identical deterministic transition/report artifacts while counting the interactions separately.
- Add `MissingComponentCandidateDTO`, always marked `candidate_unvalidated`.
- Propose `increase` or `decrease` only when direction is sufficiently consistent; otherwise propose `change`.
- Distinguish report outcomes:
  - `insufficient_evidence`;
  - `no_candidates`;
  - `candidates_found`.
- Advance the P18 roadmap to a next held-out validation slice rather than validating discoveries on their own cohort.

## Epistemic boundary

P18C identifies recurrent addressable evidence that escaped the current annotation/expectation model. It does not identify an object, infer a semantic relation, establish causality, or validate that the pattern generalizes.

## Focused validation

Tests cover:

- deterministic aggregation independent of input order;
- recurrence denominators that include no-finding observations;
- repeated identical transition/report artifacts from distinct interactions;
- individual-field and exact-signature candidates;
- separate evidence-sufficiency and candidate thresholds;
- mixed-direction fallback to a non-directional hypothesis;
- lineage, cohort, duplicate-interaction, policy, and report tamper rejection.

The clean wheel-installed `perception-package` workflow is authoritative for the complete package suite.

## Next stage

P18D should translate candidates into explicit expectations and test them against a separately identified validation cohort. Discovery and validation evidence must remain disjoint, and rejected or inconclusive candidates must remain visible.