### PR TITLE
feat(perception): add P18G materialization admission and atomic activation

### DIFF
--- a/packages/perception/docs/p18-roadmap.md
+++ b/packages/perception/docs/p18-roadmap.md
@@ -28,16 +28,22 @@ Convert only P18D-validated candidates into reviewable, content-addressed propos
 
 Approved proposals remain `not_materialized`. P18E records authorization but cannot create annotations, relations, production expectations, or runtime changes.
 
-## P18F — Reversible promotion materialization — current
+## P18F — Reversible promotion materialization — complete
 
 Convert approved proposals from a fully reviewed P18E ledger into staged annotations or relations plus transition expectations. Require an explicit ontology directive per approval, bind the exact baseline identity, reject additive collisions, and preserve globally ordered forward operations with exact reverse-order inverse operations.
 
 P18F change sets remain `staged_inactive` and `not_admitted`. A complete review without approvals produces an explicit `no_approved_changes` result rather than an empty implicit success.
 
-## P18G — Materialization admission and atomic activation — next
+## P18G — Materialization admission and atomic activation — current
 
-Verify that the active model still matches the P18F baseline, audit every staged payload and operation pair, and apply all forward operations atomically or none. Persist the inverse operation plan and require a separate governed decision for rollback.
+Audit the staged change set against the exact active schema, baseline version, and annotation/relation/expectation identity snapshot. Bind an admissible audit to expected and resulting state identities, then apply every forward operation through a compare-and-swap transaction or apply nothing.
+
+Persist one immutable activation bundle containing the audit, admission, receipt, resulting state, and exact inactive rollback plan. P18G does not execute rollback.
+
+## P18H — Durable activation and governed rollback — next
+
+Add restart-safe SQLite persistence for the P18G store protocol. Admit rollback only when the current active state exactly equals the rollback plan's activated state, then apply every inverse operation atomically and preserve activation and rollback history.
 
 ## Boundary
 
-P18 measures, tests, validates, governs, and stages visual transition hypotheses. It does not infer semantic labels from pixels, claim that correlation is causation, or activate unadmitted changes in runtime behavior.
+P18 measures, tests, validates, governs, stages, and atomically activates visual transition hypotheses. It does not infer semantic labels from pixels, claim that correlation is causation, or execute an ungoverned rollback.

--- a/packages/perception/docs/stage-p18g-materialization-admission-and-atomic-activation.md
+++ b/packages/perception/docs/stage-p18g-materialization-admission-and-atomic-activation.md
@@ -1,0 +1,173 @@
+# Stage P18G — Materialization Admission and Atomic Activation
+
+## Objective
+
+Admit and activate a non-empty P18F materialization change set only when the active annotation, relation, transition-expectation, schema, and model-version baseline remains exactly the baseline against which the change set was constructed.
+
+```text
+P18F staged inactive change set
+    + active policy state
+    + activation policy
+    ↓
+exact baseline audit
+    ↓ admissible only
+content-addressed admission
+    ↓
+compare-and-swap atomic forward application
+    ↓
+active state + receipt + stored inactive rollback plan
+```
+
+P18G is the first P18 stage that can change the active policy state. It therefore treats activation as a transaction rather than as a sequence of independent object writes.
+
+## Active state
+
+`ActivePromotionStateDTO` is a complete content-addressed state containing:
+
+- monotonic revision;
+- active baseline-version identity;
+- field-schema identity;
+- active region annotations;
+- active relations;
+- active transition expectations;
+- the most recently activated change-set identity.
+
+The DTO validates annotation and relation payload identities, relation-member integrity, transition-expectation targets, schema compatibility, uniqueness, ordering, and its own state identity.
+
+Its `baseline()` method reconstructs the exact `PromotionMaterializationBaselineDTO` used by P18F.
+
+## Admission policy
+
+`PromotionActivationPolicyDTO` declares:
+
+- the maximum number of materialized changes admitted in one activation;
+- the permitted materialization target kinds.
+
+Exact baseline equality, complete inverse coverage, and atomic application are invariants rather than optional policy settings.
+
+## Pre-activation audit
+
+`audit_promotion_activation(...)` compares the P18F change set with one exact active-state snapshot.
+
+The audit verifies:
+
+- the change set is non-empty and `staged_inactive`;
+- the field schema is unchanged;
+- the active baseline-version identity equals the staged baseline version;
+- the complete active baseline identity equals the staged baseline identity;
+- policy limits permit every staged target;
+- every forward operation resolves to one exact materialized DTO payload;
+- no operation overwrites an active object;
+- relations reference active annotations;
+- transition expectations reference active targets;
+- the complete resulting state can be constructed and content-addressed.
+
+Audit outcomes are:
+
+- `admissible`;
+- `blocked`;
+- `not_applicable` for an explicit P18F `no_approved_changes` result.
+
+A blocked or not-applicable report cannot contain a proposed resulting state.
+
+## Admission
+
+`authorize_promotion_activation(...)` converts only an admissible audit into a `PromotionActivationAdmissionDTO`.
+
+The admission binds:
+
+- change set and policy;
+- audit report;
+- exact expected state and baseline;
+- exact predicted resulting state and baseline;
+- ordered forward operation identities;
+- ordered inverse operation identities.
+
+If any supplied state differs from the audited state, authorization fails.
+
+## Atomic store boundary
+
+`PromotionActivationStore` is a DTO-only compare-and-swap boundary:
+
+```python
+get_active_state()
+commit_activation(expected_state, change_set, bundle)
+get_activation_bundle(change_set_id)
+list_activation_bundles()
+```
+
+`InMemoryPromotionActivationStore` is the P18G reference implementation. It:
+
+1. acquires one store lock;
+2. verifies the current state still equals the admitted expected state;
+3. replays every forward operation into private copied maps;
+4. validates the actual result against the admitted resulting state;
+5. prepares the activation and rollback ledger update;
+6. swaps the active state and ledger together.
+
+No active object or ledger artifact is changed before the final swap. A failure during any operation leaves the previous state and activation ledger unchanged.
+
+The compare-and-swap check prevents a valid audit from being reused after another writer changes the active state.
+
+## Activation artifacts
+
+A successful execution persists one `PromotionActivationBundleDTO` containing:
+
+- admissible audit report;
+- admission;
+- activation receipt;
+- exact resulting active state;
+- inactive rollback plan.
+
+The receipt binds the previous and resulting state, baseline, model version, revision, and forward operation sequence.
+
+The rollback plan stores:
+
+- the complete restore state;
+- activated and restore baseline identities;
+- activated and restore baseline-version identities;
+- the exact reverse-ordered P18F inverse operations.
+
+The plan remains `stored_inactive`. P18G does not execute rollback.
+
+## Baseline version advance
+
+The resulting baseline-version identity is derived deterministically from:
+
+- previous state identity;
+- previous baseline identity and version;
+- P18F change-set identity;
+- next revision.
+
+A successful activation therefore cannot retain the old baseline version or depend on wall-clock time.
+
+## Atomicity tests
+
+The P18G suite exercises the complete P18C → P18D → P18E → P18F → P18G chain and verifies:
+
+- exact baseline admission and activation;
+- active annotation/relation/expectation insertion;
+- receipt and rollback lineage;
+- baseline drift rejection;
+- target-kind policy rejection;
+- compare-and-swap race rejection;
+- injected failure after an intermediate operation with no partial state or ledger mutation;
+- explicit handling of no-approved-change sets;
+- identity tamper rejection across every new contract.
+
+## Operational boundary
+
+P18G does not:
+
+- infer ontology;
+- alter a P18F change set;
+- admit against a merely similar baseline;
+- partially apply a forward plan;
+- execute the inverse plan;
+- claim that an activated component caused the transition evidence.
+
+It activates the exact reviewed, validated, materialized policy additions—or activates nothing.
+
+## Next stage
+
+P18H should add restart-safe SQLite persistence for the P18G store protocol and separately governed rollback admission. Rollback must require the current active state to equal the rollback plan's exact activated state before applying every inverse operation atomically.

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -1,4 +1,4 @@
-"""ZeroModel perception public API through Stage P18F."""
+"""ZeroModel perception public API through Stage P18G."""
 
 from __future__ import annotations
 
@@ -68,6 +68,38 @@ from .governance_gate import (  # noqa: F401
     PerceptionGovernanceExecutionGateError,
     authorize_governance_execution,
     execute_audit_gated_approved_rollback,
+)
+from .promotion_activation import (  # noqa: F401
+    PROMOTION_ACTIVATION_ADMISSION_STATUS,
+    PROMOTION_ACTIVATION_ADMISSION_VERSION,
+    PROMOTION_ACTIVATION_AUDIT_FINDING_VERSION,
+    PROMOTION_ACTIVATION_AUDIT_REPORT_VERSION,
+    PROMOTION_ACTIVATION_AUDIT_STATUSES,
+    PROMOTION_ACTIVATION_BUNDLE_VERSION,
+    PROMOTION_ACTIVATION_FINDING_SEVERITIES,
+    PROMOTION_ACTIVATION_POLICY_VERSION,
+    PROMOTION_ACTIVATION_RECEIPT_STATUS,
+    PROMOTION_ACTIVATION_RECEIPT_VERSION,
+    PROMOTION_ACTIVATION_SEMANTICS,
+    PROMOTION_ACTIVATION_STORE_VERSION,
+    PROMOTION_ACTIVE_STATE_VERSION,
+    PROMOTION_ROLLBACK_PLAN_STATUS,
+    PROMOTION_ROLLBACK_PLAN_VERSION,
+    ActivePromotionStateDTO,
+    InMemoryPromotionActivationStore,
+    PerceptionPromotionActivationError,
+    PromotionActivationAdmissionDTO,
+    PromotionActivationAuditFindingDTO,
+    PromotionActivationAuditReportDTO,
+    PromotionActivationBundleDTO,
+    PromotionActivationPolicyDTO,
+    PromotionActivationReceiptDTO,
+    PromotionActivationStore,
+    PromotionRollbackPlanDTO,
+    audit_promotion_activation,
+    authorize_promotion_activation,
+    build_promotion_activation_bundle,
+    execute_promotion_activation,
 )
 from .promotion_materialization import (  # noqa: F401
     MATERIALIZED_PROMOTION_CHANGE_VERSION,
@@ -161,7 +193,7 @@ from .transition_evidence import (  # noqa: F401
 )
 
 PERCEPTION_PACKAGE_VERSION = "1.0.13"
-PERCEPTION_STAGE = "P18F"
+PERCEPTION_STAGE = "P18G"
 
 __all__ = [
     name

--- a/packages/perception/src/zeromodel/perception/promotion_activation.py
+++ b/packages/perception/src/zeromodel/perception/promotion_activation.py
@@ -1,0 +1,1326 @@
+"""Baseline-gated atomic activation for P18F change sets (Stage P18G).
+
+P18G audits an inactive P18F change set against the exact active baseline, creates
+an admission bound to the observed state, and applies every forward operation by
+compare-and-swap. The reference in-memory store uses copy-on-write: a failure at
+any operation leaves the active state and activation ledger unchanged. The exact
+P18F inverse plan is stored for a later, separately governed rollback stage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from dataclasses import asdict, dataclass
+from typing import Final, Mapping, Protocol
+
+from .expectations import PerceptionRegionAnnotationDTO, RelationAnnotationDTO
+from .promotion_materialization import (
+    PROMOTION_MATERIALIZATION_TARGET_KINDS,
+    PromotionMaterializationBaselineDTO,
+    PromotionMaterializationChangeSetDTO,
+    PromotionMaterializationOperationDTO,
+)
+from .transition_conformance import TransitionExpectationDTO
+
+PROMOTION_ACTIVE_STATE_VERSION: Final = "perception-promotion-active-state/1"
+PROMOTION_ACTIVATION_POLICY_VERSION: Final = "perception-promotion-activation-policy/1"
+PROMOTION_ACTIVATION_AUDIT_FINDING_VERSION: Final = (
+    "perception-promotion-activation-audit-finding/1"
+)
+PROMOTION_ACTIVATION_AUDIT_REPORT_VERSION: Final = (
+    "perception-promotion-activation-audit-report/1"
+)
+PROMOTION_ACTIVATION_ADMISSION_VERSION: Final = (
+    "perception-promotion-activation-admission/1"
+)
+PROMOTION_ROLLBACK_PLAN_VERSION: Final = "perception-promotion-rollback-plan/1"
+PROMOTION_ACTIVATION_RECEIPT_VERSION: Final = (
+    "perception-promotion-activation-receipt/1"
+)
+PROMOTION_ACTIVATION_BUNDLE_VERSION: Final = "perception-promotion-activation-bundle/1"
+PROMOTION_ACTIVATION_STORE_VERSION: Final = "perception-promotion-activation-store/1"
+PROMOTION_ACTIVATION_SEMANTICS: Final = (
+    "exact_baseline_compare_and_swap_atomic_activation_with_inactive_inverse_plan"
+)
+PROMOTION_ACTIVATION_AUDIT_STATUSES: Final = {
+    "admissible",
+    "blocked",
+    "not_applicable",
+}
+PROMOTION_ACTIVATION_FINDING_SEVERITIES: Final = {"info", "error"}
+PROMOTION_ACTIVATION_ADMISSION_STATUS: Final = "admitted"
+PROMOTION_ACTIVATION_RECEIPT_STATUS: Final = "activated"
+PROMOTION_ROLLBACK_PLAN_STATUS: Final = "stored_inactive"
+
+
+class PerceptionPromotionActivationError(ValueError):
+    """Raised when P18G admission or activation contracts are invalid."""
+
+
+def _canonical_json(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(payload: Mapping[str, object]) -> str:
+    encoded = _canonical_json(payload)
+    hasher = hashlib.sha256()
+    hasher.update(len(encoded).to_bytes(8, "big"))
+    hasher.update(encoded)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def _payload(value: object, identity_field: str) -> dict[str, object]:
+    payload = asdict(value)  # type: ignore[arg-type]
+    payload.pop(identity_field)
+    return payload
+
+
+def _ordered_unique(
+    name: str,
+    values: tuple[str, ...],
+    *,
+    allow_empty: bool = True,
+) -> None:
+    if not allow_empty and not values:
+        raise PerceptionPromotionActivationError(f"{name} must be non-empty")
+    if values != tuple(sorted(set(values))):
+        raise PerceptionPromotionActivationError(
+            f"{name} must be unique and sorted"
+        )
+
+
+def _non_negative_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise PerceptionPromotionActivationError(
+            f"{name} must be a non-negative integer"
+        )
+
+
+def _positive_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise PerceptionPromotionActivationError(
+            f"{name} must be a positive integer"
+        )
+
+
+def _object_digest(kind: str, value: object) -> str:
+    return _digest({"object_kind": kind, "payload": asdict(value)})  # type: ignore[arg-type]
+
+
+def _annotation_identity(annotation: PerceptionRegionAnnotationDTO) -> str:
+    return _digest(
+        {
+            "field_schema_id": annotation.field_schema_id,
+            "field_ids": list(annotation.field_ids),
+            "label": annotation.label,
+            "properties": [list(item) for item in annotation.properties],
+            "provenance_ref": annotation.provenance_ref,
+            "role": annotation.role,
+            "version": annotation.version,
+        }
+    )
+
+
+def _relation_identity(relation: RelationAnnotationDTO) -> str:
+    return _digest(
+        {
+            "relation_type": relation.relation_type,
+            "member_annotation_ids": relation.member_annotation_ids,
+            "derived_field_ids": relation.derived_field_ids,
+            "value": relation.value,
+            "version": relation.version,
+        }
+    )
+
+
+@dataclass(frozen=True)
+class ActivePromotionStateDTO:
+    """Complete active annotation, relation, and transition-expectation state."""
+
+    state_id: str
+    revision: int
+    baseline_version_id: str
+    field_schema_id: str
+    annotations: tuple[PerceptionRegionAnnotationDTO, ...]
+    relations: tuple[RelationAnnotationDTO, ...]
+    transition_expectations: tuple[TransitionExpectationDTO, ...]
+    last_change_set_id: str | None = None
+    version: str = PROMOTION_ACTIVE_STATE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.state_id or not self.baseline_version_id or not self.field_schema_id:
+            raise PerceptionPromotionActivationError(
+                "active promotion state identities must be non-empty"
+            )
+        _non_negative_int("active promotion state revision", self.revision)
+        annotation_ids = tuple(item.annotation_id for item in self.annotations)
+        relation_ids = tuple(item.relation_id for item in self.relations)
+        expectation_ids = tuple(
+            item.expectation_id for item in self.transition_expectations
+        )
+        _ordered_unique("active annotation identities", annotation_ids)
+        _ordered_unique("active relation identities", relation_ids)
+        _ordered_unique("active transition expectation identities", expectation_ids)
+        if any(
+            item.field_schema_id != self.field_schema_id for item in self.annotations
+        ):
+            raise PerceptionPromotionActivationError(
+                "active annotation field schema mismatch"
+            )
+        for annotation in self.annotations:
+            if annotation.annotation_id != _annotation_identity(annotation):
+                raise PerceptionPromotionActivationError(
+                    "active annotation identity disagrees with payload"
+                )
+        annotation_id_set = set(annotation_ids)
+        for relation in self.relations:
+            if relation.relation_id != _relation_identity(relation):
+                raise PerceptionPromotionActivationError(
+                    "active relation identity disagrees with payload"
+                )
+            missing_members = set(relation.member_annotation_ids) - annotation_id_set
+            if missing_members:
+                raise PerceptionPromotionActivationError(
+                    "active relation references unknown annotations: "
+                    f"{sorted(missing_members)}"
+                )
+        relation_id_set = set(relation_ids)
+        for expectation in self.transition_expectations:
+            if expectation.field_schema_id != self.field_schema_id:
+                raise PerceptionPromotionActivationError(
+                    "active transition expectation field schema mismatch"
+                )
+            unknown_annotations = set(expectation.annotation_ids) - annotation_id_set
+            unknown_relations = set(expectation.relation_ids) - relation_id_set
+            if unknown_annotations or unknown_relations:
+                raise PerceptionPromotionActivationError(
+                    "active transition expectation references unknown targets"
+                )
+        if self.version != PROMOTION_ACTIVE_STATE_VERSION:
+            raise PerceptionPromotionActivationError(
+                "unsupported active promotion state version"
+            )
+        if self.state_id != _digest(_payload(self, "state_id")):
+            raise PerceptionPromotionActivationError(
+                "active promotion state identity disagrees with canonical payload"
+            )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        revision: int,
+        baseline_version_id: str,
+        field_schema_id: str,
+        annotations: tuple[PerceptionRegionAnnotationDTO, ...] = (),
+        relations: tuple[RelationAnnotationDTO, ...] = (),
+        transition_expectations: tuple[TransitionExpectationDTO, ...] = (),
+        last_change_set_id: str | None = None,
+    ) -> "ActivePromotionStateDTO":
+        ordered_annotations = tuple(
+            sorted(annotations, key=lambda item: item.annotation_id)
+        )
+        ordered_relations = tuple(sorted(relations, key=lambda item: item.relation_id))
+        ordered_expectations = tuple(
+            sorted(
+                transition_expectations,
+                key=lambda item: item.expectation_id,
+            )
+        )
+        values: dict[str, object] = {
+            "revision": revision,
+            "baseline_version_id": baseline_version_id,
+            "field_schema_id": field_schema_id,
+            "annotations": ordered_annotations,
+            "relations": ordered_relations,
+            "transition_expectations": ordered_expectations,
+            "last_change_set_id": last_change_set_id,
+            "version": PROMOTION_ACTIVE_STATE_VERSION,
+        }
+        identity_values = dict(values)
+        identity_values["annotations"] = tuple(
+            asdict(item) for item in ordered_annotations
+        )
+        identity_values["relations"] = tuple(asdict(item) for item in ordered_relations)
+        identity_values["transition_expectations"] = tuple(
+            asdict(item) for item in ordered_expectations
+        )
+        return cls(
+            state_id=_digest(identity_values),
+            **values,  # type: ignore[arg-type]
+        )
+
+    def baseline(self) -> PromotionMaterializationBaselineDTO:
+        return PromotionMaterializationBaselineDTO.create(
+            baseline_version_id=self.baseline_version_id,
+            field_schema_id=self.field_schema_id,
+            existing_annotation_ids=tuple(
+                item.annotation_id for item in self.annotations
+            ),
+            existing_relation_ids=tuple(item.relation_id for item in self.relations),
+            existing_transition_expectation_ids=tuple(
+                item.expectation_id for item in self.transition_expectations
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PromotionActivationPolicyDTO:
+    policy_id: str
+    maximum_change_count: int = 100
+    allowed_target_kinds: tuple[str, ...] = tuple(
+        sorted(PROMOTION_MATERIALIZATION_TARGET_KINDS)
+    )
+    version: str = PROMOTION_ACTIVATION_POLICY_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.policy_id:
+            raise PerceptionPromotionActivationError(
+                "promotion activation policy identity must be non-empty"
+            )
+        _positive_int("maximum_change_count", self.maximum_change_count)
+        _ordered_unique(
+            "allowed activation target kinds",
+            self.allowed_target_kinds,
+            allow_empty=False,
+        )
+        unknown = set(self.allowed_target_kinds) - PROMOTION_MATERIALIZATION_TARGET_KINDS
+        if unknown:
+            raise PerceptionPromotionActivationError(
+                f"unsupported activation target kinds: {sorted(unknown)}"
+            )
+        if self.version != PROMOTION_ACTIVATION_POLICY_VERSION:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation policy version"
+            )
+        if self.policy_id != _digest(_payload(self, "policy_id")):
+            raise PerceptionPromotionActivationError(
+                "promotion activation policy identity disagrees with canonical payload"
+            )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        maximum_change_count: int = 100,
+        allowed_target_kinds: tuple[str, ...] = tuple(
+            sorted(PROMOTION_MATERIALIZATION_TARGET_KINDS)
+        ),
+    ) -> "PromotionActivationPolicyDTO":
+        values: dict[str, object] = {
+            "maximum_change_count": maximum_change_count,
+            "allowed_target_kinds": tuple(sorted(set(allowed_target_kinds))),
+            "version": PROMOTION_ACTIVATION_POLICY_VERSION,
+        }
+        return cls(policy_id=_digest(values), **values)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class PromotionActivationAuditFindingDTO:
+    finding_id: str
+    severity: str
+    code: str
+    subject_id: str
+    detail: str
+    version: str = PROMOTION_ACTIVATION_AUDIT_FINDING_VERSION
+
+    def __post_init__(self) -> None:
+        if not all((self.finding_id, self.code, self.subject_id, self.detail)):
+            raise PerceptionPromotionActivationError(
+                "activation audit finding identities and detail must be non-empty"
+            )
+        if self.severity not in PROMOTION_ACTIVATION_FINDING_SEVERITIES:
+            raise PerceptionPromotionActivationError(
+                f"unsupported activation finding severity: {self.severity}"
+            )
+        if self.version != PROMOTION_ACTIVATION_AUDIT_FINDING_VERSION:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation audit finding version"
+            )
+        if self.finding_id != _digest(_payload(self, "finding_id")):
+            raise PerceptionPromotionActivationError(
+                "activation audit finding identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class PromotionActivationAuditReportDTO:
+    report_id: str
+    status: str
+    change_set_id: str
+    policy_id: str
+    observed_state_id: str
+    observed_baseline_id: str
+    observed_baseline_version_id: str
+    expected_baseline_id: str
+    expected_baseline_version_id: str
+    resulting_state_id: str | None
+    resulting_baseline_id: str | None
+    resulting_baseline_version_id: str | None
+    finding_ids: tuple[str, ...]
+    findings: tuple[PromotionActivationAuditFindingDTO, ...]
+    semantics: str = PROMOTION_ACTIVATION_SEMANTICS
+    version: str = PROMOTION_ACTIVATION_AUDIT_REPORT_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.report_id,
+                self.change_set_id,
+                self.policy_id,
+                self.observed_state_id,
+                self.observed_baseline_id,
+                self.observed_baseline_version_id,
+                self.expected_baseline_id,
+                self.expected_baseline_version_id,
+            )
+        ):
+            raise PerceptionPromotionActivationError(
+                "activation audit report identities must be non-empty"
+            )
+        if self.status not in PROMOTION_ACTIVATION_AUDIT_STATUSES:
+            raise PerceptionPromotionActivationError(
+                f"unsupported promotion activation audit status: {self.status}"
+            )
+        actual_ids = tuple(sorted(item.finding_id for item in self.findings))
+        if actual_ids != self.finding_ids:
+            raise PerceptionPromotionActivationError(
+                "activation audit finding identities disagree with findings"
+            )
+        _ordered_unique("activation audit finding identities", self.finding_ids)
+        has_error = any(item.severity == "error" for item in self.findings)
+        if self.status == "admissible":
+            if has_error or not all(
+                (
+                    self.resulting_state_id,
+                    self.resulting_baseline_id,
+                    self.resulting_baseline_version_id,
+                )
+            ):
+                raise PerceptionPromotionActivationError(
+                    "admissible activation audits require a resulting state and no errors"
+                )
+        elif any(
+            value is not None
+            for value in (
+                self.resulting_state_id,
+                self.resulting_baseline_id,
+                self.resulting_baseline_version_id,
+            )
+        ):
+            raise PerceptionPromotionActivationError(
+                "non-admissible activation audits cannot declare a resulting state"
+            )
+        if self.status == "blocked" and not has_error:
+            raise PerceptionPromotionActivationError(
+                "blocked activation audits require an error finding"
+            )
+        if self.status == "not_applicable" and has_error:
+            raise PerceptionPromotionActivationError(
+                "not-applicable activation audits cannot contain errors"
+            )
+        if self.semantics != PROMOTION_ACTIVATION_SEMANTICS:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation semantics"
+            )
+        if self.version != PROMOTION_ACTIVATION_AUDIT_REPORT_VERSION:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation audit report version"
+            )
+        if self.report_id != _digest(_payload(self, "report_id")):
+            raise PerceptionPromotionActivationError(
+                "activation audit report identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class PromotionActivationAdmissionDTO:
+    admission_id: str
+    status: str
+    change_set_id: str
+    policy_id: str
+    audit_report_id: str
+    expected_state_id: str
+    expected_baseline_id: str
+    expected_baseline_version_id: str
+    resulting_state_id: str
+    resulting_baseline_id: str
+    resulting_baseline_version_id: str
+    forward_operation_ids: tuple[str, ...]
+    inverse_operation_ids: tuple[str, ...]
+    semantics: str = PROMOTION_ACTIVATION_SEMANTICS
+    version: str = PROMOTION_ACTIVATION_ADMISSION_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.admission_id,
+                self.change_set_id,
+                self.policy_id,
+                self.audit_report_id,
+                self.expected_state_id,
+                self.expected_baseline_id,
+                self.expected_baseline_version_id,
+                self.resulting_state_id,
+                self.resulting_baseline_id,
+                self.resulting_baseline_version_id,
+            )
+        ):
+            raise PerceptionPromotionActivationError(
+                "promotion activation admission identities must be non-empty"
+            )
+        if self.status != PROMOTION_ACTIVATION_ADMISSION_STATUS:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation admission status"
+            )
+        if not self.forward_operation_ids or not self.inverse_operation_ids:
+            raise PerceptionPromotionActivationError(
+                "promotion activation admission requires forward and inverse operations"
+            )
+        if len(self.forward_operation_ids) != len(set(self.forward_operation_ids)):
+            raise PerceptionPromotionActivationError(
+                "admitted forward operation identities must be unique"
+            )
+        if len(self.inverse_operation_ids) != len(set(self.inverse_operation_ids)):
+            raise PerceptionPromotionActivationError(
+                "admitted inverse operation identities must be unique"
+            )
+        if self.semantics != PROMOTION_ACTIVATION_SEMANTICS:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation semantics"
+            )
+        if self.version != PROMOTION_ACTIVATION_ADMISSION_VERSION:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation admission version"
+            )
+        if self.admission_id != _digest(_payload(self, "admission_id")):
+            raise PerceptionPromotionActivationError(
+                "promotion activation admission identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class PromotionRollbackPlanDTO:
+    rollback_plan_id: str
+    status: str
+    change_set_id: str
+    admission_id: str
+    activated_state_id: str
+    activated_baseline_id: str
+    activated_baseline_version_id: str
+    restore_state: ActivePromotionStateDTO
+    restore_baseline_id: str
+    restore_baseline_version_id: str
+    inverse_operation_ids: tuple[str, ...]
+    inverse_operations: tuple[PromotionMaterializationOperationDTO, ...]
+    semantics: str = PROMOTION_ACTIVATION_SEMANTICS
+    version: str = PROMOTION_ROLLBACK_PLAN_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.rollback_plan_id,
+                self.change_set_id,
+                self.admission_id,
+                self.activated_state_id,
+                self.activated_baseline_id,
+                self.activated_baseline_version_id,
+                self.restore_baseline_id,
+                self.restore_baseline_version_id,
+            )
+        ):
+            raise PerceptionPromotionActivationError(
+                "promotion rollback plan identities must be non-empty"
+            )
+        if self.status != PROMOTION_ROLLBACK_PLAN_STATUS:
+            raise PerceptionPromotionActivationError(
+                "promotion rollback plans must remain stored_inactive"
+            )
+        actual_ids = tuple(item.operation_id for item in self.inverse_operations)
+        if actual_ids != self.inverse_operation_ids:
+            raise PerceptionPromotionActivationError(
+                "rollback inverse operation identities disagree with operations"
+            )
+        if not self.inverse_operations or any(
+            item.direction != "inverse" for item in self.inverse_operations
+        ):
+            raise PerceptionPromotionActivationError(
+                "rollback plan requires inverse materialization operations"
+            )
+        if tuple(item.sequence for item in self.inverse_operations) != tuple(
+            range(1, len(self.inverse_operations) + 1)
+        ):
+            raise PerceptionPromotionActivationError(
+                "rollback inverse operation sequence must be contiguous"
+            )
+        restore_baseline = self.restore_state.baseline()
+        if (
+            restore_baseline.baseline_id != self.restore_baseline_id
+            or self.restore_state.baseline_version_id
+            != self.restore_baseline_version_id
+        ):
+            raise PerceptionPromotionActivationError(
+                "rollback restore baseline disagrees with restore state"
+            )
+        if self.semantics != PROMOTION_ACTIVATION_SEMANTICS:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation semantics"
+            )
+        if self.version != PROMOTION_ROLLBACK_PLAN_VERSION:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion rollback plan version"
+            )
+        if self.rollback_plan_id != _digest(_payload(self, "rollback_plan_id")):
+            raise PerceptionPromotionActivationError(
+                "promotion rollback plan identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class PromotionActivationReceiptDTO:
+    receipt_id: str
+    status: str
+    change_set_id: str
+    admission_id: str
+    audit_report_id: str
+    previous_state_id: str
+    resulting_state_id: str
+    previous_baseline_id: str
+    resulting_baseline_id: str
+    previous_baseline_version_id: str
+    resulting_baseline_version_id: str
+    resulting_revision: int
+    forward_operation_ids: tuple[str, ...]
+    rollback_plan_id: str
+    semantics: str = PROMOTION_ACTIVATION_SEMANTICS
+    version: str = PROMOTION_ACTIVATION_RECEIPT_VERSION
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.receipt_id,
+                self.change_set_id,
+                self.admission_id,
+                self.audit_report_id,
+                self.previous_state_id,
+                self.resulting_state_id,
+                self.previous_baseline_id,
+                self.resulting_baseline_id,
+                self.previous_baseline_version_id,
+                self.resulting_baseline_version_id,
+                self.rollback_plan_id,
+            )
+        ):
+            raise PerceptionPromotionActivationError(
+                "promotion activation receipt identities must be non-empty"
+            )
+        if self.status != PROMOTION_ACTIVATION_RECEIPT_STATUS:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation receipt status"
+            )
+        _positive_int("resulting activation revision", self.resulting_revision)
+        if not self.forward_operation_ids or len(self.forward_operation_ids) != len(
+            set(self.forward_operation_ids)
+        ):
+            raise PerceptionPromotionActivationError(
+                "activation receipt requires unique forward operation identities"
+            )
+        if self.semantics != PROMOTION_ACTIVATION_SEMANTICS:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation semantics"
+            )
+        if self.version != PROMOTION_ACTIVATION_RECEIPT_VERSION:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation receipt version"
+            )
+        if self.receipt_id != _digest(_payload(self, "receipt_id")):
+            raise PerceptionPromotionActivationError(
+                "promotion activation receipt identity disagrees with canonical payload"
+            )
+
+
+@dataclass(frozen=True)
+class PromotionActivationBundleDTO:
+    bundle_id: str
+    change_set_id: str
+    audit_report: PromotionActivationAuditReportDTO
+    admission: PromotionActivationAdmissionDTO
+    rollback_plan: PromotionRollbackPlanDTO
+    receipt: PromotionActivationReceiptDTO
+    resulting_state: ActivePromotionStateDTO
+    semantics: str = PROMOTION_ACTIVATION_SEMANTICS
+    version: str = PROMOTION_ACTIVATION_BUNDLE_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.bundle_id or not self.change_set_id:
+            raise PerceptionPromotionActivationError(
+                "promotion activation bundle identities must be non-empty"
+            )
+        if self.audit_report.status != "admissible":
+            raise PerceptionPromotionActivationError(
+                "activation bundles require an admissible audit"
+            )
+        if not (
+            self.audit_report.change_set_id
+            == self.admission.change_set_id
+            == self.rollback_plan.change_set_id
+            == self.receipt.change_set_id
+            == self.change_set_id
+        ):
+            raise PerceptionPromotionActivationError(
+                "activation bundle change-set lineage disagrees"
+            )
+        if (
+            self.admission.audit_report_id != self.audit_report.report_id
+            or self.receipt.audit_report_id != self.audit_report.report_id
+            or self.receipt.admission_id != self.admission.admission_id
+            or self.rollback_plan.admission_id != self.admission.admission_id
+            or self.receipt.rollback_plan_id != self.rollback_plan.rollback_plan_id
+        ):
+            raise PerceptionPromotionActivationError(
+                "activation bundle artifact lineage disagrees"
+            )
+        resulting_baseline = self.resulting_state.baseline()
+        if not (
+            self.resulting_state.state_id
+            == self.admission.resulting_state_id
+            == self.receipt.resulting_state_id
+            == self.rollback_plan.activated_state_id
+            and resulting_baseline.baseline_id
+            == self.admission.resulting_baseline_id
+            == self.receipt.resulting_baseline_id
+            == self.rollback_plan.activated_baseline_id
+            and self.resulting_state.baseline_version_id
+            == self.admission.resulting_baseline_version_id
+            == self.receipt.resulting_baseline_version_id
+            == self.rollback_plan.activated_baseline_version_id
+        ):
+            raise PerceptionPromotionActivationError(
+                "activation bundle resulting state lineage disagrees"
+            )
+        if not (
+            self.rollback_plan.restore_state.state_id
+            == self.admission.expected_state_id
+            == self.receipt.previous_state_id
+            and self.rollback_plan.restore_baseline_id
+            == self.admission.expected_baseline_id
+            == self.receipt.previous_baseline_id
+            and self.rollback_plan.restore_baseline_version_id
+            == self.admission.expected_baseline_version_id
+            == self.receipt.previous_baseline_version_id
+        ):
+            raise PerceptionPromotionActivationError(
+                "activation bundle restore-state lineage disagrees"
+            )
+        if self.semantics != PROMOTION_ACTIVATION_SEMANTICS:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation semantics"
+            )
+        if self.version != PROMOTION_ACTIVATION_BUNDLE_VERSION:
+            raise PerceptionPromotionActivationError(
+                "unsupported promotion activation bundle version"
+            )
+        if self.bundle_id != _digest(_payload(self, "bundle_id")):
+            raise PerceptionPromotionActivationError(
+                "promotion activation bundle identity disagrees with canonical payload"
+            )
+
+
+class PromotionActivationStore(Protocol):
+    """DTO-only store boundary for one active policy state and activation ledger."""
+
+    version: str
+
+    def get_active_state(self) -> ActivePromotionStateDTO:
+        ...
+
+    def commit_activation(
+        self,
+        expected_state: ActivePromotionStateDTO,
+        change_set: PromotionMaterializationChangeSetDTO,
+        bundle: PromotionActivationBundleDTO,
+    ) -> None:
+        ...
+
+    def get_activation_bundle(self, change_set_id: str) -> PromotionActivationBundleDTO:
+        ...
+
+    def list_activation_bundles(self) -> tuple[PromotionActivationBundleDTO, ...]:
+        ...
+
+
+def _finding(
+    *,
+    severity: str,
+    code: str,
+    subject_id: str,
+    detail: str,
+) -> PromotionActivationAuditFindingDTO:
+    values: dict[str, object] = {
+        "severity": severity,
+        "code": code,
+        "subject_id": subject_id,
+        "detail": detail,
+        "version": PROMOTION_ACTIVATION_AUDIT_FINDING_VERSION,
+    }
+    return PromotionActivationAuditFindingDTO(
+        finding_id=_digest(values),
+        **values,  # type: ignore[arg-type]
+    )
+
+
+def _resulting_baseline_version_id(
+    current: ActivePromotionStateDTO,
+    change_set: PromotionMaterializationChangeSetDTO,
+) -> str:
+    return _digest(
+        {
+            "previous_state_id": current.state_id,
+            "previous_baseline_id": current.baseline().baseline_id,
+            "previous_baseline_version_id": current.baseline_version_id,
+            "change_set_id": change_set.change_set_id,
+            "resulting_revision": current.revision + 1,
+            "version": PROMOTION_ACTIVE_STATE_VERSION,
+        }
+    )
+
+
+def _change_set_objects(
+    change_set: PromotionMaterializationChangeSetDTO,
+) -> dict[tuple[str, str], object]:
+    objects: dict[tuple[str, str], object] = {}
+    for change in change_set.changes:
+        if change.annotation is not None:
+            key = ("annotation", change.annotation.annotation_id)
+            value: object = change.annotation
+        else:
+            if change.relation is None:
+                raise PerceptionPromotionActivationError(
+                    "materialized promotion change has no target object"
+                )
+            key = ("relation", change.relation.relation_id)
+            value = change.relation
+        if key in objects:
+            raise PerceptionPromotionActivationError(
+                "change set repeats a materialized target object"
+            )
+        objects[key] = value
+        expectation_key = (
+            "transition_expectation",
+            change.transition_expectation.expectation_id,
+        )
+        if expectation_key in objects:
+            raise PerceptionPromotionActivationError(
+                "change set repeats a transition expectation"
+            )
+        objects[expectation_key] = change.transition_expectation
+    return objects
+
+
+def _apply_forward_operations(
+    current: ActivePromotionStateDTO,
+    change_set: PromotionMaterializationChangeSetDTO,
+    *,
+    operation_hook: object | None = None,
+) -> ActivePromotionStateDTO:
+    if change_set.status != "staged_inactive" or not change_set.changes:
+        raise PerceptionPromotionActivationError(
+            "atomic activation requires a non-empty staged_inactive change set"
+        )
+    if change_set.field_schema_id != current.field_schema_id:
+        raise PerceptionPromotionActivationError(
+            "change-set field schema differs from active state"
+        )
+    objects = _change_set_objects(change_set)
+    operations = change_set.operations("forward")
+    if {(
+        item.object_kind,
+        item.object_id,
+    ) for item in operations} != set(objects):
+        raise PerceptionPromotionActivationError(
+            "forward operations do not exactly cover materialized objects"
+        )
+    annotations = {item.annotation_id: item for item in current.annotations}
+    relations = {item.relation_id: item for item in current.relations}
+    expectations = {
+        item.expectation_id: item for item in current.transition_expectations
+    }
+    for operation in operations:
+        key = (operation.object_kind, operation.object_id)
+        try:
+            value = objects[key]
+        except KeyError as exc:
+            raise PerceptionPromotionActivationError(
+                "forward operation references an unknown materialized object"
+            ) from exc
+        if operation.payload_digest != _object_digest(operation.object_kind, value):
+            raise PerceptionPromotionActivationError(
+                "forward operation payload digest disagrees with materialized object"
+            )
+        if operation.object_kind == "annotation":
+            if not isinstance(value, PerceptionRegionAnnotationDTO):
+                raise PerceptionPromotionActivationError(
+                    "annotation operation payload has the wrong DTO type"
+                )
+            if operation.object_id in annotations:
+                raise PerceptionPromotionActivationError(
+                    "activation would overwrite an active annotation"
+                )
+            if value.field_schema_id != current.field_schema_id:
+                raise PerceptionPromotionActivationError(
+                    "materialized annotation field schema mismatch"
+                )
+            annotations[value.annotation_id] = value
+        elif operation.object_kind == "relation":
+            if not isinstance(value, RelationAnnotationDTO):
+                raise PerceptionPromotionActivationError(
+                    "relation operation payload has the wrong DTO type"
+                )
+            if operation.object_id in relations:
+                raise PerceptionPromotionActivationError(
+                    "activation would overwrite an active relation"
+                )
+            missing_members = set(value.member_annotation_ids) - set(annotations)
+            if missing_members:
+                raise PerceptionPromotionActivationError(
+                    "materialized relation references inactive annotations: "
+                    f"{sorted(missing_members)}"
+                )
+            relations[value.relation_id] = value
+        else:
+            if not isinstance(value, TransitionExpectationDTO):
+                raise PerceptionPromotionActivationError(
+                    "transition expectation operation payload has the wrong DTO type"
+                )
+            if operation.object_id in expectations:
+                raise PerceptionPromotionActivationError(
+                    "activation would overwrite an active transition expectation"
+                )
+            if value.field_schema_id != current.field_schema_id:
+                raise PerceptionPromotionActivationError(
+                    "materialized transition expectation field schema mismatch"
+                )
+            if set(value.annotation_ids) - set(annotations) or set(
+                value.relation_ids
+            ) - set(relations):
+                raise PerceptionPromotionActivationError(
+                    "materialized transition expectation references inactive targets"
+                )
+            expectations[value.expectation_id] = value
+        if operation_hook is not None:
+            hook = getattr(operation_hook, "_after_operation_applied", None)
+            if hook is not None:
+                hook(operation)
+    return ActivePromotionStateDTO.create(
+        revision=current.revision + 1,
+        baseline_version_id=_resulting_baseline_version_id(current, change_set),
+        field_schema_id=current.field_schema_id,
+        annotations=tuple(annotations.values()),
+        relations=tuple(relations.values()),
+        transition_expectations=tuple(expectations.values()),
+        last_change_set_id=change_set.change_set_id,
+    )
+
+
+def audit_promotion_activation(
+    current: ActivePromotionStateDTO,
+    change_set: PromotionMaterializationChangeSetDTO,
+    policy: PromotionActivationPolicyDTO | None = None,
+) -> PromotionActivationAuditReportDTO:
+    """Audit a staged P18F change set against one exact active-state snapshot."""
+
+    resolved = policy or PromotionActivationPolicyDTO.create()
+    observed_baseline = current.baseline()
+    findings: list[PromotionActivationAuditFindingDTO] = []
+    resulting: ActivePromotionStateDTO | None = None
+    if change_set.status == "no_approved_changes":
+        findings.append(
+            _finding(
+                severity="info",
+                code="no_approved_changes",
+                subject_id=change_set.change_set_id,
+                detail="The fully reviewed materialization contains no changes to activate.",
+            )
+        )
+        status = "not_applicable"
+    else:
+        if change_set.status != "staged_inactive" or not change_set.changes:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="change_set_not_staged",
+                    subject_id=change_set.change_set_id,
+                    detail="Activation requires a non-empty staged_inactive P18F change set.",
+                )
+            )
+        if len(change_set.changes) > resolved.maximum_change_count:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="change_count_exceeds_policy",
+                    subject_id=change_set.change_set_id,
+                    detail="The staged change count exceeds the activation policy limit.",
+                )
+            )
+        disallowed = {
+            item.target_kind for item in change_set.changes
+        } - set(resolved.allowed_target_kinds)
+        if disallowed:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="target_kind_disallowed",
+                    subject_id=change_set.change_set_id,
+                    detail=f"Activation policy disallows target kinds: {sorted(disallowed)}",
+                )
+            )
+        if current.field_schema_id != change_set.field_schema_id:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="field_schema_mismatch",
+                    subject_id=current.state_id,
+                    detail="The active field schema differs from the staged change set.",
+                )
+            )
+        if observed_baseline.baseline_version_id != change_set.baseline_version_id:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="baseline_version_mismatch",
+                    subject_id=current.state_id,
+                    detail="The active baseline version changed after materialization.",
+                )
+            )
+        if observed_baseline.baseline_id != change_set.baseline_id:
+            findings.append(
+                _finding(
+                    severity="error",
+                    code="baseline_identity_mismatch",
+                    subject_id=current.state_id,
+                    detail="The active annotation/relation/expectation identity baseline changed.",
+                )
+            )
+        if not any(item.severity == "error" for item in findings):
+            try:
+                resulting = _apply_forward_operations(current, change_set)
+            except Exception as exc:
+                findings.append(
+                    _finding(
+                        severity="error",
+                        code="forward_plan_invalid",
+                        subject_id=change_set.change_set_id,
+                        detail=str(exc),
+                    )
+                )
+        if any(item.severity == "error" for item in findings):
+            status = "blocked"
+            resulting = None
+        else:
+            findings.append(
+                _finding(
+                    severity="info",
+                    code="activation_admissible",
+                    subject_id=change_set.change_set_id,
+                    detail="Exact baseline and forward-plan audits authorize activation.",
+                )
+            )
+            status = "admissible"
+    ordered_findings = tuple(sorted(findings, key=lambda item: item.finding_id))
+    resulting_baseline = resulting.baseline() if resulting is not None else None
+    values: dict[str, object] = {
+        "status": status,
+        "change_set_id": change_set.change_set_id,
+        "policy_id": resolved.policy_id,
+        "observed_state_id": current.state_id,
+        "observed_baseline_id": observed_baseline.baseline_id,
+        "observed_baseline_version_id": current.baseline_version_id,
+        "expected_baseline_id": change_set.baseline_id,
+        "expected_baseline_version_id": change_set.baseline_version_id,
+        "resulting_state_id": None if resulting is None else resulting.state_id,
+        "resulting_baseline_id": (
+            None if resulting_baseline is None else resulting_baseline.baseline_id
+        ),
+        "resulting_baseline_version_id": (
+            None if resulting is None else resulting.baseline_version_id
+        ),
+        "finding_ids": tuple(item.finding_id for item in ordered_findings),
+        "findings": ordered_findings,
+        "semantics": PROMOTION_ACTIVATION_SEMANTICS,
+        "version": PROMOTION_ACTIVATION_AUDIT_REPORT_VERSION,
+    }
+    identity_values = dict(values)
+    identity_values["findings"] = tuple(asdict(item) for item in ordered_findings)
+    return PromotionActivationAuditReportDTO(
+        report_id=_digest(identity_values),
+        **values,  # type: ignore[arg-type]
+    )
+
+
+def authorize_promotion_activation(
+    report: PromotionActivationAuditReportDTO,
+    current: ActivePromotionStateDTO,
+    change_set: PromotionMaterializationChangeSetDTO,
+    policy: PromotionActivationPolicyDTO,
+) -> tuple[PromotionActivationAdmissionDTO, ActivePromotionStateDTO]:
+    """Bind an admissible audit to its exact expected and resulting states."""
+
+    if report.status != "admissible":
+        raise PerceptionPromotionActivationError(
+            "promotion activation audit is not admissible"
+        )
+    current_baseline = current.baseline()
+    if (
+        report.change_set_id != change_set.change_set_id
+        or report.policy_id != policy.policy_id
+        or report.observed_state_id != current.state_id
+        or report.observed_baseline_id != current_baseline.baseline_id
+        or report.observed_baseline_version_id != current.baseline_version_id
+    ):
+        raise PerceptionPromotionActivationError(
+            "promotion activation audit no longer matches the supplied pre-state"
+        )
+    resulting = _apply_forward_operations(current, change_set)
+    resulting_baseline = resulting.baseline()
+    if (
+        report.resulting_state_id != resulting.state_id
+        or report.resulting_baseline_id != resulting_baseline.baseline_id
+        or report.resulting_baseline_version_id != resulting.baseline_version_id
+    ):
+        raise PerceptionPromotionActivationError(
+            "promotion activation audit resulting-state prediction disagrees"
+        )
+    values: dict[str, object] = {
+        "status": PROMOTION_ACTIVATION_ADMISSION_STATUS,
+        "change_set_id": change_set.change_set_id,
+        "policy_id": policy.policy_id,
+        "audit_report_id": report.report_id,
+        "expected_state_id": current.state_id,
+        "expected_baseline_id": current_baseline.baseline_id,
+        "expected_baseline_version_id": current.baseline_version_id,
+        "resulting_state_id": resulting.state_id,
+        "resulting_baseline_id": resulting_baseline.baseline_id,
+        "resulting_baseline_version_id": resulting.baseline_version_id,
+        "forward_operation_ids": change_set.forward_operation_ids,
+        "inverse_operation_ids": change_set.inverse_operation_ids,
+        "semantics": PROMOTION_ACTIVATION_SEMANTICS,
+        "version": PROMOTION_ACTIVATION_ADMISSION_VERSION,
+    }
+    admission = PromotionActivationAdmissionDTO(
+        admission_id=_digest(values),
+        **values,  # type: ignore[arg-type]
+    )
+    return admission, resulting
+
+
+def build_promotion_activation_bundle(
+    current: ActivePromotionStateDTO,
+    change_set: PromotionMaterializationChangeSetDTO,
+    policy: PromotionActivationPolicyDTO | None = None,
+) -> PromotionActivationBundleDTO:
+    """Audit and prepare all immutable artifacts required for one atomic commit."""
+
+    resolved = policy or PromotionActivationPolicyDTO.create()
+    report = audit_promotion_activation(current, change_set, resolved)
+    admission, resulting = authorize_promotion_activation(
+        report,
+        current,
+        change_set,
+        resolved,
+    )
+    current_baseline = current.baseline()
+    resulting_baseline = resulting.baseline()
+    inverse_operations = change_set.operations("inverse")
+    rollback_values: dict[str, object] = {
+        "status": PROMOTION_ROLLBACK_PLAN_STATUS,
+        "change_set_id": change_set.change_set_id,
+        "admission_id": admission.admission_id,
+        "activated_state_id": resulting.state_id,
+        "activated_baseline_id": resulting_baseline.baseline_id,
+        "activated_baseline_version_id": resulting.baseline_version_id,
+        "restore_state": current,
+        "restore_baseline_id": current_baseline.baseline_id,
+        "restore_baseline_version_id": current.baseline_version_id,
+        "inverse_operation_ids": change_set.inverse_operation_ids,
+        "inverse_operations": inverse_operations,
+        "semantics": PROMOTION_ACTIVATION_SEMANTICS,
+        "version": PROMOTION_ROLLBACK_PLAN_VERSION,
+    }
+    rollback_identity = dict(rollback_values)
+    rollback_identity["restore_state"] = asdict(current)
+    rollback_identity["inverse_operations"] = tuple(
+        asdict(item) for item in inverse_operations
+    )
+    rollback_plan = PromotionRollbackPlanDTO(
+        rollback_plan_id=_digest(rollback_identity),
+        **rollback_values,  # type: ignore[arg-type]
+    )
+    receipt_values: dict[str, object] = {
+        "status": PROMOTION_ACTIVATION_RECEIPT_STATUS,
+        "change_set_id": change_set.change_set_id,
+        "admission_id": admission.admission_id,
+        "audit_report_id": report.report_id,
+        "previous_state_id": current.state_id,
+        "resulting_state_id": resulting.state_id,
+        "previous_baseline_id": current_baseline.baseline_id,
+        "resulting_baseline_id": resulting_baseline.baseline_id,
+        "previous_baseline_version_id": current.baseline_version_id,
+        "resulting_baseline_version_id": resulting.baseline_version_id,
+        "resulting_revision": resulting.revision,
+        "forward_operation_ids": change_set.forward_operation_ids,
+        "rollback_plan_id": rollback_plan.rollback_plan_id,
+        "semantics": PROMOTION_ACTIVATION_SEMANTICS,
+        "version": PROMOTION_ACTIVATION_RECEIPT_VERSION,
+    }
+    receipt = PromotionActivationReceiptDTO(
+        receipt_id=_digest(receipt_values),
+        **receipt_values,  # type: ignore[arg-type]
+    )
+    bundle_values: dict[str, object] = {
+        "change_set_id": change_set.change_set_id,
+        "audit_report": report,
+        "admission": admission,
+        "rollback_plan": rollback_plan,
+        "receipt": receipt,
+        "resulting_state": resulting,
+        "semantics": PROMOTION_ACTIVATION_SEMANTICS,
+        "version": PROMOTION_ACTIVATION_BUNDLE_VERSION,
+    }
+    bundle_identity = dict(bundle_values)
+    for name in (
+        "audit_report",
+        "admission",
+        "rollback_plan",
+        "receipt",
+        "resulting_state",
+    ):
+        bundle_identity[name] = asdict(bundle_values[name])  # type: ignore[arg-type]
+    return PromotionActivationBundleDTO(
+        bundle_id=_digest(bundle_identity),
+        **bundle_values,  # type: ignore[arg-type]
+    )
+
+
+class InMemoryPromotionActivationStore:
+    """Atomic copy-on-write reference implementation of the P18G store protocol."""
+
+    version: Final = PROMOTION_ACTIVATION_STORE_VERSION
+
+    def __init__(self, initial_state: ActivePromotionStateDTO) -> None:
+        self._state = initial_state
+        self._bundles: dict[str, PromotionActivationBundleDTO] = {}
+        self._lock = threading.RLock()
+
+    def get_active_state(self) -> ActivePromotionStateDTO:
+        with self._lock:
+            return self._state
+
+    def _after_operation_applied(
+        self,
+        operation: PromotionMaterializationOperationDTO,
+    ) -> None:
+        """Extension hook used by fault-injection tests before any atomic swap."""
+
+    def _before_atomic_swap(self, bundle: PromotionActivationBundleDTO) -> None:
+        """Extension hook used by store implementations before the final swap."""
+
+    def commit_activation(
+        self,
+        expected_state: ActivePromotionStateDTO,
+        change_set: PromotionMaterializationChangeSetDTO,
+        bundle: PromotionActivationBundleDTO,
+    ) -> None:
+        with self._lock:
+            current = self._state
+            if current != expected_state or current.state_id != expected_state.state_id:
+                raise PerceptionPromotionActivationError(
+                    "active state changed before atomic activation commit"
+                )
+            current_baseline = current.baseline()
+            admission = bundle.admission
+            if (
+                admission.expected_state_id != current.state_id
+                or admission.expected_baseline_id != current_baseline.baseline_id
+                or admission.expected_baseline_version_id
+                != current.baseline_version_id
+            ):
+                raise PerceptionPromotionActivationError(
+                    "activation admission does not authorize the current active baseline"
+                )
+            if bundle.change_set_id != change_set.change_set_id:
+                raise PerceptionPromotionActivationError(
+                    "activation bundle does not reference the supplied change set"
+                )
+            if change_set.change_set_id in self._bundles:
+                raise PerceptionPromotionActivationError(
+                    "promotion change set was already activated"
+                )
+            actual_result = _apply_forward_operations(
+                current,
+                change_set,
+                operation_hook=self,
+            )
+            if actual_result != bundle.resulting_state:
+                raise PerceptionPromotionActivationError(
+                    "atomic store result differs from admitted resulting state"
+                )
+            if (
+                bundle.rollback_plan.inverse_operation_ids
+                != change_set.inverse_operation_ids
+                or bundle.receipt.forward_operation_ids
+                != change_set.forward_operation_ids
+            ):
+                raise PerceptionPromotionActivationError(
+                    "activation bundle operation lineage disagrees with change set"
+                )
+            next_bundles = dict(self._bundles)
+            next_bundles[change_set.change_set_id] = bundle
+            self._before_atomic_swap(bundle)
+            self._state = actual_result
+            self._bundles = next_bundles
+
+    def get_activation_bundle(self, change_set_id: str) -> PromotionActivationBundleDTO:
+        with self._lock:
+            try:
+                return self._bundles[change_set_id]
+            except KeyError as exc:
+                raise PerceptionPromotionActivationError(
+                    f"unknown activated change set: {change_set_id}"
+                ) from exc
+
+    def list_activation_bundles(self) -> tuple[PromotionActivationBundleDTO, ...]:
+        with self._lock:
+            return tuple(
+                self._bundles[key] for key in sorted(self._bundles)
+            )
+
+
+def execute_promotion_activation(
+    store: PromotionActivationStore,
+    change_set: PromotionMaterializationChangeSetDTO,
+    policy: PromotionActivationPolicyDTO | None = None,
+) -> PromotionActivationBundleDTO:
+    """Audit, admit, and atomically activate one P18F change set or change nothing."""
+
+    current = store.get_active_state()
+    bundle = build_promotion_activation_bundle(current, change_set, policy)
+    store.commit_activation(current, change_set, bundle)
+    resulting = store.get_active_state()
+    if resulting != bundle.resulting_state:
+        raise PerceptionPromotionActivationError(
+            "activation store committed a state that differs from the receipt"
+        )
+    persisted = store.get_activation_bundle(change_set.change_set_id)
+    if persisted != bundle:
+        raise PerceptionPromotionActivationError(
+            "activation store did not persist the exact activation bundle"
+        )
+    return bundle

--- a/packages/perception/tests/test_promotion_activation_p18g.py
+++ b/packages/perception/tests/test_promotion_activation_p18g.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from zeromodel.perception import (
+    CandidatePromotionDecisionDTO,
+    CandidateValidationPolicyDTO,
+    HeldOutTransitionObservationDTO,
+    PerceptionRegionAnnotationDTO,
+    PromotionMaterializationBaselineDTO,
+    PromotionMaterializationDirectiveDTO,
+    SourceImageEncoderSpecDTO,
+    TransitionDiscoveryObservationDTO,
+    TransitionDiscoveryPolicyDTO,
+    TransitionExpectationDTO,
+    build_grid_field_schema,
+    build_transition_evidence_vpm,
+    discover_recurrent_unexplained_transitions,
+    encode_source_array,
+    evaluate_transition_conformance,
+    materialize_approved_candidate_promotions,
+    propose_validated_candidate_promotions,
+    review_candidate_promotion_proposals,
+    validate_discovered_transition_candidates,
+)
+from zeromodel.perception.promotion_activation import (
+    ActivePromotionStateDTO,
+    InMemoryPromotionActivationStore,
+    PerceptionPromotionActivationError,
+    PromotionActivationPolicyDTO,
+    audit_promotion_activation,
+    build_promotion_activation_bundle,
+    execute_promotion_activation,
+)
+
+
+def _fixture():
+    encoder = SourceImageEncoderSpecDTO(color_space="L")
+    source = encode_source_array(np.zeros((1, 6), dtype=np.uint8), encoder)
+    schema = build_grid_field_schema(source, tile_width=2, tile_height=1)
+    fields = tuple(sorted(schema.fields, key=lambda item: item.x0))
+    control = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[0].field_id,),
+        label="control",
+        role="stable_control",
+    )
+    expectation = TransitionExpectationDTO.create(
+        field_schema_id=schema.field_schema_id,
+        annotation_ids=(control.annotation_id,),
+        expected_change="stable",
+        maximum_mean_absolute_change=0.0,
+        maximum_changed_fraction=0.0,
+    )
+    return encoder, schema, fields, control, expectation
+
+
+def _transition(
+    before_values: list[int],
+    after_values: list[int],
+    *,
+    include_control_annotation: bool,
+):
+    encoder, schema, fields, control, expectation = _fixture()
+    before = encode_source_array(np.array([before_values], dtype=np.uint8), encoder)
+    after = encode_source_array(np.array([after_values], dtype=np.uint8), encoder)
+    transition = build_transition_evidence_vpm(
+        before,
+        after,
+        schema,
+        annotations=(control,) if include_control_annotation else (),
+    )
+    return transition, schema, fields, control, expectation
+
+
+def _discovery_observation(
+    *,
+    interaction_id: str,
+    first_value: int,
+    second_value: int,
+):
+    transition, _, _, control, expectation = _transition(
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, first_value, first_value, second_value, second_value],
+        include_control_annotation=True,
+    )
+    conformance = evaluate_transition_conformance(
+        transition,
+        (expectation,),
+        (control,),
+        minimum_unexplained_mean_absolute_change=0.05,
+        minimum_unexplained_changed_fraction=0.5,
+    )
+    return TransitionDiscoveryObservationDTO.create(
+        interaction_id=interaction_id,
+        cohort_id="discovery/train",
+        transition=transition,
+        conformance=conformance,
+    )
+
+
+def _discovery_report():
+    observations = tuple(
+        _discovery_observation(
+            interaction_id=f"discovery-{index}",
+            first_value=first,
+            second_value=second,
+        )
+        for index, (first, second) in enumerate(
+            ((200, 180), (180, 160), (160, 140), (0, 0)),
+            start=1,
+        )
+    )
+    return discover_recurrent_unexplained_transitions(
+        observations,
+        TransitionDiscoveryPolicyDTO.create(
+            minimum_observation_count=4,
+            minimum_field_occurrence_count=3,
+            minimum_field_recurrence_fraction=0.75,
+            minimum_signature_occurrence_count=3,
+            minimum_signature_recurrence_fraction=0.75,
+            minimum_direction_consistency=0.75,
+        ),
+    )
+
+
+def _validation_report(discovery):
+    observations = []
+    for index in range(1, 4):
+        transition, _, _, _, _ = _transition(
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 170, 170, 150, 150],
+            include_control_annotation=False,
+        )
+        observations.append(
+            HeldOutTransitionObservationDTO.create(
+                interaction_id=f"validation-{index}",
+                cohort_id="validation/held-out",
+                transition=transition,
+            )
+        )
+    return validate_discovered_transition_candidates(
+        discovery,
+        tuple(observations),
+        CandidateValidationPolicyDTO.create(
+            minimum_validation_observation_count=3,
+            minimum_confirmation_fraction=2 / 3,
+            minimum_rejection_fraction=2 / 3,
+            minimum_magnitude_retention_fraction=0.75,
+        ),
+    )
+
+
+def _materialization(*, target_kind: str = "region_annotation"):
+    discovery = _discovery_report()
+    validation = _validation_report(discovery)
+    proposal_set = propose_validated_candidate_promotions(discovery, validation)
+    approved_proposal = proposal_set.proposals[0]
+    decisions = [
+        CandidatePromotionDecisionDTO.create(
+            approved_proposal,
+            reviewer_id="reviewer:alice",
+            decision="approved",
+            rationale="Held-out evidence and semantic review support activation.",
+            semantic_name="projectile-shadow",
+            semantic_type=(
+                "spatial_relation" if target_kind == "relation_annotation" else "region_component"
+            ),
+            semantic_role="context",
+        )
+    ]
+    for index, proposal in enumerate(proposal_set.proposals[1:], start=1):
+        decisions.append(
+            CandidatePromotionDecisionDTO.create(
+                proposal,
+                reviewer_id=f"reviewer:reject-{index}",
+                decision="rejected",
+                rationale="This candidate is not selected for materialization.",
+            )
+        )
+    review = review_candidate_promotion_proposals(proposal_set, tuple(decisions))
+    _, schema, fields, control, stable_expectation = _fixture()
+    member = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[1].field_id,),
+        label="known-member",
+        role="context",
+    )
+    initial = ActivePromotionStateDTO.create(
+        revision=0,
+        baseline_version_id="policy-baseline:v1",
+        field_schema_id=schema.field_schema_id,
+        annotations=(control, member),
+        transition_expectations=(stable_expectation,),
+    )
+    baseline = initial.baseline()
+    assert baseline == PromotionMaterializationBaselineDTO.create(
+        baseline_version_id="policy-baseline:v1",
+        field_schema_id=schema.field_schema_id,
+        existing_annotation_ids=(control.annotation_id, member.annotation_id),
+        existing_transition_expectation_ids=(stable_expectation.expectation_id,),
+    )
+    directive = PromotionMaterializationDirectiveDTO.create(
+        approved_proposal,
+        target_kind=target_kind,
+        relation_member_annotation_ids=(
+            (control.annotation_id, member.annotation_id)
+            if target_kind == "relation_annotation"
+            else ()
+        ),
+        annotation_properties=(
+            (("source", "p18g-test"),)
+            if target_kind == "region_annotation"
+            else ()
+        ),
+    )
+    change_set = materialize_approved_candidate_promotions(
+        proposal_set,
+        review,
+        schema,
+        baseline,
+        (directive,),
+    )
+    assert change_set.status == "staged_inactive"
+    return initial, change_set
+
+
+def _no_approved_change_set():
+    discovery = _discovery_report()
+    validation = _validation_report(discovery)
+    proposal_set = propose_validated_candidate_promotions(discovery, validation)
+    decisions = tuple(
+        CandidatePromotionDecisionDTO.create(
+            proposal,
+            reviewer_id=f"reviewer:no-{index}",
+            decision="rejected",
+            rationale="No candidate is approved in this review.",
+        )
+        for index, proposal in enumerate(proposal_set.proposals, start=1)
+    )
+    review = review_candidate_promotion_proposals(proposal_set, decisions)
+    _, schema, fields, control, stable_expectation = _fixture()
+    member = PerceptionRegionAnnotationDTO.create(
+        schema,
+        (fields[1].field_id,),
+        label="known-member",
+        role="context",
+    )
+    initial = ActivePromotionStateDTO.create(
+        revision=0,
+        baseline_version_id="policy-baseline:v1",
+        field_schema_id=schema.field_schema_id,
+        annotations=(control, member),
+        transition_expectations=(stable_expectation,),
+    )
+    change_set = materialize_approved_candidate_promotions(
+        proposal_set,
+        review,
+        schema,
+        initial.baseline(),
+    )
+    return initial, change_set
+
+
+def test_activates_all_operations_and_persists_exact_inverse_plan() -> None:
+    initial, change_set = _materialization()
+    store = InMemoryPromotionActivationStore(initial)
+
+    bundle = execute_promotion_activation(store, change_set)
+    active = store.get_active_state()
+
+    assert bundle.audit_report.status == "admissible"
+    assert bundle.admission.status == "admitted"
+    assert bundle.receipt.status == "activated"
+    assert bundle.rollback_plan.status == "stored_inactive"
+    assert active == bundle.resulting_state
+    assert active.revision == 1
+    assert active.last_change_set_id == change_set.change_set_id
+    assert active.state_id != initial.state_id
+    assert active.baseline().baseline_id == bundle.receipt.resulting_baseline_id
+    assert bundle.rollback_plan.restore_state == initial
+    assert bundle.rollback_plan.inverse_operation_ids == change_set.inverse_operation_ids
+    assert bundle.receipt.forward_operation_ids == change_set.forward_operation_ids
+    assert store.get_activation_bundle(change_set.change_set_id) == bundle
+    assert store.list_activation_bundles() == (bundle,)
+
+    change = change_set.changes[0]
+    assert change.annotation is not None
+    assert change.annotation.annotation_id in {
+        item.annotation_id for item in active.annotations
+    }
+    assert change.transition_expectation.expectation_id in {
+        item.expectation_id for item in active.transition_expectations
+    }
+
+
+def test_exact_baseline_drift_blocks_activation_without_mutation() -> None:
+    initial, change_set = _materialization()
+    drifted = ActivePromotionStateDTO.create(
+        revision=initial.revision,
+        baseline_version_id="policy-baseline:v2",
+        field_schema_id=initial.field_schema_id,
+        annotations=initial.annotations,
+        relations=initial.relations,
+        transition_expectations=initial.transition_expectations,
+    )
+    report = audit_promotion_activation(drifted, change_set)
+    assert report.status == "blocked"
+    assert {item.code for item in report.findings} >= {
+        "baseline_version_mismatch",
+        "baseline_identity_mismatch",
+    }
+
+    store = InMemoryPromotionActivationStore(drifted)
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="not admissible",
+    ):
+        execute_promotion_activation(store, change_set)
+    assert store.get_active_state() == drifted
+    assert store.list_activation_bundles() == ()
+
+
+def test_activation_policy_can_forbid_relation_materialization() -> None:
+    initial, change_set = _materialization(target_kind="relation_annotation")
+    policy = PromotionActivationPolicyDTO.create(
+        allowed_target_kinds=("region_annotation",),
+    )
+
+    report = audit_promotion_activation(initial, change_set, policy)
+
+    assert report.status == "blocked"
+    assert {item.code for item in report.findings} == {
+        "target_kind_disallowed"
+    }
+
+
+def test_mid_plan_failure_is_atomic() -> None:
+    initial, change_set = _materialization()
+
+    class FailingStore(InMemoryPromotionActivationStore):
+        def _after_operation_applied(self, operation) -> None:
+            if operation.sequence == 2:
+                raise RuntimeError("injected operation failure")
+
+    store = FailingStore(initial)
+    with pytest.raises(RuntimeError, match="injected operation failure"):
+        execute_promotion_activation(store, change_set)
+
+    assert store.get_active_state() == initial
+    assert store.list_activation_bundles() == ()
+
+
+def test_compare_and_swap_rejects_concurrent_state_change() -> None:
+    initial, change_set = _materialization()
+    bundle = build_promotion_activation_bundle(initial, change_set)
+    drifted = ActivePromotionStateDTO.create(
+        revision=1,
+        baseline_version_id="concurrent:v2",
+        field_schema_id=initial.field_schema_id,
+        annotations=initial.annotations,
+        relations=initial.relations,
+        transition_expectations=initial.transition_expectations,
+        last_change_set_id="sha256:concurrent",
+    )
+    store = InMemoryPromotionActivationStore(drifted)
+
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="active state changed",
+    ):
+        store.commit_activation(initial, change_set, bundle)
+
+    assert store.get_active_state() == drifted
+    assert store.list_activation_bundles() == ()
+
+
+def test_no_approved_changes_are_explicitly_not_applicable() -> None:
+    initial, change_set = _no_approved_change_set()
+    assert change_set.status == "no_approved_changes"
+
+    report = audit_promotion_activation(initial, change_set)
+
+    assert report.status == "not_applicable"
+    assert {item.code for item in report.findings} == {"no_approved_changes"}
+    store = InMemoryPromotionActivationStore(initial)
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="not admissible",
+    ):
+        execute_promotion_activation(store, change_set)
+    assert store.get_active_state() == initial
+
+
+def test_activation_contract_identities_reject_tampering() -> None:
+    initial, change_set = _materialization()
+    policy = PromotionActivationPolicyDTO.create()
+    report = audit_promotion_activation(initial, change_set, policy)
+    bundle = build_promotion_activation_bundle(initial, change_set, policy)
+
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="policy identity",
+    ):
+        replace(policy, policy_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="audit report identity",
+    ):
+        replace(report, report_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="admission identity",
+    ):
+        replace(bundle.admission, admission_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="rollback plan identity",
+    ):
+        replace(bundle.rollback_plan, rollback_plan_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="receipt identity",
+    ):
+        replace(bundle.receipt, receipt_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="bundle identity",
+    ):
+        replace(bundle, bundle_id="sha256:tampered")
+    with pytest.raises(
+        PerceptionPromotionActivationError,
+        match="state identity",
+    ):
+        replace(initial, state_id="sha256:tampered")

--- a/packages/perception/tests/test_promotion_activation_p18g_public_surface.py
+++ b/packages/perception/tests/test_promotion_activation_p18g_public_surface.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import zeromodel.perception as perception
+
+
+def test_p18g_is_exposed_from_package_root() -> None:
+    expected = {
+        "ActivePromotionStateDTO",
+        "PromotionActivationPolicyDTO",
+        "PromotionActivationAuditFindingDTO",
+        "PromotionActivationAuditReportDTO",
+        "PromotionActivationAdmissionDTO",
+        "PromotionRollbackPlanDTO",
+        "PromotionActivationReceiptDTO",
+        "PromotionActivationBundleDTO",
+        "PromotionActivationStore",
+        "InMemoryPromotionActivationStore",
+        "PerceptionPromotionActivationError",
+        "audit_promotion_activation",
+        "authorize_promotion_activation",
+        "build_promotion_activation_bundle",
+        "execute_promotion_activation",
+        "PROMOTION_ACTIVATION_BUNDLE_VERSION",
+        "PROMOTION_ACTIVE_STATE_VERSION",
+    }
+
+    assert expected <= set(perception.__all__)
+    for name in expected:
+        assert getattr(perception, name) is not None


### PR DESCRIPTION
Audit-Exempt: adds an internal activation gate and reference atomic store for previously reviewed P18F policy additions; no public capability claim status changes.

## Objective

Implement P18G: audit a staged P18F change set against the exact active policy baseline, bind an admissible audit to expected and resulting state identities, and apply every forward operation atomically or none.

```text
P18F staged inactive change set
    + active policy state
    + activation policy
    ↓
exact baseline and payload audit
    ↓ admissible only
content-addressed admission
    ↓
compare-and-swap atomic activation
    ↓
active state + receipt + stored inactive rollback plan
```

## What changed

- Add content-addressed `ActivePromotionStateDTO` containing:
  - revision and baseline-version identity;
  - exact field-schema identity;
  - complete active annotations, relations and transition expectations;
  - last activated change-set identity.
- Recompute and validate annotation/relation payload identities, relation members, expectation targets, ordering, uniqueness and complete active-state identity.
- Add `PromotionActivationPolicyDTO` with:
  - maximum changes per activation;
  - permitted region/relation target kinds.
- Add deterministic `audit_promotion_activation(...)` outcomes:
  - `admissible`;
  - `blocked`;
  - `not_applicable` for explicit P18F no-approved-change results.
- Require exact equality for:
  - field schema;
  - baseline-version identity;
  - complete annotation/relation/transition-expectation baseline identity.
- Replay the exact forward plan during audit to validate payload digests, collisions, reference integrity and the complete resulting state.
- Add `PromotionActivationAdmissionDTO` binding:
  - audit, policy and change set;
  - exact expected state/baseline;
  - exact predicted resulting state/baseline;
  - ordered forward and inverse operation identities.
- Add `PromotionActivationStore` as a DTO-only compare-and-swap boundary.
- Add `InMemoryPromotionActivationStore` using lock-protected copy-on-write:
  - recheck the admitted baseline inside commit;
  - replay every operation into private working maps;
  - compare the actual result with the admitted result;
  - swap active state and activation ledger together.
- Add immutable activation artifacts:
  - `PromotionActivationReceiptDTO`;
  - `PromotionRollbackPlanDTO`;
  - `PromotionActivationBundleDTO`.
- Persist the complete restore state and exact reverse-ordered P18F inverse plan as `stored_inactive`.
- Derive the resulting baseline-version identity from the previous state/baseline, change-set identity and next revision.
- Advance the P18 roadmap to P18H durable activation and governed rollback.

## Atomicity and concurrency boundary

No active object or ledger artifact is mutated before the final copy-on-write swap. A mid-plan exception leaves both the active state and activation ledger unchanged. Compare-and-swap rejects an admission if another writer changes the active state after audit.

P18G does not execute rollback. It stores the exact inverse plan for a later separately governed stage.

## Focused validation

Tests cover:

- the complete P18C → P18D → P18E → P18F → P18G chain;
- exact-baseline admission and successful activation;
- active annotation and transition-expectation insertion;
- receipt, state and rollback-plan lineage;
- baseline-version and baseline-identity drift rejection;
- target-kind policy rejection;
- compare-and-swap race rejection;
- injected failure after an intermediate operation with no partial state or ledger mutation;
- explicit no-approved-change handling;
- identity tamper rejection across every new contract;
- package-root public surface.

The clean wheel-installed `perception-package` workflow is authoritative for the complete package suite.

## Next stage

P18H should implement restart-safe SQLite persistence for the P18G store protocol and governed rollback admission. Rollback must require the current active state to equal the rollback plan's exact activated state, then apply every inverse operation atomically and preserve both activation and rollback history.