### PR TITLE
feat(observer): add contradiction repair proposals

### DIFF
--- a/docs/architecture/package-public-api-1.0.13.csv
+++ b/docs/architecture/package-public-api-1.0.13.csv
@@ -824,6 +824,10 @@ zeromodel-observer,zeromodel.observer,ObserverComparisonRecipeDTO,zeromodel.obse
 zeromodel-observer,zeromodel.observer,ObserverComparisonResultDTO,zeromodel.observer,Class,zeromodel.observer.comparison,true
 zeromodel-observer,zeromodel.observer,ObserverContradictionArtifactDTO,zeromodel.observer,Class,zeromodel.observer.artifacts,true
 zeromodel-observer,zeromodel.observer,ObserverObservationArtifactDTO,zeromodel.observer,Class,zeromodel.observer.artifacts,true
+zeromodel-observer,zeromodel.observer,ObserverProposedChangeDTO,zeromodel.observer,Class,zeromodel.observer.repair,true
+zeromodel-observer,zeromodel.observer,ObserverRepairConstraintDTO,zeromodel.observer,Class,zeromodel.observer.repair,true
+zeromodel-observer,zeromodel.observer,ObserverRepairProposalDTO,zeromodel.observer,Class,zeromodel.observer.repair,true
+zeromodel-observer,zeromodel.observer,ObserverRepairProposalError,zeromodel.observer,Class,zeromodel.observer.repair,true
 zeromodel-observer,zeromodel.observer,ObserverReplacementPolicyArtifactDTO,zeromodel.observer,Class,zeromodel.observer.artifacts,true
 zeromodel-observer,zeromodel.observer,ObserverTransitionRecordDTO,zeromodel.observer,Class,zeromodel.observer.artifacts,true
 zeromodel-observer,zeromodel.observer,ObserverTransitionVerificationDTO,zeromodel.observer,Class,zeromodel.observer.transition_service,true
@@ -832,4 +836,5 @@ zeromodel-observer,zeromodel.observer,build_contradiction_artifact,zeromodel.obs
 zeromodel-observer,zeromodel.observer,build_replacement_policy_artifact,zeromodel.observer,Function,zeromodel.observer.artifacts,true
 zeromodel-observer,zeromodel.observer,build_transition_record,zeromodel.observer,Function,zeromodel.observer.artifacts,true
 zeromodel-observer,zeromodel.observer,compare_observer_transition,zeromodel.observer,Function,zeromodel.observer.comparison,true
+zeromodel-observer,zeromodel.observer,propose_observer_repair,zeromodel.observer,Function,zeromodel.observer.repair_service,true
 zeromodel-observer,zeromodel.observer,verify_observer_transition,zeromodel.observer,Function,zeromodel.observer.transition_service,true

--- a/packages/observer/README.md
+++ b/packages/observer/README.md
@@ -39,11 +39,16 @@ The top-level public surface is:
 - `ObserverReplacementPolicyArtifactDTO`
 - `ObserverTransitionVerificationDTO`
 - `ObserverTransitionVerificationError`
+- `ObserverRepairConstraintDTO`
+- `ObserverProposedChangeDTO`
+- `ObserverRepairProposalDTO`
+- `ObserverRepairProposalError`
 - `compare_observer_transition`
 - `build_transition_record`
 - `build_contradiction_artifact`
 - `build_replacement_policy_artifact`
 - `verify_observer_transition`
+- `propose_observer_repair`
 
 ## Stage O1 - Transition Verification
 
@@ -116,6 +121,65 @@ verification.verification_status
 verification.comparison_result
 verification.transition_record
 verification.contradiction_artifact
+```
+
+## Stage O2 - Bounded Repair Proposal
+
+Stage O2 converts a contradicted transition verification into a bounded repair
+proposal. It validates that a caller-supplied proposal is well-formed,
+traceable, and inside declared repair authority. It does not mutate a policy,
+verify a repair, create a replacement artifact, persist anything, or activate
+anything.
+
+`repairable` means eligible for the next stage of candidate generation and
+audit. It does not mean the proposed change is correct.
+
+```python
+from zeromodel.observer import (
+    ObserverProposedChangeDTO,
+    ObserverRepairConstraintDTO,
+    propose_observer_repair,
+)
+
+constraint = ObserverRepairConstraintDTO.create(
+    allowed_row_ids=("row:cooldown-sensitive",),
+    allowed_cell_ids=("row:cooldown-sensitive/action:move_right",),
+    allowed_context_keys=("hidden.cooldown",),
+    max_changed_rows=1,
+    max_changed_cells=1,
+    allow_action_value_change=True,
+    allow_new_context_precondition=True,
+)
+
+change = ObserverProposedChangeDTO.create(
+    target_kind="policy_cell",
+    target_id="row:cooldown-sensitive/action:move_right",
+    operation="replace",
+    field_name="action_value",
+    old_value="move_right",
+    proposed_value="wait",
+    condition_keys=("hidden.cooldown",),
+)
+
+proposal = propose_observer_repair(
+    verification=verification,
+    constraint=constraint,
+    available_policy_row_ids=("row:cooldown-sensitive",),
+    available_policy_cell_ids=("row:cooldown-sensitive/action:move_right",),
+    represented_context_keys=("hidden.cooldown",),
+    requested_changes=(change,),
+    rationale_codes=(
+        "action_effect_mismatch",
+        "affected_row_localised",
+        "repair_scope_bounded",
+    ),
+)
+
+proposal.disposition
+proposal.affected_row_ids
+proposal.required_context_keys
+proposal.missing_schema_keys
+proposal.proposed_changes
 ```
 
 ## Design Position

--- a/packages/observer/README.md
+++ b/packages/observer/README.md
@@ -133,6 +133,8 @@ anything.
 
 `repairable` means eligible for the next stage of candidate generation and
 audit. It does not mean the proposed change is correct.
+`requested_changes` records caller intent. `proposed_changes` contains only
+changes executable under the current schema and constraints.
 
 ```python
 from zeromodel.observer import (
@@ -179,6 +181,7 @@ proposal.disposition
 proposal.affected_row_ids
 proposal.required_context_keys
 proposal.missing_schema_keys
+proposal.requested_changes
 proposal.proposed_changes
 ```
 

--- a/packages/observer/src/zeromodel/observer/__init__.py
+++ b/packages/observer/src/zeromodel/observer/__init__.py
@@ -19,6 +19,13 @@ from zeromodel.observer.comparison import (
     ObserverComparisonResultDTO,
     compare_observer_transition,
 )
+from zeromodel.observer.repair import (
+    ObserverProposedChangeDTO,
+    ObserverRepairConstraintDTO,
+    ObserverRepairProposalDTO,
+    ObserverRepairProposalError,
+)
+from zeromodel.observer.repair_service import propose_observer_repair
 from zeromodel.observer.transition_service import (
     ObserverTransitionVerificationDTO,
     ObserverTransitionVerificationError,
@@ -30,6 +37,10 @@ __all__ = [
     "ObserverComparisonResultDTO",
     "ObserverContradictionArtifactDTO",
     "ObserverObservationArtifactDTO",
+    "ObserverProposedChangeDTO",
+    "ObserverRepairConstraintDTO",
+    "ObserverRepairProposalDTO",
+    "ObserverRepairProposalError",
     "ObserverReplacementPolicyArtifactDTO",
     "ObserverTransitionRecordDTO",
     "ObserverTransitionVerificationDTO",
@@ -38,5 +49,6 @@ __all__ = [
     "build_replacement_policy_artifact",
     "build_transition_record",
     "compare_observer_transition",
+    "propose_observer_repair",
     "verify_observer_transition",
 ]

--- a/packages/observer/src/zeromodel/observer/repair.py
+++ b/packages/observer/src/zeromodel/observer/repair.py
@@ -1,0 +1,371 @@
+"""Canonical DTOs for bounded Observer repair proposals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+from zeromodel.observer._canonical import canonical_id
+
+OBSERVER_REPAIR_CONSTRAINT_VERSION: Final = "observer-repair-constraint/1"
+OBSERVER_PROPOSED_CHANGE_VERSION: Final = "observer-proposed-change/1"
+OBSERVER_REPAIR_PROPOSAL_VERSION: Final = "observer-repair-proposal/1"
+
+REPAIR_DISPOSITION_REPAIRABLE: Final = "repairable"
+REPAIR_DISPOSITION_REQUIRES_SCHEMA_EXTENSION: Final = "requires_schema_extension"
+REPAIR_DISPOSITION_INSUFFICIENT_EVIDENCE: Final = "insufficient_evidence"
+REPAIR_DISPOSITION_UNSUPPORTED: Final = "unsupported"
+REPAIR_DISPOSITIONS: Final = frozenset(
+    {
+        REPAIR_DISPOSITION_REPAIRABLE,
+        REPAIR_DISPOSITION_REQUIRES_SCHEMA_EXTENSION,
+        REPAIR_DISPOSITION_INSUFFICIENT_EVIDENCE,
+        REPAIR_DISPOSITION_UNSUPPORTED,
+    }
+)
+
+CHANGE_TARGET_KINDS: Final = frozenset(
+    {
+        "policy_row",
+        "policy_cell",
+        "transition_prediction",
+        "context_precondition",
+    }
+)
+CHANGE_OPERATIONS: Final = frozenset(
+    {"replace", "add_precondition", "remove", "suspend"}
+)
+REPAIR_RATIONALE_CODES: Final = frozenset(
+    {
+        "transition_prediction_mismatch",
+        "action_effect_mismatch",
+        "observable_state_mismatch",
+        "policy_consequence_mismatch",
+        "hidden_state_exhausted",
+        "missing_required_context",
+        "affected_row_localised",
+        "repair_scope_bounded",
+        "unsupported_repair_type",
+    }
+)
+
+
+class ObserverRepairProposalError(ValueError):
+    """Raised when a bounded Observer repair proposal is invalid."""
+
+
+def _ensure_sorted_unique(values: tuple[str, ...], field_name: str) -> None:
+    if values != tuple(sorted(set(values))):
+        raise ObserverRepairProposalError(f"{field_name} must be unique and sorted")
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not value:
+        raise ObserverRepairProposalError(f"{field_name} must be non-empty")
+
+
+def _ensure_namespaced(keys: tuple[str, ...], field_name: str) -> None:
+    for key in keys:
+        if not key.startswith(("visible.", "history.", "hidden.")):
+            raise ObserverRepairProposalError(
+                f"{field_name} contains non-namespaced context key: {key!r}"
+            )
+
+
+@dataclass(frozen=True)
+class ObserverRepairConstraintDTO:
+    """Declared authority boundary for one repair proposal."""
+
+    repair_constraint_id: str
+    allowed_row_ids: tuple[str, ...]
+    allowed_cell_ids: tuple[str, ...]
+    allowed_context_keys: tuple[str, ...]
+    forbidden_row_ids: tuple[str, ...]
+    max_changed_rows: int
+    max_changed_cells: int
+    allow_action_value_change: bool
+    allow_transition_prediction_change: bool
+    allow_new_context_precondition: bool
+    allow_schema_extension_request: bool
+    version: str = OBSERVER_REPAIR_CONSTRAINT_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_REPAIR_CONSTRAINT_VERSION:
+            raise ObserverRepairProposalError("unsupported repair constraint version")
+        for field_name in (
+            "allowed_row_ids",
+            "allowed_cell_ids",
+            "allowed_context_keys",
+            "forbidden_row_ids",
+        ):
+            _ensure_sorted_unique(getattr(self, field_name), field_name)
+        _ensure_namespaced(self.allowed_context_keys, "allowed_context_keys")
+        if self.max_changed_rows < 0:
+            raise ObserverRepairProposalError("max_changed_rows must be non-negative")
+        if self.max_changed_cells < 0:
+            raise ObserverRepairProposalError("max_changed_cells must be non-negative")
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.repair_constraint_id != expected_id:
+            raise ObserverRepairProposalError(
+                "repair_constraint_id disagrees with canonical payload"
+            )
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "allow_action_value_change": self.allow_action_value_change,
+            "allow_new_context_precondition": self.allow_new_context_precondition,
+            "allow_schema_extension_request": self.allow_schema_extension_request,
+            "allow_transition_prediction_change": (
+                self.allow_transition_prediction_change
+            ),
+            "allowed_cell_ids": list(self.allowed_cell_ids),
+            "allowed_context_keys": list(self.allowed_context_keys),
+            "allowed_row_ids": list(self.allowed_row_ids),
+            "forbidden_row_ids": list(self.forbidden_row_ids),
+            "max_changed_cells": self.max_changed_cells,
+            "max_changed_rows": self.max_changed_rows,
+            "version": self.version,
+        }
+        if include_id:
+            payload["repair_constraint_id"] = self.repair_constraint_id
+        return payload
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        allowed_row_ids: tuple[str, ...],
+        allowed_cell_ids: tuple[str, ...],
+        allowed_context_keys: tuple[str, ...] = (),
+        forbidden_row_ids: tuple[str, ...] = (),
+        max_changed_rows: int = 0,
+        max_changed_cells: int = 0,
+        allow_action_value_change: bool = False,
+        allow_transition_prediction_change: bool = False,
+        allow_new_context_precondition: bool = False,
+        allow_schema_extension_request: bool = False,
+    ) -> "ObserverRepairConstraintDTO":
+        payload = {
+            "allow_action_value_change": allow_action_value_change,
+            "allow_new_context_precondition": allow_new_context_precondition,
+            "allow_schema_extension_request": allow_schema_extension_request,
+            "allow_transition_prediction_change": allow_transition_prediction_change,
+            "allowed_cell_ids": list(allowed_cell_ids),
+            "allowed_context_keys": list(allowed_context_keys),
+            "allowed_row_ids": list(allowed_row_ids),
+            "forbidden_row_ids": list(forbidden_row_ids),
+            "max_changed_cells": max_changed_cells,
+            "max_changed_rows": max_changed_rows,
+            "version": OBSERVER_REPAIR_CONSTRAINT_VERSION,
+        }
+        return cls(
+            repair_constraint_id=canonical_id(payload),
+            allowed_row_ids=allowed_row_ids,
+            allowed_cell_ids=allowed_cell_ids,
+            allowed_context_keys=allowed_context_keys,
+            forbidden_row_ids=forbidden_row_ids,
+            max_changed_rows=max_changed_rows,
+            max_changed_cells=max_changed_cells,
+            allow_action_value_change=allow_action_value_change,
+            allow_transition_prediction_change=allow_transition_prediction_change,
+            allow_new_context_precondition=allow_new_context_precondition,
+            allow_schema_extension_request=allow_schema_extension_request,
+        )
+
+
+@dataclass(frozen=True)
+class ObserverProposedChangeDTO:
+    """One explicit requested change within a bounded repair proposal."""
+
+    change_id: str
+    target_kind: str
+    target_id: str
+    operation: str
+    field_name: str
+    old_value: object | None
+    proposed_value: object | None
+    condition_keys: tuple[str, ...]
+    evidence_ids: tuple[str, ...]
+    version: str = OBSERVER_PROPOSED_CHANGE_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_PROPOSED_CHANGE_VERSION:
+            raise ObserverRepairProposalError("unsupported proposed change version")
+        if self.target_kind not in CHANGE_TARGET_KINDS:
+            raise ObserverRepairProposalError(
+                f"unsupported proposed change target_kind: {self.target_kind!r}"
+            )
+        if self.operation not in CHANGE_OPERATIONS:
+            raise ObserverRepairProposalError(
+                f"unsupported proposed change operation: {self.operation!r}"
+            )
+        for field_name in ("target_id", "field_name"):
+            _require_non_empty(getattr(self, field_name), field_name)
+        _ensure_sorted_unique(self.condition_keys, "condition_keys")
+        _ensure_sorted_unique(self.evidence_ids, "evidence_ids")
+        _ensure_namespaced(self.condition_keys, "condition_keys")
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.change_id != expected_id:
+            raise ObserverRepairProposalError(
+                "change_id disagrees with canonical payload"
+            )
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "condition_keys": list(self.condition_keys),
+            "evidence_ids": list(self.evidence_ids),
+            "field_name": self.field_name,
+            "old_value": self.old_value,
+            "operation": self.operation,
+            "proposed_value": self.proposed_value,
+            "target_id": self.target_id,
+            "target_kind": self.target_kind,
+            "version": self.version,
+        }
+        if include_id:
+            payload["change_id"] = self.change_id
+        return payload
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        target_kind: str,
+        target_id: str,
+        operation: str,
+        field_name: str,
+        old_value: object | None = None,
+        proposed_value: object | None = None,
+        condition_keys: tuple[str, ...] = (),
+        evidence_ids: tuple[str, ...] = (),
+    ) -> "ObserverProposedChangeDTO":
+        payload = {
+            "condition_keys": list(condition_keys),
+            "evidence_ids": list(evidence_ids),
+            "field_name": field_name,
+            "old_value": old_value,
+            "operation": operation,
+            "proposed_value": proposed_value,
+            "target_id": target_id,
+            "target_kind": target_kind,
+            "version": OBSERVER_PROPOSED_CHANGE_VERSION,
+        }
+        return cls(
+            change_id=canonical_id(payload),
+            target_kind=target_kind,
+            target_id=target_id,
+            operation=operation,
+            field_name=field_name,
+            old_value=old_value,
+            proposed_value=proposed_value,
+            condition_keys=condition_keys,
+            evidence_ids=evidence_ids,
+        )
+
+
+@dataclass(frozen=True)
+class ObserverRepairProposalDTO:
+    """Canonical bounded repair proposal derived from a verified contradiction."""
+
+    repair_proposal_id: str
+    source_policy_artifact_id: str
+    transition_verification_id: str
+    contradiction_artifact_id: str
+    repair_constraint_id: str
+    disposition: str
+    affected_row_ids: tuple[str, ...]
+    affected_cell_ids: tuple[str, ...]
+    required_context_keys: tuple[str, ...]
+    missing_schema_keys: tuple[str, ...]
+    proposed_changes: tuple[ObserverProposedChangeDTO, ...]
+    rationale_codes: tuple[str, ...]
+    evidence_ids: tuple[str, ...]
+    version: str = OBSERVER_REPAIR_PROPOSAL_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_REPAIR_PROPOSAL_VERSION:
+            raise ObserverRepairProposalError("unsupported repair proposal version")
+        if self.disposition not in REPAIR_DISPOSITIONS:
+            raise ObserverRepairProposalError(
+                f"unsupported repair disposition: {self.disposition!r}"
+            )
+        for field_name in (
+            "source_policy_artifact_id",
+            "transition_verification_id",
+            "contradiction_artifact_id",
+            "repair_constraint_id",
+        ):
+            _require_non_empty(getattr(self, field_name), field_name)
+        for field_name in (
+            "affected_row_ids",
+            "affected_cell_ids",
+            "required_context_keys",
+            "missing_schema_keys",
+            "rationale_codes",
+            "evidence_ids",
+        ):
+            _ensure_sorted_unique(getattr(self, field_name), field_name)
+        _ensure_namespaced(self.required_context_keys, "required_context_keys")
+        _ensure_namespaced(self.missing_schema_keys, "missing_schema_keys")
+        unknown_rationales = set(self.rationale_codes) - REPAIR_RATIONALE_CODES
+        if unknown_rationales:
+            raise ObserverRepairProposalError(
+                f"unsupported rationale_codes: {sorted(unknown_rationales)}"
+            )
+        change_ids = tuple(change.change_id for change in self.proposed_changes)
+        if change_ids != tuple(sorted(set(change_ids))):
+            raise ObserverRepairProposalError(
+                "proposed_changes must have unique change IDs in sorted order"
+            )
+        if (
+            self.disposition == REPAIR_DISPOSITION_REPAIRABLE
+            and self.missing_schema_keys
+        ):
+            raise ObserverRepairProposalError(
+                "repairable proposals cannot have missing_schema_keys"
+            )
+        if (
+            self.disposition == REPAIR_DISPOSITION_REQUIRES_SCHEMA_EXTENSION
+            and not self.missing_schema_keys
+        ):
+            raise ObserverRepairProposalError(
+                "requires_schema_extension proposals require missing_schema_keys"
+            )
+        if (
+            self.disposition
+            in {
+                REPAIR_DISPOSITION_INSUFFICIENT_EVIDENCE,
+                REPAIR_DISPOSITION_UNSUPPORTED,
+            }
+            and self.proposed_changes
+        ):
+            raise ObserverRepairProposalError(
+                f"{self.disposition} proposals cannot contain executable changes"
+            )
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.repair_proposal_id != expected_id:
+            raise ObserverRepairProposalError(
+                "repair_proposal_id disagrees with canonical payload"
+            )
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "affected_cell_ids": list(self.affected_cell_ids),
+            "affected_row_ids": list(self.affected_row_ids),
+            "contradiction_artifact_id": self.contradiction_artifact_id,
+            "disposition": self.disposition,
+            "evidence_ids": list(self.evidence_ids),
+            "missing_schema_keys": list(self.missing_schema_keys),
+            "proposed_changes": [
+                change.canonical_payload() for change in self.proposed_changes
+            ],
+            "rationale_codes": list(self.rationale_codes),
+            "repair_constraint_id": self.repair_constraint_id,
+            "required_context_keys": list(self.required_context_keys),
+            "source_policy_artifact_id": self.source_policy_artifact_id,
+            "transition_verification_id": self.transition_verification_id,
+            "version": self.version,
+        }
+        if include_id:
+            payload["repair_proposal_id"] = self.repair_proposal_id
+        return payload

--- a/packages/observer/src/zeromodel/observer/repair.py
+++ b/packages/observer/src/zeromodel/observer/repair.py
@@ -9,7 +9,7 @@ from zeromodel.observer._canonical import canonical_id
 
 OBSERVER_REPAIR_CONSTRAINT_VERSION: Final = "observer-repair-constraint/1"
 OBSERVER_PROPOSED_CHANGE_VERSION: Final = "observer-proposed-change/1"
-OBSERVER_REPAIR_PROPOSAL_VERSION: Final = "observer-repair-proposal/1"
+OBSERVER_REPAIR_PROPOSAL_VERSION: Final = "observer-repair-proposal/2"
 
 REPAIR_DISPOSITION_REPAIRABLE: Final = "repairable"
 REPAIR_DISPOSITION_REQUIRES_SCHEMA_EXTENSION: Final = "requires_schema_extension"
@@ -277,6 +277,7 @@ class ObserverRepairProposalDTO:
     affected_cell_ids: tuple[str, ...]
     required_context_keys: tuple[str, ...]
     missing_schema_keys: tuple[str, ...]
+    requested_changes: tuple[ObserverProposedChangeDTO, ...]
     proposed_changes: tuple[ObserverProposedChangeDTO, ...]
     rationale_codes: tuple[str, ...]
     evidence_ids: tuple[str, ...]
@@ -312,11 +313,12 @@ class ObserverRepairProposalDTO:
             raise ObserverRepairProposalError(
                 f"unsupported rationale_codes: {sorted(unknown_rationales)}"
             )
-        change_ids = tuple(change.change_id for change in self.proposed_changes)
-        if change_ids != tuple(sorted(set(change_ids))):
-            raise ObserverRepairProposalError(
-                "proposed_changes must have unique change IDs in sorted order"
-            )
+        for field_name in ("requested_changes", "proposed_changes"):
+            change_ids = tuple(change.change_id for change in getattr(self, field_name))
+            if change_ids != tuple(sorted(set(change_ids))):
+                raise ObserverRepairProposalError(
+                    f"{field_name} must have unique change IDs in sorted order"
+                )
         if (
             self.disposition == REPAIR_DISPOSITION_REPAIRABLE
             and self.missing_schema_keys
@@ -331,14 +333,7 @@ class ObserverRepairProposalDTO:
             raise ObserverRepairProposalError(
                 "requires_schema_extension proposals require missing_schema_keys"
             )
-        if (
-            self.disposition
-            in {
-                REPAIR_DISPOSITION_INSUFFICIENT_EVIDENCE,
-                REPAIR_DISPOSITION_UNSUPPORTED,
-            }
-            and self.proposed_changes
-        ):
+        if self.disposition != REPAIR_DISPOSITION_REPAIRABLE and self.proposed_changes:
             raise ObserverRepairProposalError(
                 f"{self.disposition} proposals cannot contain executable changes"
             )
@@ -361,6 +356,9 @@ class ObserverRepairProposalDTO:
             ],
             "rationale_codes": list(self.rationale_codes),
             "repair_constraint_id": self.repair_constraint_id,
+            "requested_changes": [
+                change.canonical_payload() for change in self.requested_changes
+            ],
             "required_context_keys": list(self.required_context_keys),
             "source_policy_artifact_id": self.source_policy_artifact_id,
             "transition_verification_id": self.transition_verification_id,

--- a/packages/observer/src/zeromodel/observer/repair_service.py
+++ b/packages/observer/src/zeromodel/observer/repair_service.py
@@ -1,0 +1,328 @@
+"""Application service for bounded Observer repair proposals."""
+
+from __future__ import annotations
+
+from zeromodel.observer._canonical import canonical_id
+from zeromodel.observer.repair import (
+    REPAIR_DISPOSITION_INSUFFICIENT_EVIDENCE,
+    REPAIR_DISPOSITION_REPAIRABLE,
+    REPAIR_DISPOSITION_REQUIRES_SCHEMA_EXTENSION,
+    REPAIR_DISPOSITION_UNSUPPORTED,
+    ObserverProposedChangeDTO,
+    ObserverRepairConstraintDTO,
+    ObserverRepairProposalDTO,
+    ObserverRepairProposalError,
+)
+from zeromodel.observer.transition_service import (
+    OBSERVER_VERIFICATION_CONTRADICTED,
+    ObserverTransitionVerificationDTO,
+)
+
+
+def _ensure_sorted_unique(values: tuple[str, ...], field_name: str) -> None:
+    if values != tuple(sorted(set(values))):
+        raise ObserverRepairProposalError(f"{field_name} must be unique and sorted")
+
+
+def _ensure_namespaced(keys: tuple[str, ...], field_name: str) -> None:
+    for key in keys:
+        if not key.startswith(("visible.", "history.", "hidden.")):
+            raise ObserverRepairProposalError(
+                f"{field_name} contains non-namespaced context key: {key!r}"
+            )
+
+
+def _row_for_cell(cell_id: str, available_policy_row_ids: tuple[str, ...]) -> str:
+    matches = tuple(
+        row_id
+        for row_id in available_policy_row_ids
+        if cell_id == row_id or cell_id.startswith(f"{row_id}/")
+    )
+    if not matches:
+        raise ObserverRepairProposalError(
+            f"policy cell {cell_id!r} does not identify an available policy row"
+        )
+    return max(matches, key=len)
+
+
+def _change_row_ids(
+    changes: tuple[ObserverProposedChangeDTO, ...],
+    available_policy_row_ids: tuple[str, ...],
+) -> tuple[str, ...]:
+    rows: set[str] = set()
+    for change in changes:
+        if change.target_kind == "policy_row":
+            rows.add(change.target_id)
+        elif change.target_kind == "context_precondition":
+            rows.add(change.target_id)
+        elif change.target_kind in {"policy_cell", "transition_prediction"}:
+            rows.add(_row_for_cell(change.target_id, available_policy_row_ids))
+    return tuple(sorted(rows))
+
+
+def _change_cell_ids(changes: tuple[ObserverProposedChangeDTO, ...]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                change.target_id
+                for change in changes
+                if change.target_kind in {"policy_cell", "transition_prediction"}
+            }
+        )
+    )
+
+
+def _required_context_keys(
+    changes: tuple[ObserverProposedChangeDTO, ...],
+) -> tuple[str, ...]:
+    return tuple(sorted({key for change in changes for key in change.condition_keys}))
+
+
+def _validate_preconditions(verification: ObserverTransitionVerificationDTO) -> None:
+    if verification.verification_status != OBSERVER_VERIFICATION_CONTRADICTED:
+        raise ObserverRepairProposalError(
+            "repair proposals require a contradicted transition verification"
+        )
+    if verification.contradiction_artifact is None:
+        raise ObserverRepairProposalError(
+            "contradicted transition verification is missing a contradiction artifact"
+        )
+    contradiction = verification.contradiction_artifact
+    if (
+        contradiction.transition_record_id
+        != verification.transition_record.transition_record_id
+    ):
+        raise ObserverRepairProposalError(
+            "contradiction artifact does not reference the verification transition record"
+        )
+    if (
+        contradiction.comparison_result_id
+        != verification.comparison_result.comparison_result_id
+    ):
+        raise ObserverRepairProposalError(
+            "contradiction artifact does not reference the verification comparison result"
+        )
+    if (
+        contradiction.source_policy_artifact_id
+        != verification.transition_record.policy_artifact_id
+    ):
+        raise ObserverRepairProposalError(
+            "contradiction source policy does not match transition record policy"
+        )
+
+
+def _validate_change_scope(
+    *,
+    changes: tuple[ObserverProposedChangeDTO, ...],
+    constraint: ObserverRepairConstraintDTO,
+    available_policy_row_ids: tuple[str, ...],
+    available_policy_cell_ids: tuple[str, ...],
+    affected_row_ids: tuple[str, ...],
+    affected_cell_ids: tuple[str, ...],
+) -> None:
+    allowed_rows = set(constraint.allowed_row_ids)
+    allowed_cells = set(constraint.allowed_cell_ids)
+    available_rows = set(available_policy_row_ids)
+    available_cells = set(available_policy_cell_ids)
+    forbidden_rows = set(constraint.forbidden_row_ids)
+
+    unknown_rows = set(affected_row_ids) - available_rows
+    if unknown_rows:
+        raise ObserverRepairProposalError(
+            f"proposed target rows are not available: {sorted(unknown_rows)}"
+        )
+    unknown_cells = set(affected_cell_ids) - available_cells
+    if unknown_cells:
+        raise ObserverRepairProposalError(
+            f"proposed target cells are not available: {sorted(unknown_cells)}"
+        )
+    outside_rows = set(affected_row_ids) - allowed_rows
+    if outside_rows:
+        raise ObserverRepairProposalError(
+            f"proposed target rows are outside allowed_row_ids: {sorted(outside_rows)}"
+        )
+    outside_cells = set(affected_cell_ids) - allowed_cells
+    if outside_cells:
+        raise ObserverRepairProposalError(
+            f"proposed target cells are outside allowed_cell_ids: {sorted(outside_cells)}"
+        )
+    forbidden_hits = set(affected_row_ids) & forbidden_rows
+    if forbidden_hits:
+        raise ObserverRepairProposalError(
+            f"proposed target rows are forbidden: {sorted(forbidden_hits)}"
+        )
+    if len(affected_row_ids) > constraint.max_changed_rows:
+        raise ObserverRepairProposalError(
+            "proposed change exceeds max_changed_rows "
+            f"({len(affected_row_ids)} > {constraint.max_changed_rows})"
+        )
+    if len(affected_cell_ids) > constraint.max_changed_cells:
+        raise ObserverRepairProposalError(
+            "proposed change exceeds max_changed_cells "
+            f"({len(affected_cell_ids)} > {constraint.max_changed_cells})"
+        )
+    for change in changes:
+        if (
+            change.field_name == "action_value"
+            and not constraint.allow_action_value_change
+        ):
+            raise ObserverRepairProposalError(
+                "action-value changes are not permitted by the repair constraint"
+            )
+        if (
+            change.target_kind == "transition_prediction"
+            or change.field_name == "transition_prediction"
+        ) and not constraint.allow_transition_prediction_change:
+            raise ObserverRepairProposalError(
+                "transition-prediction changes are not permitted by the repair constraint"
+            )
+        if (
+            change.target_kind == "context_precondition"
+            or change.operation == "add_precondition"
+            or change.condition_keys
+        ) and not constraint.allow_new_context_precondition:
+            raise ObserverRepairProposalError(
+                "new context preconditions are not permitted by the repair constraint"
+            )
+
+
+def _derive_disposition(
+    *,
+    requested_changes: tuple[ObserverProposedChangeDTO, ...],
+    missing_schema_keys: tuple[str, ...],
+    rationale_codes: tuple[str, ...],
+) -> str:
+    if missing_schema_keys:
+        return REPAIR_DISPOSITION_REQUIRES_SCHEMA_EXTENSION
+    if "unsupported_repair_type" in rationale_codes:
+        return REPAIR_DISPOSITION_UNSUPPORTED
+    if not requested_changes:
+        return REPAIR_DISPOSITION_INSUFFICIENT_EVIDENCE
+    return REPAIR_DISPOSITION_REPAIRABLE
+
+
+def propose_observer_repair(
+    *,
+    verification: ObserverTransitionVerificationDTO,
+    constraint: ObserverRepairConstraintDTO,
+    available_policy_row_ids: tuple[str, ...],
+    available_policy_cell_ids: tuple[str, ...],
+    represented_context_keys: tuple[str, ...],
+    requested_changes: tuple[ObserverProposedChangeDTO, ...] = (),
+    missing_schema_keys: tuple[str, ...] = (),
+    rationale_codes: tuple[str, ...] = (),
+    evidence_ids: tuple[str, ...] = (),
+) -> ObserverRepairProposalDTO:
+    """Validate and canonicalize a bounded repair proposal.
+
+    `repairable` means the proposal is well-formed and eligible for later
+    candidate generation. It does not mean the policy has been repaired.
+    """
+
+    _ensure_sorted_unique(available_policy_row_ids, "available_policy_row_ids")
+    _ensure_sorted_unique(available_policy_cell_ids, "available_policy_cell_ids")
+    _ensure_sorted_unique(represented_context_keys, "represented_context_keys")
+    _ensure_sorted_unique(missing_schema_keys, "missing_schema_keys")
+    _ensure_sorted_unique(rationale_codes, "rationale_codes")
+    _ensure_sorted_unique(evidence_ids, "evidence_ids")
+    _ensure_namespaced(represented_context_keys, "represented_context_keys")
+    _ensure_namespaced(missing_schema_keys, "missing_schema_keys")
+    _validate_preconditions(verification)
+    requested_changes = tuple(
+        sorted(requested_changes, key=lambda item: item.change_id)
+    )
+
+    contradiction = verification.contradiction_artifact
+    assert contradiction is not None
+    source_policy_artifact_id = contradiction.source_policy_artifact_id
+    if source_policy_artifact_id != verification.transition_record.policy_artifact_id:
+        raise ObserverRepairProposalError(
+            "source policy identity does not match verification transition record"
+        )
+
+    required_context_keys = _required_context_keys(requested_changes)
+    _ensure_namespaced(required_context_keys, "required_context_keys")
+    missing_from_schema = tuple(
+        sorted(set(required_context_keys) - set(represented_context_keys))
+    )
+    effective_missing_schema_keys = tuple(
+        sorted(set(missing_schema_keys) | set(missing_from_schema))
+    )
+    if effective_missing_schema_keys and not constraint.allow_schema_extension_request:
+        raise ObserverRepairProposalError(
+            "repair requires schema extension but constraint does not permit schema-extension requests"
+        )
+
+    affected_row_ids = _change_row_ids(requested_changes, available_policy_row_ids)
+    affected_cell_ids = _change_cell_ids(requested_changes)
+    if (
+        requested_changes
+        and contradiction.affected_policy_row_id not in affected_row_ids
+    ):
+        raise ObserverRepairProposalError(
+            "requested changes must stay within the contradiction's affected policy row"
+        )
+    _validate_change_scope(
+        changes=requested_changes,
+        constraint=constraint,
+        available_policy_row_ids=available_policy_row_ids,
+        available_policy_cell_ids=available_policy_cell_ids,
+        affected_row_ids=affected_row_ids,
+        affected_cell_ids=affected_cell_ids,
+    )
+
+    disposition = _derive_disposition(
+        requested_changes=requested_changes,
+        missing_schema_keys=effective_missing_schema_keys,
+        rationale_codes=rationale_codes,
+    )
+    executable_changes = (
+        ()
+        if disposition
+        in {REPAIR_DISPOSITION_INSUFFICIENT_EVIDENCE, REPAIR_DISPOSITION_UNSUPPORTED}
+        else requested_changes
+    )
+    if disposition == REPAIR_DISPOSITION_REQUIRES_SCHEMA_EXTENSION:
+        executable_changes = requested_changes
+
+    mandatory_evidence_ids = (
+        verification.verification_id,
+        verification.comparison_result.comparison_result_id,
+        verification.transition_record.transition_record_id,
+        contradiction.contradiction_artifact_id,
+    )
+    proposal_evidence_ids = tuple(
+        sorted(set(evidence_ids) | set(mandatory_evidence_ids))
+    )
+    payload = {
+        "affected_cell_ids": list(affected_cell_ids),
+        "affected_row_ids": list(affected_row_ids),
+        "contradiction_artifact_id": contradiction.contradiction_artifact_id,
+        "disposition": disposition,
+        "evidence_ids": list(proposal_evidence_ids),
+        "missing_schema_keys": list(effective_missing_schema_keys),
+        "proposed_changes": [
+            change.canonical_payload() for change in executable_changes
+        ],
+        "rationale_codes": list(rationale_codes),
+        "repair_constraint_id": constraint.repair_constraint_id,
+        "required_context_keys": list(required_context_keys),
+        "source_policy_artifact_id": source_policy_artifact_id,
+        "transition_verification_id": verification.verification_id,
+        "version": "observer-repair-proposal/1",
+    }
+    return ObserverRepairProposalDTO(
+        repair_proposal_id=canonical_id(payload),
+        source_policy_artifact_id=source_policy_artifact_id,
+        transition_verification_id=verification.verification_id,
+        contradiction_artifact_id=contradiction.contradiction_artifact_id,
+        repair_constraint_id=constraint.repair_constraint_id,
+        disposition=disposition,
+        affected_row_ids=affected_row_ids,
+        affected_cell_ids=affected_cell_ids,
+        required_context_keys=required_context_keys,
+        missing_schema_keys=effective_missing_schema_keys,
+        proposed_changes=executable_changes,
+        rationale_codes=rationale_codes,
+        evidence_ids=proposal_evidence_ids,
+    )

--- a/packages/observer/src/zeromodel/observer/repair_service.py
+++ b/packages/observer/src/zeromodel/observer/repair_service.py
@@ -277,13 +277,8 @@ def propose_observer_repair(
         rationale_codes=rationale_codes,
     )
     executable_changes = (
-        ()
-        if disposition
-        in {REPAIR_DISPOSITION_INSUFFICIENT_EVIDENCE, REPAIR_DISPOSITION_UNSUPPORTED}
-        else requested_changes
+        requested_changes if disposition == REPAIR_DISPOSITION_REPAIRABLE else ()
     )
-    if disposition == REPAIR_DISPOSITION_REQUIRES_SCHEMA_EXTENSION:
-        executable_changes = requested_changes
 
     mandatory_evidence_ids = (
         verification.verification_id,
@@ -306,10 +301,13 @@ def propose_observer_repair(
         ],
         "rationale_codes": list(rationale_codes),
         "repair_constraint_id": constraint.repair_constraint_id,
+        "requested_changes": [
+            change.canonical_payload() for change in requested_changes
+        ],
         "required_context_keys": list(required_context_keys),
         "source_policy_artifact_id": source_policy_artifact_id,
         "transition_verification_id": verification.verification_id,
-        "version": "observer-repair-proposal/1",
+        "version": "observer-repair-proposal/2",
     }
     return ObserverRepairProposalDTO(
         repair_proposal_id=canonical_id(payload),
@@ -322,6 +320,7 @@ def propose_observer_repair(
         affected_cell_ids=affected_cell_ids,
         required_context_keys=required_context_keys,
         missing_schema_keys=effective_missing_schema_keys,
+        requested_changes=requested_changes,
         proposed_changes=executable_changes,
         rationale_codes=rationale_codes,
         evidence_ids=proposal_evidence_ids,

--- a/packages/observer/tests/test_repair_service.py
+++ b/packages/observer/tests/test_repair_service.py
@@ -226,6 +226,7 @@ def test_locally_repairable_cooldown_proposal_replays() -> None:
     assert first.affected_cell_ids == (CELL_ID,)
     assert first.required_context_keys == ("hidden.cooldown",)
     assert first.missing_schema_keys == ()
+    assert first.requested_changes == (change,)
     assert len(first.proposed_changes) == 1
     assert not hasattr(first, "replacement_policy_artifact_id")
     assert first.repair_proposal_id == second.repair_proposal_id
@@ -247,7 +248,8 @@ def test_requires_schema_extension_preserves_blocking_key() -> None:
 
     assert proposal.disposition == "requires_schema_extension"
     assert proposal.missing_schema_keys == ("hidden.actuator_mode",)
-    assert proposal.proposed_changes == (change,)
+    assert proposal.requested_changes == (change,)
+    assert proposal.proposed_changes == ()
     assert not hasattr(proposal, "replacement_policy_artifact_id")
 
 
@@ -261,6 +263,7 @@ def test_insufficient_evidence_has_no_executable_changes() -> None:
     )
 
     assert proposal.disposition == "insufficient_evidence"
+    assert proposal.requested_changes == ()
     assert proposal.proposed_changes == ()
     assert verification.contradiction_artifact.contradiction_artifact_id in (
         proposal.evidence_ids
@@ -327,6 +330,7 @@ def test_unsupported_repair_type_is_reported_without_changes() -> None:
     )
 
     assert proposal.disposition == "unsupported"
+    assert proposal.requested_changes == ()
     assert proposal.proposed_changes == ()
 
 
@@ -413,6 +417,9 @@ def test_replay_identity_canonicalizes_change_order() -> None:
     assert left.repair_constraint_id == right.repair_constraint_id
     assert tuple(change.change_id for change in left.proposed_changes) == tuple(
         change.change_id for change in right.proposed_changes
+    )
+    assert tuple(change.change_id for change in left.requested_changes) == tuple(
+        change.change_id for change in right.requested_changes
     )
     assert left.repair_proposal_id == right.repair_proposal_id
 

--- a/packages/observer/tests/test_repair_service.py
+++ b/packages/observer/tests/test_repair_service.py
@@ -1,0 +1,431 @@
+import pytest
+
+from zeromodel.observer import (
+    ObserverComparisonRecipeDTO,
+    ObserverObservationArtifactDTO,
+    ObserverProposedChangeDTO,
+    ObserverRepairConstraintDTO,
+    ObserverRepairProposalError,
+    propose_observer_repair,
+    verify_observer_transition,
+)
+
+
+ROW_ID = "row:cooldown-sensitive"
+CELL_ID = f"{ROW_ID}/action:move_right"
+
+
+def observation(
+    *,
+    sequence_index: int = 1,
+    visible: dict[str, object],
+    hidden: dict[str, object] | None = None,
+) -> ObserverObservationArtifactDTO:
+    return ObserverObservationArtifactDTO.create(
+        visible_state_features=visible,
+        hidden_state_uncertainty=hidden or {},
+        provenance={"fixture": "stage-o2"},
+        sequence_index=sequence_index,
+    )
+
+
+def cooldown_recipe() -> ObserverComparisonRecipeDTO:
+    return ObserverComparisonRecipeDTO.create(
+        observable_feature_keys=("visible.agent_x", "visible.target_x"),
+        action_effect_keys=("visible.action_effect",),
+        policy_consequence_key="visible.next_action",
+        hidden_state_keys=("hidden.cooldown",),
+        wake_on_policy_consequence_mismatch=True,
+    )
+
+
+def contradicted_verification():
+    predicted = observation(
+        visible={
+            "agent_x": 5,
+            "target_x": 9,
+            "action_effect": "moved_right",
+            "next_action": "move_right",
+        },
+        hidden={"cooldown": "clear"},
+    )
+    observed = observation(
+        visible={
+            "agent_x": 4,
+            "target_x": 9,
+            "action_effect": "blocked_by_cooldown",
+            "next_action": "wait",
+        },
+        hidden={"cooldown": "active"},
+    )
+    return verify_observer_transition(
+        recipe=cooldown_recipe(),
+        predicted_observation=predicted,
+        observed_observation=observed,
+        policy_artifact_id="policy:A",
+        state_before_id="state:before",
+        action="move_right",
+        affected_policy_row_id=ROW_ID,
+        predicted_decision_margin=0.30,
+        observed_decision_margin=0.12,
+        hidden_state_hypotheses_remaining=1,
+        reproduction={"episode_id": "episode:1", "step": 7},
+        relevant_context_keys=("hidden.cooldown",),
+    )
+
+
+def confirmed_verification():
+    predicted = observation(
+        visible={
+            "agent_x": 5,
+            "target_x": 9,
+            "action_effect": "moved_right",
+            "next_action": "move_right",
+        },
+        hidden={"cooldown": "clear"},
+    )
+    observed = observation(
+        visible={
+            "agent_x": 5,
+            "target_x": 9,
+            "action_effect": "moved_right",
+            "next_action": "move_right",
+        },
+        hidden={"cooldown": "clear"},
+    )
+    return verify_observer_transition(
+        recipe=cooldown_recipe(),
+        predicted_observation=predicted,
+        observed_observation=observed,
+        policy_artifact_id="policy:A",
+        state_before_id="state:before",
+        action="move_right",
+        affected_policy_row_id=ROW_ID,
+        predicted_decision_margin=0.30,
+        observed_decision_margin=0.30,
+        hidden_state_hypotheses_remaining=1,
+    )
+
+
+def inconclusive_verification():
+    predicted = observation(
+        visible={"agent_x": 5, "target_x": 9, "action_effect": "moved_right"},
+        hidden={"cooldown": "clear"},
+    )
+    observed = observation(
+        visible={"agent_x": 5, "target_x": 9},
+        hidden={"cooldown": "clear"},
+    )
+    return verify_observer_transition(
+        recipe=cooldown_recipe(),
+        predicted_observation=predicted,
+        observed_observation=observed,
+        policy_artifact_id="policy:A",
+        state_before_id="state:before",
+        action="move_right",
+        affected_policy_row_id=ROW_ID,
+        predicted_decision_margin=0.30,
+        observed_decision_margin=0.30,
+        hidden_state_hypotheses_remaining=1,
+    )
+
+
+def repair_constraint(
+    *,
+    allowed_rows: tuple[str, ...] = (ROW_ID,),
+    allowed_cells: tuple[str, ...] = (CELL_ID,),
+    forbidden_rows: tuple[str, ...] = (),
+    max_rows: int = 1,
+    max_cells: int = 1,
+    allow_schema: bool = True,
+) -> ObserverRepairConstraintDTO:
+    return ObserverRepairConstraintDTO.create(
+        allowed_row_ids=allowed_rows,
+        allowed_cell_ids=allowed_cells,
+        allowed_context_keys=("hidden.actuator_mode", "hidden.cooldown"),
+        forbidden_row_ids=forbidden_rows,
+        max_changed_rows=max_rows,
+        max_changed_cells=max_cells,
+        allow_action_value_change=True,
+        allow_new_context_precondition=True,
+        allow_schema_extension_request=allow_schema,
+    )
+
+
+def cooldown_change(
+    *,
+    target_id: str = CELL_ID,
+    condition_keys: tuple[str, ...] = ("hidden.cooldown",),
+    proposed_value: object = "wait",
+    evidence_ids: tuple[str, ...] = (),
+) -> ObserverProposedChangeDTO:
+    return ObserverProposedChangeDTO.create(
+        target_kind="policy_cell",
+        target_id=target_id,
+        operation="replace",
+        field_name="action_value",
+        old_value="move_right",
+        proposed_value=proposed_value,
+        condition_keys=condition_keys,
+        evidence_ids=evidence_ids,
+    )
+
+
+def propose(
+    *,
+    verification=None,
+    constraint=None,
+    changes: tuple[ObserverProposedChangeDTO, ...] = (),
+    represented_context_keys: tuple[str, ...] = (
+        "hidden.cooldown",
+        "visible.agent_x",
+        "visible.target_x",
+    ),
+    missing_schema_keys: tuple[str, ...] = (),
+    rationale_codes: tuple[str, ...] = (
+        "action_effect_mismatch",
+        "affected_row_localised",
+        "repair_scope_bounded",
+    ),
+    evidence_ids: tuple[str, ...] = (),
+):
+    return propose_observer_repair(
+        verification=verification or contradicted_verification(),
+        constraint=constraint or repair_constraint(),
+        available_policy_row_ids=(ROW_ID, "row:other"),
+        available_policy_cell_ids=(
+            CELL_ID,
+            f"{ROW_ID}/action:wait",
+            f"{ROW_ID}/transition:move_right",
+            "row:other/action:move_left",
+        ),
+        represented_context_keys=represented_context_keys,
+        requested_changes=changes,
+        missing_schema_keys=missing_schema_keys,
+        rationale_codes=rationale_codes,
+        evidence_ids=evidence_ids,
+    )
+
+
+def test_locally_repairable_cooldown_proposal_replays() -> None:
+    verification = contradicted_verification()
+    change = cooldown_change(
+        evidence_ids=(verification.contradiction_artifact.contradiction_artifact_id,)
+    )
+
+    first = propose(verification=verification, changes=(change,))
+    second = propose(verification=verification, changes=(change,))
+
+    assert first.disposition == "repairable"
+    assert first.source_policy_artifact_id == "policy:A"
+    assert first.transition_verification_id == verification.verification_id
+    assert first.contradiction_artifact_id == (
+        verification.contradiction_artifact.contradiction_artifact_id
+    )
+    assert first.affected_row_ids == (ROW_ID,)
+    assert first.affected_cell_ids == (CELL_ID,)
+    assert first.required_context_keys == ("hidden.cooldown",)
+    assert first.missing_schema_keys == ()
+    assert len(first.proposed_changes) == 1
+    assert not hasattr(first, "replacement_policy_artifact_id")
+    assert first.repair_proposal_id == second.repair_proposal_id
+    assert first.proposed_changes[0].change_id == second.proposed_changes[0].change_id
+
+
+def test_requires_schema_extension_preserves_blocking_key() -> None:
+    change = cooldown_change(condition_keys=("hidden.actuator_mode",))
+
+    proposal = propose(
+        changes=(change,),
+        represented_context_keys=("hidden.cooldown", "visible.agent_x"),
+        rationale_codes=(
+            "action_effect_mismatch",
+            "missing_required_context",
+            "repair_scope_bounded",
+        ),
+    )
+
+    assert proposal.disposition == "requires_schema_extension"
+    assert proposal.missing_schema_keys == ("hidden.actuator_mode",)
+    assert proposal.proposed_changes == (change,)
+    assert not hasattr(proposal, "replacement_policy_artifact_id")
+
+
+def test_insufficient_evidence_has_no_executable_changes() -> None:
+    verification = contradicted_verification()
+
+    proposal = propose(
+        verification=verification,
+        changes=(),
+        rationale_codes=("affected_row_localised",),
+    )
+
+    assert proposal.disposition == "insufficient_evidence"
+    assert proposal.proposed_changes == ()
+    assert verification.contradiction_artifact.contradiction_artifact_id in (
+        proposal.evidence_ids
+    )
+    assert not hasattr(proposal, "replacement_policy_artifact_id")
+
+
+def test_confirmed_verification_is_rejected() -> None:
+    with pytest.raises(ObserverRepairProposalError, match="contradicted"):
+        propose(verification=confirmed_verification(), changes=(cooldown_change(),))
+
+
+def test_inconclusive_verification_is_rejected() -> None:
+    with pytest.raises(ObserverRepairProposalError, match="contradicted"):
+        propose(verification=inconclusive_verification(), changes=(cooldown_change(),))
+
+
+def test_scope_violation_outside_allowed_rows_is_rejected() -> None:
+    change = cooldown_change(target_id="row:other/action:move_left")
+
+    with pytest.raises(ObserverRepairProposalError, match="affected policy row"):
+        propose(changes=(change,))
+
+
+def test_row_limit_violation_is_rejected() -> None:
+    constraint = repair_constraint(max_rows=0)
+
+    with pytest.raises(ObserverRepairProposalError, match="max_changed_rows"):
+        propose(constraint=constraint, changes=(cooldown_change(),))
+
+
+def test_cell_limit_violation_is_rejected() -> None:
+    other = ObserverProposedChangeDTO.create(
+        target_kind="policy_cell",
+        target_id=f"{ROW_ID}/transition:move_right",
+        operation="replace",
+        field_name="action_value",
+        old_value="move_right",
+        proposed_value="wait",
+        condition_keys=("hidden.cooldown",),
+    )
+    constraint = repair_constraint(
+        allowed_cells=(CELL_ID, f"{ROW_ID}/transition:move_right"),
+        max_rows=1,
+        max_cells=1,
+    )
+
+    with pytest.raises(ObserverRepairProposalError, match="max_changed_cells"):
+        propose(constraint=constraint, changes=(cooldown_change(), other))
+
+
+def test_forbidden_region_is_rejected() -> None:
+    with pytest.raises(ObserverRepairProposalError, match="forbidden"):
+        propose(
+            constraint=repair_constraint(forbidden_rows=(ROW_ID,)),
+            changes=(cooldown_change(),),
+        )
+
+
+def test_unsupported_repair_type_is_reported_without_changes() -> None:
+    proposal = propose(
+        changes=(),
+        rationale_codes=("unsupported_repair_type",),
+    )
+
+    assert proposal.disposition == "unsupported"
+    assert proposal.proposed_changes == ()
+
+
+def test_unsupported_change_operation_is_rejected() -> None:
+    with pytest.raises(ObserverRepairProposalError, match="unsupported"):
+        ObserverProposedChangeDTO.create(
+            target_kind="policy_cell",
+            target_id=CELL_ID,
+            operation="merge",
+            field_name="action_value",
+        )
+
+
+def test_missing_namespace_is_rejected() -> None:
+    with pytest.raises(ObserverRepairProposalError, match="non-namespaced"):
+        cooldown_change(condition_keys=("cooldown",))
+
+
+@pytest.mark.parametrize(
+    "make_proposal",
+    [
+        lambda: propose(
+            constraint=repair_constraint(max_cells=2),
+            changes=(cooldown_change(),),
+        ),
+        lambda: propose(
+            changes=(
+                ObserverProposedChangeDTO.create(
+                    target_kind="policy_row",
+                    target_id=ROW_ID,
+                    operation="suspend",
+                    field_name="row_status",
+                    old_value="active",
+                    proposed_value="suspended",
+                ),
+            ),
+        ),
+        lambda: propose(
+            constraint=repair_constraint(
+                allowed_cells=(CELL_ID, f"{ROW_ID}/action:wait"),
+                max_cells=2,
+            ),
+            changes=(cooldown_change(target_id=f"{ROW_ID}/action:wait"),),
+        ),
+        lambda: propose(changes=(cooldown_change(proposed_value="move_left"),)),
+        lambda: propose(
+            changes=(cooldown_change(condition_keys=("hidden.actuator_mode",)),),
+            represented_context_keys=("hidden.cooldown",),
+        ),
+        lambda: propose(
+            changes=(cooldown_change(),),
+            rationale_codes=("action_effect_mismatch", "repair_scope_bounded"),
+        ),
+        lambda: propose(
+            changes=(cooldown_change(),),
+            evidence_ids=("manual:evidence",),
+        ),
+    ],
+)
+def test_canonical_identity_changes_on_relevant_mutation(make_proposal) -> None:
+    baseline = propose(changes=(cooldown_change(),))
+
+    mutated = make_proposal()
+
+    assert mutated.repair_proposal_id != baseline.repair_proposal_id
+
+
+def test_replay_identity_canonicalizes_change_order() -> None:
+    first = cooldown_change(evidence_ids=("evidence:a",))
+    second = ObserverProposedChangeDTO.create(
+        target_kind="context_precondition",
+        target_id=ROW_ID,
+        operation="add_precondition",
+        field_name="context_precondition",
+        proposed_value="hidden.cooldown == active",
+        condition_keys=("hidden.cooldown",),
+        evidence_ids=("evidence:b",),
+    )
+    constraint = repair_constraint(max_rows=1, max_cells=1)
+
+    left = propose(constraint=constraint, changes=(first, second))
+    right = propose(constraint=constraint, changes=(second, first))
+
+    assert left.repair_constraint_id == right.repair_constraint_id
+    assert tuple(change.change_id for change in left.proposed_changes) == tuple(
+        change.change_id for change in right.proposed_changes
+    )
+    assert left.repair_proposal_id == right.repair_proposal_id
+
+
+def test_repair_public_api() -> None:
+    import zeromodel.observer as observer
+
+    for name in (
+        "ObserverRepairConstraintDTO",
+        "ObserverProposedChangeDTO",
+        "ObserverRepairProposalDTO",
+        "ObserverRepairProposalError",
+        "propose_observer_repair",
+    ):
+        assert name in observer.__all__
+        assert hasattr(observer, name)


### PR DESCRIPTION
## Objective

Implement Stage O2: convert a contradicted Stage O1 transition verification into a bounded, canonical repair proposal.

The new vertical slice is:

```text
ObserverTransitionVerificationDTO
  -> ObserverContradictionArtifactDTO
  -> declared repair constraints
  -> ObserverRepairProposalDTO
```

## Architecture

- Adds `zeromodel.observer.repair` for canonical DTOs and bounded vocabularies.
- Adds `zeromodel.observer.repair_service` for application-level proposal validation.
- Keeps all work inside `packages/observer`; no core, observation, perception, persistence, model-provider, or policy mutation changes.
- The service validates a caller-supplied proposal. It does not infer or invent repairs.

## New Public API

- `ObserverRepairConstraintDTO`
- `ObserverProposedChangeDTO`
- `ObserverRepairProposalDTO`
- `ObserverRepairProposalError`
- `propose_observer_repair`

## Repair Dispositions

- `repairable`: proposal is bounded, traceable, and eligible for a later candidate-generation/audit stage.
- `requires_schema_extension`: proposal depends on missing represented context keys.
- `insufficient_evidence`: contradiction lineage exists, but no executable bounded proposal was supplied.
- `unsupported`: contradiction requires a repair type outside Stage O2.

`repairable` does not mean the policy is repaired or the proposal is correct.

## Scope Enforcement

The service enforces:

- contradictory verification precondition;
- contradiction/transition/comparison/source-policy identity agreement;
- sorted unique tuple contracts;
- namespaced context keys (`visible.*`, `history.*`, `hidden.*`);
- row/cell availability and allowed scope;
- forbidden rows;
- row/cell change limits;
- action-value, transition-prediction, and context-precondition permissions.

Out-of-scope changes raise `ObserverRepairProposalError` rather than silently producing a blocked disposition.

## Schema Extension Behaviour

If requested condition keys are not present in `represented_context_keys`, the proposal disposition becomes `requires_schema_extension`, with explicit `missing_schema_keys`. The service does not silently add features or classify the proposal as locally repairable.

## Explicit Non-Goals

This PR does not mutate a policy, rewrite VPM rows/cells, create candidate policies, create replacement lineage, audit/admit/activate repairs, persist records, call models, add SQLAlchemy integration, implement streams, or add habit machinery.

## Tests

Added focused tests covering:

- locally repairable hidden-cooldown proposal;
- schema-extension requirement;
- insufficient evidence;
- confirmed/inconclusive verification rejection;
- scope, row-limit, cell-limit, and forbidden-region violations;
- unsupported operations and unsupported disposition;
- missing namespace rejection;
- proposal ID mutation across relevant fields;
- replay identity and change-order canonicalization;
- public API exposure.

## Local Validation

- `pytest packages/observer/tests -q` -> `35 passed`
- `python scripts/check_package_boundaries.py` -> `Package boundary check passed: 202 production modules`
- `pytest tests/test_public_api_manifest.py -q` -> `17 passed, 1 deselected`
- `pytest tests/test_package_boundaries.py -q` -> `3 passed`
- `pytest tests/test_fast_suite_completeness.py -q` -> `10 passed`
- `ruff check packages/observer/src packages/observer/tests` -> `All checks passed!`
- `ruff format --check packages/observer/src packages/observer/tests` -> `10 files already formatted`
- `python scripts/run_fast_tests.py` -> `1293 passed, 1 skipped, 200 deselected`
- `git diff --check` -> passed; Git reported only line-ending normalization warnings for touched text files.

## Evidence Status

Local validation is complete. CI is not claimed green until GitHub Actions completes.

Audit-Exempt: adds bounded internal Observer repair-proposal contracts and validation; no public empirical capability claim changed.