### PR TITLE
feat(observer): harden observation and comparison contracts

### DIFF
--- a/.github/workflows/observer-package.yml
+++ b/.github/workflows/observer-package.yml
@@ -48,16 +48,23 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install build twine pytest ruff mypy "numpy<2.0"
 
+      - name: Install workspace
+        run: python -m pip install -r requirements-dev.txt
+
       - name: Observer quality
         run: |
           python -m ruff format --check packages/observer/src packages/observer/tests
           python -m ruff check packages/observer/src packages/observer/tests
+          python -m mypy packages/observer/src
 
       - name: Package boundaries
         run: python scripts/check_package_boundaries.py
 
       - name: Public API manifest
         run: python -m pytest -q tests/test_public_api_manifest.py
+
+      - name: Workflow coverage
+        run: python -m pytest -q tests/test_package_workflow_coverage.py
 
       - name: Observer tests
         run: python -m pytest -q packages/observer/tests

--- a/.github/workflows/observer-package.yml
+++ b/.github/workflows/observer-package.yml
@@ -1,0 +1,69 @@
+name: Observer package
+
+on:
+  pull_request:
+    paths:
+      - "packages/core/**"
+      - "packages/observation/**"
+      - "packages/perception/**"
+      - "packages/observer/**"
+      - "package-boundaries.toml"
+      - "requirements-dev.txt"
+      - "pyproject.toml"
+      - "scripts/**"
+      - "tests/**"
+      - ".github/workflows/observer-package.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/core/**"
+      - "packages/observation/**"
+      - "packages/perception/**"
+      - "packages/observer/**"
+      - "package-boundaries.toml"
+      - "requirements-dev.txt"
+      - "pyproject.toml"
+      - "scripts/**"
+      - "tests/**"
+      - ".github/workflows/observer-package.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  observer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install validation tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine pytest ruff mypy "numpy<2.0"
+
+      - name: Observer quality
+        run: |
+          python -m ruff format --check packages/observer/src packages/observer/tests
+          python -m ruff check packages/observer/src packages/observer/tests
+
+      - name: Package boundaries
+        run: python scripts/check_package_boundaries.py
+
+      - name: Public API manifest
+        run: python -m pytest -q tests/test_public_api_manifest.py
+
+      - name: Observer tests
+        run: python -m pytest -q packages/observer/tests
+
+      - name: Build observer wheel
+        run: |
+          rm -rf packages/observer/dist packages/observer/build
+          python -m build packages/observer
+          python -m twine check packages/observer/dist/*

--- a/docs/architecture/package-public-api-1.0.13.csv
+++ b/docs/architecture/package-public-api-1.0.13.csv
@@ -823,7 +823,14 @@ zeromodel-vision,zeromodel.vision,visual_input_digest,zeromodel.vision,Function,
 zeromodel-observer,zeromodel.observer,ObserverComparisonRecipeDTO,zeromodel.observer,Class,zeromodel.observer.comparison,true
 zeromodel-observer,zeromodel.observer,ObserverComparisonResultDTO,zeromodel.observer,Class,zeromodel.observer.comparison,true
 zeromodel-observer,zeromodel.observer,ObserverContradictionArtifactDTO,zeromodel.observer,Class,zeromodel.observer.artifacts,true
+zeromodel-observer,zeromodel.observer,ObserverFeatureComparisonDTO,zeromodel.observer,Class,zeromodel.observer.comparison,true
+zeromodel-observer,zeromodel.observer,ObserverFeatureComparisonResultDTO,zeromodel.observer,Class,zeromodel.observer.comparison,true
+zeromodel-observer,zeromodel.observer,ObserverFeatureDefinitionDTO,zeromodel.observer,Class,zeromodel.observer.artifacts,true
+zeromodel-observer,zeromodel.observer,ObserverHiddenStateHypothesisDTO,zeromodel.observer,Class,zeromodel.observer.comparison,true
+zeromodel-observer,zeromodel.observer,ObserverHiddenStateHypothesisSetDTO,zeromodel.observer,Class,zeromodel.observer.comparison,true
 zeromodel-observer,zeromodel.observer,ObserverObservationArtifactDTO,zeromodel.observer,Class,zeromodel.observer.artifacts,true
+zeromodel-observer,zeromodel.observer,ObserverObservationSchemaDTO,zeromodel.observer,Class,zeromodel.observer.artifacts,true
+zeromodel-observer,zeromodel.observer,ObserverPolicyConsequenceEvidenceDTO,zeromodel.observer,Class,zeromodel.observer.comparison,true
 zeromodel-observer,zeromodel.observer,ObserverProposedChangeDTO,zeromodel.observer,Class,zeromodel.observer.repair,true
 zeromodel-observer,zeromodel.observer,ObserverRepairConstraintDTO,zeromodel.observer,Class,zeromodel.observer.repair,true
 zeromodel-observer,zeromodel.observer,ObserverRepairProposalDTO,zeromodel.observer,Class,zeromodel.observer.repair,true

--- a/packages/observer/README.md
+++ b/packages/observer/README.md
@@ -119,9 +119,6 @@ verification = verify_observer_transition(
     state_before_id="state:before",
     action="move_right",
     affected_policy_row_id="row:before",
-    predicted_decision_margin=0.3,
-    observed_decision_margin=0.3,
-    hidden_state_hypotheses_remaining=1,
 )
 
 verification.verification_status
@@ -306,8 +303,6 @@ verification = verify_observer_transition(
     state_before_id="state:before",
     action="move_right",
     affected_policy_row_id="row:before",
-    predicted_decision_margin=0.3,
-    observed_decision_margin=0.3,
     hidden_state_hypothesis_set=hypotheses,
 )
 ```

--- a/packages/observer/README.md
+++ b/packages/observer/README.md
@@ -32,8 +32,15 @@ Observer is a consumer package. It depends on `core`, `observation`, and
 The top-level public surface is:
 
 - `ObserverObservationArtifactDTO`
+- `ObserverObservationSchemaDTO`
+- `ObserverFeatureDefinitionDTO`
 - `ObserverComparisonRecipeDTO`
+- `ObserverFeatureComparisonDTO`
+- `ObserverFeatureComparisonResultDTO`
 - `ObserverComparisonResultDTO`
+- `ObserverHiddenStateHypothesisDTO`
+- `ObserverHiddenStateHypothesisSetDTO`
+- `ObserverPolicyConsequenceEvidenceDTO`
 - `ObserverTransitionRecordDTO`
 - `ObserverContradictionArtifactDTO`
 - `ObserverReplacementPolicyArtifactDTO`
@@ -184,6 +191,131 @@ proposal.missing_schema_keys
 proposal.requested_changes
 proposal.proposed_changes
 ```
+
+## Stage O3.0 - Contract Hardening
+
+Stage O3.0 hardens the evidence contracts used by transition verification. It
+still does not generate predictions, invoke an Observer, execute a wake policy,
+create a graph, promote habits, or materialize policy repairs.
+
+The hardened path is:
+
+```text
+observation schema
+  + schema-validated observations
+  + per-feature comparison specs
+  + hidden-state hypothesis set
+  + external policy consequence evidence
+        ↓
+versioned comparison result
+        ↓
+transition verification
+```
+
+Feature comparison semantics are declared per feature. `exact` requires strict
+type identity, so `True` does not equal `1`, and `1` does not equal `1.0`.
+`numeric_tolerance` requires explicit absolute and relative tolerances and
+rejects booleans, NaN, and infinity.
+
+Observation artifacts now carry an `observation_schema_id`. Construction rejects
+undeclared keys, missing required keys, mistyped values, and non-finite numeric
+values. Schema identity is part of observation identity; comparing observations
+from different schemas is inconclusive unless a later stage declares
+compatibility.
+
+Hidden-state exhaustion is derived from an
+`ObserverHiddenStateHypothesisSetDTO`. The public transition verifier no longer
+accepts a naked caller-supplied remaining count.
+
+Policy consequence equivalence is supplied as
+`ObserverPolicyConsequenceEvidenceDTO`, with external decision-trace IDs. A
+caller-authored feature such as `visible.next_action` is not proof of policy
+reader equivalence.
+
+```python
+from zeromodel.observer import (
+    ObserverComparisonRecipeDTO,
+    ObserverFeatureComparisonDTO,
+    ObserverFeatureDefinitionDTO,
+    ObserverHiddenStateHypothesisDTO,
+    ObserverHiddenStateHypothesisSetDTO,
+    ObserverObservationArtifactDTO,
+    ObserverObservationSchemaDTO,
+    verify_observer_transition,
+)
+
+agent_x = ObserverFeatureComparisonDTO.create(
+    feature_key="visible.agent_x",
+    mode="numeric_tolerance",
+    expected_type="number",
+    absolute_tolerance=0.0,
+    relative_tolerance=0.01,
+)
+
+schema = ObserverObservationSchemaDTO.create(
+    schema_name="cooldown-v1",
+    features=(
+        ObserverFeatureDefinitionDTO.create(
+            qualified_key="hidden.cooldown",
+            value_type="str",
+            required=False,
+        ),
+        ObserverFeatureDefinitionDTO.create(
+            qualified_key="visible.agent_x",
+            value_type="number",
+            required=True,
+            comparison_id=agent_x.comparison_id,
+        ),
+    ),
+)
+
+recipe = ObserverComparisonRecipeDTO.create(
+    feature_comparisons=(agent_x,),
+    observable_feature_keys=("visible.agent_x",),
+)
+
+predicted = ObserverObservationArtifactDTO.create(
+    observation_schema=schema,
+    visible_state_features={"agent_x": 5},
+    hidden_state_uncertainty={"cooldown": "clear"},
+    sequence_index=1,
+)
+observed = ObserverObservationArtifactDTO.create(
+    observation_schema=schema,
+    visible_state_features={"agent_x": 5},
+    hidden_state_uncertainty={"cooldown": "clear"},
+    sequence_index=1,
+)
+
+hypotheses = ObserverHiddenStateHypothesisSetDTO.create(
+    observation_schema_id=schema.schema_id,
+    hypotheses=(
+        ObserverHiddenStateHypothesisDTO.create(
+            state_key="hidden.cooldown",
+            state_value="clear",
+            status="possible",
+        ),
+    ),
+)
+
+verification = verify_observer_transition(
+    recipe=recipe,
+    predicted_observation=predicted,
+    observed_observation=observed,
+    policy_artifact_id="policy:A",
+    state_before_id="state:before",
+    action="move_right",
+    affected_policy_row_id="row:before",
+    predicted_decision_margin=0.3,
+    observed_decision_margin=0.3,
+    hidden_state_hypothesis_set=hypotheses,
+)
+```
+
+Migration note: `observer-comparison-recipe/1` is not silently reinterpreted.
+Stage O3.0 callers must construct `observer-comparison-recipe/2` with explicit
+`feature_comparisons`. `observer-observation-artifact/2` requires an
+`ObserverObservationSchemaDTO`.
 
 ## Design Position
 

--- a/packages/observer/src/zeromodel/observer/__init__.py
+++ b/packages/observer/src/zeromodel/observer/__init__.py
@@ -7,7 +7,9 @@ does not widen the core VPM artifact contract.
 
 from zeromodel.observer.artifacts import (
     ObserverContradictionArtifactDTO,
+    ObserverFeatureDefinitionDTO,
     ObserverObservationArtifactDTO,
+    ObserverObservationSchemaDTO,
     ObserverReplacementPolicyArtifactDTO,
     ObserverTransitionRecordDTO,
     build_contradiction_artifact,
@@ -17,6 +19,11 @@ from zeromodel.observer.artifacts import (
 from zeromodel.observer.comparison import (
     ObserverComparisonRecipeDTO,
     ObserverComparisonResultDTO,
+    ObserverFeatureComparisonDTO,
+    ObserverFeatureComparisonResultDTO,
+    ObserverHiddenStateHypothesisDTO,
+    ObserverHiddenStateHypothesisSetDTO,
+    ObserverPolicyConsequenceEvidenceDTO,
     compare_observer_transition,
 )
 from zeromodel.observer.repair import (
@@ -36,7 +43,14 @@ __all__ = [
     "ObserverComparisonRecipeDTO",
     "ObserverComparisonResultDTO",
     "ObserverContradictionArtifactDTO",
+    "ObserverFeatureComparisonDTO",
+    "ObserverFeatureComparisonResultDTO",
+    "ObserverFeatureDefinitionDTO",
+    "ObserverHiddenStateHypothesisDTO",
+    "ObserverHiddenStateHypothesisSetDTO",
     "ObserverObservationArtifactDTO",
+    "ObserverObservationSchemaDTO",
+    "ObserverPolicyConsequenceEvidenceDTO",
     "ObserverProposedChangeDTO",
     "ObserverRepairConstraintDTO",
     "ObserverRepairProposalDTO",

--- a/packages/observer/src/zeromodel/observer/artifacts.py
+++ b/packages/observer/src/zeromodel/observer/artifacts.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
+from numbers import Real
 from typing import Final, Mapping
 
 from zeromodel.observer._canonical import canonical_id
 from zeromodel.observer.comparison import ObserverComparisonResultDTO
 
-OBSERVER_OBSERVATION_ARTIFACT_VERSION: Final = "observer-observation-artifact/1"
+OBSERVER_FEATURE_DEFINITION_VERSION: Final = "observer-feature-definition/1"
+OBSERVER_OBSERVATION_SCHEMA_VERSION: Final = "observer-observation-schema/1"
+OBSERVER_OBSERVATION_ARTIFACT_VERSION: Final = "observer-observation-artifact/2"
 OBSERVER_TRANSITION_RECORD_VERSION: Final = "observer-transition-record/1"
 OBSERVER_CONTRADICTION_ARTIFACT_VERSION: Final = "observer-contradiction-artifact/1"
 OBSERVER_REPLACEMENT_POLICY_VERSION: Final = "observer-replacement-policy/1"
@@ -26,9 +30,202 @@ def _validate_mapping(value: Mapping[str, object], field_name: str) -> None:
             raise ObserverArtifactError(f"{field_name} keys must be non-empty strings")
 
 
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not value:
+        raise ObserverArtifactError(f"{field_name} must be non-empty")
+
+
+def _validate_qualified_key(value: str) -> str:
+    if "." not in value:
+        raise ObserverArtifactError(f"qualified feature key is malformed: {value!r}")
+    namespace, local = value.split(".", 1)
+    if namespace not in {"visible", "history", "hidden"} or not local:
+        raise ObserverArtifactError(f"qualified feature key is malformed: {value!r}")
+    return namespace
+
+
+def _type_name(value: object) -> str:
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "str"
+    return type(value).__name__
+
+
+def _is_value_type(value: object, value_type: str) -> bool:
+    if value_type == "bool":
+        return isinstance(value, bool)
+    if value_type == "int":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if value_type == "float":
+        return isinstance(value, float) and math.isfinite(value)
+    if value_type == "number":
+        return (
+            isinstance(value, Real)
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+        )
+    if value_type == "str":
+        return isinstance(value, str)
+    if value_type == "none":
+        return value is None
+    return False
+
+
+def _ensure_canonical_value(value: object, field_name: str) -> None:
+    from zeromodel.observer._canonical import canonical_json
+
+    try:
+        canonical_json({"value": value})
+    except (TypeError, ValueError) as exc:
+        raise ObserverArtifactError(
+            f"{field_name} must be canonical JSON compatible"
+        ) from exc
+
+
 def _ensure_sorted_unique(values: tuple[str, ...], field_name: str) -> None:
     if values != tuple(sorted(set(values))):
         raise ObserverArtifactError(f"{field_name} must be unique and sorted")
+
+
+@dataclass(frozen=True)
+class ObserverFeatureDefinitionDTO:
+    """Declared schema entry for one observation feature."""
+
+    feature_definition_id: str
+    qualified_key: str
+    namespace: str
+    value_type: str
+    required: bool
+    nullable: bool = False
+    comparison_id: str | None = None
+    description_code: str | None = None
+    version: str = OBSERVER_FEATURE_DEFINITION_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_FEATURE_DEFINITION_VERSION:
+            raise ObserverArtifactError("unsupported feature definition version")
+        namespace = _validate_qualified_key(self.qualified_key)
+        if self.namespace != namespace:
+            raise ObserverArtifactError("namespace must match qualified_key prefix")
+        if self.value_type not in {"bool", "int", "float", "number", "str", "none"}:
+            raise ObserverArtifactError(
+                f"unsupported feature value_type: {self.value_type!r}"
+            )
+        if self.comparison_id == "":
+            raise ObserverArtifactError("comparison_id cannot be empty")
+        if self.description_code == "":
+            raise ObserverArtifactError("description_code cannot be empty")
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.feature_definition_id != expected_id:
+            raise ObserverArtifactError(
+                "feature_definition_id disagrees with canonical payload"
+            )
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "comparison_id": self.comparison_id,
+            "description_code": self.description_code,
+            "namespace": self.namespace,
+            "nullable": self.nullable,
+            "qualified_key": self.qualified_key,
+            "required": self.required,
+            "value_type": self.value_type,
+            "version": self.version,
+        }
+        if include_id:
+            payload["feature_definition_id"] = self.feature_definition_id
+        return payload
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        qualified_key: str,
+        value_type: str,
+        required: bool,
+        nullable: bool = False,
+        comparison_id: str | None = None,
+        description_code: str | None = None,
+    ) -> "ObserverFeatureDefinitionDTO":
+        namespace = _validate_qualified_key(qualified_key)
+        payload = {
+            "comparison_id": comparison_id,
+            "description_code": description_code,
+            "namespace": namespace,
+            "nullable": nullable,
+            "qualified_key": qualified_key,
+            "required": required,
+            "value_type": value_type,
+            "version": OBSERVER_FEATURE_DEFINITION_VERSION,
+        }
+        return cls(
+            feature_definition_id=canonical_id(payload),
+            qualified_key=qualified_key,
+            namespace=namespace,
+            value_type=value_type,
+            required=required,
+            nullable=nullable,
+            comparison_id=comparison_id,
+            description_code=description_code,
+        )
+
+
+@dataclass(frozen=True)
+class ObserverObservationSchemaDTO:
+    """Versioned feature vocabulary for observation artifacts."""
+
+    schema_id: str
+    schema_name: str
+    features: tuple[ObserverFeatureDefinitionDTO, ...]
+    version: str = OBSERVER_OBSERVATION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_OBSERVATION_SCHEMA_VERSION:
+            raise ObserverArtifactError("unsupported observation schema version")
+        _require_non_empty(self.schema_name, "schema_name")
+        keys = tuple(item.qualified_key for item in self.features)
+        if keys != tuple(sorted(set(keys))):
+            raise ObserverArtifactError("features must be unique and sorted by key")
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.schema_id != expected_id:
+            raise ObserverArtifactError("schema_id disagrees with canonical payload")
+
+    def definition_map(self) -> Mapping[str, ObserverFeatureDefinitionDTO]:
+        return {item.qualified_key: item for item in self.features}
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "features": [item.canonical_payload() for item in self.features],
+            "schema_name": self.schema_name,
+            "version": self.version,
+        }
+        if include_id:
+            payload["schema_id"] = self.schema_id
+        return payload
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        schema_name: str,
+        features: tuple[ObserverFeatureDefinitionDTO, ...],
+    ) -> "ObserverObservationSchemaDTO":
+        features = tuple(sorted(features, key=lambda item: item.qualified_key))
+        payload = {
+            "features": [item.canonical_payload() for item in features],
+            "schema_name": schema_name,
+            "version": OBSERVER_OBSERVATION_SCHEMA_VERSION,
+        }
+        return cls(
+            schema_id=canonical_id(payload), schema_name=schema_name, features=features
+        )
 
 
 @dataclass(frozen=True)
@@ -36,6 +233,7 @@ class ObserverObservationArtifactDTO:
     """Encoded observation state separated from policy action scores."""
 
     observation_artifact_id: str
+    observation_schema_id: str
     visible_state_features: Mapping[str, object]
     recent_history_features: Mapping[str, object]
     hidden_state_uncertainty: Mapping[str, object]
@@ -48,6 +246,7 @@ class ObserverObservationArtifactDTO:
             raise ObserverArtifactError("unsupported observation artifact version")
         if self.sequence_index < 0:
             raise ObserverArtifactError("sequence_index must be non-negative")
+        _require_non_empty(self.observation_schema_id, "observation_schema_id")
         _validate_mapping(self.visible_state_features, "visible_state_features")
         _validate_mapping(self.recent_history_features, "recent_history_features")
         _validate_mapping(self.hidden_state_uncertainty, "hidden_state_uncertainty")
@@ -61,6 +260,7 @@ class ObserverObservationArtifactDTO:
     def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
         payload: dict[str, object] = {
             "hidden_state_uncertainty": dict(self.hidden_state_uncertainty),
+            "observation_schema_id": self.observation_schema_id,
             "provenance": dict(self.provenance),
             "recent_history_features": dict(self.recent_history_features),
             "sequence_index": self.sequence_index,
@@ -75,21 +275,63 @@ class ObserverObservationArtifactDTO:
     def create(
         cls,
         *,
+        observation_schema: ObserverObservationSchemaDTO,
         visible_state_features: Mapping[str, object],
         recent_history_features: Mapping[str, object] | None = None,
         hidden_state_uncertainty: Mapping[str, object] | None = None,
         provenance: Mapping[str, object] | None = None,
         sequence_index: int = 0,
     ) -> "ObserverObservationArtifactDTO":
+        visible = dict(visible_state_features)
+        history = dict(recent_history_features or {})
+        hidden = dict(hidden_state_uncertainty or {})
+        projected = {
+            **{f"visible.{key}": value for key, value in visible.items()},
+            **{f"history.{key}": value for key, value in history.items()},
+            **{f"hidden.{key}": value for key, value in hidden.items()},
+        }
+        definitions = observation_schema.definition_map()
+        undeclared = set(projected) - set(definitions)
+        if undeclared:
+            raise ObserverArtifactError(
+                f"observation contains undeclared feature keys: {sorted(undeclared)}"
+            )
+        missing_required = tuple(
+            item.qualified_key
+            for item in observation_schema.features
+            if item.required and item.qualified_key not in projected
+        )
+        if missing_required:
+            raise ObserverArtifactError(
+                f"observation is missing required feature keys: {list(missing_required)}"
+            )
+        for qualified_key, value in projected.items():
+            definition = definitions[qualified_key]
+            _ensure_canonical_value(value, qualified_key)
+            if value is None and definition.nullable:
+                continue
+            if not _is_value_type(value, definition.value_type):
+                raise ObserverArtifactError(
+                    f"{qualified_key} expected {definition.value_type}, got {_type_name(value)}"
+                )
         payload = {
-            "hidden_state_uncertainty": dict(hidden_state_uncertainty or {}),
+            "hidden_state_uncertainty": hidden,
+            "observation_schema_id": observation_schema.schema_id,
             "provenance": dict(provenance or {}),
-            "recent_history_features": dict(recent_history_features or {}),
+            "recent_history_features": history,
             "sequence_index": sequence_index,
             "version": OBSERVER_OBSERVATION_ARTIFACT_VERSION,
-            "visible_state_features": dict(visible_state_features),
+            "visible_state_features": visible,
         }
-        return cls(observation_artifact_id=canonical_id(payload), **payload)
+        return cls(
+            observation_artifact_id=canonical_id(payload),
+            observation_schema_id=observation_schema.schema_id,
+            visible_state_features=visible,
+            recent_history_features=history,
+            hidden_state_uncertainty=hidden,
+            provenance=dict(provenance or {}),
+            sequence_index=sequence_index,
+        )
 
 
 @dataclass(frozen=True)

--- a/packages/observer/src/zeromodel/observer/comparison.py
+++ b/packages/observer/src/zeromodel/observer/comparison.py
@@ -520,7 +520,6 @@ class ObserverComparisonRecipeDTO:
     action_effect_keys: tuple[str, ...] = ()
     hidden_state_keys: tuple[str, ...] = ()
     require_policy_consequence_evidence: bool = False
-    decision_margin_tolerance: float = 0.0
     wake_on_observable_mismatch: bool = True
     wake_on_action_effect_mismatch: bool = True
     wake_on_policy_consequence_mismatch: bool = False
@@ -557,13 +556,11 @@ class ObserverComparisonRecipeDTO:
             )
         )
         missing_specs = set(required_keys) - set(comparison_keys)
-        if missing_specs:
+        extra_specs = set(comparison_keys) - set(required_keys)
+        if missing_specs or extra_specs:
             raise ObserverComparisonError(
-                f"required feature keys lack comparison specs: {sorted(missing_specs)}"
-            )
-        if self.decision_margin_tolerance < 0.0:
-            raise ObserverComparisonError(
-                "decision_margin_tolerance must be non-negative"
+                "feature comparison specs must exactly match required feature keys "
+                f"(missing={sorted(missing_specs)}, extra={sorted(extra_specs)})"
             )
         expected_id = canonical_id(self.canonical_payload(include_id=False))
         if self.recipe_id != expected_id:
@@ -572,7 +569,6 @@ class ObserverComparisonRecipeDTO:
     def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
         payload: dict[str, object] = {
             "action_effect_keys": list(self.action_effect_keys),
-            "decision_margin_tolerance": self.decision_margin_tolerance,
             "feature_comparisons": [
                 item.canonical_payload() for item in self.feature_comparisons
             ],
@@ -602,7 +598,6 @@ class ObserverComparisonRecipeDTO:
         action_effect_keys: tuple[str, ...] = (),
         hidden_state_keys: tuple[str, ...] = (),
         require_policy_consequence_evidence: bool = False,
-        decision_margin_tolerance: float = 0.0,
         wake_on_observable_mismatch: bool = True,
         wake_on_action_effect_mismatch: bool = True,
         wake_on_policy_consequence_mismatch: bool = False,
@@ -613,7 +608,6 @@ class ObserverComparisonRecipeDTO:
         )
         payload = {
             "action_effect_keys": list(action_effect_keys),
-            "decision_margin_tolerance": decision_margin_tolerance,
             "feature_comparisons": [
                 item.canonical_payload() for item in feature_comparisons
             ],
@@ -635,7 +629,6 @@ class ObserverComparisonRecipeDTO:
             action_effect_keys=action_effect_keys,
             hidden_state_keys=hidden_state_keys,
             require_policy_consequence_evidence=require_policy_consequence_evidence,
-            decision_margin_tolerance=decision_margin_tolerance,
             wake_on_observable_mismatch=wake_on_observable_mismatch,
             wake_on_action_effect_mismatch=wake_on_action_effect_mismatch,
             wake_on_policy_consequence_mismatch=(wake_on_policy_consequence_mismatch),

--- a/packages/observer/src/zeromodel/observer/comparison.py
+++ b/packages/observer/src/zeromodel/observer/comparison.py
@@ -2,13 +2,50 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
+from numbers import Real
 from typing import Final, Mapping
 
-from zeromodel.observer._canonical import canonical_id
+from zeromodel.observer._canonical import canonical_id, canonical_json
 
-OBSERVER_COMPARISON_RECIPE_VERSION: Final = "observer-comparison-recipe/1"
-OBSERVER_COMPARISON_RESULT_VERSION: Final = "observer-comparison-result/2"
+OBSERVER_FEATURE_COMPARISON_VERSION: Final = "observer-feature-comparison/1"
+OBSERVER_FEATURE_COMPARISON_RESULT_VERSION: Final = (
+    "observer-feature-comparison-result/1"
+)
+OBSERVER_HIDDEN_STATE_HYPOTHESIS_VERSION: Final = "observer-hidden-state-hypothesis/1"
+OBSERVER_HIDDEN_STATE_HYPOTHESIS_SET_VERSION: Final = (
+    "observer-hidden-state-hypothesis-set/1"
+)
+OBSERVER_POLICY_CONSEQUENCE_EVIDENCE_VERSION: Final = (
+    "observer-policy-consequence-evidence/1"
+)
+OBSERVER_COMPARISON_RECIPE_VERSION: Final = "observer-comparison-recipe/2"
+OBSERVER_LEGACY_COMPARISON_RECIPE_VERSION: Final = "observer-comparison-recipe/1"
+OBSERVER_COMPARISON_RESULT_VERSION: Final = "observer-comparison-result/3"
+
+COMPARISON_MODES: Final = frozenset({"exact", "categorical", "numeric_tolerance"})
+EXPECTED_TYPES: Final = frozenset({"bool", "int", "float", "number", "str", "none"})
+FEATURE_RESULT_STATUSES: Final = frozenset(
+    {
+        "match",
+        "mismatch",
+        "missing_predicted",
+        "missing_observed",
+        "type_mismatch",
+        "invalid_value",
+    }
+)
+HYPOTHESIS_STATUSES: Final = frozenset({"possible", "eliminated", "confirmed"})
+INCONCLUSIVE_REASONS: Final = frozenset(
+    {
+        "missing_required_feature",
+        "schema_mismatch",
+        "missing_policy_consequence_evidence",
+        "missing_hidden_state_hypothesis_set",
+        "invalid_feature_value",
+    }
+)
 
 
 class ObserverComparisonError(ValueError):
@@ -20,15 +57,469 @@ def _ensure_sorted_unique(values: tuple[str, ...], field_name: str) -> None:
         raise ObserverComparisonError(f"{field_name} must be unique and sorted")
 
 
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not value:
+        raise ObserverComparisonError(f"{field_name} must be non-empty")
+
+
+def _validate_feature_key(feature_key: str) -> None:
+    if (
+        not feature_key
+        or "." not in feature_key
+        or feature_key.split(".", 1)[0] not in {"visible", "history", "hidden"}
+        or not feature_key.split(".", 1)[1]
+    ):
+        raise ObserverComparisonError(f"malformed feature key: {feature_key!r}")
+
+
+def _type_name(value: object) -> str:
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "str"
+    if isinstance(value, Mapping):
+        return "mapping"
+    if isinstance(value, (tuple, list)):
+        return "array"
+    return type(value).__name__
+
+
+def _is_finite_json_value(value: object) -> bool:
+    try:
+        canonical_json({"value": value})
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _matches_expected_type(value: object, expected_type: str | None) -> bool:
+    if expected_type is None:
+        return True
+    if expected_type == "bool":
+        return isinstance(value, bool)
+    if expected_type == "int":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "float":
+        return isinstance(value, float) and math.isfinite(value)
+    if expected_type == "number":
+        return (
+            isinstance(value, Real)
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+        )
+    if expected_type == "str":
+        return isinstance(value, str)
+    if expected_type == "none":
+        return value is None
+    return False
+
+
+@dataclass(frozen=True)
+class ObserverFeatureComparisonDTO:
+    """Declared comparison semantics for one qualified feature."""
+
+    comparison_id: str
+    feature_key: str
+    mode: str
+    absolute_tolerance: float | None = None
+    relative_tolerance: float | None = None
+    expected_type: str | None = None
+    version: str = OBSERVER_FEATURE_COMPARISON_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_FEATURE_COMPARISON_VERSION:
+            raise ObserverComparisonError("unsupported feature comparison version")
+        _validate_feature_key(self.feature_key)
+        if self.mode not in COMPARISON_MODES:
+            raise ObserverComparisonError(f"unsupported comparison mode: {self.mode!r}")
+        if self.expected_type is not None and self.expected_type not in EXPECTED_TYPES:
+            raise ObserverComparisonError(
+                f"unsupported expected_type: {self.expected_type!r}"
+            )
+        if self.mode == "numeric_tolerance":
+            if self.absolute_tolerance is None or self.relative_tolerance is None:
+                raise ObserverComparisonError(
+                    "numeric_tolerance requires absolute and relative tolerances"
+                )
+            if self.absolute_tolerance < 0.0 or self.relative_tolerance < 0.0:
+                raise ObserverComparisonError("numeric tolerances must be non-negative")
+        elif self.absolute_tolerance is not None or self.relative_tolerance is not None:
+            raise ObserverComparisonError(
+                "only numeric_tolerance comparisons may declare tolerances"
+            )
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.comparison_id != expected_id:
+            raise ObserverComparisonError(
+                "comparison_id disagrees with canonical payload"
+            )
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "absolute_tolerance": self.absolute_tolerance,
+            "expected_type": self.expected_type,
+            "feature_key": self.feature_key,
+            "mode": self.mode,
+            "relative_tolerance": self.relative_tolerance,
+            "version": self.version,
+        }
+        if include_id:
+            payload["comparison_id"] = self.comparison_id
+        return payload
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        feature_key: str,
+        mode: str = "exact",
+        absolute_tolerance: float | None = None,
+        relative_tolerance: float | None = None,
+        expected_type: str | None = None,
+    ) -> "ObserverFeatureComparisonDTO":
+        payload = {
+            "absolute_tolerance": absolute_tolerance,
+            "expected_type": expected_type,
+            "feature_key": feature_key,
+            "mode": mode,
+            "relative_tolerance": relative_tolerance,
+            "version": OBSERVER_FEATURE_COMPARISON_VERSION,
+        }
+        return cls(
+            comparison_id=canonical_id(payload),
+            feature_key=feature_key,
+            mode=mode,
+            absolute_tolerance=absolute_tolerance,
+            relative_tolerance=relative_tolerance,
+            expected_type=expected_type,
+        )
+
+
+@dataclass(frozen=True)
+class ObserverFeatureComparisonResultDTO:
+    """Canonical result for one evaluated feature comparison."""
+
+    result_id: str
+    feature_key: str
+    comparison_id: str
+    status: str
+    predicted_type: str | None
+    observed_type: str | None
+    absolute_delta: float | None = None
+    tolerance_limit: float | None = None
+    version: str = OBSERVER_FEATURE_COMPARISON_RESULT_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_FEATURE_COMPARISON_RESULT_VERSION:
+            raise ObserverComparisonError("unsupported feature result version")
+        _validate_feature_key(self.feature_key)
+        _require_non_empty(self.comparison_id, "comparison_id")
+        if self.status not in FEATURE_RESULT_STATUSES:
+            raise ObserverComparisonError(
+                f"unsupported feature result status: {self.status!r}"
+            )
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.result_id != expected_id:
+            raise ObserverComparisonError("result_id disagrees with canonical payload")
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "absolute_delta": self.absolute_delta,
+            "comparison_id": self.comparison_id,
+            "feature_key": self.feature_key,
+            "observed_type": self.observed_type,
+            "predicted_type": self.predicted_type,
+            "status": self.status,
+            "tolerance_limit": self.tolerance_limit,
+            "version": self.version,
+        }
+        if include_id:
+            payload["result_id"] = self.result_id
+        return payload
+
+
+def _feature_result(
+    *,
+    feature_key: str,
+    comparison_id: str,
+    status: str,
+    predicted_type: str | None,
+    observed_type: str | None,
+    absolute_delta: float | None = None,
+    tolerance_limit: float | None = None,
+) -> ObserverFeatureComparisonResultDTO:
+    payload = {
+        "absolute_delta": absolute_delta,
+        "comparison_id": comparison_id,
+        "feature_key": feature_key,
+        "observed_type": observed_type,
+        "predicted_type": predicted_type,
+        "status": status,
+        "tolerance_limit": tolerance_limit,
+        "version": OBSERVER_FEATURE_COMPARISON_RESULT_VERSION,
+    }
+    return ObserverFeatureComparisonResultDTO(
+        result_id=canonical_id(payload),
+        feature_key=feature_key,
+        comparison_id=comparison_id,
+        status=status,
+        predicted_type=predicted_type,
+        observed_type=observed_type,
+        absolute_delta=absolute_delta,
+        tolerance_limit=tolerance_limit,
+    )
+
+
+@dataclass(frozen=True)
+class ObserverHiddenStateHypothesisDTO:
+    """Evidence-bearing hidden-state hypothesis."""
+
+    hypothesis_id: str
+    state_key: str
+    state_value: object
+    evidence_ids: tuple[str, ...]
+    status: str
+    version: str = OBSERVER_HIDDEN_STATE_HYPOTHESIS_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_HIDDEN_STATE_HYPOTHESIS_VERSION:
+            raise ObserverComparisonError("unsupported hidden-state hypothesis version")
+        _validate_feature_key(self.state_key)
+        if not self.state_key.startswith("hidden."):
+            raise ObserverComparisonError("state_key must be in the hidden namespace")
+        if self.status not in HYPOTHESIS_STATUSES:
+            raise ObserverComparisonError(
+                f"unsupported hypothesis status: {self.status!r}"
+            )
+        _ensure_sorted_unique(self.evidence_ids, "evidence_ids")
+        if not _is_finite_json_value(self.state_value):
+            raise ObserverComparisonError(
+                "state_value must be canonical JSON compatible"
+            )
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.hypothesis_id != expected_id:
+            raise ObserverComparisonError(
+                "hypothesis_id disagrees with canonical payload"
+            )
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "evidence_ids": list(self.evidence_ids),
+            "state_key": self.state_key,
+            "state_value": self.state_value,
+            "status": self.status,
+            "version": self.version,
+        }
+        if include_id:
+            payload["hypothesis_id"] = self.hypothesis_id
+        return payload
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        state_key: str,
+        state_value: object,
+        evidence_ids: tuple[str, ...] = (),
+        status: str = "possible",
+    ) -> "ObserverHiddenStateHypothesisDTO":
+        payload = {
+            "evidence_ids": list(evidence_ids),
+            "state_key": state_key,
+            "state_value": state_value,
+            "status": status,
+            "version": OBSERVER_HIDDEN_STATE_HYPOTHESIS_VERSION,
+        }
+        return cls(
+            hypothesis_id=canonical_id(payload),
+            state_key=state_key,
+            state_value=state_value,
+            evidence_ids=evidence_ids,
+            status=status,
+        )
+
+
+@dataclass(frozen=True)
+class ObserverHiddenStateHypothesisSetDTO:
+    """Canonical set that owns hidden-state exhaustion evidence."""
+
+    hypothesis_set_id: str
+    observation_schema_id: str
+    hypotheses: tuple[ObserverHiddenStateHypothesisDTO, ...]
+    derivation_evidence_ids: tuple[str, ...] = ()
+    version: str = OBSERVER_HIDDEN_STATE_HYPOTHESIS_SET_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_HIDDEN_STATE_HYPOTHESIS_SET_VERSION:
+            raise ObserverComparisonError("unsupported hypothesis set version")
+        _require_non_empty(self.observation_schema_id, "observation_schema_id")
+        ids = tuple(item.hypothesis_id for item in self.hypotheses)
+        if ids != tuple(sorted(set(ids))):
+            raise ObserverComparisonError(
+                "hypotheses must have unique IDs in sorted order"
+            )
+        _ensure_sorted_unique(self.derivation_evidence_ids, "derivation_evidence_ids")
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.hypothesis_set_id != expected_id:
+            raise ObserverComparisonError(
+                "hypothesis_set_id disagrees with canonical payload"
+            )
+
+    @property
+    def possible_count(self) -> int:
+        return sum(1 for item in self.hypotheses if item.status == "possible")
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "derivation_evidence_ids": list(self.derivation_evidence_ids),
+            "hypotheses": [item.canonical_payload() for item in self.hypotheses],
+            "observation_schema_id": self.observation_schema_id,
+            "version": self.version,
+        }
+        if include_id:
+            payload["hypothesis_set_id"] = self.hypothesis_set_id
+        return payload
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        observation_schema_id: str,
+        hypotheses: tuple[ObserverHiddenStateHypothesisDTO, ...],
+        derivation_evidence_ids: tuple[str, ...] = (),
+    ) -> "ObserverHiddenStateHypothesisSetDTO":
+        hypotheses = tuple(sorted(hypotheses, key=lambda item: item.hypothesis_id))
+        payload = {
+            "derivation_evidence_ids": list(derivation_evidence_ids),
+            "hypotheses": [item.canonical_payload() for item in hypotheses],
+            "observation_schema_id": observation_schema_id,
+            "version": OBSERVER_HIDDEN_STATE_HYPOTHESIS_SET_VERSION,
+        }
+        return cls(
+            hypothesis_set_id=canonical_id(payload),
+            observation_schema_id=observation_schema_id,
+            hypotheses=hypotheses,
+            derivation_evidence_ids=derivation_evidence_ids,
+        )
+
+
+@dataclass(frozen=True)
+class ObserverPolicyConsequenceEvidenceDTO:
+    """Externally computed policy consequence evidence."""
+
+    policy_consequence_evidence_id: str
+    policy_artifact_id: str
+    predicted_state_artifact_id: str
+    observed_state_artifact_id: str
+    predicted_selected_action: str
+    observed_selected_action: str
+    predicted_decision_trace_id: str
+    observed_decision_trace_id: str
+    equivalent: bool
+    reader_contract_id: str
+    version: str = OBSERVER_POLICY_CONSEQUENCE_EVIDENCE_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != OBSERVER_POLICY_CONSEQUENCE_EVIDENCE_VERSION:
+            raise ObserverComparisonError(
+                "unsupported policy consequence evidence version"
+            )
+        for field_name in (
+            "policy_artifact_id",
+            "predicted_state_artifact_id",
+            "observed_state_artifact_id",
+            "predicted_selected_action",
+            "observed_selected_action",
+            "predicted_decision_trace_id",
+            "observed_decision_trace_id",
+            "reader_contract_id",
+        ):
+            _require_non_empty(getattr(self, field_name), field_name)
+        if self.equivalent != (
+            self.predicted_selected_action == self.observed_selected_action
+        ):
+            raise ObserverComparisonError(
+                "equivalent must match selected action equality"
+            )
+        expected_id = canonical_id(self.canonical_payload(include_id=False))
+        if self.policy_consequence_evidence_id != expected_id:
+            raise ObserverComparisonError(
+                "policy_consequence_evidence_id disagrees with canonical payload"
+            )
+
+    def canonical_payload(self, *, include_id: bool = True) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "equivalent": self.equivalent,
+            "observed_decision_trace_id": self.observed_decision_trace_id,
+            "observed_selected_action": self.observed_selected_action,
+            "observed_state_artifact_id": self.observed_state_artifact_id,
+            "policy_artifact_id": self.policy_artifact_id,
+            "predicted_decision_trace_id": self.predicted_decision_trace_id,
+            "predicted_selected_action": self.predicted_selected_action,
+            "predicted_state_artifact_id": self.predicted_state_artifact_id,
+            "reader_contract_id": self.reader_contract_id,
+            "version": self.version,
+        }
+        if include_id:
+            payload["policy_consequence_evidence_id"] = (
+                self.policy_consequence_evidence_id
+            )
+        return payload
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        policy_artifact_id: str,
+        predicted_state_artifact_id: str,
+        observed_state_artifact_id: str,
+        predicted_selected_action: str,
+        observed_selected_action: str,
+        predicted_decision_trace_id: str,
+        observed_decision_trace_id: str,
+        reader_contract_id: str,
+    ) -> "ObserverPolicyConsequenceEvidenceDTO":
+        payload = {
+            "equivalent": predicted_selected_action == observed_selected_action,
+            "observed_decision_trace_id": observed_decision_trace_id,
+            "observed_selected_action": observed_selected_action,
+            "observed_state_artifact_id": observed_state_artifact_id,
+            "policy_artifact_id": policy_artifact_id,
+            "predicted_decision_trace_id": predicted_decision_trace_id,
+            "predicted_selected_action": predicted_selected_action,
+            "predicted_state_artifact_id": predicted_state_artifact_id,
+            "reader_contract_id": reader_contract_id,
+            "version": OBSERVER_POLICY_CONSEQUENCE_EVIDENCE_VERSION,
+        }
+        return cls(
+            policy_consequence_evidence_id=canonical_id(payload),
+            policy_artifact_id=policy_artifact_id,
+            predicted_state_artifact_id=predicted_state_artifact_id,
+            observed_state_artifact_id=observed_state_artifact_id,
+            predicted_selected_action=predicted_selected_action,
+            observed_selected_action=observed_selected_action,
+            predicted_decision_trace_id=predicted_decision_trace_id,
+            observed_decision_trace_id=observed_decision_trace_id,
+            equivalent=predicted_selected_action == observed_selected_action,
+            reader_contract_id=reader_contract_id,
+        )
+
+
 @dataclass(frozen=True)
 class ObserverComparisonRecipeDTO:
     """Declared hypothesis for comparing predicted and observed transitions."""
 
     recipe_id: str
+    feature_comparisons: tuple[ObserverFeatureComparisonDTO, ...]
     observable_feature_keys: tuple[str, ...]
     action_effect_keys: tuple[str, ...] = ()
-    policy_consequence_key: str | None = None
     hidden_state_keys: tuple[str, ...] = ()
+    require_policy_consequence_evidence: bool = False
     decision_margin_tolerance: float = 0.0
     wake_on_observable_mismatch: bool = True
     wake_on_action_effect_mismatch: bool = True
@@ -38,14 +529,38 @@ class ObserverComparisonRecipeDTO:
 
     def __post_init__(self) -> None:
         if self.version != OBSERVER_COMPARISON_RECIPE_VERSION:
-            raise ObserverComparisonError("unsupported comparison recipe version")
+            raise ObserverComparisonError(
+                "legacy comparison recipes are not accepted by the O3.0 contract; "
+                "create observer-comparison-recipe/2 with feature_comparisons"
+            )
         if not self.observable_feature_keys:
             raise ObserverComparisonError("observable_feature_keys must be non-empty")
-        _ensure_sorted_unique(self.observable_feature_keys, "observable_feature_keys")
-        _ensure_sorted_unique(self.action_effect_keys, "action_effect_keys")
-        _ensure_sorted_unique(self.hidden_state_keys, "hidden_state_keys")
-        if self.policy_consequence_key == "":
-            raise ObserverComparisonError("policy_consequence_key cannot be empty")
+        for field_name in (
+            "observable_feature_keys",
+            "action_effect_keys",
+            "hidden_state_keys",
+        ):
+            values = getattr(self, field_name)
+            _ensure_sorted_unique(values, field_name)
+            for key in values:
+                _validate_feature_key(key)
+        comparison_keys = tuple(item.feature_key for item in self.feature_comparisons)
+        if comparison_keys != tuple(sorted(set(comparison_keys))):
+            raise ObserverComparisonError(
+                "feature_comparisons must be unique and sorted by feature_key"
+            )
+        required_keys = tuple(
+            sorted(
+                set(self.observable_feature_keys)
+                | set(self.action_effect_keys)
+                | set(self.hidden_state_keys)
+            )
+        )
+        missing_specs = set(required_keys) - set(comparison_keys)
+        if missing_specs:
+            raise ObserverComparisonError(
+                f"required feature keys lack comparison specs: {sorted(missing_specs)}"
+            )
         if self.decision_margin_tolerance < 0.0:
             raise ObserverComparisonError(
                 "decision_margin_tolerance must be non-negative"
@@ -58,9 +573,14 @@ class ObserverComparisonRecipeDTO:
         payload: dict[str, object] = {
             "action_effect_keys": list(self.action_effect_keys),
             "decision_margin_tolerance": self.decision_margin_tolerance,
+            "feature_comparisons": [
+                item.canonical_payload() for item in self.feature_comparisons
+            ],
             "hidden_state_keys": list(self.hidden_state_keys),
             "observable_feature_keys": list(self.observable_feature_keys),
-            "policy_consequence_key": self.policy_consequence_key,
+            "require_policy_consequence_evidence": (
+                self.require_policy_consequence_evidence
+            ),
             "version": self.version,
             "wake_on_action_effect_mismatch": self.wake_on_action_effect_mismatch,
             "wake_on_hidden_state_exhausted": self.wake_on_hidden_state_exhausted,
@@ -77,22 +597,29 @@ class ObserverComparisonRecipeDTO:
     def create(
         cls,
         *,
+        feature_comparisons: tuple[ObserverFeatureComparisonDTO, ...],
         observable_feature_keys: tuple[str, ...],
         action_effect_keys: tuple[str, ...] = (),
-        policy_consequence_key: str | None = None,
         hidden_state_keys: tuple[str, ...] = (),
+        require_policy_consequence_evidence: bool = False,
         decision_margin_tolerance: float = 0.0,
         wake_on_observable_mismatch: bool = True,
         wake_on_action_effect_mismatch: bool = True,
         wake_on_policy_consequence_mismatch: bool = False,
         wake_on_hidden_state_exhausted: bool = True,
     ) -> "ObserverComparisonRecipeDTO":
+        feature_comparisons = tuple(
+            sorted(feature_comparisons, key=lambda item: item.feature_key)
+        )
         payload = {
             "action_effect_keys": list(action_effect_keys),
             "decision_margin_tolerance": decision_margin_tolerance,
+            "feature_comparisons": [
+                item.canonical_payload() for item in feature_comparisons
+            ],
             "hidden_state_keys": list(hidden_state_keys),
             "observable_feature_keys": list(observable_feature_keys),
-            "policy_consequence_key": policy_consequence_key,
+            "require_policy_consequence_evidence": require_policy_consequence_evidence,
             "version": OBSERVER_COMPARISON_RECIPE_VERSION,
             "wake_on_action_effect_mismatch": wake_on_action_effect_mismatch,
             "wake_on_hidden_state_exhausted": wake_on_hidden_state_exhausted,
@@ -103,10 +630,11 @@ class ObserverComparisonRecipeDTO:
         }
         return cls(
             recipe_id=canonical_id(payload),
+            feature_comparisons=feature_comparisons,
             observable_feature_keys=observable_feature_keys,
             action_effect_keys=action_effect_keys,
-            policy_consequence_key=policy_consequence_key,
             hidden_state_keys=hidden_state_keys,
+            require_policy_consequence_evidence=require_policy_consequence_evidence,
             decision_margin_tolerance=decision_margin_tolerance,
             wake_on_observable_mismatch=wake_on_observable_mismatch,
             wake_on_action_effect_mismatch=wake_on_action_effect_mismatch,
@@ -121,36 +649,72 @@ class ObserverComparisonResultDTO:
 
     comparison_result_id: str
     recipe_id: str
+    predicted_observation_artifact_id: str
+    observed_observation_artifact_id: str
+    feature_results: tuple[ObserverFeatureComparisonResultDTO, ...]
+    policy_consequence_evidence_id: str | None
+    hidden_state_hypothesis_set_id: str | None
     observable_feature_match: bool
     action_effect_match: bool
-    next_action_equivalent: bool
-    decision_margin_delta: float
-    hidden_state_hypotheses_remaining: int
-    mismatched_feature_keys: tuple[str, ...]
+    policy_consequence_match: bool
+    hidden_state_exhausted: bool
     wake_required: bool
     contradiction: bool
-    missing_predicted_feature_keys: tuple[str, ...] = ()
-    missing_observed_feature_keys: tuple[str, ...] = ()
+    inconclusive_reasons: tuple[str, ...] = ()
     version: str = OBSERVER_COMPARISON_RESULT_VERSION
+
+    @property
+    def next_action_equivalent(self) -> bool:
+        return self.policy_consequence_match
+
+    @property
+    def mismatched_feature_keys(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                item.feature_key
+                for item in self.feature_results
+                if item.status in {"mismatch", "type_mismatch", "invalid_value"}
+            )
+        )
+
+    @property
+    def missing_predicted_feature_keys(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                item.feature_key
+                for item in self.feature_results
+                if item.status == "missing_predicted"
+            )
+        )
+
+    @property
+    def missing_observed_feature_keys(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                item.feature_key
+                for item in self.feature_results
+                if item.status == "missing_observed"
+            )
+        )
 
     def __post_init__(self) -> None:
         if self.version != OBSERVER_COMPARISON_RESULT_VERSION:
             raise ObserverComparisonError("unsupported comparison result version")
-        if not self.recipe_id:
-            raise ObserverComparisonError("recipe_id must be non-empty")
-        if self.decision_margin_delta < 0.0:
-            raise ObserverComparisonError("decision_margin_delta must be non-negative")
-        if self.hidden_state_hypotheses_remaining < 0:
+        for field_name in (
+            "recipe_id",
+            "predicted_observation_artifact_id",
+            "observed_observation_artifact_id",
+        ):
+            _require_non_empty(getattr(self, field_name), field_name)
+        keys = tuple(item.feature_key for item in self.feature_results)
+        if keys != tuple(sorted(set(keys))):
+            raise ObserverComparisonError("feature_results must be unique and sorted")
+        _ensure_sorted_unique(self.inconclusive_reasons, "inconclusive_reasons")
+        unknown = set(self.inconclusive_reasons) - INCONCLUSIVE_REASONS
+        if unknown:
             raise ObserverComparisonError(
-                "hidden_state_hypotheses_remaining must be non-negative"
+                f"unsupported inconclusive_reasons: {sorted(unknown)}"
             )
-        _ensure_sorted_unique(self.mismatched_feature_keys, "mismatched_feature_keys")
-        _ensure_sorted_unique(
-            self.missing_predicted_feature_keys, "missing_predicted_feature_keys"
-        )
-        _ensure_sorted_unique(
-            self.missing_observed_feature_keys, "missing_observed_feature_keys"
-        )
         expected_id = canonical_id(self.canonical_payload(include_id=False))
         if self.comparison_result_id != expected_id:
             raise ObserverComparisonError(
@@ -161,15 +725,19 @@ class ObserverComparisonResultDTO:
         payload: dict[str, object] = {
             "action_effect_match": self.action_effect_match,
             "contradiction": self.contradiction,
-            "decision_margin_delta": self.decision_margin_delta,
-            "hidden_state_hypotheses_remaining": (
-                self.hidden_state_hypotheses_remaining
-            ),
-            "mismatched_feature_keys": list(self.mismatched_feature_keys),
-            "missing_observed_feature_keys": list(self.missing_observed_feature_keys),
-            "missing_predicted_feature_keys": list(self.missing_predicted_feature_keys),
-            "next_action_equivalent": self.next_action_equivalent,
+            "feature_results": [
+                item.canonical_payload() for item in self.feature_results
+            ],
+            "hidden_state_exhausted": self.hidden_state_exhausted,
+            "hidden_state_hypothesis_set_id": self.hidden_state_hypothesis_set_id,
+            "inconclusive_reasons": list(self.inconclusive_reasons),
             "observable_feature_match": self.observable_feature_match,
+            "observed_observation_artifact_id": self.observed_observation_artifact_id,
+            "policy_consequence_evidence_id": self.policy_consequence_evidence_id,
+            "policy_consequence_match": self.policy_consequence_match,
+            "predicted_observation_artifact_id": (
+                self.predicted_observation_artifact_id
+            ),
             "recipe_id": self.recipe_id,
             "version": self.version,
             "wake_required": self.wake_required,
@@ -179,122 +747,272 @@ class ObserverComparisonResultDTO:
         return payload
 
 
+def _compare_value(
+    comparison: ObserverFeatureComparisonDTO,
+    predicted: object,
+    observed: object,
+) -> ObserverFeatureComparisonResultDTO:
+    predicted_type = _type_name(predicted)
+    observed_type = _type_name(observed)
+    if not _is_finite_json_value(predicted) or not _is_finite_json_value(observed):
+        return _feature_result(
+            feature_key=comparison.feature_key,
+            comparison_id=comparison.comparison_id,
+            status="invalid_value",
+            predicted_type=predicted_type,
+            observed_type=observed_type,
+        )
+    if comparison.mode == "numeric_tolerance" and (
+        isinstance(predicted, bool) or isinstance(observed, bool)
+    ):
+        return _feature_result(
+            feature_key=comparison.feature_key,
+            comparison_id=comparison.comparison_id,
+            status="invalid_value",
+            predicted_type=predicted_type,
+            observed_type=observed_type,
+        )
+    if not _matches_expected_type(
+        predicted, comparison.expected_type
+    ) or not _matches_expected_type(observed, comparison.expected_type):
+        return _feature_result(
+            feature_key=comparison.feature_key,
+            comparison_id=comparison.comparison_id,
+            status="type_mismatch",
+            predicted_type=predicted_type,
+            observed_type=observed_type,
+        )
+    if comparison.mode in {"exact", "categorical"}:
+        if type(predicted) is not type(observed):
+            status = "type_mismatch"
+        else:
+            status = "match" if predicted == observed else "mismatch"
+        return _feature_result(
+            feature_key=comparison.feature_key,
+            comparison_id=comparison.comparison_id,
+            status=status,
+            predicted_type=predicted_type,
+            observed_type=observed_type,
+        )
+    if (
+        not isinstance(predicted, Real)
+        or not isinstance(observed, Real)
+        or isinstance(predicted, bool)
+        or isinstance(observed, bool)
+        or not math.isfinite(predicted)
+        or not math.isfinite(observed)
+    ):
+        return _feature_result(
+            feature_key=comparison.feature_key,
+            comparison_id=comparison.comparison_id,
+            status="invalid_value",
+            predicted_type=predicted_type,
+            observed_type=observed_type,
+        )
+    absolute_delta = abs(float(predicted) - float(observed))
+    assert comparison.absolute_tolerance is not None
+    assert comparison.relative_tolerance is not None
+    tolerance_limit = max(
+        comparison.absolute_tolerance,
+        comparison.relative_tolerance
+        * max(abs(float(predicted)), abs(float(observed))),
+    )
+    return _feature_result(
+        feature_key=comparison.feature_key,
+        comparison_id=comparison.comparison_id,
+        status="match" if absolute_delta <= tolerance_limit else "mismatch",
+        predicted_type=predicted_type,
+        observed_type=observed_type,
+        absolute_delta=absolute_delta,
+        tolerance_limit=tolerance_limit,
+    )
+
+
 def compare_observer_transition(
     *,
     recipe: ObserverComparisonRecipeDTO,
+    predicted_observation_artifact_id: str,
+    observed_observation_artifact_id: str,
+    predicted_observation_schema_id: str,
+    observed_observation_schema_id: str,
     predicted_features: Mapping[str, object],
     observed_features: Mapping[str, object],
-    predicted_decision_margin: float,
-    observed_decision_margin: float,
-    hidden_state_hypotheses_remaining: int,
+    hidden_state_hypothesis_set: ObserverHiddenStateHypothesisSetDTO | None = None,
+    policy_consequence_evidence: ObserverPolicyConsequenceEvidenceDTO | None = None,
 ) -> ObserverComparisonResultDTO:
-    """Compare predicted and observed state without collapsing to one scalar."""
+    """Compare predicted and observed state using declared evidence contracts."""
 
-    if predicted_decision_margin < 0.0 or observed_decision_margin < 0.0:
-        raise ObserverComparisonError("decision margins must be non-negative")
-    if hidden_state_hypotheses_remaining < 0:
+    if recipe.version != OBSERVER_COMPARISON_RECIPE_VERSION:
         raise ObserverComparisonError(
-            "hidden_state_hypotheses_remaining must be non-negative"
+            "compare_observer_transition requires observer-comparison-recipe/2"
         )
+    for field_name, value in (
+        ("predicted_observation_artifact_id", predicted_observation_artifact_id),
+        ("observed_observation_artifact_id", observed_observation_artifact_id),
+        ("predicted_observation_schema_id", predicted_observation_schema_id),
+        ("observed_observation_schema_id", observed_observation_schema_id),
+    ):
+        _require_non_empty(value, field_name)
 
+    inconclusive_reasons: set[str] = set()
+    if predicted_observation_schema_id != observed_observation_schema_id:
+        inconclusive_reasons.add("schema_mismatch")
+
+    comparisons = {item.feature_key: item for item in recipe.feature_comparisons}
     required_keys = tuple(
         sorted(
             set(recipe.observable_feature_keys)
             | set(recipe.action_effect_keys)
             | set(recipe.hidden_state_keys)
-            | (
-                {recipe.policy_consequence_key}
-                if recipe.policy_consequence_key is not None
-                else set()
-            )
         )
     )
-    missing_predicted = tuple(
-        key for key in required_keys if key not in predicted_features
-    )
-    missing_observed = tuple(
-        key for key in required_keys if key not in observed_features
-    )
-    missing_evidence = bool(missing_predicted or missing_observed)
+    feature_results: list[ObserverFeatureComparisonResultDTO] = []
+    if "schema_mismatch" not in inconclusive_reasons:
+        for key in required_keys:
+            comparison = comparisons[key]
+            if key not in predicted_features:
+                feature_results.append(
+                    _feature_result(
+                        feature_key=key,
+                        comparison_id=comparison.comparison_id,
+                        status="missing_predicted",
+                        predicted_type=None,
+                        observed_type=(
+                            _type_name(observed_features[key])
+                            if key in observed_features
+                            else None
+                        ),
+                    )
+                )
+                inconclusive_reasons.add("missing_required_feature")
+            elif key not in observed_features:
+                feature_results.append(
+                    _feature_result(
+                        feature_key=key,
+                        comparison_id=comparison.comparison_id,
+                        status="missing_observed",
+                        predicted_type=_type_name(predicted_features[key]),
+                        observed_type=None,
+                    )
+                )
+                inconclusive_reasons.add("missing_required_feature")
+            else:
+                result = _compare_value(
+                    comparison, predicted_features[key], observed_features[key]
+                )
+                feature_results.append(result)
+                if result.status == "invalid_value":
+                    inconclusive_reasons.add("invalid_feature_value")
 
-    observable_mismatches = tuple(
-        key
-        for key in recipe.observable_feature_keys
-        if key not in missing_predicted
-        and key not in missing_observed
-        and predicted_features[key] != observed_features[key]
+    feature_results_tuple = tuple(
+        sorted(feature_results, key=lambda item: item.feature_key)
     )
-    action_effect_mismatches = tuple(
-        key
-        for key in recipe.action_effect_keys
-        if key not in missing_predicted
-        and key not in missing_observed
-        and predicted_features[key] != observed_features[key]
+    observable_feature_match = all(
+        item.status == "match"
+        for item in feature_results_tuple
+        if item.feature_key in recipe.observable_feature_keys
+    ) and not any(
+        item.status.startswith("missing")
+        for item in feature_results_tuple
+        if item.feature_key in recipe.observable_feature_keys
     )
-    policy_mismatch = (
-        recipe.policy_consequence_key is not None
-        and recipe.policy_consequence_key not in missing_predicted
-        and recipe.policy_consequence_key not in missing_observed
-        and predicted_features[recipe.policy_consequence_key]
-        != observed_features[recipe.policy_consequence_key]
+    action_effect_match = all(
+        item.status == "match"
+        for item in feature_results_tuple
+        if item.feature_key in recipe.action_effect_keys
+    ) and not any(
+        item.status.startswith("missing")
+        for item in feature_results_tuple
+        if item.feature_key in recipe.action_effect_keys
     )
-    mismatches = tuple(
-        sorted(
-            set(observable_mismatches)
-            | set(action_effect_mismatches)
-            | (
-                {recipe.policy_consequence_key}
-                if policy_mismatch and recipe.policy_consequence_key is not None
-                else set()
-            )
+
+    if recipe.hidden_state_keys and hidden_state_hypothesis_set is None:
+        hidden_state_exhausted = False
+        inconclusive_reasons.add("missing_hidden_state_hypothesis_set")
+        hidden_set_id = None
+    else:
+        hidden_state_exhausted = (
+            hidden_state_hypothesis_set is not None
+            and hidden_state_hypothesis_set.possible_count == 0
         )
-    )
-    observable_feature_match = not observable_mismatches and not any(
-        key in missing_predicted or key in missing_observed
-        for key in recipe.observable_feature_keys
-    )
-    action_effect_match = not action_effect_mismatches and not any(
-        key in missing_predicted or key in missing_observed
-        for key in recipe.action_effect_keys
-    )
-    next_action_equivalent = not policy_mismatch
-    if recipe.policy_consequence_key is not None and (
-        recipe.policy_consequence_key in missing_predicted
-        or recipe.policy_consequence_key in missing_observed
+        hidden_set_id = (
+            None
+            if hidden_state_hypothesis_set is None
+            else hidden_state_hypothesis_set.hypothesis_set_id
+        )
+
+    if (
+        recipe.require_policy_consequence_evidence
+        and policy_consequence_evidence is None
     ):
-        next_action_equivalent = False
-    hidden_state_exhausted = (
-        bool(recipe.hidden_state_keys) and hidden_state_hypotheses_remaining == 0
+        policy_consequence_match = False
+        policy_evidence_id = None
+        inconclusive_reasons.add("missing_policy_consequence_evidence")
+    else:
+        policy_consequence_match = (
+            True
+            if policy_consequence_evidence is None
+            else policy_consequence_evidence.equivalent
+        )
+        policy_evidence_id = (
+            None
+            if policy_consequence_evidence is None
+            else policy_consequence_evidence.policy_consequence_evidence_id
+        )
+
+    evaluated_bad_features = any(
+        item.status in {"mismatch", "type_mismatch"} for item in feature_results_tuple
     )
-    decision_margin_delta = abs(predicted_decision_margin - observed_decision_margin)
-    contradiction = False
-    if not missing_evidence:
-        contradiction = (
-            not observable_feature_match
-            or not action_effect_match
+    contradiction = (
+        "schema_mismatch" not in inconclusive_reasons
+        and "missing_required_feature" not in inconclusive_reasons
+        and "invalid_feature_value" not in inconclusive_reasons
+        and (
+            evaluated_bad_features
             or hidden_state_exhausted
             or (
-                not next_action_equivalent
-                and decision_margin_delta > recipe.decision_margin_tolerance
+                policy_consequence_evidence is not None
+                and not policy_consequence_evidence.equivalent
             )
         )
+    )
     wake_required = (
-        missing_evidence
-        or (recipe.wake_on_observable_mismatch and not observable_feature_match)
-        or (recipe.wake_on_action_effect_mismatch and not action_effect_match)
-        or (recipe.wake_on_policy_consequence_mismatch and not next_action_equivalent)
+        bool(inconclusive_reasons)
+        or (
+            recipe.wake_on_observable_mismatch
+            and any(
+                item.status in {"mismatch", "type_mismatch"}
+                for item in feature_results_tuple
+                if item.feature_key in recipe.observable_feature_keys
+            )
+        )
+        or (
+            recipe.wake_on_action_effect_mismatch
+            and any(
+                item.status in {"mismatch", "type_mismatch"}
+                for item in feature_results_tuple
+                if item.feature_key in recipe.action_effect_keys
+            )
+        )
+        or (
+            recipe.wake_on_policy_consequence_mismatch
+            and policy_consequence_evidence is not None
+            and not policy_consequence_evidence.equivalent
+        )
         or (recipe.wake_on_hidden_state_exhausted and hidden_state_exhausted)
     )
     payload = {
         "action_effect_match": action_effect_match,
         "contradiction": contradiction,
-        "decision_margin_delta": decision_margin_delta,
-        "hidden_state_hypotheses_remaining": hidden_state_hypotheses_remaining,
-        "mismatched_feature_keys": list(mismatches),
-        "missing_observed_feature_keys": list(missing_observed),
-        "missing_predicted_feature_keys": list(missing_predicted),
-        "next_action_equivalent": next_action_equivalent,
+        "feature_results": [item.canonical_payload() for item in feature_results_tuple],
+        "hidden_state_exhausted": hidden_state_exhausted,
+        "hidden_state_hypothesis_set_id": hidden_set_id,
+        "inconclusive_reasons": sorted(inconclusive_reasons),
         "observable_feature_match": observable_feature_match,
+        "observed_observation_artifact_id": observed_observation_artifact_id,
+        "policy_consequence_evidence_id": policy_evidence_id,
+        "policy_consequence_match": policy_consequence_match,
+        "predicted_observation_artifact_id": predicted_observation_artifact_id,
         "recipe_id": recipe.recipe_id,
         "version": OBSERVER_COMPARISON_RESULT_VERSION,
         "wake_required": wake_required,
@@ -302,14 +1020,16 @@ def compare_observer_transition(
     return ObserverComparisonResultDTO(
         comparison_result_id=canonical_id(payload),
         recipe_id=recipe.recipe_id,
+        predicted_observation_artifact_id=predicted_observation_artifact_id,
+        observed_observation_artifact_id=observed_observation_artifact_id,
+        feature_results=feature_results_tuple,
+        policy_consequence_evidence_id=policy_evidence_id,
+        hidden_state_hypothesis_set_id=hidden_set_id,
         observable_feature_match=observable_feature_match,
         action_effect_match=action_effect_match,
-        next_action_equivalent=next_action_equivalent,
-        decision_margin_delta=decision_margin_delta,
-        hidden_state_hypotheses_remaining=hidden_state_hypotheses_remaining,
-        mismatched_feature_keys=mismatches,
+        policy_consequence_match=policy_consequence_match,
+        hidden_state_exhausted=hidden_state_exhausted,
         wake_required=wake_required,
         contradiction=contradiction,
-        missing_predicted_feature_keys=missing_predicted,
-        missing_observed_feature_keys=missing_observed,
+        inconclusive_reasons=tuple(sorted(inconclusive_reasons)),
     )

--- a/packages/observer/src/zeromodel/observer/transition_service.py
+++ b/packages/observer/src/zeromodel/observer/transition_service.py
@@ -222,8 +222,6 @@ def verify_observer_transition(
     state_before_id: str,
     action: str,
     affected_policy_row_id: str,
-    predicted_decision_margin: float,
-    observed_decision_margin: float,
     hidden_state_hypothesis_set: ObserverHiddenStateHypothesisSetDTO | None = None,
     policy_consequence_evidence: ObserverPolicyConsequenceEvidenceDTO | None = None,
     reproduction: Mapping[str, object] | None = None,
@@ -242,9 +240,11 @@ def verify_observer_transition(
     if hidden_state_hypothesis_set is not None and (
         hidden_state_hypothesis_set.observation_schema_id
         != predicted_observation.observation_schema_id
+        or hidden_state_hypothesis_set.observation_schema_id
+        != observed_observation.observation_schema_id
     ):
         raise ObserverTransitionVerificationError(
-            "hidden-state hypothesis set schema does not match predicted observation schema"
+            "hidden-state hypothesis set schema must match predicted and observed observation schemas"
         )
     if policy_consequence_evidence is not None:
         _validate_policy_consequence_evidence(

--- a/packages/observer/src/zeromodel/observer/transition_service.py
+++ b/packages/observer/src/zeromodel/observer/transition_service.py
@@ -18,10 +18,12 @@ from zeromodel.observer.comparison import (
     ObserverComparisonError,
     ObserverComparisonRecipeDTO,
     ObserverComparisonResultDTO,
+    ObserverHiddenStateHypothesisSetDTO,
+    ObserverPolicyConsequenceEvidenceDTO,
     compare_observer_transition,
 )
 
-OBSERVER_TRANSITION_VERIFICATION_VERSION: Final = "observer-transition-verification/1"
+OBSERVER_TRANSITION_VERIFICATION_VERSION: Final = "observer-transition-verification/2"
 OBSERVER_VERIFICATION_CONFIRMED: Final = "confirmed"
 OBSERVER_VERIFICATION_CONTRADICTED: Final = "contradicted"
 OBSERVER_VERIFICATION_INCONCLUSIVE: Final = "inconclusive"
@@ -67,13 +69,36 @@ def _project_feature_surface(
 def _derive_status(comparison: ObserverComparisonResultDTO) -> str:
     if comparison.contradiction:
         return OBSERVER_VERIFICATION_CONTRADICTED
-    if (
-        comparison.missing_predicted_feature_keys
-        or comparison.missing_observed_feature_keys
-        or comparison.wake_required
-    ):
+    if comparison.inconclusive_reasons or comparison.wake_required:
         return OBSERVER_VERIFICATION_INCONCLUSIVE
     return OBSERVER_VERIFICATION_CONFIRMED
+
+
+def _validate_policy_consequence_evidence(
+    *,
+    evidence: ObserverPolicyConsequenceEvidenceDTO,
+    policy_artifact_id: str,
+    predicted_observation: ObserverObservationArtifactDTO,
+    observed_observation: ObserverObservationArtifactDTO,
+) -> None:
+    if evidence.policy_artifact_id != policy_artifact_id:
+        raise ObserverTransitionVerificationError(
+            "policy consequence evidence policy_artifact_id does not match transition policy"
+        )
+    if (
+        evidence.predicted_state_artifact_id
+        != predicted_observation.observation_artifact_id
+    ):
+        raise ObserverTransitionVerificationError(
+            "policy consequence evidence predicted_state_artifact_id does not match"
+        )
+    if (
+        evidence.observed_state_artifact_id
+        != observed_observation.observation_artifact_id
+    ):
+        raise ObserverTransitionVerificationError(
+            "policy consequence evidence observed_state_artifact_id does not match"
+        )
 
 
 @dataclass(frozen=True)
@@ -199,7 +224,8 @@ def verify_observer_transition(
     affected_policy_row_id: str,
     predicted_decision_margin: float,
     observed_decision_margin: float,
-    hidden_state_hypotheses_remaining: int,
+    hidden_state_hypothesis_set: ObserverHiddenStateHypothesisSetDTO | None = None,
+    policy_consequence_evidence: ObserverPolicyConsequenceEvidenceDTO | None = None,
     reproduction: Mapping[str, object] | None = None,
     relevant_context_keys: tuple[str, ...] = (),
 ) -> ObserverTransitionVerificationDTO:
@@ -213,6 +239,20 @@ def verify_observer_transition(
     ):
         _require_non_empty(value, field_name)
     _ensure_sorted_unique(relevant_context_keys, "relevant_context_keys")
+    if hidden_state_hypothesis_set is not None and (
+        hidden_state_hypothesis_set.observation_schema_id
+        != predicted_observation.observation_schema_id
+    ):
+        raise ObserverTransitionVerificationError(
+            "hidden-state hypothesis set schema does not match predicted observation schema"
+        )
+    if policy_consequence_evidence is not None:
+        _validate_policy_consequence_evidence(
+            evidence=policy_consequence_evidence,
+            policy_artifact_id=policy_artifact_id,
+            predicted_observation=predicted_observation,
+            observed_observation=observed_observation,
+        )
     if observed_observation.sequence_index != predicted_observation.sequence_index:
         raise ObserverTransitionVerificationError(
             "predicted and observed observations must describe the same "
@@ -224,11 +264,16 @@ def verify_observer_transition(
     try:
         comparison = compare_observer_transition(
             recipe=recipe,
+            predicted_observation_artifact_id=(
+                predicted_observation.observation_artifact_id
+            ),
+            observed_observation_artifact_id=observed_observation.observation_artifact_id,
+            predicted_observation_schema_id=predicted_observation.observation_schema_id,
+            observed_observation_schema_id=observed_observation.observation_schema_id,
             predicted_features=_project_feature_surface(predicted_observation),
             observed_features=_project_feature_surface(observed_observation),
-            predicted_decision_margin=predicted_decision_margin,
-            observed_decision_margin=observed_decision_margin,
-            hidden_state_hypotheses_remaining=hidden_state_hypotheses_remaining,
+            hidden_state_hypothesis_set=hidden_state_hypothesis_set,
+            policy_consequence_evidence=policy_consequence_evidence,
         )
         verification_status = _derive_status(comparison)
         transition = build_transition_record(

--- a/packages/observer/tests/test_contract_hardening.py
+++ b/packages/observer/tests/test_contract_hardening.py
@@ -11,7 +11,9 @@ from zeromodel.observer import (
     ObserverObservationArtifactDTO,
     ObserverObservationSchemaDTO,
     ObserverPolicyConsequenceEvidenceDTO,
+    ObserverTransitionVerificationError,
     compare_observer_transition,
+    verify_observer_transition,
 )
 from zeromodel.observer.artifacts import ObserverArtifactError
 from zeromodel.observer.comparison import ObserverComparisonError
@@ -173,6 +175,17 @@ def test_recipe_identity_changes_with_comparison_semantics() -> None:
     assert all(item.recipe_id != baseline.recipe_id for item in variants)
 
 
+def test_recipe_rejects_unused_comparison_specs() -> None:
+    required = comparison("visible.score", mode="exact")
+    extra = comparison("visible.label", mode="exact")
+
+    with pytest.raises(ObserverComparisonError, match="exactly match"):
+        ObserverComparisonRecipeDTO.create(
+            feature_comparisons=(extra, required),
+            observable_feature_keys=("visible.score",),
+        )
+
+
 def test_per_feature_evidence_statuses() -> None:
     observation_schema = schema()
     spec = comparison("visible.label", mode="exact")
@@ -308,6 +321,46 @@ def test_hypothesis_set_evidence_controls_exhaustion_and_identity() -> None:
     assert still_possible.hidden_state_exhausted is False
     assert exhausted.hidden_state_exhausted is True
     assert still_possible.comparison_result_id != exhausted.comparison_result_id
+
+
+def test_transition_rejects_hypothesis_set_schema_mismatch_with_observed() -> None:
+    predicted_schema = schema(name="predicted")
+    observed_schema = schema(name="observed")
+    predicted = ObserverObservationArtifactDTO.create(
+        observation_schema=predicted_schema,
+        visible_state_features={"score": 1},
+    )
+    observed = ObserverObservationArtifactDTO.create(
+        observation_schema=observed_schema,
+        visible_state_features={"score": 1},
+    )
+    hypotheses = ObserverHiddenStateHypothesisSetDTO.create(
+        observation_schema_id=predicted_schema.schema_id,
+        hypotheses=(
+            ObserverHiddenStateHypothesisDTO.create(
+                state_key="hidden.cooldown", state_value="clear"
+            ),
+        ),
+    )
+
+    visible_score_recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=(comparison("visible.score", mode="exact"),),
+        observable_feature_keys=("visible.score",),
+    )
+
+    with pytest.raises(
+        ObserverTransitionVerificationError, match="predicted and observed"
+    ):
+        verify_observer_transition(
+            recipe=visible_score_recipe,
+            predicted_observation=predicted,
+            observed_observation=observed,
+            policy_artifact_id="policy:A",
+            state_before_id="state:before",
+            action="wait",
+            affected_policy_row_id="row:before",
+            hidden_state_hypothesis_set=hypotheses,
+        )
 
 
 def test_policy_consequence_evidence_is_required_and_validated() -> None:

--- a/packages/observer/tests/test_contract_hardening.py
+++ b/packages/observer/tests/test_contract_hardening.py
@@ -1,0 +1,415 @@
+import math
+
+import pytest
+
+from zeromodel.observer import (
+    ObserverComparisonRecipeDTO,
+    ObserverFeatureComparisonDTO,
+    ObserverFeatureDefinitionDTO,
+    ObserverHiddenStateHypothesisDTO,
+    ObserverHiddenStateHypothesisSetDTO,
+    ObserverObservationArtifactDTO,
+    ObserverObservationSchemaDTO,
+    ObserverPolicyConsequenceEvidenceDTO,
+    compare_observer_transition,
+)
+from zeromodel.observer.artifacts import ObserverArtifactError
+from zeromodel.observer.comparison import ObserverComparisonError
+
+
+def schema(*, name: str = "contract") -> ObserverObservationSchemaDTO:
+    return ObserverObservationSchemaDTO.create(
+        schema_name=name,
+        features=(
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="hidden.cooldown", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.label", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.score", value_type="number", required=False
+            ),
+        ),
+    )
+
+
+def comparison(
+    key: str,
+    *,
+    mode: str = "exact",
+    expected_type: str | None = None,
+    absolute_tolerance: float | None = None,
+    relative_tolerance: float | None = None,
+) -> ObserverFeatureComparisonDTO:
+    return ObserverFeatureComparisonDTO.create(
+        feature_key=key,
+        mode=mode,
+        expected_type=expected_type,
+        absolute_tolerance=absolute_tolerance,
+        relative_tolerance=relative_tolerance,
+    )
+
+
+def recipe(
+    spec: ObserverFeatureComparisonDTO,
+    *,
+    require_policy: bool = False,
+    wake_policy: bool = False,
+    hidden: bool = False,
+    wake_observable: bool = True,
+) -> ObserverComparisonRecipeDTO:
+    return ObserverComparisonRecipeDTO.create(
+        feature_comparisons=(spec,),
+        observable_feature_keys=(spec.feature_key,),
+        hidden_state_keys=(spec.feature_key,) if hidden else (),
+        require_policy_consequence_evidence=require_policy,
+        wake_on_policy_consequence_mismatch=wake_policy,
+        wake_on_observable_mismatch=wake_observable,
+    )
+
+
+def compare(
+    spec: ObserverFeatureComparisonDTO,
+    predicted: object,
+    observed: object,
+):
+    observation_schema = schema()
+    return compare_observer_transition(
+        recipe=recipe(spec),
+        predicted_observation_artifact_id="obs:predicted",
+        observed_observation_artifact_id="obs:observed",
+        predicted_observation_schema_id=observation_schema.schema_id,
+        observed_observation_schema_id=observation_schema.schema_id,
+        predicted_features={spec.feature_key: predicted},
+        observed_features={spec.feature_key: observed},
+    ).feature_results[0]
+
+
+@pytest.mark.parametrize(
+    ("predicted", "observed", "status"),
+    [
+        (True, 1, "type_mismatch"),
+        (1, 1.0, "type_mismatch"),
+        ("1", 1, "type_mismatch"),
+        (1, 1, "match"),
+    ],
+)
+def test_strict_exact_comparison(
+    predicted: object, observed: object, status: str
+) -> None:
+    result = compare(comparison("visible.score", mode="exact"), predicted, observed)
+
+    assert result.status == status
+
+
+def test_numeric_tolerance_absolute_and_relative() -> None:
+    tolerant = comparison(
+        "visible.score",
+        mode="numeric_tolerance",
+        expected_type="number",
+        absolute_tolerance=1e-12,
+        relative_tolerance=0.0,
+    )
+    strict = comparison(
+        "visible.score",
+        mode="numeric_tolerance",
+        expected_type="number",
+        absolute_tolerance=0.0,
+        relative_tolerance=0.0,
+    )
+    relative = comparison(
+        "visible.score",
+        mode="numeric_tolerance",
+        expected_type="number",
+        absolute_tolerance=0.0,
+        relative_tolerance=0.1,
+    )
+
+    assert compare(tolerant, 0.30000000000000004, 0.3).status == "match"
+    assert compare(strict, 0.30000000000000004, 0.3).status == "mismatch"
+    assert compare(relative, 100.0, 105.0).status == "match"
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf, True])
+def test_invalid_numeric_values(value: object) -> None:
+    spec = comparison(
+        "visible.score",
+        mode="numeric_tolerance",
+        expected_type="number",
+        absolute_tolerance=0.0,
+        relative_tolerance=0.0,
+    )
+
+    assert compare(spec, value, 1.0).status == "invalid_value"
+
+
+def test_recipe_identity_changes_with_comparison_semantics() -> None:
+    baseline = recipe(comparison("visible.score", mode="exact"))
+
+    variants = (
+        recipe(comparison("visible.score", mode="categorical", expected_type="int")),
+        recipe(comparison("visible.score", mode="exact", expected_type="int")),
+        recipe(
+            comparison(
+                "visible.score",
+                mode="numeric_tolerance",
+                expected_type="number",
+                absolute_tolerance=0.1,
+                relative_tolerance=0.0,
+            )
+        ),
+        recipe(
+            comparison(
+                "visible.score",
+                mode="numeric_tolerance",
+                expected_type="number",
+                absolute_tolerance=0.0,
+                relative_tolerance=0.1,
+            )
+        ),
+    )
+
+    assert all(item.recipe_id != baseline.recipe_id for item in variants)
+
+
+def test_per_feature_evidence_statuses() -> None:
+    observation_schema = schema()
+    spec = comparison("visible.label", mode="exact")
+    base = {
+        "recipe": recipe(spec),
+        "predicted_observation_artifact_id": "obs:p",
+        "observed_observation_artifact_id": "obs:o",
+        "predicted_observation_schema_id": observation_schema.schema_id,
+        "observed_observation_schema_id": observation_schema.schema_id,
+    }
+
+    assert compare(spec, "a", "a").status == "match"
+    assert compare(spec, "a", "b").status == "mismatch"
+    assert (
+        compare_observer_transition(
+            **base, predicted_features={}, observed_features={"visible.label": "a"}
+        )
+        .feature_results[0]
+        .status
+        == "missing_predicted"
+    )
+    assert (
+        compare_observer_transition(
+            **base, predicted_features={"visible.label": "a"}, observed_features={}
+        )
+        .feature_results[0]
+        .status
+        == "missing_observed"
+    )
+    assert compare(spec, "1", 1).status == "type_mismatch"
+
+
+def test_observation_schema_enforcement_and_identity() -> None:
+    observation_schema = schema(name="one")
+    other_schema = schema(name="two")
+
+    with pytest.raises(ObserverArtifactError, match="undeclared"):
+        ObserverObservationArtifactDTO.create(
+            observation_schema=observation_schema,
+            visible_state_features={"unknown": 1},
+        )
+    required_schema = ObserverObservationSchemaDTO.create(
+        schema_name="required",
+        features=(
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.score", value_type="number", required=True
+            ),
+        ),
+    )
+    with pytest.raises(ObserverArtifactError, match="missing required"):
+        ObserverObservationArtifactDTO.create(
+            observation_schema=required_schema,
+            visible_state_features={},
+        )
+    with pytest.raises(ObserverArtifactError, match="expected number"):
+        ObserverObservationArtifactDTO.create(
+            observation_schema=observation_schema,
+            visible_state_features={"score": True},
+        )
+
+    left = ObserverObservationArtifactDTO.create(
+        observation_schema=observation_schema,
+        visible_state_features={"score": 1},
+    )
+    right = ObserverObservationArtifactDTO.create(
+        observation_schema=other_schema,
+        visible_state_features={"score": 1},
+    )
+    assert left.observation_artifact_id != right.observation_artifact_id
+
+
+def test_schema_mismatch_is_inconclusive_not_contradiction() -> None:
+    left_schema = schema(name="left")
+    right_schema = schema(name="right")
+    result = compare_observer_transition(
+        recipe=recipe(comparison("visible.score", mode="exact")),
+        predicted_observation_artifact_id="obs:p",
+        observed_observation_artifact_id="obs:o",
+        predicted_observation_schema_id=left_schema.schema_id,
+        observed_observation_schema_id=right_schema.schema_id,
+        predicted_features={"visible.score": 1},
+        observed_features={"visible.score": 2},
+    )
+
+    assert result.contradiction is False
+    assert result.inconclusive_reasons == ("schema_mismatch",)
+
+
+def test_hypothesis_set_evidence_controls_exhaustion_and_identity() -> None:
+    observation_schema = schema()
+    spec = comparison("hidden.cooldown", mode="exact")
+    possible = ObserverHiddenStateHypothesisSetDTO.create(
+        observation_schema_id=observation_schema.schema_id,
+        hypotheses=(
+            ObserverHiddenStateHypothesisDTO.create(
+                state_key="hidden.cooldown",
+                state_value="clear",
+                status="possible",
+                evidence_ids=("evidence:a",),
+            ),
+        ),
+    )
+    eliminated = ObserverHiddenStateHypothesisSetDTO.create(
+        observation_schema_id=observation_schema.schema_id,
+        hypotheses=(
+            ObserverHiddenStateHypothesisDTO.create(
+                state_key="hidden.cooldown",
+                state_value="clear",
+                status="eliminated",
+                evidence_ids=("evidence:b",),
+            ),
+        ),
+    )
+
+    common = {
+        "recipe": recipe(spec, hidden=True),
+        "predicted_observation_artifact_id": "obs:p",
+        "observed_observation_artifact_id": "obs:o",
+        "predicted_observation_schema_id": observation_schema.schema_id,
+        "observed_observation_schema_id": observation_schema.schema_id,
+        "predicted_features": {"hidden.cooldown": "clear"},
+        "observed_features": {"hidden.cooldown": "clear"},
+    }
+    missing = compare_observer_transition(**common)
+    still_possible = compare_observer_transition(
+        **common, hidden_state_hypothesis_set=possible
+    )
+    exhausted = compare_observer_transition(
+        **common, hidden_state_hypothesis_set=eliminated
+    )
+
+    assert missing.inconclusive_reasons == ("missing_hidden_state_hypothesis_set",)
+    assert still_possible.hidden_state_exhausted is False
+    assert exhausted.hidden_state_exhausted is True
+    assert still_possible.comparison_result_id != exhausted.comparison_result_id
+
+
+def test_policy_consequence_evidence_is_required_and_validated() -> None:
+    observation_schema = schema()
+    spec = comparison("visible.label", mode="exact")
+    required = recipe(spec, require_policy=True)
+    absent = compare_observer_transition(
+        recipe=required,
+        predicted_observation_artifact_id="obs:p",
+        observed_observation_artifact_id="obs:o",
+        predicted_observation_schema_id=observation_schema.schema_id,
+        observed_observation_schema_id=observation_schema.schema_id,
+        predicted_features={"visible.label": "same", "visible.next_action": "go"},
+        observed_features={"visible.label": "same", "visible.next_action": "go"},
+    )
+    equal = ObserverPolicyConsequenceEvidenceDTO.create(
+        policy_artifact_id="policy:A",
+        predicted_state_artifact_id="obs:p",
+        observed_state_artifact_id="obs:o",
+        predicted_selected_action="go",
+        observed_selected_action="go",
+        predicted_decision_trace_id="trace:p",
+        observed_decision_trace_id="trace:o",
+        reader_contract_id="reader:v1",
+    )
+    different = ObserverPolicyConsequenceEvidenceDTO.create(
+        policy_artifact_id="policy:A",
+        predicted_state_artifact_id="obs:p",
+        observed_state_artifact_id="obs:o",
+        predicted_selected_action="go",
+        observed_selected_action="wait",
+        predicted_decision_trace_id="trace:p",
+        observed_decision_trace_id="trace:o",
+        reader_contract_id="reader:v1",
+    )
+
+    assert absent.inconclusive_reasons == ("missing_policy_consequence_evidence",)
+    assert absent.contradiction is False
+    assert equal.equivalent is True
+    assert different.equivalent is False
+    with pytest.raises(ObserverComparisonError, match="equivalent"):
+        ObserverPolicyConsequenceEvidenceDTO(
+            policy_consequence_evidence_id=different.policy_consequence_evidence_id,
+            policy_artifact_id="policy:A",
+            predicted_state_artifact_id="obs:p",
+            observed_state_artifact_id="obs:o",
+            predicted_selected_action="go",
+            observed_selected_action="wait",
+            predicted_decision_trace_id="trace:p",
+            observed_decision_trace_id="trace:o",
+            equivalent=True,
+            reader_contract_id="reader:v1",
+        )
+
+
+def test_contradiction_and_wake_independence_and_replay() -> None:
+    observation_schema = schema()
+    spec = comparison("visible.score", mode="exact")
+    no_wake = compare_observer_transition(
+        recipe=recipe(spec, wake_observable=False),
+        predicted_observation_artifact_id="obs:p",
+        observed_observation_artifact_id="obs:o",
+        predicted_observation_schema_id=observation_schema.schema_id,
+        observed_observation_schema_id=observation_schema.schema_id,
+        predicted_features={"visible.score": 1},
+        observed_features={"visible.score": 2},
+    )
+    missing = compare_observer_transition(
+        recipe=recipe(spec),
+        predicted_observation_artifact_id="obs:p",
+        observed_observation_artifact_id="obs:o",
+        predicted_observation_schema_id=observation_schema.schema_id,
+        observed_observation_schema_id=observation_schema.schema_id,
+        predicted_features={},
+        observed_features={},
+    )
+    replay = compare_observer_transition(
+        recipe=recipe(spec, wake_observable=False),
+        predicted_observation_artifact_id="obs:p",
+        observed_observation_artifact_id="obs:o",
+        predicted_observation_schema_id=observation_schema.schema_id,
+        observed_observation_schema_id=observation_schema.schema_id,
+        predicted_features={"visible.score": 1},
+        observed_features={"visible.score": 2},
+    )
+
+    assert no_wake.contradiction is True
+    assert no_wake.wake_required is False
+    assert missing.contradiction is False
+    assert missing.wake_required is True
+    assert no_wake.comparison_result_id == replay.comparison_result_id
+
+
+def test_legacy_recipe_version_is_rejected() -> None:
+    spec = comparison("visible.score", mode="exact")
+    payload = recipe(spec).canonical_payload(include_id=False)
+    payload["version"] = "observer-comparison-recipe/1"
+
+    with pytest.raises(ObserverComparisonError, match="legacy comparison recipes"):
+        ObserverComparisonRecipeDTO(
+            recipe_id=recipe(spec).recipe_id,
+            feature_comparisons=(spec,),
+            observable_feature_keys=("visible.score",),
+            version="observer-comparison-recipe/1",
+        )

--- a/packages/observer/tests/test_observer_artifacts.py
+++ b/packages/observer/tests/test_observer_artifacts.py
@@ -1,8 +1,14 @@
 import pytest
 
 from zeromodel.observer import (
-    ObserverComparisonRecipeDTO,
+    ObserverFeatureComparisonDTO,
+    ObserverFeatureDefinitionDTO,
+    ObserverHiddenStateHypothesisDTO,
+    ObserverHiddenStateHypothesisSetDTO,
     ObserverObservationArtifactDTO,
+    ObserverObservationSchemaDTO,
+    ObserverPolicyConsequenceEvidenceDTO,
+    ObserverComparisonRecipeDTO,
     build_contradiction_artifact,
     build_replacement_policy_artifact,
     build_transition_record,
@@ -11,18 +17,55 @@ from zeromodel.observer import (
 from zeromodel.observer.artifacts import ObserverArtifactError
 
 
+def schema() -> ObserverObservationSchemaDTO:
+    return ObserverObservationSchemaDTO.create(
+        schema_name="artifact-test",
+        features=(
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="hidden.cooldown", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="history.previous_action",
+                value_type="str",
+                required=False,
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.action_effect",
+                value_type="str",
+                required=False,
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.agent_x", value_type="int", required=True
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.target_x", value_type="int", required=False
+            ),
+        ),
+    )
+
+
+def specs(*keys: str) -> tuple[ObserverFeatureComparisonDTO, ...]:
+    return tuple(
+        ObserverFeatureComparisonDTO.create(feature_key=key, mode="exact")
+        for key in sorted(keys)
+    )
+
+
 def test_observation_artifact_identity_is_canonical() -> None:
+    observation_schema = schema()
     left = ObserverObservationArtifactDTO.create(
+        observation_schema=observation_schema,
         visible_state_features={"target_x": 9, "agent_x": 4},
         recent_history_features={"previous_action": "move_right"},
-        hidden_state_uncertainty={"cooldown": ("unknown", "maybe_active")},
+        hidden_state_uncertainty={"cooldown": "maybe_active"},
         provenance={"fixture": "hidden-cooldown-v0"},
         sequence_index=3,
     )
     right = ObserverObservationArtifactDTO.create(
+        observation_schema=observation_schema,
         visible_state_features={"agent_x": 4, "target_x": 9},
         recent_history_features={"previous_action": "move_right"},
-        hidden_state_uncertainty={"cooldown": ("unknown", "maybe_active")},
+        hidden_state_uncertainty={"cooldown": "maybe_active"},
         provenance={"fixture": "hidden-cooldown-v0"},
         sequence_index=3,
     )
@@ -31,90 +74,164 @@ def test_observation_artifact_identity_is_canonical() -> None:
 
 
 def test_comparison_result_is_structured_and_replayable() -> None:
+    observation_schema = schema()
+    predicted = ObserverObservationArtifactDTO.create(
+        observation_schema=observation_schema,
+        visible_state_features={
+            "agent_x": 5,
+            "target_x": 9,
+            "action_effect": "moved_right",
+        },
+        hidden_state_uncertainty={"cooldown": "clear"},
+    )
+    observed = ObserverObservationArtifactDTO.create(
+        observation_schema=observation_schema,
+        visible_state_features={
+            "agent_x": 4,
+            "target_x": 9,
+            "action_effect": "blocked_by_cooldown",
+        },
+        hidden_state_uncertainty={"cooldown": "active"},
+    )
     recipe = ObserverComparisonRecipeDTO.create(
-        observable_feature_keys=("agent_x", "target_x"),
-        action_effect_keys=("action_effect",),
-        policy_consequence_key="next_action",
-        hidden_state_keys=("cooldown",),
-        wake_on_policy_consequence_mismatch=True,
+        feature_comparisons=specs(
+            "hidden.cooldown",
+            "visible.action_effect",
+            "visible.agent_x",
+            "visible.target_x",
+        ),
+        observable_feature_keys=("visible.agent_x", "visible.target_x"),
+        action_effect_keys=("visible.action_effect",),
+        hidden_state_keys=("hidden.cooldown",),
+    )
+    hypotheses = ObserverHiddenStateHypothesisSetDTO.create(
+        observation_schema_id=observation_schema.schema_id,
+        hypotheses=(
+            ObserverHiddenStateHypothesisDTO.create(
+                state_key="hidden.cooldown", state_value="clear"
+            ),
+        ),
+    )
+    policy_evidence = ObserverPolicyConsequenceEvidenceDTO.create(
+        policy_artifact_id="policy:A",
+        predicted_state_artifact_id=predicted.observation_artifact_id,
+        observed_state_artifact_id=observed.observation_artifact_id,
+        predicted_selected_action="move_right",
+        observed_selected_action="wait",
+        predicted_decision_trace_id="trace:predicted",
+        observed_decision_trace_id="trace:observed",
+        reader_contract_id="reader:v1",
     )
 
     result = compare_observer_transition(
         recipe=recipe,
+        predicted_observation_artifact_id=predicted.observation_artifact_id,
+        observed_observation_artifact_id=observed.observation_artifact_id,
+        predicted_observation_schema_id=predicted.observation_schema_id,
+        observed_observation_schema_id=observed.observation_schema_id,
         predicted_features={
-            "agent_x": 5,
-            "target_x": 9,
-            "action_effect": "moved_right",
-            "next_action": "move_right",
-            "cooldown": "clear",
+            "hidden.cooldown": "clear",
+            "visible.agent_x": 5,
+            "visible.target_x": 9,
+            "visible.action_effect": "moved_right",
         },
         observed_features={
-            "agent_x": 4,
-            "target_x": 9,
-            "action_effect": "blocked_by_cooldown",
-            "next_action": "wait",
-            "cooldown": "active",
+            "hidden.cooldown": "active",
+            "visible.agent_x": 4,
+            "visible.target_x": 9,
+            "visible.action_effect": "blocked_by_cooldown",
         },
-        predicted_decision_margin=0.30,
-        observed_decision_margin=0.12,
-        hidden_state_hypotheses_remaining=1,
+        hidden_state_hypothesis_set=hypotheses,
+        policy_consequence_evidence=policy_evidence,
+    )
+
+    replay = compare_observer_transition(
+        recipe=recipe,
+        predicted_observation_artifact_id=predicted.observation_artifact_id,
+        observed_observation_artifact_id=observed.observation_artifact_id,
+        predicted_observation_schema_id=predicted.observation_schema_id,
+        observed_observation_schema_id=observed.observation_schema_id,
+        predicted_features={
+            "hidden.cooldown": "clear",
+            "visible.agent_x": 5,
+            "visible.target_x": 9,
+            "visible.action_effect": "moved_right",
+        },
+        observed_features={
+            "hidden.cooldown": "active",
+            "visible.agent_x": 4,
+            "visible.target_x": 9,
+            "visible.action_effect": "blocked_by_cooldown",
+        },
+        hidden_state_hypothesis_set=hypotheses,
+        policy_consequence_evidence=policy_evidence,
     )
 
     assert result.observable_feature_match is False
     assert result.action_effect_match is False
-    assert result.next_action_equivalent is False
+    assert result.policy_consequence_match is False
     assert result.wake_required is True
     assert result.contradiction is True
     assert result.mismatched_feature_keys == (
-        "action_effect",
-        "agent_x",
-        "next_action",
+        "hidden.cooldown",
+        "visible.action_effect",
+        "visible.agent_x",
     )
+    assert result.comparison_result_id == replay.comparison_result_id
 
 
 def test_contradiction_requires_failing_comparison() -> None:
+    observation_schema = schema()
     recipe = ObserverComparisonRecipeDTO.create(
-        observable_feature_keys=("agent_x",),
+        feature_comparisons=specs("visible.agent_x"),
+        observable_feature_keys=("visible.agent_x",),
     )
     result = compare_observer_transition(
         recipe=recipe,
-        predicted_features={"agent_x": 4},
-        observed_features={"agent_x": 4},
-        predicted_decision_margin=0.1,
-        observed_decision_margin=0.1,
-        hidden_state_hypotheses_remaining=0,
+        predicted_observation_artifact_id="state:predicted",
+        observed_observation_artifact_id="state:observed",
+        predicted_observation_schema_id=observation_schema.schema_id,
+        observed_observation_schema_id=observation_schema.schema_id,
+        predicted_features={"visible.agent_x": 4},
+        observed_features={"visible.agent_x": 4},
     )
     transition = build_transition_record(
         policy_artifact_id="policy:A",
         state_before_id="state:before",
         action="wait",
-        predicted_state_after_id="state:after",
-        observed_state_after_id="state:after",
+        predicted_state_after_id="state:predicted",
+        observed_state_after_id="state:observed",
         comparison_recipe_id=recipe.recipe_id,
         comparison_result_id=result.comparison_result_id,
-        verification_status="accepted",
+        verification_status="confirmed",
         affected_policy_row_id="row:state-before",
     )
 
     with pytest.raises(ObserverArtifactError, match="not a contradiction"):
-        build_contradiction_artifact(
-            transition=transition,
-            comparison=result,
-        )
+        build_contradiction_artifact(transition=transition, comparison=result)
 
 
 def test_contradiction_and_replacement_lineage_are_content_addressed() -> None:
+    observation_schema = schema()
     recipe = ObserverComparisonRecipeDTO.create(
-        observable_feature_keys=("agent_x",),
-        action_effect_keys=("action_effect",),
+        feature_comparisons=specs("visible.action_effect", "visible.agent_x"),
+        observable_feature_keys=("visible.agent_x",),
+        action_effect_keys=("visible.action_effect",),
     )
     result = compare_observer_transition(
         recipe=recipe,
-        predicted_features={"agent_x": 5, "action_effect": "moved_right"},
-        observed_features={"agent_x": 4, "action_effect": "blocked_by_cooldown"},
-        predicted_decision_margin=0.3,
-        observed_decision_margin=0.2,
-        hidden_state_hypotheses_remaining=1,
+        predicted_observation_artifact_id="state:x5",
+        observed_observation_artifact_id="state:x4",
+        predicted_observation_schema_id=observation_schema.schema_id,
+        observed_observation_schema_id=observation_schema.schema_id,
+        predicted_features={
+            "visible.agent_x": 5,
+            "visible.action_effect": "moved_right",
+        },
+        observed_features={
+            "visible.agent_x": 4,
+            "visible.action_effect": "blocked_by_cooldown",
+        },
     )
     transition = build_transition_record(
         policy_artifact_id="policy:A",
@@ -131,7 +248,7 @@ def test_contradiction_and_replacement_lineage_are_content_addressed() -> None:
         transition=transition,
         comparison=result,
         reproduction={"episode_id": "episode:1", "step": 7},
-        relevant_context_keys=("previous_action",),
+        relevant_context_keys=("history.previous_action",),
     )
     replacement = build_replacement_policy_artifact(
         parent_policy_artifact_id="policy:A",

--- a/packages/observer/tests/test_repair_service.py
+++ b/packages/observer/tests/test_repair_service.py
@@ -68,7 +68,6 @@ def cooldown_recipe() -> ObserverComparisonRecipeDTO:
             "hidden.cooldown",
             "visible.action_effect",
             "visible.agent_x",
-            "visible.next_action",
             "visible.target_x",
         )
     )
@@ -121,8 +120,6 @@ def contradicted_verification():
         state_before_id="state:before",
         action="move_right",
         affected_policy_row_id=ROW_ID,
-        predicted_decision_margin=0.30,
-        observed_decision_margin=0.12,
         hidden_state_hypothesis_set=hypothesis_set(possible=True),
         reproduction={"episode_id": "episode:1", "step": 7},
         relevant_context_keys=("hidden.cooldown",),
@@ -156,8 +153,6 @@ def confirmed_verification():
         state_before_id="state:before",
         action="move_right",
         affected_policy_row_id=ROW_ID,
-        predicted_decision_margin=0.30,
-        observed_decision_margin=0.30,
         hidden_state_hypothesis_set=hypothesis_set(possible=True),
     )
 
@@ -179,8 +174,6 @@ def inconclusive_verification():
         state_before_id="state:before",
         action="move_right",
         affected_policy_row_id=ROW_ID,
-        predicted_decision_margin=0.30,
-        observed_decision_margin=0.30,
         hidden_state_hypothesis_set=hypothesis_set(possible=True),
     )
 

--- a/packages/observer/tests/test_repair_service.py
+++ b/packages/observer/tests/test_repair_service.py
@@ -2,7 +2,12 @@ import pytest
 
 from zeromodel.observer import (
     ObserverComparisonRecipeDTO,
+    ObserverFeatureComparisonDTO,
+    ObserverFeatureDefinitionDTO,
+    ObserverHiddenStateHypothesisDTO,
+    ObserverHiddenStateHypothesisSetDTO,
     ObserverObservationArtifactDTO,
+    ObserverObservationSchemaDTO,
     ObserverProposedChangeDTO,
     ObserverRepairConstraintDTO,
     ObserverRepairProposalError,
@@ -15,6 +20,32 @@ ROW_ID = "row:cooldown-sensitive"
 CELL_ID = f"{ROW_ID}/action:move_right"
 
 
+def observer_schema() -> ObserverObservationSchemaDTO:
+    return ObserverObservationSchemaDTO.create(
+        schema_name="stage-o3-repair",
+        features=(
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="hidden.cooldown", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.action_effect", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.agent_x", value_type="int", required=True
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.next_action", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.target_x", value_type="int", required=True
+            ),
+        ),
+    )
+
+
+SCHEMA = observer_schema()
+
+
 def observation(
     *,
     sequence_index: int = 1,
@@ -22,6 +53,7 @@ def observation(
     hidden: dict[str, object] | None = None,
 ) -> ObserverObservationArtifactDTO:
     return ObserverObservationArtifactDTO.create(
+        observation_schema=SCHEMA,
         visible_state_features=visible,
         hidden_state_uncertainty=hidden or {},
         provenance={"fixture": "stage-o2"},
@@ -30,12 +62,35 @@ def observation(
 
 
 def cooldown_recipe() -> ObserverComparisonRecipeDTO:
+    feature_comparisons = tuple(
+        ObserverFeatureComparisonDTO.create(feature_key=key, mode="exact")
+        for key in (
+            "hidden.cooldown",
+            "visible.action_effect",
+            "visible.agent_x",
+            "visible.next_action",
+            "visible.target_x",
+        )
+    )
     return ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_comparisons,
         observable_feature_keys=("visible.agent_x", "visible.target_x"),
         action_effect_keys=("visible.action_effect",),
-        policy_consequence_key="visible.next_action",
         hidden_state_keys=("hidden.cooldown",),
         wake_on_policy_consequence_mismatch=True,
+    )
+
+
+def hypothesis_set(*, possible: bool = True) -> ObserverHiddenStateHypothesisSetDTO:
+    return ObserverHiddenStateHypothesisSetDTO.create(
+        observation_schema_id=SCHEMA.schema_id,
+        hypotheses=(
+            ObserverHiddenStateHypothesisDTO.create(
+                state_key="hidden.cooldown",
+                state_value="clear",
+                status="possible" if possible else "eliminated",
+            ),
+        ),
     )
 
 
@@ -68,7 +123,7 @@ def contradicted_verification():
         affected_policy_row_id=ROW_ID,
         predicted_decision_margin=0.30,
         observed_decision_margin=0.12,
-        hidden_state_hypotheses_remaining=1,
+        hidden_state_hypothesis_set=hypothesis_set(possible=True),
         reproduction={"episode_id": "episode:1", "step": 7},
         relevant_context_keys=("hidden.cooldown",),
     )
@@ -103,7 +158,7 @@ def confirmed_verification():
         affected_policy_row_id=ROW_ID,
         predicted_decision_margin=0.30,
         observed_decision_margin=0.30,
-        hidden_state_hypotheses_remaining=1,
+        hidden_state_hypothesis_set=hypothesis_set(possible=True),
     )
 
 
@@ -126,7 +181,7 @@ def inconclusive_verification():
         affected_policy_row_id=ROW_ID,
         predicted_decision_margin=0.30,
         observed_decision_margin=0.30,
-        hidden_state_hypotheses_remaining=1,
+        hidden_state_hypothesis_set=hypothesis_set(possible=True),
     )
 
 

--- a/packages/observer/tests/test_transition_service.py
+++ b/packages/observer/tests/test_transition_service.py
@@ -1,12 +1,53 @@
 import pytest
 
 from zeromodel.observer import (
+    ObserverFeatureComparisonDTO,
+    ObserverFeatureDefinitionDTO,
+    ObserverHiddenStateHypothesisDTO,
+    ObserverHiddenStateHypothesisSetDTO,
     ObserverComparisonRecipeDTO,
     ObserverObservationArtifactDTO,
+    ObserverObservationSchemaDTO,
+    ObserverPolicyConsequenceEvidenceDTO,
     ObserverTransitionVerificationDTO,
     ObserverTransitionVerificationError,
     verify_observer_transition,
 )
+
+
+def schema(*, name: str = "stage-o3") -> ObserverObservationSchemaDTO:
+    return ObserverObservationSchemaDTO.create(
+        schema_name=name,
+        features=(
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="hidden.cooldown", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="hidden.mode", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="history.mode", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.action_effect", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.agent_x", value_type="int", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.mode", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.next_action", value_type="str", required=False
+            ),
+            ObserverFeatureDefinitionDTO.create(
+                qualified_key="visible.target_x", value_type="int", required=False
+            ),
+        ),
+    )
+
+
+SCHEMA = schema()
 
 
 def observation(
@@ -17,6 +58,7 @@ def observation(
     hidden: dict[str, object] | None = None,
 ) -> ObserverObservationArtifactDTO:
     return ObserverObservationArtifactDTO.create(
+        observation_schema=SCHEMA,
         visible_state_features=visible,
         recent_history_features=history or {},
         hidden_state_uncertainty=hidden or {},
@@ -33,6 +75,7 @@ def verify(
     predicted_margin: float = 0.3,
     observed_margin: float = 0.3,
     hidden_remaining: int = 1,
+    policy_evidence: ObserverPolicyConsequenceEvidenceDTO | None = None,
     reproduction: dict[str, object] | None = None,
     relevant_context_keys: tuple[str, ...] = (),
 ):
@@ -46,17 +89,39 @@ def verify(
         affected_policy_row_id="row:before",
         predicted_decision_margin=predicted_margin,
         observed_decision_margin=observed_margin,
-        hidden_state_hypotheses_remaining=hidden_remaining,
+        hidden_state_hypothesis_set=ObserverHiddenStateHypothesisSetDTO.create(
+            observation_schema_id=SCHEMA.schema_id,
+            hypotheses=(
+                ObserverHiddenStateHypothesisDTO.create(
+                    state_key="hidden.cooldown",
+                    state_value="clear",
+                    status="possible" if hidden_remaining else "eliminated",
+                ),
+            ),
+        ),
+        policy_consequence_evidence=policy_evidence,
         reproduction=reproduction,
         relevant_context_keys=relevant_context_keys,
     )
 
 
+def feature_specs(*keys: str) -> tuple[ObserverFeatureComparisonDTO, ...]:
+    return tuple(
+        ObserverFeatureComparisonDTO.create(feature_key=key, mode="exact")
+        for key in sorted(keys)
+    )
+
+
 def test_confirmed_transition_replays_to_identical_ids() -> None:
     recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs(
+            "hidden.cooldown",
+            "visible.action_effect",
+            "visible.agent_x",
+            "visible.target_x",
+        ),
         observable_feature_keys=("visible.agent_x", "visible.target_x"),
         action_effect_keys=("visible.action_effect",),
-        policy_consequence_key="visible.next_action",
         hidden_state_keys=("hidden.cooldown",),
     )
     predicted = observation(
@@ -105,9 +170,14 @@ def test_confirmed_transition_replays_to_identical_ids() -> None:
 
 def test_hidden_cooldown_contradiction_builds_artifact() -> None:
     recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs(
+            "hidden.cooldown",
+            "visible.action_effect",
+            "visible.agent_x",
+            "visible.target_x",
+        ),
         observable_feature_keys=("visible.agent_x", "visible.target_x"),
         action_effect_keys=("visible.action_effect",),
-        policy_consequence_key="visible.next_action",
         hidden_state_keys=("hidden.cooldown",),
         wake_on_policy_consequence_mismatch=True,
     )
@@ -156,6 +226,11 @@ def test_hidden_cooldown_contradiction_builds_artifact() -> None:
 
 def test_missing_required_feature_is_inconclusive_not_match_or_contradiction() -> None:
     recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs(
+            "visible.action_effect",
+            "visible.agent_x",
+            "visible.target_x",
+        ),
         observable_feature_keys=("visible.agent_x", "visible.target_x"),
         action_effect_keys=("visible.action_effect",),
     )
@@ -181,6 +256,9 @@ def test_missing_required_feature_is_inconclusive_not_match_or_contradiction() -
 
 def test_feature_projection_namespaces_visible_history_and_hidden_keys() -> None:
     recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs(
+            "hidden.mode", "history.mode", "visible.mode"
+        ),
         observable_feature_keys=("visible.mode",),
         action_effect_keys=("history.mode",),
         hidden_state_keys=("hidden.mode",),
@@ -207,6 +285,7 @@ def test_feature_projection_namespaces_visible_history_and_hidden_keys() -> None
 
 def test_invalid_sequence_order_is_rejected() -> None:
     recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs("visible.agent_x"),
         observable_feature_keys=("visible.agent_x",),
     )
     predicted = observation(sequence_index=2, visible={"agent_x": 4})
@@ -228,14 +307,26 @@ def test_recipe_sensitivity_changes_wake_and_ids() -> None:
         sequence_index=1,
         visible={"agent_x": 4, "next_action": "wait"},
     )
+    policy_evidence = ObserverPolicyConsequenceEvidenceDTO.create(
+        policy_artifact_id="policy:A",
+        predicted_state_artifact_id=predicted.observation_artifact_id,
+        observed_state_artifact_id=observed.observation_artifact_id,
+        predicted_selected_action="move_right",
+        observed_selected_action="wait",
+        predicted_decision_trace_id="trace:predicted",
+        observed_decision_trace_id="trace:observed",
+        reader_contract_id="reader:v1",
+    )
     passive = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs("visible.agent_x"),
         observable_feature_keys=("visible.agent_x",),
-        policy_consequence_key="visible.next_action",
+        require_policy_consequence_evidence=True,
         wake_on_policy_consequence_mismatch=False,
     )
     waking = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs("visible.agent_x"),
         observable_feature_keys=("visible.agent_x",),
-        policy_consequence_key="visible.next_action",
+        require_policy_consequence_evidence=True,
         wake_on_policy_consequence_mismatch=True,
     )
 
@@ -243,6 +334,7 @@ def test_recipe_sensitivity_changes_wake_and_ids() -> None:
         recipe=passive,
         predicted=predicted,
         observed=observed,
+        policy_evidence=policy_evidence,
         predicted_margin=0.3,
         observed_margin=0.29,
     )
@@ -250,6 +342,7 @@ def test_recipe_sensitivity_changes_wake_and_ids() -> None:
         recipe=waking,
         predicted=predicted,
         observed=observed,
+        policy_evidence=policy_evidence,
         predicted_margin=0.3,
         observed_margin=0.29,
     )
@@ -270,6 +363,7 @@ def test_recipe_sensitivity_changes_wake_and_ids() -> None:
 
 def test_contradiction_can_be_recorded_without_wake() -> None:
     recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs("visible.agent_x"),
         observable_feature_keys=("visible.agent_x",),
         wake_on_observable_mismatch=False,
     )
@@ -286,6 +380,7 @@ def test_contradiction_can_be_recorded_without_wake() -> None:
 
 def test_verification_identity_changes_with_reproduction_evidence() -> None:
     recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs("visible.agent_x"),
         observable_feature_keys=("visible.agent_x",),
     )
     predicted = observation(sequence_index=1, visible={"agent_x": 5})
@@ -325,6 +420,7 @@ def test_transition_service_public_api() -> None:
 
 def test_canonical_payload_reconstruction_preserves_identity() -> None:
     recipe = ObserverComparisonRecipeDTO.create(
+        feature_comparisons=feature_specs("visible.agent_x"),
         observable_feature_keys=("visible.agent_x",),
     )
     predicted = observation(sequence_index=1, visible={"agent_x": 4})

--- a/packages/observer/tests/test_transition_service.py
+++ b/packages/observer/tests/test_transition_service.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 
 from zeromodel.observer import (
@@ -72,8 +74,6 @@ def verify(
     recipe: ObserverComparisonRecipeDTO,
     predicted: ObserverObservationArtifactDTO,
     observed: ObserverObservationArtifactDTO,
-    predicted_margin: float = 0.3,
-    observed_margin: float = 0.3,
     hidden_remaining: int = 1,
     policy_evidence: ObserverPolicyConsequenceEvidenceDTO | None = None,
     reproduction: dict[str, object] | None = None,
@@ -87,8 +87,6 @@ def verify(
         state_before_id="state:before",
         action="move_right",
         affected_policy_row_id="row:before",
-        predicted_decision_margin=predicted_margin,
-        observed_decision_margin=observed_margin,
         hidden_state_hypothesis_set=ObserverHiddenStateHypothesisSetDTO.create(
             observation_schema_id=SCHEMA.schema_id,
             hypotheses=(
@@ -206,7 +204,6 @@ def test_hidden_cooldown_contradiction_builds_artifact() -> None:
         recipe=recipe,
         predicted=predicted,
         observed=observed,
-        observed_margin=0.12,
         reproduction={"episode_id": "episode:1", "step": 7},
         relevant_context_keys=("history.previous_action",),
     )
@@ -335,16 +332,12 @@ def test_recipe_sensitivity_changes_wake_and_ids() -> None:
         predicted=predicted,
         observed=observed,
         policy_evidence=policy_evidence,
-        predicted_margin=0.3,
-        observed_margin=0.29,
     )
     waking_result = verify(
         recipe=waking,
         predicted=predicted,
         observed=observed,
         policy_evidence=policy_evidence,
-        predicted_margin=0.3,
-        observed_margin=0.29,
     )
 
     assert passive_result.comparison_result.wake_required is False
@@ -416,6 +409,13 @@ def test_transition_service_public_api() -> None:
     assert hasattr(observer, "ObserverTransitionVerificationDTO")
     assert hasattr(observer, "ObserverTransitionVerificationError")
     assert hasattr(observer, "verify_observer_transition")
+
+
+def test_verifier_signature_has_no_dead_margin_inputs() -> None:
+    parameters = inspect.signature(verify_observer_transition).parameters
+
+    assert "predicted_decision_margin" not in parameters
+    assert "observed_decision_margin" not in parameters
 
 
 def test_canonical_payload_reconstruction_preserves_identity() -> None:

--- a/tests/test_package_workflow_coverage.py
+++ b/tests/test_package_workflow_coverage.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOUNDARIES_PATH = REPO_ROOT / "package-boundaries.toml"
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+PACKAGE_WORKFLOWS = {
+    "analysis": "analysis-package.yml",
+    "artifacts": "artifacts-package.yml",
+    "core": "core-package.yml",
+    "navigation": "navigation-package.yml",
+    "observation": "observation-package.yml",
+    "observer": "observer-package.yml",
+    "perception": "perception-package.yml",
+    "sqlalchemy": "sqlalchemy-package.yml",
+    "trust": "trust-package.yml",
+    "video": "video-package.yml",
+    "vision": "vision-package.yml",
+}
+
+
+def _publishable_packages(boundaries: dict[str, object]) -> set[str]:
+    packages = boundaries["packages"]
+    assert isinstance(packages, dict)
+    return {
+        key
+        for key, package in packages.items()
+        if isinstance(package, dict) and package.get("publishable") is True
+    }
+
+
+def _assert_workflow_coverage(
+    *,
+    boundaries: dict[str, object],
+    workflow_dir: Path = WORKFLOW_DIR,
+) -> None:
+    packages = _publishable_packages(boundaries)
+    missing_mapping = packages - set(PACKAGE_WORKFLOWS)
+    assert not missing_mapping, (
+        "publishable packages lack declared workflow coverage mapping: "
+        f"{sorted(missing_mapping)}"
+    )
+    missing_files = {
+        package
+        for package in packages
+        if not (workflow_dir / PACKAGE_WORKFLOWS[package]).is_file()
+    }
+    assert not missing_files, (
+        f"publishable packages lack workflow files: {sorted(missing_files)}"
+    )
+
+
+def test_every_publishable_package_has_workflow_coverage() -> None:
+    with BOUNDARIES_PATH.open("rb") as handle:
+        boundaries = tomllib.load(handle)
+
+    _assert_workflow_coverage(boundaries=boundaries)
+
+
+def test_synthetic_publishable_package_without_workflow_fails() -> None:
+    with BOUNDARIES_PATH.open("rb") as handle:
+        boundaries = tomllib.load(handle)
+    synthetic = dict(boundaries)
+    packages = dict(synthetic["packages"])
+    packages["synthetic"] = {
+        "distribution": "zeromodel-synthetic",
+        "namespace": "zeromodel.synthetic",
+        "source_root": "packages/synthetic/src",
+        "depends_on": [],
+        "publishable": True,
+        "owned_prefixes": ["zeromodel.synthetic"],
+    }
+    synthetic["packages"] = packages
+
+    try:
+        _assert_workflow_coverage(boundaries=synthetic)
+    except AssertionError as exc:
+        assert "synthetic" in str(exc)
+    else:
+        raise AssertionError("synthetic package without workflow coverage passed")


### PR DESCRIPTION
## Objective

Harden the Observer Stage O1/O2 evidence contracts before loop, graph, or candidate-policy work begins.

## Confirmed Defects Addressed

- Observer package now has an explicit package workflow.
- Repository tests verify every publishable package in `package-boundaries.toml` has workflow coverage.
- Feature comparison no longer relies on raw Python equality alone.
- Hidden-state exhaustion no longer depends on a naked caller-supplied count.
- Policy consequence equivalence now comes from externally computed decision-trace evidence, not a caller-authored feature.

## Recipe-Version Migration

- Adds `observer-comparison-recipe/2` with explicit `ObserverFeatureComparisonDTO` entries.
- Rejects legacy recipe version 1 at the O3.0 comparison boundary rather than silently reinterpreting it.
- Bumps comparison result payloads to `observer-comparison-result/3`.
- Bumps transition verification payloads to `observer-transition-verification/2`.

## Observation Schema

- Adds `ObserverFeatureDefinitionDTO` and `ObserverObservationSchemaDTO`.
- Observation artifacts are now `observer-observation-artifact/2` and include `observation_schema_id`.
- Construction rejects undeclared keys, missing required keys, wrong types, boolean-as-integer/number coercion, NaN, and infinity.

## Per-Feature Comparison Modes

- Adds strict `exact`, `categorical`, and `numeric_tolerance` modes.
- `exact` requires strict type identity, so `True != 1` and `1 != 1.0`.
- Numeric tolerance requires declared absolute and relative tolerances.

## Hypothesis-Set Ownership

- Adds `ObserverHiddenStateHypothesisDTO` and `ObserverHiddenStateHypothesisSetDTO`.
- Exhaustion is derived from possible hypotheses in the canonical set.
- Missing required hidden-state evidence yields inconclusive comparison evidence.

## Policy Consequence Evidence

- Adds `ObserverPolicyConsequenceEvidenceDTO` with external decision trace IDs.
- Required but absent policy consequence evidence yields inconclusive evidence and wake.
- Transition verification validates policy and observation IDs when evidence is supplied.

## Explicit Non-Goals

No candidate policy materialization, policy mutation, graph construction, event transport, wake-policy runtime, habit promotion, persistence, SQLAlchemy, model provider calls, embeddings, or empirical capability claim changes are introduced.

## Local Validation

- `pytest packages/observer/tests -q` -> 52 passed
- `python scripts/check_package_boundaries.py` -> passed
- `pytest tests/test_public_api_manifest.py -q` -> 17 passed, 1 deselected
- `pytest tests/test_package_boundaries.py -q` -> 3 passed
- `pytest tests/test_fast_suite_completeness.py -q` -> 10 passed
- `pytest tests/test_package_workflow_coverage.py -q` -> 2 passed
- `ruff check packages/observer/src packages/observer/tests tests/test_package_workflow_coverage.py` -> passed
- `ruff format --check packages/observer/src packages/observer/tests tests/test_package_workflow_coverage.py` -> passed
- `python -m mypy packages/observer/src` -> passed
- `python -m build packages/observer` -> passed
- `python -m twine check packages/observer/dist/*` -> passed
- `python scripts/run_fast_tests.py` -> 1312 passed, 1 skipped, 200 deselected
- `git diff --check` -> passed with Git line-ending warnings only

## Evidence Status

Local validation is clean. GitHub Actions remains authoritative.

Audit-Exempt: hardens internal Observer evidence contracts and CI coverage; no public empirical capability claim changed.
