### PR TITLE
feat(perception): add P18E governed candidate promotion

### DIFF
--- a/packages/perception/docs/p18-roadmap.md
+++ b/packages/perception/docs/p18-roadmap.md
@@ -16,16 +16,22 @@ Aggregate P18A evidence and P18B findings across an explicit discovery cohort. P
 
 Observations without unexplained findings remain in the denominator. Repeated deterministic transition artifacts from distinct interactions remain valid evidence. Discovery never doubles as validation.
 
-## P18D — Held-out candidate validation — current
+## P18D — Held-out candidate validation — complete
 
-Derive explicit, content-addressed expectations from P18C candidates and their source statistics, then evaluate every candidate against a separately identified validation cohort. Discovery and validation cohort, interaction, transition, and observation identities must remain disjoint.
+Derive explicit, content-addressed expectations from P18C candidates and their source statistics, then evaluate every candidate against a separately identified validation cohort. Discovery and validation cohort, interaction, transition, and observation identities remain disjoint.
 
 Preserve validated, rejected, inconclusive, and insufficient-evidence outcomes. Failed candidates remain visible and cannot be silently discarded.
 
-## P18E — Governed candidate promotion — next
+## P18E — Governed candidate promotion — current
 
-Convert only P18D-validated candidates into reviewable promotion proposals for the annotation and expectation model. Promotion should bind discovery and validation lineage, require an explicit approval decision, and never automatically assign semantic labels or rewrite production expectations.
+Convert only P18D-validated candidates into reviewable, content-addressed proposals. Bind complete discovery and validation lineage, require an explicit reviewer decision, and require reviewer-supplied semantic identity for approval.
+
+Approved proposals remain `not_materialized`. P18E records authorization but cannot create annotations, relations, production expectations, or runtime changes.
+
+## P18F — Reversible promotion materialization — next
+
+Convert only approved proposals from a fully reviewed P18E ledger into versioned annotation and expectation change sets. Materialization must be reversible, preserve complete P18C/P18D/P18E lineage, and remain inactive until a separate admission decision succeeds.
 
 ## Boundary
 
-P18 measures and tests visual transitions. It does not infer semantic labels from pixels, claim that correlation is causation, or replace the source and result VPMs with an opaque learned representation.
+P18 measures, tests, validates, and governs visual transition hypotheses. It does not infer semantic labels from pixels, claim that correlation is causation, or replace the source and result VPMs with an opaque learned representation.

--- a/packages/perception/docs/stage-p18e-governed-candidate-promotion.md
+++ b/packages/perception/docs/stage-p18e-governed-candidate-promotion.md
@@ -1,0 +1,95 @@
+# Stage P18E — Governed Candidate Promotion
+
+## Objective
+
+Turn P18D-validated transition candidates into immutable, reviewable promotion proposals without mutating production annotations, relations, or expectations.
+
+```text
+P18C discovery report
+    +
+P18D validation report
+    ↓ validated results only
+CandidatePromotionProposalSetDTO
+    ↓ explicit reviewer decisions
+CandidatePromotionReviewDTO
+```
+
+P18E is an authorization layer. It is not a deployment layer.
+
+## Promotion proposals
+
+`propose_validated_candidate_promotions(...)` creates proposals only for P18D results whose status is `validated`. Rejected, inconclusive, and insufficient-evidence results remain in the validation report but do not become proposals.
+
+Each proposal binds:
+
+- discovery report, candidate, statistic, cohort, and supporting evidence identities;
+- validation report, result, expectation, cohort, observation, interaction, and transition identities;
+- exact field identities and candidate kind;
+- the held-out expectation thresholds;
+- discovery recurrence and direction measurements;
+- held-out confirmation counts and fraction.
+
+Every proposal begins as `pending_review` and `not_materialized`.
+
+## Decisions
+
+A `CandidatePromotionDecisionDTO` records one reviewer decision for one proposal:
+
+- `approved`;
+- `rejected`;
+- `deferred`;
+- `needs_semantic_annotation`.
+
+Approval requires an explicit semantic name and semantic type. Those values are supplied by the reviewer; P18E never invents them from spatial recurrence.
+
+Non-approved decisions cannot carry semantic materialization fields. This prevents deferred or rejected hypotheses from quietly acquiring production meaning.
+
+All decisions remain `not_materialized`, including approved decisions.
+
+## Review ledger
+
+`review_candidate_promotion_proposals(...)` produces an immutable review ledger with one of three coverage states:
+
+- `pending_review` — no proposals have decisions;
+- `partially_reviewed` — some proposals have decisions;
+- `review_complete` — every proposal has exactly one decision.
+
+The ledger partitions every proposal into:
+
+- pending;
+- approved;
+- rejected;
+- deferred;
+- semantic annotation required.
+
+It rejects duplicate decisions, multiple decisions for one proposal, and decisions belonging to another proposal set.
+
+## Integrity boundary
+
+Proposals, proposal sets, decisions, and reviews are content-addressed. P18E rejects:
+
+- validation reports that do not reference the supplied discovery report;
+- discovery or validation cohort/schema mismatches;
+- validation-result expectations that disagree with discovery candidates;
+- candidates that disagree with their source statistics;
+- proposal lineage/count inconsistencies;
+- missing semantic identity on approval;
+- semantic fields on non-approved decisions;
+- unknown, duplicate, or conflicting decisions;
+- identity tampering.
+
+## Non-claims
+
+An approved promotion decision does not mean that:
+
+- a production annotation was created;
+- a relation was added;
+- a production transition expectation was changed;
+- the candidate has a universally correct semantic interpretation;
+- the candidate caused the observed transition.
+
+It means only that an identified reviewer approved the exact validated proposal and supplied the semantic description required for a later materialization stage.
+
+## Next stage
+
+P18F should materialize only approved, fully reviewed proposals into versioned annotation and expectation change sets. Materialization must remain reversible, preserve the P18C/P18D/P18E lineage, and produce no runtime activation until a separate admission step succeeds.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -1,8 +1,26 @@
-"""ZeroModel perception public API through Stage P18D."""
+"""ZeroModel perception public API through Stage P18E."""
 
 from __future__ import annotations
 
 from ._public_api_p17f import *  # noqa: F401,F403
+from .candidate_promotion import (  # noqa: F401
+    CANDIDATE_PROMOTION_DECISIONS,
+    CANDIDATE_PROMOTION_DECISION_VERSION,
+    CANDIDATE_PROMOTION_MATERIALIZATION_STATUS,
+    CANDIDATE_PROMOTION_PROPOSAL_SET_VERSION,
+    CANDIDATE_PROMOTION_PROPOSAL_STATUS,
+    CANDIDATE_PROMOTION_PROPOSAL_VERSION,
+    CANDIDATE_PROMOTION_REVIEW_STATUSES,
+    CANDIDATE_PROMOTION_REVIEW_VERSION,
+    CANDIDATE_PROMOTION_SEMANTICS,
+    CandidatePromotionDecisionDTO,
+    CandidatePromotionProposalDTO,
+    CandidatePromotionProposalSetDTO,
+    CandidatePromotionReviewDTO,
+    PerceptionCandidatePromotionError,
+    propose_validated_candidate_promotions,
+    review_candidate_promotion_proposals,
+)
 from .candidate_validation import (  # noqa: F401
     CANDIDATE_VALIDATION_EXPECTATION_VERSION,
     CANDIDATE_VALIDATION_FINDING_STATUSES,
@@ -121,7 +139,7 @@ from .transition_evidence import (  # noqa: F401
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P18D"
+PERCEPTION_STAGE = "P18E"
 
 __all__ = [
     name

--- a/packages/perception/src/zeromodel/perception/candidate_promotion.py
+++ b/packages/perception/src/zeromodel/perception/candidate_promotion.py
@@ -1,0 +1,820 @@
+"""Governed promotion proposals for held-out validated candidates (Stage P18E).
+
+P18E turns P18D-validated candidates into reviewable, content-addressed promotion
+proposals. Human decisions are recorded separately. Even an approved decision is
+explicitly not materialized: this stage never mutates production annotations,
+relations, or transition expectations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Final, Mapping
+
+from .candidate_validation import (
+    CandidateValidationReportDTO,
+    CandidateValidationResultDTO,
+)
+from .transition_discovery import (
+    RECURRENT_UNEXPLAINED_STATISTIC_KINDS,
+    MissingComponentCandidateDTO,
+    RecurrentUnexplainedStatisticDTO,
+    TransitionDiscoveryReportDTO,
+)
+
+CANDIDATE_PROMOTION_PROPOSAL_VERSION: Final = (
+    "perception-candidate-promotion-proposal/1"
+)
+CANDIDATE_PROMOTION_PROPOSAL_SET_VERSION: Final = (
+    "perception-candidate-promotion-proposal-set/1"
+)
+CANDIDATE_PROMOTION_DECISION_VERSION: Final = (
+    "perception-candidate-promotion-decision/1"
+)
+CANDIDATE_PROMOTION_REVIEW_VERSION: Final = (
+    "perception-candidate-promotion-review/1"
+)
+CANDIDATE_PROMOTION_SEMANTICS: Final = (
+    "reviewable_authorization_without_automatic_semantic_or_production_materialization"
+)
+CANDIDATE_PROMOTION_PROPOSAL_STATUS: Final = "pending_review"
+CANDIDATE_PROMOTION_MATERIALIZATION_STATUS: Final = "not_materialized"
+CANDIDATE_PROMOTION_DECISIONS: Final = {
+    "approved",
+    "rejected",
+    "deferred",
+    "needs_semantic_annotation",
+}
+CANDIDATE_PROMOTION_REVIEW_STATUSES: Final = {
+    "pending_review",
+    "partially_reviewed",
+    "review_complete",
+}
+
+
+class PerceptionCandidatePromotionError(ValueError):
+    """Raised when governed promotion contracts are invalid."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    encoded = _canonical_json(payload)
+    hasher = hashlib.sha256()
+    hasher.update(len(encoded).to_bytes(8, "big"))
+    hasher.update(encoded)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def _payload(value: object, identity_field: str) -> dict[str, object]:
+    payload = asdict(value)  # type: ignore[arg-type]
+    payload.pop(identity_field)
+    return payload
+
+
+def _unit(name: str, value: float) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise PerceptionCandidatePromotionError(f"{name} must be in [0, 1]")
+
+
+def _positive_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise PerceptionCandidatePromotionError(
+            f"{name} must be a positive integer"
+        )
+
+
+def _non_negative_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise PerceptionCandidatePromotionError(
+            f"{name} must be a non-negative integer"
+        )
+
+
+def _ordered_unique(
+    name: str,
+    values: tuple[str, ...],
+    *,
+    allow_empty: bool = True,
+) -> None:
+    if not allow_empty and not values:
+        raise PerceptionCandidatePromotionError(f"{name} must be non-empty")
+    if values != tuple(sorted(set(values))):
+        raise PerceptionCandidatePromotionError(
+            f"{name} must be unique and sorted"
+        )
+
+
+def _ordered_with_repetition(
+    name: str,
+    values: tuple[str, ...],
+    *,
+    allow_empty: bool = True,
+) -> None:
+    if not allow_empty and not values:
+        raise PerceptionCandidatePromotionError(f"{name} must be non-empty")
+    if values != tuple(sorted(values)):
+        raise PerceptionCandidatePromotionError(f"{name} must be sorted")
+
+
+def _same_float(left: float, right: float) -> bool:
+    return abs(left - right) <= 1e-12
+
+
+@dataclass(frozen=True)
+class CandidatePromotionProposalDTO:
+    """Reviewable proposal derived from one P18D-validated candidate."""
+
+    proposal_id: str
+    discovery_report_id: str
+    validation_report_id: str
+    validation_result_id: str
+    candidate_id: str
+    source_statistic_id: str
+    validation_expectation_id: str
+    candidate_kind: str
+    field_schema_id: str
+    field_ids: tuple[str, ...]
+    proposed_expected_change: str
+    minimum_mean_absolute_change: float
+    minimum_changed_fraction: float
+    minimum_signed_change_magnitude: float
+    discovery_cohort_id: str
+    validation_cohort_id: str
+    discovery_occurrence_count: int
+    discovery_observation_count: int
+    discovery_recurrence_fraction: float
+    dominant_direction: str
+    direction_consistency: float
+    validation_confirmation_count: int
+    validation_observation_count: int
+    validation_confirmation_fraction: float
+    supporting_discovery_observation_ids: tuple[str, ...]
+    supporting_discovery_interaction_ids: tuple[str, ...]
+    supporting_discovery_transition_evidence_ids: tuple[str, ...]
+    supporting_discovery_conformance_report_ids: tuple[str, ...]
+    supporting_discovery_finding_ids: tuple[str, ...]
+    validation_observation_ids: tuple[str, ...]
+    validation_interaction_ids: tuple[str, ...]
+    validation_transition_evidence_ids: tuple[str, ...]
+    status: str = CANDIDATE_PROMOTION_PROPOSAL_STATUS
+    materialization_status: str = CANDIDATE_PROMOTION_MATERIALIZATION_STATUS
+    version: str = CANDIDATE_PROMOTION_PROPOSAL_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.proposal_id,
+                self.discovery_report_id,
+                self.validation_report_id,
+                self.validation_result_id,
+                self.candidate_id,
+                self.source_statistic_id,
+                self.validation_expectation_id,
+                self.candidate_kind,
+                self.field_schema_id,
+                self.discovery_cohort_id,
+                self.validation_cohort_id,
+                self.dominant_direction,
+            )
+        ):
+            raise PerceptionCandidatePromotionError(
+                "promotion proposal identities must be non-empty"
+            )
+        if self.discovery_cohort_id == self.validation_cohort_id:
+            raise PerceptionCandidatePromotionError(
+                "promotion proposal discovery and validation cohorts must differ"
+            )
+        if self.candidate_kind not in RECURRENT_UNEXPLAINED_STATISTIC_KINDS:
+            raise PerceptionCandidatePromotionError(
+                f"unsupported promotion candidate_kind: {self.candidate_kind}"
+            )
+        _ordered_unique("promotion proposal field_ids", self.field_ids, allow_empty=False)
+        if self.candidate_kind == "field" and len(self.field_ids) != 1:
+            raise PerceptionCandidatePromotionError(
+                "field promotion proposals require exactly one field"
+            )
+        if self.candidate_kind == "cooccurrence_signature" and len(self.field_ids) < 2:
+            raise PerceptionCandidatePromotionError(
+                "signature promotion proposals require at least two fields"
+            )
+        if self.proposed_expected_change not in {"change", "increase", "decrease"}:
+            raise PerceptionCandidatePromotionError(
+                "unsupported proposed_expected_change"
+            )
+        for name in (
+            "minimum_mean_absolute_change",
+            "minimum_changed_fraction",
+            "minimum_signed_change_magnitude",
+            "discovery_recurrence_fraction",
+            "direction_consistency",
+            "validation_confirmation_fraction",
+        ):
+            _unit(name, getattr(self, name))
+        if (
+            self.proposed_expected_change == "change"
+            and self.minimum_signed_change_magnitude != 0.0
+        ):
+            raise PerceptionCandidatePromotionError(
+                "non-directional promotion proposal cannot require signed magnitude"
+            )
+        _positive_int("discovery_occurrence_count", self.discovery_occurrence_count)
+        _positive_int("discovery_observation_count", self.discovery_observation_count)
+        _positive_int("validation_observation_count", self.validation_observation_count)
+        _non_negative_int(
+            "validation_confirmation_count",
+            self.validation_confirmation_count,
+        )
+        if self.discovery_occurrence_count > self.discovery_observation_count:
+            raise PerceptionCandidatePromotionError(
+                "discovery occurrence count exceeds observation count"
+            )
+        if self.validation_confirmation_count > self.validation_observation_count:
+            raise PerceptionCandidatePromotionError(
+                "validation confirmation count exceeds observation count"
+            )
+        if not _same_float(
+            self.discovery_recurrence_fraction,
+            self.discovery_occurrence_count / self.discovery_observation_count,
+        ):
+            raise PerceptionCandidatePromotionError(
+                "discovery recurrence fraction disagrees with counts"
+            )
+        if not _same_float(
+            self.validation_confirmation_fraction,
+            self.validation_confirmation_count / self.validation_observation_count,
+        ):
+            raise PerceptionCandidatePromotionError(
+                "validation confirmation fraction disagrees with counts"
+            )
+        _ordered_unique(
+            "supporting discovery observation identities",
+            self.supporting_discovery_observation_ids,
+            allow_empty=False,
+        )
+        _ordered_unique(
+            "supporting discovery interaction identities",
+            self.supporting_discovery_interaction_ids,
+            allow_empty=False,
+        )
+        _ordered_with_repetition(
+            "supporting discovery transition identities",
+            self.supporting_discovery_transition_evidence_ids,
+            allow_empty=False,
+        )
+        _ordered_with_repetition(
+            "supporting discovery conformance identities",
+            self.supporting_discovery_conformance_report_ids,
+            allow_empty=False,
+        )
+        _ordered_unique(
+            "supporting discovery finding identities",
+            self.supporting_discovery_finding_ids,
+            allow_empty=False,
+        )
+        if not (
+            len(self.supporting_discovery_observation_ids)
+            == len(self.supporting_discovery_interaction_ids)
+            == len(self.supporting_discovery_transition_evidence_ids)
+            == len(self.supporting_discovery_conformance_report_ids)
+            == self.discovery_occurrence_count
+        ):
+            raise PerceptionCandidatePromotionError(
+                "supporting discovery lineage counts disagree with occurrences"
+            )
+        _ordered_unique(
+            "validation observation identities",
+            self.validation_observation_ids,
+            allow_empty=False,
+        )
+        _ordered_unique(
+            "validation interaction identities",
+            self.validation_interaction_ids,
+            allow_empty=False,
+        )
+        _ordered_with_repetition(
+            "validation transition identities",
+            self.validation_transition_evidence_ids,
+            allow_empty=False,
+        )
+        if not (
+            len(self.validation_observation_ids)
+            == len(self.validation_interaction_ids)
+            == len(self.validation_transition_evidence_ids)
+            == self.validation_observation_count
+        ):
+            raise PerceptionCandidatePromotionError(
+                "validation lineage counts disagree with observation count"
+            )
+        if self.status != CANDIDATE_PROMOTION_PROPOSAL_STATUS:
+            raise PerceptionCandidatePromotionError(
+                "unsupported candidate promotion proposal status"
+            )
+        if self.materialization_status != CANDIDATE_PROMOTION_MATERIALIZATION_STATUS:
+            raise PerceptionCandidatePromotionError(
+                "promotion proposals must remain not_materialized"
+            )
+        if self.version != CANDIDATE_PROMOTION_PROPOSAL_VERSION:
+            raise PerceptionCandidatePromotionError(
+                "unsupported candidate promotion proposal version"
+            )
+        if self.proposal_id != _digest(_payload(self, "proposal_id")):
+            raise PerceptionCandidatePromotionError(
+                "candidate promotion proposal identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class CandidatePromotionProposalSetDTO:
+    proposal_set_id: str
+    discovery_report_id: str
+    validation_report_id: str
+    discovery_cohort_id: str
+    validation_cohort_id: str
+    field_schema_id: str
+    proposal_ids: tuple[str, ...]
+    proposals: tuple[CandidatePromotionProposalDTO, ...]
+    semantics: str = CANDIDATE_PROMOTION_SEMANTICS
+    version: str = CANDIDATE_PROMOTION_PROPOSAL_SET_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.proposal_set_id,
+                self.discovery_report_id,
+                self.validation_report_id,
+                self.discovery_cohort_id,
+                self.validation_cohort_id,
+                self.field_schema_id,
+            )
+        ):
+            raise PerceptionCandidatePromotionError(
+                "promotion proposal-set identities must be non-empty"
+            )
+        if self.discovery_cohort_id == self.validation_cohort_id:
+            raise PerceptionCandidatePromotionError(
+                "promotion proposal-set cohorts must differ"
+            )
+        _ordered_unique("promotion proposal identities", self.proposal_ids, allow_empty=False)
+        actual_ids = tuple(sorted(item.proposal_id for item in self.proposals))
+        if actual_ids != self.proposal_ids:
+            raise PerceptionCandidatePromotionError(
+                "promotion proposal identities disagree with proposals"
+            )
+        if any(
+            item.discovery_report_id != self.discovery_report_id
+            or item.validation_report_id != self.validation_report_id
+            or item.discovery_cohort_id != self.discovery_cohort_id
+            or item.validation_cohort_id != self.validation_cohort_id
+            or item.field_schema_id != self.field_schema_id
+            for item in self.proposals
+        ):
+            raise PerceptionCandidatePromotionError(
+                "promotion proposal lineage disagrees with proposal set"
+            )
+        if self.semantics != CANDIDATE_PROMOTION_SEMANTICS:
+            raise PerceptionCandidatePromotionError(
+                "unsupported candidate promotion semantics"
+            )
+        if self.version != CANDIDATE_PROMOTION_PROPOSAL_SET_VERSION:
+            raise PerceptionCandidatePromotionError(
+                "unsupported candidate promotion proposal-set version"
+            )
+        if self.proposal_set_id != _digest(_payload(self, "proposal_set_id")):
+            raise PerceptionCandidatePromotionError(
+                "candidate promotion proposal-set identity disagrees with canonical payload"
+            )
+
+    def proposal_for_candidate(self, candidate_id: str) -> CandidatePromotionProposalDTO:
+        for proposal in self.proposals:
+            if proposal.candidate_id == candidate_id:
+                return proposal
+        raise KeyError(candidate_id)
+
+
+@dataclass(frozen=True)
+class CandidatePromotionDecisionDTO:
+    decision_id: str
+    proposal_id: str
+    reviewer_id: str
+    decision: str
+    rationale: str
+    semantic_name: str | None = None
+    semantic_type: str | None = None
+    semantic_role: str | None = None
+    materialization_status: str = CANDIDATE_PROMOTION_MATERIALIZATION_STATUS
+    version: str = CANDIDATE_PROMOTION_DECISION_VERSION
+
+    def __post_init__(self) -> None:
+        if not all((self.decision_id, self.proposal_id, self.reviewer_id, self.rationale)):
+            raise PerceptionCandidatePromotionError(
+                "promotion decision identities and rationale must be non-empty"
+            )
+        if self.decision not in CANDIDATE_PROMOTION_DECISIONS:
+            raise PerceptionCandidatePromotionError(
+                f"unsupported candidate promotion decision: {self.decision}"
+            )
+        semantic_values = (self.semantic_name, self.semantic_type, self.semantic_role)
+        if self.decision == "approved":
+            if not self.semantic_name or not self.semantic_type:
+                raise PerceptionCandidatePromotionError(
+                    "approved promotion decisions require semantic_name and semantic_type"
+                )
+        elif any(value is not None for value in semantic_values):
+            raise PerceptionCandidatePromotionError(
+                "non-approved promotion decisions cannot carry semantic materialization"
+            )
+        if self.materialization_status != CANDIDATE_PROMOTION_MATERIALIZATION_STATUS:
+            raise PerceptionCandidatePromotionError(
+                "promotion decisions must remain not_materialized"
+            )
+        if self.version != CANDIDATE_PROMOTION_DECISION_VERSION:
+            raise PerceptionCandidatePromotionError(
+                "unsupported candidate promotion decision version"
+            )
+        if self.decision_id != _digest(_payload(self, "decision_id")):
+            raise PerceptionCandidatePromotionError(
+                "candidate promotion decision identity disagrees with canonical payload"
+            )
+
+    @classmethod
+    def create(
+        cls,
+        proposal: CandidatePromotionProposalDTO,
+        *,
+        reviewer_id: str,
+        decision: str,
+        rationale: str,
+        semantic_name: str | None = None,
+        semantic_type: str | None = None,
+        semantic_role: str | None = None,
+    ) -> "CandidatePromotionDecisionDTO":
+        values: dict[str, object] = {
+            "proposal_id": proposal.proposal_id,
+            "reviewer_id": reviewer_id,
+            "decision": decision,
+            "rationale": rationale,
+            "semantic_name": semantic_name,
+            "semantic_type": semantic_type,
+            "semantic_role": semantic_role,
+            "materialization_status": CANDIDATE_PROMOTION_MATERIALIZATION_STATUS,
+            "version": CANDIDATE_PROMOTION_DECISION_VERSION,
+        }
+        return cls(decision_id=_digest(values), **values)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class CandidatePromotionReviewDTO:
+    review_id: str
+    status: str
+    proposal_set_id: str
+    proposal_ids: tuple[str, ...]
+    decision_ids: tuple[str, ...]
+    decisions: tuple[CandidatePromotionDecisionDTO, ...]
+    pending_proposal_ids: tuple[str, ...]
+    approved_proposal_ids: tuple[str, ...]
+    rejected_proposal_ids: tuple[str, ...]
+    deferred_proposal_ids: tuple[str, ...]
+    semantic_annotation_required_proposal_ids: tuple[str, ...]
+    semantics: str = CANDIDATE_PROMOTION_SEMANTICS
+    version: str = CANDIDATE_PROMOTION_REVIEW_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.review_id or not self.proposal_set_id:
+            raise PerceptionCandidatePromotionError(
+                "promotion review identities must be non-empty"
+            )
+        if self.status not in CANDIDATE_PROMOTION_REVIEW_STATUSES:
+            raise PerceptionCandidatePromotionError(
+                f"unsupported promotion review status: {self.status}"
+            )
+        _ordered_unique("promotion review proposal_ids", self.proposal_ids, allow_empty=False)
+        _ordered_unique("promotion review decision_ids", self.decision_ids)
+        actual_decision_ids = tuple(sorted(item.decision_id for item in self.decisions))
+        if actual_decision_ids != self.decision_ids:
+            raise PerceptionCandidatePromotionError(
+                "promotion review decision identities disagree with decisions"
+            )
+        decided_proposals = tuple(sorted(item.proposal_id for item in self.decisions))
+        if len(decided_proposals) != len(set(decided_proposals)):
+            raise PerceptionCandidatePromotionError(
+                "promotion review allows one decision per proposal"
+            )
+        if not set(decided_proposals) <= set(self.proposal_ids):
+            raise PerceptionCandidatePromotionError(
+                "promotion decision references an unknown proposal"
+            )
+        categories = (
+            self.pending_proposal_ids,
+            self.approved_proposal_ids,
+            self.rejected_proposal_ids,
+            self.deferred_proposal_ids,
+            self.semantic_annotation_required_proposal_ids,
+        )
+        for index, category in enumerate(categories):
+            _ordered_unique(f"promotion review category {index}", category)
+        flattened = tuple(item for category in categories for item in category)
+        if len(flattened) != len(set(flattened)) or set(flattened) != set(
+            self.proposal_ids
+        ):
+            raise PerceptionCandidatePromotionError(
+                "promotion review categories must partition every proposal"
+            )
+        decision_map = {item.proposal_id: item.decision for item in self.decisions}
+        expected = {
+            "approved": set(self.approved_proposal_ids),
+            "rejected": set(self.rejected_proposal_ids),
+            "deferred": set(self.deferred_proposal_ids),
+            "needs_semantic_annotation": set(
+                self.semantic_annotation_required_proposal_ids
+            ),
+        }
+        for decision, proposal_ids in expected.items():
+            if {
+                proposal_id
+                for proposal_id, value in decision_map.items()
+                if value == decision
+            } != proposal_ids:
+                raise PerceptionCandidatePromotionError(
+                    "promotion review decision categories disagree with decisions"
+                )
+        expected_pending = set(self.proposal_ids) - set(decision_map)
+        if expected_pending != set(self.pending_proposal_ids):
+            raise PerceptionCandidatePromotionError(
+                "promotion review pending proposals disagree with decisions"
+            )
+        expected_status = (
+            "pending_review"
+            if not self.decisions
+            else "review_complete"
+            if not self.pending_proposal_ids
+            else "partially_reviewed"
+        )
+        if self.status != expected_status:
+            raise PerceptionCandidatePromotionError(
+                "promotion review status disagrees with decision coverage"
+            )
+        if self.semantics != CANDIDATE_PROMOTION_SEMANTICS:
+            raise PerceptionCandidatePromotionError(
+                "unsupported candidate promotion semantics"
+            )
+        if self.version != CANDIDATE_PROMOTION_REVIEW_VERSION:
+            raise PerceptionCandidatePromotionError(
+                "unsupported candidate promotion review version"
+            )
+        if self.review_id != _digest(_payload(self, "review_id")):
+            raise PerceptionCandidatePromotionError(
+                "candidate promotion review identity disagrees with canonical payload"
+            )
+
+    def decisions_for_status(
+        self,
+        decision: str,
+    ) -> tuple[CandidatePromotionDecisionDTO, ...]:
+        if decision not in CANDIDATE_PROMOTION_DECISIONS:
+            raise PerceptionCandidatePromotionError(
+                f"unsupported candidate promotion decision: {decision}"
+            )
+        return tuple(item for item in self.decisions if item.decision == decision)
+
+
+def _candidate_and_statistic(
+    discovery: TransitionDiscoveryReportDTO,
+    result: CandidateValidationResultDTO,
+) -> tuple[MissingComponentCandidateDTO, RecurrentUnexplainedStatisticDTO]:
+    candidates = {item.candidate_id: item for item in discovery.candidates}
+    statistics = {item.statistic_id: item for item in discovery.statistics}
+    try:
+        candidate = candidates[result.candidate_id]
+    except KeyError as exc:
+        raise PerceptionCandidatePromotionError(
+            "validated result references an unknown discovery candidate"
+        ) from exc
+    try:
+        statistic = statistics[candidate.source_statistic_id]
+    except KeyError as exc:
+        raise PerceptionCandidatePromotionError(
+            "promotion candidate references an unknown discovery statistic"
+        ) from exc
+    expectation = result.expectation
+    if (
+        expectation.discovery_report_id != discovery.report_id
+        or expectation.candidate_id != candidate.candidate_id
+        or expectation.source_statistic_id != statistic.statistic_id
+        or expectation.candidate_kind != candidate.candidate_kind
+        or expectation.field_schema_id != discovery.field_schema_id
+        or expectation.field_ids != candidate.field_ids
+        or expectation.expected_change != candidate.proposed_expected_change
+    ):
+        raise PerceptionCandidatePromotionError(
+            "validated result expectation disagrees with discovery lineage"
+        )
+    if (
+        statistic.statistic_kind != candidate.candidate_kind
+        or statistic.field_ids != candidate.field_ids
+    ):
+        raise PerceptionCandidatePromotionError(
+            "promotion candidate disagrees with its source statistic"
+        )
+    return candidate, statistic
+
+
+def _proposal(
+    *,
+    discovery: TransitionDiscoveryReportDTO,
+    validation: CandidateValidationReportDTO,
+    result: CandidateValidationResultDTO,
+) -> CandidatePromotionProposalDTO:
+    candidate, statistic = _candidate_and_statistic(discovery, result)
+    expectation = result.expectation
+    values: dict[str, object] = {
+        "discovery_report_id": discovery.report_id,
+        "validation_report_id": validation.report_id,
+        "validation_result_id": result.result_id,
+        "candidate_id": candidate.candidate_id,
+        "source_statistic_id": statistic.statistic_id,
+        "validation_expectation_id": expectation.expectation_id,
+        "candidate_kind": candidate.candidate_kind,
+        "field_schema_id": discovery.field_schema_id,
+        "field_ids": candidate.field_ids,
+        "proposed_expected_change": candidate.proposed_expected_change,
+        "minimum_mean_absolute_change": expectation.minimum_mean_absolute_change,
+        "minimum_changed_fraction": expectation.minimum_changed_fraction,
+        "minimum_signed_change_magnitude": (
+            expectation.minimum_signed_change_magnitude
+        ),
+        "discovery_cohort_id": discovery.cohort_id,
+        "validation_cohort_id": validation.validation_cohort_id,
+        "discovery_occurrence_count": statistic.occurrence_count,
+        "discovery_observation_count": statistic.observation_count,
+        "discovery_recurrence_fraction": statistic.recurrence_fraction,
+        "dominant_direction": statistic.dominant_direction,
+        "direction_consistency": statistic.direction_consistency,
+        "validation_confirmation_count": result.confirmation_count,
+        "validation_observation_count": result.observation_count,
+        "validation_confirmation_fraction": result.confirmation_fraction,
+        "supporting_discovery_observation_ids": (
+            statistic.supporting_observation_ids
+        ),
+        "supporting_discovery_interaction_ids": (
+            statistic.supporting_interaction_ids
+        ),
+        "supporting_discovery_transition_evidence_ids": (
+            statistic.supporting_transition_evidence_ids
+        ),
+        "supporting_discovery_conformance_report_ids": (
+            statistic.supporting_conformance_report_ids
+        ),
+        "supporting_discovery_finding_ids": statistic.supporting_finding_ids,
+        "validation_observation_ids": validation.validation_observation_ids,
+        "validation_interaction_ids": validation.validation_interaction_ids,
+        "validation_transition_evidence_ids": (
+            validation.validation_transition_evidence_ids
+        ),
+        "status": CANDIDATE_PROMOTION_PROPOSAL_STATUS,
+        "materialization_status": CANDIDATE_PROMOTION_MATERIALIZATION_STATUS,
+        "version": CANDIDATE_PROMOTION_PROPOSAL_VERSION,
+    }
+    return CandidatePromotionProposalDTO(
+        proposal_id=_digest(values),
+        **values,  # type: ignore[arg-type]
+    )
+
+
+def propose_validated_candidate_promotions(
+    discovery: TransitionDiscoveryReportDTO,
+    validation: CandidateValidationReportDTO,
+) -> CandidatePromotionProposalSetDTO:
+    """Create reviewable proposals for P18D-validated candidates only."""
+
+    if validation.discovery_report_id != discovery.report_id:
+        raise PerceptionCandidatePromotionError(
+            "validation report does not reference the supplied discovery report"
+        )
+    if validation.discovery_cohort_id != discovery.cohort_id:
+        raise PerceptionCandidatePromotionError(
+            "validation report discovery cohort disagrees with discovery report"
+        )
+    if validation.field_schema_id != discovery.field_schema_id:
+        raise PerceptionCandidatePromotionError(
+            "validation and discovery field schemas differ"
+        )
+    if validation.discovery_cohort_id == validation.validation_cohort_id:
+        raise PerceptionCandidatePromotionError(
+            "promotion requires disjoint discovery and validation cohorts"
+        )
+    validated_results = tuple(
+        item for item in validation.results if item.status == "validated"
+    )
+    if not validated_results:
+        raise PerceptionCandidatePromotionError(
+            "candidate promotion requires at least one validated result"
+        )
+    proposals = tuple(
+        sorted(
+            (
+                _proposal(
+                    discovery=discovery,
+                    validation=validation,
+                    result=result,
+                )
+                for result in validated_results
+            ),
+            key=lambda item: item.proposal_id,
+        )
+    )
+    values: dict[str, object] = {
+        "discovery_report_id": discovery.report_id,
+        "validation_report_id": validation.report_id,
+        "discovery_cohort_id": discovery.cohort_id,
+        "validation_cohort_id": validation.validation_cohort_id,
+        "field_schema_id": discovery.field_schema_id,
+        "proposal_ids": tuple(sorted(item.proposal_id for item in proposals)),
+        "proposals": proposals,
+        "semantics": CANDIDATE_PROMOTION_SEMANTICS,
+        "version": CANDIDATE_PROMOTION_PROPOSAL_SET_VERSION,
+    }
+    identity_values = dict(values)
+    identity_values["proposals"] = tuple(asdict(item) for item in proposals)
+    return CandidatePromotionProposalSetDTO(
+        proposal_set_id=_digest(identity_values),
+        **values,  # type: ignore[arg-type]
+    )
+
+
+def review_candidate_promotion_proposals(
+    proposal_set: CandidatePromotionProposalSetDTO,
+    decisions: tuple[CandidatePromotionDecisionDTO, ...] = (),
+) -> CandidatePromotionReviewDTO:
+    """Build an immutable review ledger without applying approved proposals."""
+
+    decision_ids = tuple(item.decision_id for item in decisions)
+    if len(decision_ids) != len(set(decision_ids)):
+        raise PerceptionCandidatePromotionError(
+            "promotion decisions must have unique identities"
+        )
+    proposal_ids = tuple(item.proposal_id for item in decisions)
+    if len(proposal_ids) != len(set(proposal_ids)):
+        raise PerceptionCandidatePromotionError(
+            "promotion review allows one decision per proposal"
+        )
+    unknown = set(proposal_ids) - set(proposal_set.proposal_ids)
+    if unknown:
+        raise PerceptionCandidatePromotionError(
+            f"promotion decisions reference unknown proposals: {sorted(unknown)}"
+        )
+    ordered_decisions = tuple(sorted(decisions, key=lambda item: item.decision_id))
+    by_decision = {
+        decision: tuple(
+            sorted(
+                item.proposal_id
+                for item in ordered_decisions
+                if item.decision == decision
+            )
+        )
+        for decision in CANDIDATE_PROMOTION_DECISIONS
+    }
+    pending = tuple(sorted(set(proposal_set.proposal_ids) - set(proposal_ids)))
+    status = (
+        "pending_review"
+        if not ordered_decisions
+        else "review_complete"
+        if not pending
+        else "partially_reviewed"
+    )
+    values: dict[str, object] = {
+        "status": status,
+        "proposal_set_id": proposal_set.proposal_set_id,
+        "proposal_ids": proposal_set.proposal_ids,
+        "decision_ids": tuple(
+            sorted(item.decision_id for item in ordered_decisions)
+        ),
+        "decisions": ordered_decisions,
+        "pending_proposal_ids": pending,
+        "approved_proposal_ids": by_decision["approved"],
+        "rejected_proposal_ids": by_decision["rejected"],
+        "deferred_proposal_ids": by_decision["deferred"],
+        "semantic_annotation_required_proposal_ids": by_decision[
+            "needs_semantic_annotation"
+        ],
+        "semantics": CANDIDATE_PROMOTION_SEMANTICS,
+        "version": CANDIDATE_PROMOTION_REVIEW_VERSION,
+    }
+    identity_values = dict(values)
+    identity_values["decisions"] = tuple(
+        asdict(item) for item in ordered_decisions
+    )
+    return CandidatePromotionReviewDTO(
+        review_id=_digest(identity_values),
+        **values,  # type: ignore[arg-type]
+    )

--- a/packages/perception/tests/test_candidate_promotion_p18e.py
+++ b/packages/perception/tests/test_candidate_promotion_p18e.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    CandidateValidationPolicyDTO,
+    HeldOutTransitionObservationDTO,
+    PerceptionRegionAnnotationDTO,
+    SourceImageEncoderSpecDTO,
+    TransitionDiscoveryObservationDTO,
+    TransitionDiscoveryPolicyDTO,
+    TransitionExpectationDTO,
+    build_grid_field_schema,
+    build_transition_evidence_vpm,
+    discover_recurrent_unexplained_transitions,
+    encode_source_array,
+    evaluate_transition_conformance,
+    validate_discovered_transition_candidates,
+)
+from zeromodel.perception.candidate_promotion import (
+    CandidatePromotionDecisionDTO,
+    PerceptionCandidatePromotionError,
+    propose_validated_candidate_promotions,
+    review_candidate_promotion_proposals,
+)
+
+
+def _fixture():
+    encoder = SourceImageEncoderSpecDTO(color_space="L")
+    source = encode_source_array(np.zeros((1, 6), dtype=np.uint8), encoder)
+    schema = build_grid_field_schema(source, tile_width=2, tile_height=1)
+    fields = tuple(sorted(schema.fields, key=lambda item: item.x0))
+    control = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[0].field_id,),
+        label="control",
+        role="stable_control",
+    )
+    expectation = TransitionExpectationDTO.create(
+        field_schema_id=schema.field_schema_id,
+        annotation_ids=(control.annotation_id,),
+        expected_change="stable",
+        maximum_mean_absolute_change=0.0,
+        maximum_changed_fraction=0.0,
+    )
+    return encoder, schema, fields, control, expectation
+
+
+def _transition(
+    before_values: list[int],
+    after_values: list[int],
+    *,
+    include_control_annotation: bool,
+):
+    encoder, schema, fields, control, expectation = _fixture()
+    before = encode_source_array(np.array([before_values], dtype=np.uint8), encoder)
+    after = encode_source_array(np.array([after_values], dtype=np.uint8), encoder)
+    transition = build_transition_evidence_vpm(
+        before,
+        after,
+        schema,
+        annotations=(control,) if include_control_annotation else (),
+    )
+    return transition, fields, control, expectation
+
+
+def _discovery_observation(
+    *,
+    interaction_id: str,
+    first_value: int,
+    second_value: int,
+    cohort_id: str = "discovery/train",
+):
+    transition, _, control, expectation = _transition(
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, first_value, first_value, second_value, second_value],
+        include_control_annotation=True,
+    )
+    conformance = evaluate_transition_conformance(
+        transition,
+        (expectation,),
+        (control,),
+        minimum_unexplained_mean_absolute_change=0.05,
+        minimum_unexplained_changed_fraction=0.5,
+    )
+    return TransitionDiscoveryObservationDTO.create(
+        interaction_id=interaction_id,
+        cohort_id=cohort_id,
+        transition=transition,
+        conformance=conformance,
+    )
+
+
+def _discovery_report(*, cohort_id: str = "discovery/train"):
+    values = ((200, 180), (180, 160), (160, 140), (0, 0))
+    observations = tuple(
+        _discovery_observation(
+            interaction_id=f"{cohort_id}-{index}",
+            first_value=first,
+            second_value=second,
+            cohort_id=cohort_id,
+        )
+        for index, (first, second) in enumerate(values, start=1)
+    )
+    policy = TransitionDiscoveryPolicyDTO.create(
+        minimum_observation_count=4,
+        minimum_field_occurrence_count=3,
+        minimum_field_recurrence_fraction=0.75,
+        minimum_signature_occurrence_count=3,
+        minimum_signature_recurrence_fraction=0.75,
+        minimum_direction_consistency=0.75,
+    )
+    report = discover_recurrent_unexplained_transitions(observations, policy)
+    assert report.status == "candidates_found"
+    assert len(report.candidates) == 3
+    return report
+
+
+def _held_out(
+    *,
+    interaction_id: str,
+    first_value: int,
+    second_value: int,
+    cohort_id: str = "validation/held-out",
+):
+    transition, _, _, _ = _transition(
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, first_value, first_value, second_value, second_value],
+        include_control_annotation=False,
+    )
+    return HeldOutTransitionObservationDTO.create(
+        interaction_id=interaction_id,
+        cohort_id=cohort_id,
+        transition=transition,
+    )
+
+
+def _validation_report(discovery, *, validate_all: bool):
+    second_value = 150 if validate_all else 0
+    observations = tuple(
+        _held_out(
+            interaction_id=f"validation-{validate_all}-{index}",
+            first_value=170,
+            second_value=second_value,
+        )
+        for index in range(1, 4)
+    )
+    policy = CandidateValidationPolicyDTO.create(
+        minimum_validation_observation_count=3,
+        minimum_confirmation_fraction=2 / 3,
+        minimum_rejection_fraction=2 / 3,
+        minimum_magnitude_retention_fraction=0.75,
+        direction_epsilon=0.01,
+    )
+    return validate_discovered_transition_candidates(
+        discovery,
+        observations,
+        policy,
+    )
+
+
+def test_proposes_only_validated_candidates_and_binds_complete_lineage() -> None:
+    discovery = _discovery_report()
+    validation = _validation_report(discovery, validate_all=False)
+    validated = validation.results_for_status("validated")
+    rejected = validation.results_for_status("rejected")
+
+    first = propose_validated_candidate_promotions(discovery, validation)
+    second = propose_validated_candidate_promotions(discovery, validation)
+
+    assert first == second
+    assert len(validated) == 1
+    assert len(rejected) == 2
+    assert len(first.proposals) == 1
+    proposal = first.proposals[0]
+    assert proposal.candidate_id == validated[0].candidate_id
+    assert proposal.validation_result_id == validated[0].result_id
+    assert proposal.validation_expectation_id == validated[0].expectation.expectation_id
+    assert proposal.materialization_status == "not_materialized"
+    assert proposal.status == "pending_review"
+    assert proposal.validation_observation_ids == validation.validation_observation_ids
+    assert proposal.validation_interaction_ids == validation.validation_interaction_ids
+    assert proposal.validation_transition_evidence_ids == (
+        validation.validation_transition_evidence_ids
+    )
+    assert proposal.discovery_occurrence_count == len(
+        proposal.supporting_discovery_observation_ids
+    )
+    assert {item.candidate_id for item in first.proposals}.isdisjoint(
+        {item.candidate_id for item in rejected}
+    )
+
+
+def test_review_records_decisions_without_materializing_approved_proposals() -> None:
+    discovery = _discovery_report()
+    validation = _validation_report(discovery, validate_all=True)
+    proposal_set = propose_validated_candidate_promotions(discovery, validation)
+    assert len(proposal_set.proposals) == 3
+
+    pending = review_candidate_promotion_proposals(proposal_set)
+    assert pending.status == "pending_review"
+    assert pending.pending_proposal_ids == proposal_set.proposal_ids
+
+    approved = CandidatePromotionDecisionDTO.create(
+        proposal_set.proposals[0],
+        reviewer_id="reviewer:alice",
+        decision="approved",
+        rationale="Held-out evidence is strong and the semantic identity is known.",
+        semantic_name="projectile-shadow",
+        semantic_type="region_component",
+        semantic_role="context",
+    )
+    partial = review_candidate_promotion_proposals(proposal_set, (approved,))
+    assert partial.status == "partially_reviewed"
+    assert partial.approved_proposal_ids == (approved.proposal_id,)
+    assert approved.materialization_status == "not_materialized"
+
+    rejected = CandidatePromotionDecisionDTO.create(
+        proposal_set.proposals[1],
+        reviewer_id="reviewer:bob",
+        decision="rejected",
+        rationale="The spatial signature is not semantically coherent.",
+    )
+    needs_semantic = CandidatePromotionDecisionDTO.create(
+        proposal_set.proposals[2],
+        reviewer_id="reviewer:carol",
+        decision="needs_semantic_annotation",
+        rationale="Evidence is valid but the component cannot yet be named.",
+    )
+    complete = review_candidate_promotion_proposals(
+        proposal_set,
+        (needs_semantic, approved, rejected),
+    )
+
+    assert complete.status == "review_complete"
+    assert complete.pending_proposal_ids == ()
+    assert complete.approved_proposal_ids == (approved.proposal_id,)
+    assert complete.rejected_proposal_ids == (rejected.proposal_id,)
+    assert complete.semantic_annotation_required_proposal_ids == (
+        needs_semantic.proposal_id,
+    )
+    assert complete.decisions_for_status("approved") == (approved,)
+
+    deferred = CandidatePromotionDecisionDTO.create(
+        proposal_set.proposals[1],
+        reviewer_id="reviewer:dana",
+        decision="deferred",
+        rationale="Collect a second validation cohort before approval.",
+    )
+    assert deferred.decision == "deferred"
+    assert deferred.materialization_status == "not_materialized"
+
+
+def test_decision_semantics_and_identity_are_strict() -> None:
+    discovery = _discovery_report()
+    validation = _validation_report(discovery, validate_all=False)
+    proposal = propose_validated_candidate_promotions(
+        discovery,
+        validation,
+    ).proposals[0]
+
+    with pytest.raises(
+        PerceptionCandidatePromotionError,
+        match="require semantic_name",
+    ):
+        CandidatePromotionDecisionDTO.create(
+            proposal,
+            reviewer_id="reviewer:missing-label",
+            decision="approved",
+            rationale="Approve without an invented label.",
+        )
+
+    with pytest.raises(
+        PerceptionCandidatePromotionError,
+        match="non-approved",
+    ):
+        CandidatePromotionDecisionDTO.create(
+            proposal,
+            reviewer_id="reviewer:invalid",
+            decision="deferred",
+            rationale="This should not carry semantic materialization.",
+            semantic_name="invented",
+            semantic_type="region_component",
+        )
+
+    decision = CandidatePromotionDecisionDTO.create(
+        proposal,
+        reviewer_id="reviewer:valid",
+        decision="needs_semantic_annotation",
+        rationale="A label must be established separately.",
+    )
+    with pytest.raises(
+        PerceptionCandidatePromotionError,
+        match="decision identity",
+    ):
+        replace(decision, decision_id="sha256:tampered")
+
+    review = review_candidate_promotion_proposals(
+        propose_validated_candidate_promotions(discovery, validation),
+        (decision,),
+    )
+    with pytest.raises(
+        PerceptionCandidatePromotionError,
+        match="review identity",
+    ):
+        replace(review, review_id="sha256:tampered")
+
+
+def test_rejects_nonvalidated_and_mismatched_promotion_lineage() -> None:
+    discovery = _discovery_report()
+    rejected_observations = tuple(
+        _held_out(
+            interaction_id=f"rejected-all-{index}",
+            first_value=0,
+            second_value=0,
+        )
+        for index in range(1, 4)
+    )
+    rejected_validation = validate_discovered_transition_candidates(
+        discovery,
+        rejected_observations,
+        CandidateValidationPolicyDTO.create(
+            minimum_validation_observation_count=3,
+            minimum_confirmation_fraction=2 / 3,
+            minimum_rejection_fraction=2 / 3,
+            minimum_magnitude_retention_fraction=0.75,
+        ),
+    )
+    assert not rejected_validation.results_for_status("validated")
+    with pytest.raises(
+        PerceptionCandidatePromotionError,
+        match="at least one validated result",
+    ):
+        propose_validated_candidate_promotions(discovery, rejected_validation)
+
+    other_discovery = _discovery_report(cohort_id="discovery/other")
+    other_validation = _validation_report(other_discovery, validate_all=False)
+    with pytest.raises(
+        PerceptionCandidatePromotionError,
+        match="does not reference",
+    ):
+        propose_validated_candidate_promotions(discovery, other_validation)
+
+    first_set = propose_validated_candidate_promotions(
+        discovery,
+        _validation_report(discovery, validate_all=False),
+    )
+    second_set = propose_validated_candidate_promotions(
+        other_discovery,
+        other_validation,
+    )
+    foreign_decision = CandidatePromotionDecisionDTO.create(
+        second_set.proposals[0],
+        reviewer_id="reviewer:foreign",
+        decision="deferred",
+        rationale="Valid decision for another proposal set.",
+    )
+    with pytest.raises(
+        PerceptionCandidatePromotionError,
+        match="unknown proposals",
+    ):
+        review_candidate_promotion_proposals(first_set, (foreign_decision,))

--- a/packages/perception/tests/test_candidate_promotion_p18e_public_surface.py
+++ b/packages/perception/tests/test_candidate_promotion_p18e_public_surface.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import zeromodel.perception as perception
+
+
+def test_p18e_is_exposed_from_package_root() -> None:
+    expected = {
+        "PerceptionCandidatePromotionError",
+        "CandidatePromotionProposalDTO",
+        "CandidatePromotionProposalSetDTO",
+        "CandidatePromotionDecisionDTO",
+        "CandidatePromotionReviewDTO",
+        "propose_validated_candidate_promotions",
+        "review_candidate_promotion_proposals",
+        "CANDIDATE_PROMOTION_PROPOSAL_VERSION",
+        "CANDIDATE_PROMOTION_DECISION_VERSION",
+        "CANDIDATE_PROMOTION_REVIEW_VERSION",
+    }
+
+    assert expected <= set(perception.__all__)
+    for name in expected:
+        assert getattr(perception, name) is not None


### PR DESCRIPTION
Audit-Exempt: adds an internal review and authorization layer for P18D-validated hypotheses; no public capability claim status changes.

## Objective

Implement P18E: turn held-out validated transition candidates into immutable, reviewable promotion proposals and explicit reviewer decisions without mutating production annotations, relations, expectations, or runtime behavior.

```text
P18C discovery report
    + P18D validation report
    ↓ validated results only
CandidatePromotionProposalSetDTO
    ↓ explicit reviewer decisions
CandidatePromotionReviewDTO
```

## What changed

- Add content-addressed `CandidatePromotionProposalDTO` binding:
  - discovery report, candidate, source statistic, cohort, recurrence, direction, and supporting lineage;
  - validation report, result, expectation, cohort, observations, interactions, transitions, and confirmation evidence;
  - exact field identities and held-out expectation thresholds.
- Add `CandidatePromotionProposalSetDTO` containing only P18D results whose status is `validated`.
- Keep rejected, inconclusive, and insufficient-evidence results visible in P18D but ineligible for proposal creation.
- Add explicit `CandidatePromotionDecisionDTO` outcomes:
  - `approved`;
  - `rejected`;
  - `deferred`;
  - `needs_semantic_annotation`.
- Require reviewer-supplied semantic name and type for approval.
- Forbid semantic materialization fields on non-approved decisions.
- Add immutable `CandidatePromotionReviewDTO` ledgers with:
  - `pending_review`;
  - `partially_reviewed`;
  - `review_complete`.
- Partition every proposal into pending, approved, rejected, deferred, or semantic-annotation-required categories.
- Enforce one decision per proposal and reject foreign, duplicate, or conflicting decisions.
- Mark every proposal and every decision `not_materialized`, including approvals.
- Advance the P18 roadmap to P18F reversible promotion materialization.

## Epistemic and operational boundary

P18E records review authorization. It does not create a production annotation, assign a relation, rewrite an expectation, activate runtime behavior, or claim causality. Semantic names are supplied explicitly by reviewers rather than inferred from recurrent spatial evidence.

## Focused validation

Tests cover:

- full P18C → P18D → P18E lineage;
- proposal creation for validated candidates only;
- exclusion of rejected candidates;
- deterministic proposal and review identities;
- complete discovery and validation lineage retention;
- pending, partial, and complete reviews;
- approved, rejected, deferred, and semantic-annotation-required decisions;
- mandatory semantic identity for approval;
- forbidden semantic fields on non-approved decisions;
- foreign decisions, lineage mismatches, and identity tampering.

The clean wheel-installed `perception-package` workflow is authoritative for the complete package suite.

## Next stage

P18F should materialize only approved proposals from a fully reviewed ledger into reversible, versioned annotation and expectation change sets. Materialization must remain inactive until a separate admission decision succeeds.