### PR TITLE
feat(perception): add P18F reversible promotion materialization

### DIFF
--- a/packages/perception/docs/p18-roadmap.md
+++ b/packages/perception/docs/p18-roadmap.md
@@ -22,16 +22,22 @@ Derive explicit, content-addressed expectations from P18C candidates and their s
 
 Preserve validated, rejected, inconclusive, and insufficient-evidence outcomes. Failed candidates remain visible and cannot be silently discarded.
 
-## P18E — Governed candidate promotion — current
+## P18E — Governed candidate promotion — complete
 
 Convert only P18D-validated candidates into reviewable, content-addressed proposals. Bind complete discovery and validation lineage, require an explicit reviewer decision, and require reviewer-supplied semantic identity for approval.
 
 Approved proposals remain `not_materialized`. P18E records authorization but cannot create annotations, relations, production expectations, or runtime changes.
 
-## P18F — Reversible promotion materialization — next
+## P18F — Reversible promotion materialization — current
 
-Convert only approved proposals from a fully reviewed P18E ledger into versioned annotation and expectation change sets. Materialization must be reversible, preserve complete P18C/P18D/P18E lineage, and remain inactive until a separate admission decision succeeds.
+Convert approved proposals from a fully reviewed P18E ledger into staged annotations or relations plus transition expectations. Require an explicit ontology directive per approval, bind the exact baseline identity, reject additive collisions, and preserve globally ordered forward operations with exact reverse-order inverse operations.
+
+P18F change sets remain `staged_inactive` and `not_admitted`. A complete review without approvals produces an explicit `no_approved_changes` result rather than an empty implicit success.
+
+## P18G — Materialization admission and atomic activation — next
+
+Verify that the active model still matches the P18F baseline, audit every staged payload and operation pair, and apply all forward operations atomically or none. Persist the inverse operation plan and require a separate governed decision for rollback.
 
 ## Boundary
 
-P18 measures, tests, validates, and governs visual transition hypotheses. It does not infer semantic labels from pixels, claim that correlation is causation, or replace the source and result VPMs with an opaque learned representation.
+P18 measures, tests, validates, governs, and stages visual transition hypotheses. It does not infer semantic labels from pixels, claim that correlation is causation, or activate unadmitted changes in runtime behavior.

--- a/packages/perception/docs/stage-p18f-reversible-promotion-materialization.md
+++ b/packages/perception/docs/stage-p18f-reversible-promotion-materialization.md
@@ -1,0 +1,135 @@
+# Stage P18F — Reversible Promotion Materialization
+
+## Objective
+
+Convert approved proposals from a fully reviewed P18E ledger into a versioned, reversible, inactive annotation/relation and transition-expectation change set.
+
+```text
+P18E proposal set
+    + complete review ledger
+    + explicit materialization directives
+    + exact field schema
+    + baseline identity snapshot
+    ↓
+PromotionMaterializationChangeSetDTO
+    ├── staged annotations or relations
+    ├── staged transition expectations
+    ├── ordered forward operations
+    └── reverse-ordered inverse operations
+```
+
+P18F materializes data contracts. It does not admit, persist into an active model, or execute them.
+
+## Explicit ontology directives
+
+A P18C co-occurrence signature is not automatically a relation, and a single recurrent field is not automatically an object. Each approved proposal therefore requires one `PromotionMaterializationDirectiveDTO` declaring either:
+
+- `region_annotation`; or
+- `relation_annotation`.
+
+A region directive may provide additional annotation properties. Reserved provenance and semantic-property keys cannot be overridden.
+
+A relation directive must name at least two existing baseline annotation identities. Its recurrent candidate fields become explicit `derived_field_ids`; they are not interpreted as relation members.
+
+The directive set must exactly cover approved proposals—no missing directives and no directives for rejected, deferred, or semantic-annotation-required proposals.
+
+## Baseline snapshot
+
+`PromotionMaterializationBaselineDTO` records:
+
+- baseline model-version identity;
+- field-schema identity;
+- existing annotation identities;
+- existing relation identities;
+- existing transition-expectation identities.
+
+The baseline is content-addressed. P18F rejects generated identities that already exist in the baseline or collide with another generated change. This matters for reversibility: a rollback may remove only objects introduced by its own change set.
+
+Relation directives may reference only annotation identities present in this baseline.
+
+## Staged objects
+
+For a region target, P18F creates:
+
+- `PerceptionRegionAnnotationDTO` using the reviewer-supplied semantic name and role;
+- a `semantic_type` property from the reviewer decision;
+- proposal and decision provenance properties;
+- `provenance_ref` bound to the approval decision;
+- `TransitionExpectationDTO` targeting the new annotation.
+
+For a relation target, P18F creates:
+
+- `RelationAnnotationDTO` using the reviewer-supplied semantic type;
+- explicit baseline member annotations;
+- candidate fields as derived fields;
+- reviewer-supplied semantic name as the relation value;
+- `TransitionExpectationDTO` targeting the new relation.
+
+Expectation direction and minimum magnitude thresholds are copied exactly from the P18E proposal, which already preserves the held-out P18D expectation.
+
+## Forward and inverse operations
+
+Every materialized approval produces two forward operations:
+
+1. add the annotation or relation;
+2. add its transition expectation.
+
+It also produces two exact inverse operations:
+
+1. remove the transition expectation;
+2. remove the annotation or relation.
+
+Each forward/inverse pair shares a content-addressed `pair_id` over:
+
+- object kind;
+- object identity;
+- exact payload digest;
+- proposal identity;
+- decision identity.
+
+Across multiple changes, forward operations are ordered from first target to final expectation. Inverse operations reverse the entire sequence, removing dependent expectations before their targets.
+
+## Change-set states
+
+A complete review with approvals produces:
+
+- `status = staged_inactive`;
+- `activation_status = not_admitted`.
+
+A complete review with no approvals produces a content-addressed `no_approved_changes` change set with no operations.
+
+Partial reviews are rejected. An approval cannot be materialized twice through an already-materialized proposal or decision contract.
+
+## Integrity boundary
+
+P18F rejects:
+
+- reviews for another proposal set;
+- incomplete review ledgers;
+- schema or baseline mismatches;
+- inexact directive coverage;
+- implicit relation members;
+- relation members outside the baseline;
+- candidate fields outside the schema;
+- baseline or within-change-set identity collisions;
+- semantic payloads that disagree with the approved decision;
+- annotation or relation identity tampering;
+- transition expectations targeting the wrong materialized object;
+- incomplete, duplicated, reordered, or non-paired forward/inverse operations;
+- baseline, directive, operation, change, or change-set identity tampering.
+
+## Non-claims
+
+A staged P18F change set does not mean that:
+
+- the annotation or relation is active;
+- the expectation participates in runtime decisions;
+- the current baseline still matches when execution is attempted;
+- the semantic interpretation is universally correct;
+- the candidate caused the observed transition.
+
+It means only that a fully reviewed approval has been converted into an exact, reversible and inactive change proposal.
+
+## Next stage
+
+P18G should implement materialization admission and atomic activation. Admission must verify that the active baseline still equals `baseline_id` and `baseline_version_id`, audit every payload and operation pair, then either apply all forward operations atomically or apply none. It should also persist the inverse operation plan for governed rollback.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -1,4 +1,4 @@
-"""ZeroModel perception public API through Stage P18E."""
+"""ZeroModel perception public API through Stage P18F."""
 
 from __future__ import annotations
 
@@ -68,6 +68,28 @@ from .governance_gate import (  # noqa: F401
     PerceptionGovernanceExecutionGateError,
     authorize_governance_execution,
     execute_audit_gated_approved_rollback,
+)
+from .promotion_materialization import (  # noqa: F401
+    MATERIALIZED_PROMOTION_CHANGE_VERSION,
+    PROMOTION_MATERIALIZATION_ACTIVATION_STATUS,
+    PROMOTION_MATERIALIZATION_BASELINE_VERSION,
+    PROMOTION_MATERIALIZATION_CHANGE_SET_STATUSES,
+    PROMOTION_MATERIALIZATION_CHANGE_SET_VERSION,
+    PROMOTION_MATERIALIZATION_DIRECTIONS,
+    PROMOTION_MATERIALIZATION_DIRECTIVE_VERSION,
+    PROMOTION_MATERIALIZATION_ITEM_STATUS,
+    PROMOTION_MATERIALIZATION_OBJECT_KINDS,
+    PROMOTION_MATERIALIZATION_OPERATION_ACTIONS,
+    PROMOTION_MATERIALIZATION_OPERATION_VERSION,
+    PROMOTION_MATERIALIZATION_SEMANTICS,
+    PROMOTION_MATERIALIZATION_TARGET_KINDS,
+    MaterializedPromotionChangeDTO,
+    PerceptionPromotionMaterializationError,
+    PromotionMaterializationBaselineDTO,
+    PromotionMaterializationChangeSetDTO,
+    PromotionMaterializationDirectiveDTO,
+    PromotionMaterializationOperationDTO,
+    materialize_approved_candidate_promotions,
 )
 from .sql_admission import (  # noqa: F401
     SQL_ADMISSION_SCHEMA_VERSION,
@@ -139,7 +161,7 @@ from .transition_evidence import (  # noqa: F401
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P18E"
+PERCEPTION_STAGE = "P18F"
 
 __all__ = [
     name

--- a/packages/perception/src/zeromodel/perception/promotion_materialization.py
+++ b/packages/perception/src/zeromodel/perception/promotion_materialization.py
@@ -1,0 +1,1076 @@
+"""Reversible, inactive promotion materialization for Stage P18F.
+
+P18F converts only fully reviewed P18E approvals into versioned annotation or
+relation additions plus transition expectations. The resulting change set is
+content-addressed, carries exact inverse operations, and remains inactive until
+a later admission stage authorizes execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Final, Mapping
+
+from .candidate_promotion import (
+    CANDIDATE_PROMOTION_MATERIALIZATION_STATUS,
+    CandidatePromotionDecisionDTO,
+    CandidatePromotionProposalDTO,
+    CandidatePromotionProposalSetDTO,
+    CandidatePromotionReviewDTO,
+)
+from .expectations import (
+    RELATION_ANNOTATION_VERSION,
+    PerceptionRegionAnnotationDTO,
+    RelationAnnotationDTO,
+)
+from .fields import VPMFieldSchemaDTO
+from .transition_conformance import TransitionExpectationDTO
+
+PROMOTION_MATERIALIZATION_DIRECTIVE_VERSION: Final = (
+    "perception-promotion-materialization-directive/1"
+)
+PROMOTION_MATERIALIZATION_BASELINE_VERSION: Final = (
+    "perception-promotion-materialization-baseline/1"
+)
+PROMOTION_MATERIALIZATION_OPERATION_VERSION: Final = (
+    "perception-promotion-materialization-operation/1"
+)
+MATERIALIZED_PROMOTION_CHANGE_VERSION: Final = (
+    "perception-materialized-promotion-change/1"
+)
+PROMOTION_MATERIALIZATION_CHANGE_SET_VERSION: Final = (
+    "perception-promotion-materialization-change-set/1"
+)
+PROMOTION_MATERIALIZATION_SEMANTICS: Final = (
+    "reversible_inactive_materialization_of_fully_reviewed_p18e_approvals"
+)
+PROMOTION_MATERIALIZATION_TARGET_KINDS: Final = {
+    "region_annotation",
+    "relation_annotation",
+}
+PROMOTION_MATERIALIZATION_OBJECT_KINDS: Final = {
+    "annotation",
+    "relation",
+    "transition_expectation",
+}
+PROMOTION_MATERIALIZATION_OPERATION_ACTIONS: Final = {
+    "add_annotation",
+    "remove_annotation",
+    "add_relation",
+    "remove_relation",
+    "add_transition_expectation",
+    "remove_transition_expectation",
+}
+PROMOTION_MATERIALIZATION_DIRECTIONS: Final = {"forward", "inverse"}
+PROMOTION_MATERIALIZATION_CHANGE_SET_STATUSES: Final = {
+    "staged_inactive",
+    "no_approved_changes",
+}
+PROMOTION_MATERIALIZATION_ACTIVATION_STATUS: Final = "not_admitted"
+PROMOTION_MATERIALIZATION_ITEM_STATUS: Final = "staged_inactive"
+_RESERVED_ANNOTATION_PROPERTY_KEYS: Final = {
+    "semantic_type",
+    "promotion_proposal_id",
+    "promotion_decision_id",
+}
+
+
+class PerceptionPromotionMaterializationError(ValueError):
+    """Raised when P18F materialization contracts are invalid."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    encoded = _canonical_json(payload)
+    hasher = hashlib.sha256()
+    hasher.update(len(encoded).to_bytes(8, "big"))
+    hasher.update(encoded)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def _payload(value: object, identity_field: str) -> dict[str, object]:
+    payload = asdict(value)  # type: ignore[arg-type]
+    payload.pop(identity_field)
+    return payload
+
+
+def _ordered_unique(
+    name: str,
+    values: tuple[str, ...],
+    *,
+    allow_empty: bool = True,
+) -> None:
+    if not allow_empty and not values:
+        raise PerceptionPromotionMaterializationError(f"{name} must be non-empty")
+    if values != tuple(sorted(set(values))):
+        raise PerceptionPromotionMaterializationError(
+            f"{name} must be unique and sorted"
+        )
+
+
+def _positive_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise PerceptionPromotionMaterializationError(
+            f"{name} must be a positive integer"
+        )
+
+
+def _object_digest(kind: str, value: object) -> str:
+    return _digest({"object_kind": kind, "payload": asdict(value)})  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class PromotionMaterializationDirectiveDTO:
+    """Explicit ontology choice for one approved P18E proposal."""
+
+    directive_id: str
+    proposal_id: str
+    target_kind: str
+    relation_member_annotation_ids: tuple[str, ...] = ()
+    annotation_properties: tuple[tuple[str, str], ...] = ()
+    version: str = PROMOTION_MATERIALIZATION_DIRECTIVE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.directive_id or not self.proposal_id:
+            raise PerceptionPromotionMaterializationError(
+                "materialization directive identities must be non-empty"
+            )
+        if self.target_kind not in PROMOTION_MATERIALIZATION_TARGET_KINDS:
+            raise PerceptionPromotionMaterializationError(
+                f"unsupported materialization target_kind: {self.target_kind}"
+            )
+        _ordered_unique(
+            "directive relation_member_annotation_ids",
+            self.relation_member_annotation_ids,
+        )
+        if self.annotation_properties != tuple(sorted(set(self.annotation_properties))):
+            raise PerceptionPromotionMaterializationError(
+                "directive annotation_properties must be unique and sorted"
+            )
+        if any(not key or not value for key, value in self.annotation_properties):
+            raise PerceptionPromotionMaterializationError(
+                "directive annotation properties require non-empty keys and values"
+            )
+        property_keys = {key for key, _ in self.annotation_properties}
+        reserved = property_keys & _RESERVED_ANNOTATION_PROPERTY_KEYS
+        if reserved:
+            raise PerceptionPromotionMaterializationError(
+                f"directive annotation properties use reserved keys: {sorted(reserved)}"
+            )
+        if self.target_kind == "region_annotation":
+            if self.relation_member_annotation_ids:
+                raise PerceptionPromotionMaterializationError(
+                    "region directives cannot declare relation members"
+                )
+        else:
+            if len(self.relation_member_annotation_ids) < 2:
+                raise PerceptionPromotionMaterializationError(
+                    "relation directives require at least two annotation members"
+                )
+            if self.annotation_properties:
+                raise PerceptionPromotionMaterializationError(
+                    "relation directives cannot carry annotation properties"
+                )
+        if self.version != PROMOTION_MATERIALIZATION_DIRECTIVE_VERSION:
+            raise PerceptionPromotionMaterializationError(
+                "unsupported materialization directive version"
+            )
+        if self.directive_id != _digest(_payload(self, "directive_id")):
+            raise PerceptionPromotionMaterializationError(
+                "materialization directive identity disagrees with canonical payload"
+            )
+
+    @classmethod
+    def create(
+        cls,
+        proposal: CandidatePromotionProposalDTO,
+        *,
+        target_kind: str,
+        relation_member_annotation_ids: tuple[str, ...] = (),
+        annotation_properties: tuple[tuple[str, str], ...] = (),
+    ) -> "PromotionMaterializationDirectiveDTO":
+        values: dict[str, object] = {
+            "proposal_id": proposal.proposal_id,
+            "target_kind": target_kind,
+            "relation_member_annotation_ids": tuple(
+                sorted(set(relation_member_annotation_ids))
+            ),
+            "annotation_properties": tuple(sorted(set(annotation_properties))),
+            "version": PROMOTION_MATERIALIZATION_DIRECTIVE_VERSION,
+        }
+        return cls(directive_id=_digest(values), **values)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class PromotionMaterializationBaselineDTO:
+    """Identity snapshot used to prevent non-reversible additive collisions."""
+
+    baseline_id: str
+    baseline_version_id: str
+    field_schema_id: str
+    existing_annotation_ids: tuple[str, ...] = ()
+    existing_relation_ids: tuple[str, ...] = ()
+    existing_transition_expectation_ids: tuple[str, ...] = ()
+    version: str = PROMOTION_MATERIALIZATION_BASELINE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.baseline_id or not self.baseline_version_id or not self.field_schema_id:
+            raise PerceptionPromotionMaterializationError(
+                "materialization baseline identities must be non-empty"
+            )
+        for name in (
+            "existing_annotation_ids",
+            "existing_relation_ids",
+            "existing_transition_expectation_ids",
+        ):
+            _ordered_unique(name, getattr(self, name))
+        if self.version != PROMOTION_MATERIALIZATION_BASELINE_VERSION:
+            raise PerceptionPromotionMaterializationError(
+                "unsupported materialization baseline version"
+            )
+        if self.baseline_id != _digest(_payload(self, "baseline_id")):
+            raise PerceptionPromotionMaterializationError(
+                "materialization baseline identity disagrees with canonical payload"
+            )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        baseline_version_id: str,
+        field_schema_id: str,
+        existing_annotation_ids: tuple[str, ...] = (),
+        existing_relation_ids: tuple[str, ...] = (),
+        existing_transition_expectation_ids: tuple[str, ...] = (),
+    ) -> "PromotionMaterializationBaselineDTO":
+        values: dict[str, object] = {
+            "baseline_version_id": baseline_version_id,
+            "field_schema_id": field_schema_id,
+            "existing_annotation_ids": tuple(sorted(set(existing_annotation_ids))),
+            "existing_relation_ids": tuple(sorted(set(existing_relation_ids))),
+            "existing_transition_expectation_ids": tuple(
+                sorted(set(existing_transition_expectation_ids))
+            ),
+            "version": PROMOTION_MATERIALIZATION_BASELINE_VERSION,
+        }
+        return cls(baseline_id=_digest(values), **values)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class PromotionMaterializationOperationDTO:
+    operation_id: str
+    pair_id: str
+    direction: str
+    action: str
+    object_kind: str
+    object_id: str
+    payload_digest: str
+    proposal_id: str
+    decision_id: str
+    sequence: int
+    version: str = PROMOTION_MATERIALIZATION_OPERATION_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.operation_id,
+                self.pair_id,
+                self.object_id,
+                self.payload_digest,
+                self.proposal_id,
+                self.decision_id,
+            )
+        ):
+            raise PerceptionPromotionMaterializationError(
+                "materialization operation identities must be non-empty"
+            )
+        if self.direction not in PROMOTION_MATERIALIZATION_DIRECTIONS:
+            raise PerceptionPromotionMaterializationError(
+                f"unsupported operation direction: {self.direction}"
+            )
+        if self.action not in PROMOTION_MATERIALIZATION_OPERATION_ACTIONS:
+            raise PerceptionPromotionMaterializationError(
+                f"unsupported materialization operation: {self.action}"
+            )
+        if self.object_kind not in PROMOTION_MATERIALIZATION_OBJECT_KINDS:
+            raise PerceptionPromotionMaterializationError(
+                f"unsupported materialization object_kind: {self.object_kind}"
+            )
+        _positive_int("materialization operation sequence", self.sequence)
+        expected_action = {
+            ("forward", "annotation"): "add_annotation",
+            ("inverse", "annotation"): "remove_annotation",
+            ("forward", "relation"): "add_relation",
+            ("inverse", "relation"): "remove_relation",
+            ("forward", "transition_expectation"): "add_transition_expectation",
+            ("inverse", "transition_expectation"): "remove_transition_expectation",
+        }[(self.direction, self.object_kind)]
+        if self.action != expected_action:
+            raise PerceptionPromotionMaterializationError(
+                "materialization action disagrees with direction and object kind"
+            )
+        expected_pair = _digest(
+            {
+                "object_kind": self.object_kind,
+                "object_id": self.object_id,
+                "payload_digest": self.payload_digest,
+                "proposal_id": self.proposal_id,
+                "decision_id": self.decision_id,
+            }
+        )
+        if self.pair_id != expected_pair:
+            raise PerceptionPromotionMaterializationError(
+                "materialization operation pair identity disagrees with object payload"
+            )
+        if self.version != PROMOTION_MATERIALIZATION_OPERATION_VERSION:
+            raise PerceptionPromotionMaterializationError(
+                "unsupported materialization operation version"
+            )
+        if self.operation_id != _digest(_payload(self, "operation_id")):
+            raise PerceptionPromotionMaterializationError(
+                "materialization operation identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class MaterializedPromotionChangeDTO:
+    change_id: str
+    proposal_id: str
+    decision_id: str
+    directive_id: str
+    target_kind: str
+    semantic_name: str
+    semantic_type: str
+    semantic_role: str | None
+    annotation: PerceptionRegionAnnotationDTO | None
+    relation: RelationAnnotationDTO | None
+    transition_expectation: TransitionExpectationDTO
+    forward_operations: tuple[PromotionMaterializationOperationDTO, ...]
+    inverse_operations: tuple[PromotionMaterializationOperationDTO, ...]
+    materialization_status: str = PROMOTION_MATERIALIZATION_ITEM_STATUS
+    version: str = MATERIALIZED_PROMOTION_CHANGE_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.change_id,
+                self.proposal_id,
+                self.decision_id,
+                self.directive_id,
+                self.semantic_name,
+                self.semantic_type,
+            )
+        ):
+            raise PerceptionPromotionMaterializationError(
+                "materialized promotion change identities and semantics must be non-empty"
+            )
+        if self.target_kind not in PROMOTION_MATERIALIZATION_TARGET_KINDS:
+            raise PerceptionPromotionMaterializationError(
+                f"unsupported materialized target_kind: {self.target_kind}"
+            )
+        if self.target_kind == "region_annotation":
+            if self.annotation is None or self.relation is not None:
+                raise PerceptionPromotionMaterializationError(
+                    "region changes require annotation and forbid relation"
+                )
+            target_kind = "annotation"
+            target_id = self.annotation.annotation_id
+            if self.transition_expectation.annotation_ids != (target_id,):
+                raise PerceptionPromotionMaterializationError(
+                    "region transition expectation must target materialized annotation"
+                )
+            if self.transition_expectation.relation_ids:
+                raise PerceptionPromotionMaterializationError(
+                    "region transition expectation cannot target relations"
+                )
+        else:
+            if self.relation is None or self.annotation is not None:
+                raise PerceptionPromotionMaterializationError(
+                    "relation changes require relation and forbid annotation"
+                )
+            target_kind = "relation"
+            target_id = self.relation.relation_id
+            if self.transition_expectation.relation_ids != (target_id,):
+                raise PerceptionPromotionMaterializationError(
+                    "relation transition expectation must target materialized relation"
+                )
+            if self.transition_expectation.annotation_ids:
+                raise PerceptionPromotionMaterializationError(
+                    "relation transition expectation cannot target annotations"
+                )
+        if self.annotation is not None:
+            expected_annotation_id = _digest(
+                {
+                    "field_schema_id": self.annotation.field_schema_id,
+                    "field_ids": list(self.annotation.field_ids),
+                    "label": self.annotation.label,
+                    "properties": [list(item) for item in self.annotation.properties],
+                    "provenance_ref": self.annotation.provenance_ref,
+                    "role": self.annotation.role,
+                    "version": self.annotation.version,
+                }
+            )
+            if self.annotation.annotation_id != expected_annotation_id:
+                raise PerceptionPromotionMaterializationError(
+                    "materialized annotation identity disagrees with payload"
+                )
+            properties = dict(self.annotation.properties)
+            if (
+                self.annotation.label != self.semantic_name
+                or self.annotation.role != self.semantic_role
+                or properties.get("semantic_type") != self.semantic_type
+                or self.annotation.provenance_ref != self.decision_id
+            ):
+                raise PerceptionPromotionMaterializationError(
+                    "materialized annotation disagrees with approved semantics"
+                )
+        if self.relation is not None:
+            expected_relation_id = _digest(
+                {
+                    "relation_type": self.relation.relation_type,
+                    "member_annotation_ids": self.relation.member_annotation_ids,
+                    "derived_field_ids": self.relation.derived_field_ids,
+                    "value": self.relation.value,
+                    "version": self.relation.version,
+                }
+            )
+            if self.relation.relation_id != expected_relation_id:
+                raise PerceptionPromotionMaterializationError(
+                    "materialized relation identity disagrees with payload"
+                )
+            if (
+                self.relation.relation_type != self.semantic_type
+                or self.relation.value != self.semantic_name
+            ):
+                raise PerceptionPromotionMaterializationError(
+                    "materialized relation disagrees with approved semantics"
+                )
+        if len(self.forward_operations) != 2 or len(self.inverse_operations) != 2:
+            raise PerceptionPromotionMaterializationError(
+                "each materialized change requires two forward and two inverse operations"
+            )
+        for operations, direction in (
+            (self.forward_operations, "forward"),
+            (self.inverse_operations, "inverse"),
+        ):
+            if any(item.direction != direction for item in operations):
+                raise PerceptionPromotionMaterializationError(
+                    "change operation direction disagrees with operation collection"
+                )
+            if any(
+                item.proposal_id != self.proposal_id
+                or item.decision_id != self.decision_id
+                for item in operations
+            ):
+                raise PerceptionPromotionMaterializationError(
+                    "change operations disagree with proposal or decision lineage"
+                )
+        forward_pairs = {item.pair_id: item for item in self.forward_operations}
+        inverse_pairs = {item.pair_id: item for item in self.inverse_operations}
+        if set(forward_pairs) != set(inverse_pairs):
+            raise PerceptionPromotionMaterializationError(
+                "forward and inverse operations do not form exact pairs"
+            )
+        object_pairs = {
+            (item.object_kind, item.object_id, item.payload_digest)
+            for item in self.forward_operations
+        }
+        expected_objects = {
+            (
+                target_kind,
+                target_id,
+                _object_digest(target_kind, self.annotation or self.relation),
+            ),
+            (
+                "transition_expectation",
+                self.transition_expectation.expectation_id,
+                _object_digest("transition_expectation", self.transition_expectation),
+            ),
+        }
+        if object_pairs != expected_objects:
+            raise PerceptionPromotionMaterializationError(
+                "materialization operations disagree with materialized objects"
+            )
+        if self.materialization_status != PROMOTION_MATERIALIZATION_ITEM_STATUS:
+            raise PerceptionPromotionMaterializationError(
+                "materialized promotion changes must remain staged_inactive"
+            )
+        if self.version != MATERIALIZED_PROMOTION_CHANGE_VERSION:
+            raise PerceptionPromotionMaterializationError(
+                "unsupported materialized promotion change version"
+            )
+        if self.change_id != _digest(_payload(self, "change_id")):
+            raise PerceptionPromotionMaterializationError(
+                "materialized promotion change identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class PromotionMaterializationChangeSetDTO:
+    change_set_id: str
+    status: str
+    proposal_set_id: str
+    review_id: str
+    baseline_id: str
+    baseline_version_id: str
+    field_schema_id: str
+    approved_proposal_ids: tuple[str, ...]
+    decision_ids: tuple[str, ...]
+    directive_ids: tuple[str, ...]
+    change_ids: tuple[str, ...]
+    changes: tuple[MaterializedPromotionChangeDTO, ...]
+    forward_operation_ids: tuple[str, ...]
+    inverse_operation_ids: tuple[str, ...]
+    activation_status: str = PROMOTION_MATERIALIZATION_ACTIVATION_STATUS
+    semantics: str = PROMOTION_MATERIALIZATION_SEMANTICS
+    version: str = PROMOTION_MATERIALIZATION_CHANGE_SET_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.change_set_id,
+                self.proposal_set_id,
+                self.review_id,
+                self.baseline_id,
+                self.baseline_version_id,
+                self.field_schema_id,
+            )
+        ):
+            raise PerceptionPromotionMaterializationError(
+                "materialization change-set identities must be non-empty"
+            )
+        if self.status not in PROMOTION_MATERIALIZATION_CHANGE_SET_STATUSES:
+            raise PerceptionPromotionMaterializationError(
+                f"unsupported materialization change-set status: {self.status}"
+            )
+        for name in (
+            "approved_proposal_ids",
+            "decision_ids",
+            "directive_ids",
+            "change_ids",
+        ):
+            _ordered_unique(name, getattr(self, name))
+        actual_change_ids = tuple(sorted(item.change_id for item in self.changes))
+        if actual_change_ids != self.change_ids:
+            raise PerceptionPromotionMaterializationError(
+                "materialization change identities disagree with changes"
+            )
+        if tuple(sorted(item.proposal_id for item in self.changes)) != self.approved_proposal_ids:
+            raise PerceptionPromotionMaterializationError(
+                "approved proposal identities disagree with materialized changes"
+            )
+        if tuple(sorted(item.decision_id for item in self.changes)) != self.decision_ids:
+            raise PerceptionPromotionMaterializationError(
+                "decision identities disagree with materialized changes"
+            )
+        if tuple(sorted(item.directive_id for item in self.changes)) != self.directive_ids:
+            raise PerceptionPromotionMaterializationError(
+                "directive identities disagree with materialized changes"
+            )
+        if not (
+            len(self.approved_proposal_ids)
+            == len(self.decision_ids)
+            == len(self.directive_ids)
+            == len(self.change_ids)
+            == len(self.changes)
+        ):
+            raise PerceptionPromotionMaterializationError(
+                "materialization change-set lineage counts disagree"
+            )
+        if self.status == "staged_inactive" and not self.changes:
+            raise PerceptionPromotionMaterializationError(
+                "staged_inactive change sets require materialized changes"
+            )
+        if self.status == "no_approved_changes" and self.changes:
+            raise PerceptionPromotionMaterializationError(
+                "no_approved_changes change sets cannot contain changes"
+            )
+        forward = tuple(
+            sorted(
+                (
+                    operation
+                    for change in self.changes
+                    for operation in change.forward_operations
+                ),
+                key=lambda item: item.sequence,
+            )
+        )
+        inverse = tuple(
+            sorted(
+                (
+                    operation
+                    for change in self.changes
+                    for operation in change.inverse_operations
+                ),
+                key=lambda item: item.sequence,
+            )
+        )
+        if len(self.forward_operation_ids) != len(set(self.forward_operation_ids)):
+            raise PerceptionPromotionMaterializationError(
+                "forward operation identities must be unique"
+            )
+        if len(self.inverse_operation_ids) != len(set(self.inverse_operation_ids)):
+            raise PerceptionPromotionMaterializationError(
+                "inverse operation identities must be unique"
+            )
+        if tuple(item.operation_id for item in forward) != self.forward_operation_ids:
+            raise PerceptionPromotionMaterializationError(
+                "forward operation identities disagree with execution order"
+            )
+        if tuple(item.operation_id for item in inverse) != self.inverse_operation_ids:
+            raise PerceptionPromotionMaterializationError(
+                "inverse operation identities disagree with execution order"
+            )
+        if tuple(item.sequence for item in forward) != tuple(range(1, len(forward) + 1)):
+            raise PerceptionPromotionMaterializationError(
+                "forward operation sequence must be contiguous"
+            )
+        if tuple(item.sequence for item in inverse) != tuple(range(1, len(inverse) + 1)):
+            raise PerceptionPromotionMaterializationError(
+                "inverse operation sequence must be contiguous"
+            )
+        if {item.pair_id for item in forward} != {item.pair_id for item in inverse}:
+            raise PerceptionPromotionMaterializationError(
+                "change-set forward and inverse operations do not pair exactly"
+            )
+        if self.activation_status != PROMOTION_MATERIALIZATION_ACTIVATION_STATUS:
+            raise PerceptionPromotionMaterializationError(
+                "materialization change sets must remain not_admitted"
+            )
+        if self.semantics != PROMOTION_MATERIALIZATION_SEMANTICS:
+            raise PerceptionPromotionMaterializationError(
+                "unsupported promotion materialization semantics"
+            )
+        if self.version != PROMOTION_MATERIALIZATION_CHANGE_SET_VERSION:
+            raise PerceptionPromotionMaterializationError(
+                "unsupported promotion materialization change-set version"
+            )
+        if self.change_set_id != _digest(_payload(self, "change_set_id")):
+            raise PerceptionPromotionMaterializationError(
+                "promotion materialization change-set identity disagrees with canonical payload"
+            )
+
+    def operations(
+        self,
+        direction: str,
+    ) -> tuple[PromotionMaterializationOperationDTO, ...]:
+        if direction not in PROMOTION_MATERIALIZATION_DIRECTIONS:
+            raise PerceptionPromotionMaterializationError(
+                f"unsupported operation direction: {direction}"
+            )
+        operations = tuple(
+            operation
+            for change in self.changes
+            for operation in (
+                change.forward_operations
+                if direction == "forward"
+                else change.inverse_operations
+            )
+        )
+        return tuple(sorted(operations, key=lambda item: item.sequence))
+
+
+def _operation(
+    *,
+    direction: str,
+    object_kind: str,
+    object_id: str,
+    payload_digest: str,
+    proposal_id: str,
+    decision_id: str,
+    sequence: int,
+) -> PromotionMaterializationOperationDTO:
+    action = {
+        ("forward", "annotation"): "add_annotation",
+        ("inverse", "annotation"): "remove_annotation",
+        ("forward", "relation"): "add_relation",
+        ("inverse", "relation"): "remove_relation",
+        ("forward", "transition_expectation"): "add_transition_expectation",
+        ("inverse", "transition_expectation"): "remove_transition_expectation",
+    }[(direction, object_kind)]
+    pair_id = _digest(
+        {
+            "object_kind": object_kind,
+            "object_id": object_id,
+            "payload_digest": payload_digest,
+            "proposal_id": proposal_id,
+            "decision_id": decision_id,
+        }
+    )
+    values: dict[str, object] = {
+        "pair_id": pair_id,
+        "direction": direction,
+        "action": action,
+        "object_kind": object_kind,
+        "object_id": object_id,
+        "payload_digest": payload_digest,
+        "proposal_id": proposal_id,
+        "decision_id": decision_id,
+        "sequence": sequence,
+        "version": PROMOTION_MATERIALIZATION_OPERATION_VERSION,
+    }
+    return PromotionMaterializationOperationDTO(
+        operation_id=_digest(values),
+        **values,  # type: ignore[arg-type]
+    )
+
+
+def _relation(
+    *,
+    proposal: CandidatePromotionProposalDTO,
+    decision: CandidatePromotionDecisionDTO,
+    directive: PromotionMaterializationDirectiveDTO,
+) -> RelationAnnotationDTO:
+    payload: dict[str, object] = {
+        "relation_type": decision.semantic_type,
+        "member_annotation_ids": directive.relation_member_annotation_ids,
+        "derived_field_ids": proposal.field_ids,
+        "value": decision.semantic_name,
+        "version": RELATION_ANNOTATION_VERSION,
+    }
+    return RelationAnnotationDTO(
+        relation_id=_digest(payload),
+        relation_type=decision.semantic_type or "",
+        member_annotation_ids=directive.relation_member_annotation_ids,
+        derived_field_ids=proposal.field_ids,
+        value=decision.semantic_name,
+    )
+
+
+def _objects_for_approval(
+    *,
+    proposal: CandidatePromotionProposalDTO,
+    decision: CandidatePromotionDecisionDTO,
+    directive: PromotionMaterializationDirectiveDTO,
+    field_schema: VPMFieldSchemaDTO,
+) -> tuple[
+    PerceptionRegionAnnotationDTO | None,
+    RelationAnnotationDTO | None,
+    TransitionExpectationDTO,
+]:
+    if decision.decision != "approved" or not decision.semantic_name or not decision.semantic_type:
+        raise PerceptionPromotionMaterializationError(
+            "materialization requires an approved decision with semantic identity"
+        )
+    if directive.target_kind == "region_annotation":
+        properties = tuple(
+            sorted(
+                set(directive.annotation_properties)
+                | {
+                    ("semantic_type", decision.semantic_type),
+                    ("promotion_proposal_id", proposal.proposal_id),
+                    ("promotion_decision_id", decision.decision_id),
+                }
+            )
+        )
+        annotation = PerceptionRegionAnnotationDTO.create(
+            field_schema,
+            proposal.field_ids,
+            label=decision.semantic_name,
+            role=decision.semantic_role,
+            properties=properties,
+            provenance_ref=decision.decision_id,
+        )
+        relation = None
+        expectation = TransitionExpectationDTO.create(
+            field_schema_id=proposal.field_schema_id,
+            annotation_ids=(annotation.annotation_id,),
+            expected_change=proposal.proposed_expected_change,
+            minimum_mean_absolute_change=proposal.minimum_mean_absolute_change,
+            minimum_changed_fraction=proposal.minimum_changed_fraction,
+            minimum_signed_change_magnitude=proposal.minimum_signed_change_magnitude,
+        )
+    else:
+        annotation = None
+        relation = _relation(
+            proposal=proposal,
+            decision=decision,
+            directive=directive,
+        )
+        expectation = TransitionExpectationDTO.create(
+            field_schema_id=proposal.field_schema_id,
+            relation_ids=(relation.relation_id,),
+            expected_change=proposal.proposed_expected_change,
+            minimum_mean_absolute_change=proposal.minimum_mean_absolute_change,
+            minimum_changed_fraction=proposal.minimum_changed_fraction,
+            minimum_signed_change_magnitude=proposal.minimum_signed_change_magnitude,
+        )
+    return annotation, relation, expectation
+
+
+def materialize_approved_candidate_promotions(
+    proposal_set: CandidatePromotionProposalSetDTO,
+    review: CandidatePromotionReviewDTO,
+    field_schema: VPMFieldSchemaDTO,
+    baseline: PromotionMaterializationBaselineDTO,
+    directives: tuple[PromotionMaterializationDirectiveDTO, ...] = (),
+) -> PromotionMaterializationChangeSetDTO:
+    """Create an inactive reversible change set from fully reviewed approvals."""
+
+    if review.proposal_set_id != proposal_set.proposal_set_id:
+        raise PerceptionPromotionMaterializationError(
+            "promotion review does not reference the supplied proposal set"
+        )
+    if review.proposal_ids != proposal_set.proposal_ids:
+        raise PerceptionPromotionMaterializationError(
+            "promotion review proposal identities disagree with proposal set"
+        )
+    if review.status != "review_complete":
+        raise PerceptionPromotionMaterializationError(
+            "promotion materialization requires a fully reviewed ledger"
+        )
+    if proposal_set.field_schema_id != field_schema.field_schema_id:
+        raise PerceptionPromotionMaterializationError(
+            "field schema does not match promotion proposal set"
+        )
+    if baseline.field_schema_id != field_schema.field_schema_id:
+        raise PerceptionPromotionMaterializationError(
+            "materialization baseline field schema mismatch"
+        )
+    proposal_map = {item.proposal_id: item for item in proposal_set.proposals}
+    decision_map = {item.proposal_id: item for item in review.decisions}
+    approved_ids = review.approved_proposal_ids
+    approved_decisions = tuple(decision_map[item] for item in approved_ids)
+    if any(item.decision != "approved" for item in approved_decisions):
+        raise PerceptionPromotionMaterializationError(
+            "approved review category contains a non-approved decision"
+        )
+    directive_map = {item.proposal_id: item for item in directives}
+    if len(directive_map) != len(directives):
+        raise PerceptionPromotionMaterializationError(
+            "materialization directives require one unique directive per proposal"
+        )
+    if set(directive_map) != set(approved_ids):
+        raise PerceptionPromotionMaterializationError(
+            "materialization directives must exactly cover approved proposals"
+        )
+    known_fields = {item.field_id for item in field_schema.fields}
+    for proposal_id in approved_ids:
+        proposal = proposal_map[proposal_id]
+        decision = decision_map[proposal_id]
+        directive = directive_map[proposal_id]
+        if not set(proposal.field_ids) <= known_fields:
+            raise PerceptionPromotionMaterializationError(
+                "approved proposal references fields outside the supplied schema"
+            )
+        if proposal.materialization_status != CANDIDATE_PROMOTION_MATERIALIZATION_STATUS:
+            raise PerceptionPromotionMaterializationError(
+                "approved proposal was already materialized"
+            )
+        if decision.materialization_status != CANDIDATE_PROMOTION_MATERIALIZATION_STATUS:
+            raise PerceptionPromotionMaterializationError(
+                "approved decision was already materialized"
+            )
+        if directive.target_kind == "relation_annotation":
+            missing_members = set(directive.relation_member_annotation_ids) - set(
+                baseline.existing_annotation_ids
+            )
+            if missing_members:
+                raise PerceptionPromotionMaterializationError(
+                    "relation directive references annotations outside the baseline: "
+                    f"{sorted(missing_members)}"
+                )
+
+    ordered_ids = tuple(sorted(approved_ids))
+    object_rows: list[
+        tuple[
+            CandidatePromotionProposalDTO,
+            CandidatePromotionDecisionDTO,
+            PromotionMaterializationDirectiveDTO,
+            PerceptionRegionAnnotationDTO | None,
+            RelationAnnotationDTO | None,
+            TransitionExpectationDTO,
+        ]
+    ] = []
+    new_annotation_ids: set[str] = set()
+    new_relation_ids: set[str] = set()
+    new_expectation_ids: set[str] = set()
+    for proposal_id in ordered_ids:
+        proposal = proposal_map[proposal_id]
+        decision = decision_map[proposal_id]
+        directive = directive_map[proposal_id]
+        annotation, relation, expectation = _objects_for_approval(
+            proposal=proposal,
+            decision=decision,
+            directive=directive,
+            field_schema=field_schema,
+        )
+        if annotation is not None:
+            if (
+                annotation.annotation_id in baseline.existing_annotation_ids
+                or annotation.annotation_id in new_annotation_ids
+            ):
+                raise PerceptionPromotionMaterializationError(
+                    "materialized annotation collides with baseline or another change"
+                )
+            new_annotation_ids.add(annotation.annotation_id)
+        if relation is not None:
+            if (
+                relation.relation_id in baseline.existing_relation_ids
+                or relation.relation_id in new_relation_ids
+            ):
+                raise PerceptionPromotionMaterializationError(
+                    "materialized relation collides with baseline or another change"
+                )
+            new_relation_ids.add(relation.relation_id)
+        if (
+            expectation.expectation_id in baseline.existing_transition_expectation_ids
+            or expectation.expectation_id in new_expectation_ids
+        ):
+            raise PerceptionPromotionMaterializationError(
+                "materialized transition expectation collides with baseline or another change"
+            )
+        new_expectation_ids.add(expectation.expectation_id)
+        object_rows.append(
+            (proposal, decision, directive, annotation, relation, expectation)
+        )
+
+    count = len(object_rows)
+    changes: list[MaterializedPromotionChangeDTO] = []
+    for index, row in enumerate(object_rows):
+        proposal, decision, directive, annotation, relation, expectation = row
+        target = annotation or relation
+        target_kind = "annotation" if annotation is not None else "relation"
+        target_id = (
+            annotation.annotation_id if annotation is not None else relation.relation_id  # type: ignore[union-attr]
+        )
+        target_digest = _object_digest(target_kind, target)
+        expectation_digest = _object_digest("transition_expectation", expectation)
+        forward_target_sequence = index * 2 + 1
+        forward_expectation_sequence = index * 2 + 2
+        inverse_expectation_sequence = (count - index - 1) * 2 + 1
+        inverse_target_sequence = (count - index - 1) * 2 + 2
+        forward_operations = (
+            _operation(
+                direction="forward",
+                object_kind=target_kind,
+                object_id=target_id,
+                payload_digest=target_digest,
+                proposal_id=proposal.proposal_id,
+                decision_id=decision.decision_id,
+                sequence=forward_target_sequence,
+            ),
+            _operation(
+                direction="forward",
+                object_kind="transition_expectation",
+                object_id=expectation.expectation_id,
+                payload_digest=expectation_digest,
+                proposal_id=proposal.proposal_id,
+                decision_id=decision.decision_id,
+                sequence=forward_expectation_sequence,
+            ),
+        )
+        inverse_operations = (
+            _operation(
+                direction="inverse",
+                object_kind="transition_expectation",
+                object_id=expectation.expectation_id,
+                payload_digest=expectation_digest,
+                proposal_id=proposal.proposal_id,
+                decision_id=decision.decision_id,
+                sequence=inverse_expectation_sequence,
+            ),
+            _operation(
+                direction="inverse",
+                object_kind=target_kind,
+                object_id=target_id,
+                payload_digest=target_digest,
+                proposal_id=proposal.proposal_id,
+                decision_id=decision.decision_id,
+                sequence=inverse_target_sequence,
+            ),
+        )
+        values: dict[str, object] = {
+            "proposal_id": proposal.proposal_id,
+            "decision_id": decision.decision_id,
+            "directive_id": directive.directive_id,
+            "target_kind": directive.target_kind,
+            "semantic_name": decision.semantic_name,
+            "semantic_type": decision.semantic_type,
+            "semantic_role": decision.semantic_role,
+            "annotation": annotation,
+            "relation": relation,
+            "transition_expectation": expectation,
+            "forward_operations": forward_operations,
+            "inverse_operations": inverse_operations,
+            "materialization_status": PROMOTION_MATERIALIZATION_ITEM_STATUS,
+            "version": MATERIALIZED_PROMOTION_CHANGE_VERSION,
+        }
+        identity_values = dict(values)
+        identity_values["annotation"] = None if annotation is None else asdict(annotation)
+        identity_values["relation"] = None if relation is None else asdict(relation)
+        identity_values["transition_expectation"] = asdict(expectation)
+        identity_values["forward_operations"] = tuple(
+            asdict(item) for item in forward_operations
+        )
+        identity_values["inverse_operations"] = tuple(
+            asdict(item) for item in inverse_operations
+        )
+        changes.append(
+            MaterializedPromotionChangeDTO(
+                change_id=_digest(identity_values),
+                **values,  # type: ignore[arg-type]
+            )
+        )
+
+    ordered_changes = tuple(sorted(changes, key=lambda item: item.change_id))
+    forward = tuple(
+        sorted(
+            (
+                operation
+                for change in ordered_changes
+                for operation in change.forward_operations
+            ),
+            key=lambda item: item.sequence,
+        )
+    )
+    inverse = tuple(
+        sorted(
+            (
+                operation
+                for change in ordered_changes
+                for operation in change.inverse_operations
+            ),
+            key=lambda item: item.sequence,
+        )
+    )
+    status = "staged_inactive" if ordered_changes else "no_approved_changes"
+    values = {
+        "status": status,
+        "proposal_set_id": proposal_set.proposal_set_id,
+        "review_id": review.review_id,
+        "baseline_id": baseline.baseline_id,
+        "baseline_version_id": baseline.baseline_version_id,
+        "field_schema_id": field_schema.field_schema_id,
+        "approved_proposal_ids": ordered_ids,
+        "decision_ids": tuple(
+            sorted(decision_map[item].decision_id for item in ordered_ids)
+        ),
+        "directive_ids": tuple(
+            sorted(directive_map[item].directive_id for item in ordered_ids)
+        ),
+        "change_ids": tuple(sorted(item.change_id for item in ordered_changes)),
+        "changes": ordered_changes,
+        "forward_operation_ids": tuple(item.operation_id for item in forward),
+        "inverse_operation_ids": tuple(item.operation_id for item in inverse),
+        "activation_status": PROMOTION_MATERIALIZATION_ACTIVATION_STATUS,
+        "semantics": PROMOTION_MATERIALIZATION_SEMANTICS,
+        "version": PROMOTION_MATERIALIZATION_CHANGE_SET_VERSION,
+    }
+    identity_values = dict(values)
+    identity_values["changes"] = tuple(asdict(item) for item in ordered_changes)
+    return PromotionMaterializationChangeSetDTO(
+        change_set_id=_digest(identity_values),
+        **values,  # type: ignore[arg-type]
+    )

--- a/packages/perception/tests/test_promotion_materialization_p18f.py
+++ b/packages/perception/tests/test_promotion_materialization_p18f.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    CandidatePromotionDecisionDTO,
+    CandidateValidationPolicyDTO,
+    HeldOutTransitionObservationDTO,
+    PerceptionRegionAnnotationDTO,
+    SourceImageEncoderSpecDTO,
+    TransitionDiscoveryObservationDTO,
+    TransitionDiscoveryPolicyDTO,
+    TransitionExpectationDTO,
+    build_grid_field_schema,
+    build_transition_evidence_vpm,
+    discover_recurrent_unexplained_transitions,
+    encode_source_array,
+    evaluate_transition_conformance,
+    propose_validated_candidate_promotions,
+    review_candidate_promotion_proposals,
+    validate_discovered_transition_candidates,
+)
+from zeromodel.perception.promotion_materialization import (
+    PerceptionPromotionMaterializationError,
+    PromotionMaterializationBaselineDTO,
+    PromotionMaterializationDirectiveDTO,
+    materialize_approved_candidate_promotions,
+)
+
+
+def _fixture():
+    encoder = SourceImageEncoderSpecDTO(color_space="L")
+    source = encode_source_array(np.zeros((1, 6), dtype=np.uint8), encoder)
+    schema = build_grid_field_schema(source, tile_width=2, tile_height=1)
+    fields = tuple(sorted(schema.fields, key=lambda item: item.x0))
+    control = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[0].field_id,),
+        label="control",
+        role="stable_control",
+    )
+    anchor = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[0].field_id,),
+        label="anchor",
+        role="reference",
+    )
+    expectation = TransitionExpectationDTO.create(
+        field_schema_id=schema.field_schema_id,
+        annotation_ids=(control.annotation_id,),
+        expected_change="stable",
+        maximum_mean_absolute_change=0.0,
+        maximum_changed_fraction=0.0,
+    )
+    return encoder, schema, fields, control, anchor, expectation
+
+
+def _transition(
+    before_values: list[int],
+    after_values: list[int],
+    *,
+    include_control_annotation: bool,
+):
+    encoder, schema, fields, control, anchor, expectation = _fixture()
+    before = encode_source_array(np.array([before_values], dtype=np.uint8), encoder)
+    after = encode_source_array(np.array([after_values], dtype=np.uint8), encoder)
+    transition = build_transition_evidence_vpm(
+        before,
+        after,
+        schema,
+        annotations=(control,) if include_control_annotation else (),
+    )
+    return transition, fields, control, anchor, expectation, schema
+
+
+def _discovery_observation(
+    *,
+    interaction_id: str,
+    first_value: int,
+    second_value: int,
+):
+    transition, _, control, _, expectation, _ = _transition(
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, first_value, first_value, second_value, second_value],
+        include_control_annotation=True,
+    )
+    conformance = evaluate_transition_conformance(
+        transition,
+        (expectation,),
+        (control,),
+        minimum_unexplained_mean_absolute_change=0.05,
+        minimum_unexplained_changed_fraction=0.5,
+    )
+    return TransitionDiscoveryObservationDTO.create(
+        interaction_id=interaction_id,
+        cohort_id="discovery/train",
+        transition=transition,
+        conformance=conformance,
+    )
+
+
+def _discovery_report():
+    observations = tuple(
+        _discovery_observation(
+            interaction_id=f"discovery-{index}",
+            first_value=first,
+            second_value=second,
+        )
+        for index, (first, second) in enumerate(
+            ((200, 180), (180, 160), (160, 140), (0, 0)),
+            start=1,
+        )
+    )
+    policy = TransitionDiscoveryPolicyDTO.create(
+        minimum_observation_count=4,
+        minimum_field_occurrence_count=3,
+        minimum_field_recurrence_fraction=0.75,
+        minimum_signature_occurrence_count=3,
+        minimum_signature_recurrence_fraction=0.75,
+        minimum_direction_consistency=0.75,
+    )
+    return discover_recurrent_unexplained_transitions(observations, policy)
+
+
+def _held_out(*, interaction_id: str, first_value: int, second_value: int):
+    transition, _, _, _, _, _ = _transition(
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, first_value, first_value, second_value, second_value],
+        include_control_annotation=False,
+    )
+    return HeldOutTransitionObservationDTO.create(
+        interaction_id=interaction_id,
+        cohort_id="validation/held-out",
+        transition=transition,
+    )
+
+
+def _proposal_set():
+    discovery = _discovery_report()
+    observations = tuple(
+        _held_out(
+            interaction_id=f"validation-{index}",
+            first_value=170,
+            second_value=150,
+        )
+        for index in range(1, 4)
+    )
+    validation = validate_discovered_transition_candidates(
+        discovery,
+        observations,
+        CandidateValidationPolicyDTO.create(
+            minimum_validation_observation_count=3,
+            minimum_confirmation_fraction=2 / 3,
+            minimum_rejection_fraction=2 / 3,
+            minimum_magnitude_retention_fraction=0.75,
+            direction_epsilon=0.01,
+        ),
+    )
+    return propose_validated_candidate_promotions(discovery, validation)
+
+
+def _review_with_two_approvals():
+    proposal_set = _proposal_set()
+    approved_region = CandidatePromotionDecisionDTO.create(
+        proposal_set.proposals[0],
+        reviewer_id="reviewer:region",
+        decision="approved",
+        rationale="The held-out field is stable enough to stage as a region.",
+        semantic_name="projectile-shadow",
+        semantic_type="region_component",
+        semantic_role="context",
+    )
+    approved_relation = CandidatePromotionDecisionDTO.create(
+        proposal_set.proposals[1],
+        reviewer_id="reviewer:relation",
+        decision="approved",
+        rationale="The held-out signature is suitable for an explicit relation.",
+        semantic_name="paired-signal",
+        semantic_type="relative_context",
+        semantic_role="context",
+    )
+    rejected = CandidatePromotionDecisionDTO.create(
+        proposal_set.proposals[2],
+        reviewer_id="reviewer:reject",
+        decision="rejected",
+        rationale="This candidate remains semantically incoherent.",
+    )
+    review = review_candidate_promotion_proposals(
+        proposal_set,
+        (rejected, approved_relation, approved_region),
+    )
+    return proposal_set, review, approved_region, approved_relation
+
+
+def _baseline(schema, control, anchor, **changes):
+    values = {
+        "baseline_version_id": "perception-model/v42",
+        "field_schema_id": schema.field_schema_id,
+        "existing_annotation_ids": tuple(
+            sorted((control.annotation_id, anchor.annotation_id))
+        ),
+        "existing_relation_ids": (),
+        "existing_transition_expectation_ids": (),
+    }
+    values.update(changes)
+    return PromotionMaterializationBaselineDTO.create(**values)
+
+
+def test_materializes_approved_region_and_relation_as_inactive_reversible_changes() -> None:
+    proposal_set, review, approved_region, approved_relation = (
+        _review_with_two_approvals()
+    )
+    _, schema, _, control, anchor, _ = _fixture()
+    proposal_map = {item.proposal_id: item for item in proposal_set.proposals}
+    directives = (
+        PromotionMaterializationDirectiveDTO.create(
+            proposal_map[approved_region.proposal_id],
+            target_kind="region_annotation",
+            annotation_properties=(("review_class", "held_out_validated"),),
+        ),
+        PromotionMaterializationDirectiveDTO.create(
+            proposal_map[approved_relation.proposal_id],
+            target_kind="relation_annotation",
+            relation_member_annotation_ids=(
+                control.annotation_id,
+                anchor.annotation_id,
+            ),
+        ),
+    )
+    baseline = _baseline(schema, control, anchor)
+
+    first = materialize_approved_candidate_promotions(
+        proposal_set,
+        review,
+        schema,
+        baseline,
+        directives,
+    )
+    second = materialize_approved_candidate_promotions(
+        proposal_set,
+        review,
+        schema,
+        baseline,
+        tuple(reversed(directives)),
+    )
+
+    assert first == second
+    assert first.status == "staged_inactive"
+    assert first.activation_status == "not_admitted"
+    assert len(first.changes) == 2
+    assert len(first.operations("forward")) == 4
+    assert len(first.operations("inverse")) == 4
+    assert {item.pair_id for item in first.operations("forward")} == {
+        item.pair_id for item in first.operations("inverse")
+    }
+
+    region = next(item for item in first.changes if item.annotation is not None)
+    relation = next(item for item in first.changes if item.relation is not None)
+    assert region.annotation.label == "projectile-shadow"
+    assert region.annotation.role == "context"
+    assert dict(region.annotation.properties)["semantic_type"] == "region_component"
+    assert region.annotation.provenance_ref == region.decision_id
+    assert region.transition_expectation.annotation_ids == (
+        region.annotation.annotation_id,
+    )
+    assert relation.relation.relation_type == "relative_context"
+    assert relation.relation.value == "paired-signal"
+    assert relation.relation.member_annotation_ids == tuple(
+        sorted((control.annotation_id, anchor.annotation_id))
+    )
+    assert relation.transition_expectation.relation_ids == (
+        relation.relation.relation_id,
+    )
+
+    forward_actions = tuple(item.action for item in first.operations("forward"))
+    inverse_actions = tuple(item.action for item in first.operations("inverse"))
+    assert forward_actions[1::2] == (
+        "add_transition_expectation",
+        "add_transition_expectation",
+    )
+    assert inverse_actions[0::2] == (
+        "remove_transition_expectation",
+        "remove_transition_expectation",
+    )
+    assert baseline.existing_relation_ids == ()
+    assert baseline.existing_transition_expectation_ids == ()
+
+
+def test_complete_review_without_approvals_produces_empty_inactive_change_set() -> None:
+    proposal_set = _proposal_set()
+    decisions = tuple(
+        CandidatePromotionDecisionDTO.create(
+            proposal,
+            reviewer_id=f"reviewer:{index}",
+            decision="rejected" if index % 2 else "deferred",
+            rationale="Do not stage this candidate yet.",
+        )
+        for index, proposal in enumerate(proposal_set.proposals, start=1)
+    )
+    review = review_candidate_promotion_proposals(proposal_set, decisions)
+    _, schema, _, control, anchor, _ = _fixture()
+
+    change_set = materialize_approved_candidate_promotions(
+        proposal_set,
+        review,
+        schema,
+        _baseline(schema, control, anchor),
+    )
+
+    assert change_set.status == "no_approved_changes"
+    assert change_set.changes == ()
+    assert change_set.forward_operation_ids == ()
+    assert change_set.inverse_operation_ids == ()
+    assert change_set.activation_status == "not_admitted"
+
+
+def test_rejects_partial_review_and_inexact_directive_coverage() -> None:
+    proposal_set, complete, approved_region, approved_relation = (
+        _review_with_two_approvals()
+    )
+    partial = review_candidate_promotion_proposals(
+        proposal_set,
+        (complete.decisions_for_status("approved")[0],),
+    )
+    _, schema, _, control, anchor, _ = _fixture()
+    baseline = _baseline(schema, control, anchor)
+    proposal_map = {item.proposal_id: item for item in proposal_set.proposals}
+    region_only = (
+        PromotionMaterializationDirectiveDTO.create(
+            proposal_map[approved_region.proposal_id],
+            target_kind="region_annotation",
+        ),
+    )
+
+    with pytest.raises(
+        PerceptionPromotionMaterializationError,
+        match="fully reviewed",
+    ):
+        materialize_approved_candidate_promotions(
+            proposal_set,
+            partial,
+            schema,
+            baseline,
+            region_only,
+        )
+    with pytest.raises(
+        PerceptionPromotionMaterializationError,
+        match="exactly cover",
+    ):
+        materialize_approved_candidate_promotions(
+            proposal_set,
+            complete,
+            schema,
+            baseline,
+            region_only,
+        )
+
+    relation = PromotionMaterializationDirectiveDTO.create(
+        proposal_map[approved_relation.proposal_id],
+        target_kind="relation_annotation",
+        relation_member_annotation_ids=("sha256:missing-a", "sha256:missing-b"),
+    )
+    with pytest.raises(
+        PerceptionPromotionMaterializationError,
+        match="outside the baseline",
+    ):
+        materialize_approved_candidate_promotions(
+            proposal_set,
+            complete,
+            schema,
+            baseline,
+            region_only + (relation,),
+        )
+
+
+def test_collision_and_identity_tampering_are_rejected() -> None:
+    proposal_set, review, approved_region, approved_relation = (
+        _review_with_two_approvals()
+    )
+    _, schema, _, control, anchor, _ = _fixture()
+    proposal_map = {item.proposal_id: item for item in proposal_set.proposals}
+    directives = (
+        PromotionMaterializationDirectiveDTO.create(
+            proposal_map[approved_region.proposal_id],
+            target_kind="region_annotation",
+        ),
+        PromotionMaterializationDirectiveDTO.create(
+            proposal_map[approved_relation.proposal_id],
+            target_kind="relation_annotation",
+            relation_member_annotation_ids=(
+                control.annotation_id,
+                anchor.annotation_id,
+            ),
+        ),
+    )
+    baseline = _baseline(schema, control, anchor)
+    change_set = materialize_approved_candidate_promotions(
+        proposal_set,
+        review,
+        schema,
+        baseline,
+        directives,
+    )
+    generated_annotations = tuple(
+        item.annotation.annotation_id
+        for item in change_set.changes
+        if item.annotation is not None
+    )
+    collision_baseline = _baseline(
+        schema,
+        control,
+        anchor,
+        existing_annotation_ids=tuple(
+            sorted((control.annotation_id, anchor.annotation_id, *generated_annotations))
+        ),
+    )
+    with pytest.raises(
+        PerceptionPromotionMaterializationError,
+        match="collides",
+    ):
+        materialize_approved_candidate_promotions(
+            proposal_set,
+            review,
+            schema,
+            collision_baseline,
+            directives,
+        )
+
+    with pytest.raises(
+        PerceptionPromotionMaterializationError,
+        match="directive identity",
+    ):
+        replace(directives[0], directive_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionPromotionMaterializationError,
+        match="baseline identity",
+    ):
+        replace(baseline, baseline_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionPromotionMaterializationError,
+        match="change-set identity",
+    ):
+        replace(change_set, change_set_id="sha256:tampered")

--- a/packages/perception/tests/test_promotion_materialization_p18f_public_surface.py
+++ b/packages/perception/tests/test_promotion_materialization_p18f_public_surface.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import zeromodel.perception as perception
+
+
+def test_p18f_is_exposed_from_package_root() -> None:
+    expected = {
+        "PerceptionPromotionMaterializationError",
+        "PromotionMaterializationDirectiveDTO",
+        "PromotionMaterializationBaselineDTO",
+        "PromotionMaterializationOperationDTO",
+        "MaterializedPromotionChangeDTO",
+        "PromotionMaterializationChangeSetDTO",
+        "materialize_approved_candidate_promotions",
+        "PROMOTION_MATERIALIZATION_CHANGE_SET_VERSION",
+        "PROMOTION_MATERIALIZATION_DIRECTIVE_VERSION",
+    }
+
+    assert expected <= set(perception.__all__)
+    for name in expected:
+        assert getattr(perception, name) is not None


### PR DESCRIPTION
Audit-Exempt: adds an internal inactive change-set layer for P18E approvals; no public capability claim status changes.

## Objective

Implement P18F: convert approved proposals from a fully reviewed P18E ledger into exact, versioned, reversible and inactive annotation/relation plus transition-expectation change sets.

```text
P18E proposal set
    + complete review ledger
    + explicit ontology directives
    + field schema
    + baseline identity snapshot
    ↓
PromotionMaterializationChangeSetDTO
```

## What changed

- Add content-addressed `PromotionMaterializationDirectiveDTO` requiring an explicit target per approved proposal:
  - `region_annotation`; or
  - `relation_annotation`.
- Refuse to infer that a recurrent co-occurrence signature is automatically a relation.
- Add `PromotionMaterializationBaselineDTO` containing the exact model-version, schema, annotation, relation and transition-expectation identity baseline.
- Materialize reviewer semantics into staged objects:
  - `PerceptionRegionAnnotationDTO` with semantic and approval provenance properties; or
  - `RelationAnnotationDTO` with explicit baseline members and candidate fields as derived fields;
  - `TransitionExpectationDTO` targeting the newly staged object.
- Copy P18E/P18D direction and minimum magnitude thresholds exactly into the staged transition expectation.
- Add globally ordered forward operations:
  - add annotation/relation;
  - add transition expectation.
- Add reverse-ordered inverse operations:
  - remove transition expectation;
  - remove annotation/relation.
- Bind every forward/inverse pair through a content-addressed pair identity over the exact object payload and P18E lineage.
- Reject generated object identities that collide with the baseline or another change, ensuring rollback removes only objects introduced by this change set.
- Require a fully reviewed P18E ledger and exact directive coverage of approved proposals.
- Allow a complete review with no approvals to produce an explicit `no_approved_changes` change set.
- Keep every non-empty change set `staged_inactive` and `not_admitted`.
- Advance the P18 roadmap to P18G materialization admission and atomic activation.

## Operational boundary

P18F creates data contracts only. It does not write to an active store, change runtime behavior, admit the change set, or execute either the forward or inverse operations.

## Focused validation

Tests cover:

- the full P18C → P18D → P18E → P18F chain;
- deterministic materialization independent of directive ordering;
- explicit region and relation targets;
- reviewer semantic and provenance transfer;
- exact transition-expectation targets and thresholds;
- globally ordered forward operations and reverse-order inverse operations;
- exact operation-pair equality;
- complete reviews with no approvals;
- partial-review rejection;
- missing and foreign directive rejection;
- relation-member baseline enforcement;
- baseline collision rejection;
- directive, baseline and change-set identity tampering.

The clean wheel-installed `perception-package` workflow is authoritative for the complete package suite.

## Next stage

P18G should audit and admit a P18F change set only when the active baseline still matches its exact baseline identity and version. Activation must apply every forward operation atomically or none, and persist the inverse plan for separately governed rollback.