### PR TITLE
Establish ZeroModel 1.2.0 Visual AI Computing foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,44 @@
 # Changelog
 
-## Unreleased
+## 1.2.0 - Unreleased
 
-No unreleased changes have been recorded since the preparation of ZeroModel 1.1.0.
+See the [ZeroModel 1.2.0 release posture](docs/releases/1.2.0.md).
+
+ZeroModel 1.2.0 establishes the coordinated foundation for Visual AI Computing.
+
+### Product and architecture
+
+* Rewrites the repository README around the exact bounded 1.2.0 headline claim.
+* Adds a system-wide package and repository architecture map.
+* Introduces the five-state evidence ladder prominently.
+* Links major capabilities to their implementation proof, demonstration programme, and explicit boundary.
+* Defines the coordinated relationship between `zeromodel`, `zeromodel-demos`, `zeromodel.org`, and `zeromodel.github.io`.
+
+### Package system
+
+* Coordinates eleven distributions at version `1.2.0`:
+
+  * `zeromodel`
+  * `zeromodel-analysis`
+  * `zeromodel-observation`
+  * `zeromodel-vision`
+  * `zeromodel-perception`
+  * `zeromodel-observer`
+  * `zeromodel-video`
+  * `zeromodel-sqlalchemy`
+  * `zeromodel-artifacts`
+  * `zeromodel-trust`
+  * `zeromodel-navigation`
+* Updates all internal package dependency pins to `1.2.0`.
+* Updates public package documentation links to `https://zeromodel.org/`.
+* Makes the observer package an explicit part of the coordinated architecture and install surface.
+* Updates release validation and release documentation for the eleven-package topology.
+
+### Claim boundary
+
+* Retains the claims audit as the authoritative evidence record.
+* Preserves unsupported, refuted, and insufficient-observability findings as first-class results.
+* Positions 1.2.0 as the **foundation for Visual AI Computing**, not as proof of general open-world Visual AI.
 
 ## 1.1.0 - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,172 @@
-# ZeroModel
+# ZeroModel 1.2.0
 
-**ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts and small consumers that can operate without a model at decision time.**
+## The foundation for Visual AI Computing
 
-A VPM is a deterministic spatial view over a table of scored items. It carries values, stable row and metric identifiers, a layout recipe, view ordering, source mapping, provenance, and deterministic identity.
+**ZeroModel turns scored state, visual evidence, and bounded decision logic into deterministic, inspectable, identity-bearing computational artifacts.**
 
-The 1.0.13 release candidate is split into nine namespace-package distributions:
-`zeromodel` (core), `zeromodel-analysis`, `zeromodel-observation`, `zeromodel-vision`,
-`zeromodel-video`, `zeromodel-sqlalchemy`, `zeromodel-artifacts`, `zeromodel-trust`,
-and `zeromodel-navigation`. Import from the package namespaces directly; the legacy
-root compatibility surface (`zeromodel/__init__.py` re-exporting every capability)
-has been removed and is not present in a clean checkout.
+Models, rules, optimizers, sensors, and people can produce intelligence. ZeroModel gives the resulting evidence and decisions a durable form: Visual Policy Maps, observation records, transition contracts, verification reports, provenance chains, trust receipts, and small deterministic consumers.
 
-Public claims for the original VPM/policy-lookup/visual-addressing surface are
-tracked in [`docs/claims-audit.md`](docs/claims-audit.md); treat that file as the
-source of truth for what is validated, what is implemented with thin evidence, and
-what remains a roadmap claim for those packages. That audit predates the nine-package
-split and does not yet cover `zeromodel-artifacts`, `zeromodel-trust`, or
-`zeromodel-navigation` — see the scope note at the top of the file, and consult
-those packages' own READMEs and stage completion reports for their claims.
+> **ZeroModel 1.2.0 establishes the foundation for Visual AI Computing: a coordinated artifact system in which bounded visual evidence and policy can be compiled, addressed, compared, verified, persisted, trusted, navigated, and consumed without hiding the result inside the process that created it.**
 
-## Install
+This is a deliberately bounded claim. ZeroModel does **not** currently claim general open-world visual intelligence, arbitrary image understanding, universal causal diagnosis, or safe autonomous deployment. The authoritative evidence boundary is maintained in [`docs/claims-audit.md`](docs/claims-audit.md).
 
-These packages are not currently published to a package index. Install from a
-local clone:
+- Website: [zeromodel.org](https://zeromodel.org/)
+- Demonstrations: [ernanhughes/zeromodel-demos](https://github.com/ernanhughes/zeromodel-demos)
+- Claims and evidence: [`docs/claims-audit.md`](docs/claims-audit.md)
+- Release posture: [`docs/releases/1.2.0.md`](docs/releases/1.2.0.md)
+
+---
+
+## What Visual AI Computing means
+
+Most AI systems produce an answer and leave the evidence, alternatives, policy state, representation choices, and operational consequences scattered across model calls, logs, databases, and application code.
+
+ZeroModel treats those structures as first-class computational artifacts:
+
+```text
+observation, scores, rules, model output, or expert policy
+                         ↓
+              explicit representation contract
+                         ↓
+         deterministic identity-bearing artifact
+                         ↓
+       inspect · compare · verify · persist · trust
+                         ↓
+        small runtime, application, person, or model
+```
+
+A Visual Policy Map is the core artifact: a deterministic spatial view over scored rows and metrics with stable identifiers, a declared layout recipe, source mapping, provenance, and content identity. The wider ZeroModel package system builds observation, perception, policy, persistence, trust, navigation, and operational contracts around that kernel.
+
+The architectural shift is:
+
+> **Do not repeatedly reconstruct stable intelligence when it can be compiled into an identified artifact and read as a sign.**
+
+The intelligence required to create the artifact remains upstream. ZeroModel makes its result inspectable, portable, testable, and governable.
+
+---
+
+## System architecture
+
+```mermaid
+flowchart TB
+    SOURCES["Models · rules · optimizers · sensors · people"]
+
+    CORE["zeromodel.core\nVPM artifact kernel\nidentity · layout · source mapping · policy lookup"]
+    ANALYSIS["zeromodel.analysis\nviews · composition · diagnostics · verification · manifolds"]
+    OBSERVATION["zeromodel.observation\nprovider-neutral observations and address contracts"]
+    VISION["zeromodel.vision\ndeterministic bounded visual addressing"]
+    PERCEPTION["zeromodel.perception\nfields · evidence · transitions · discovery · governed promotion"]
+    OBSERVER["zeromodel.observer\ntransition inspection and evidence-lineage application layer"]
+    VIDEO["zeromodel.video\ntemporal policy and provider-evaluation aggregates"]
+    SQL["zeromodel.persistence.sqlalchemy\nSQLite and SQLAlchemy persistence"]
+    ARTIFACTS["zeromodel.artifacts\ncontent-addressed storage and artifact references"]
+    TRUST["zeromodel.trust\nsignatures · receipts · revocation · deployment scope"]
+    NAVIGATION["zeromodel.navigation\nfinite artifact hierarchy and traversal"]
+
+    DEMOS["zeromodel-demos\nreproducible demos · apps · showcases · labs"]
+    WEBSITE["zeromodel.org\nproduct · documentation · research · evidence"]
+
+    SOURCES --> CORE
+    SOURCES --> OBSERVATION
+
+    CORE --> ANALYSIS
+    CORE --> OBSERVATION
+    CORE --> ARTIFACTS
+
+    OBSERVATION --> VISION
+    OBSERVATION --> PERCEPTION
+    OBSERVATION --> VIDEO
+
+    PERCEPTION --> OBSERVER
+    VIDEO --> SQL
+    ARTIFACTS --> TRUST
+    ARTIFACTS --> NAVIGATION
+
+    CORE --> DEMOS
+    ANALYSIS --> DEMOS
+    VISION --> DEMOS
+    PERCEPTION --> DEMOS
+    OBSERVER --> DEMOS
+    VIDEO --> DEMOS
+    TRUST --> DEMOS
+    NAVIGATION --> DEMOS
+
+    DEMOS --> WEBSITE
+```
+
+The machine-readable package authority is [`package-boundaries.toml`](package-boundaries.toml). Core has no ZeroModel package dependency; higher-level packages consume explicitly declared lower-level contracts.
+
+---
+
+## Evidence before advertising
+
+ZeroModel uses a five-state evidence ladder. The qualifier attached to a result—such as *within the committed fixture* or *at the tested operating point*—is part of the status.
+
+| Status | Meaning |
+|---|---|
+| **Not implemented** | The repository does not contain the claimed mechanism. |
+| **Implemented / unmeasured** | Code exists, but no committed benchmark or evidence package measures the claimed capability. |
+| **Measured / unsupported** | A measurement exists, but it does not support the stronger public claim or a useful operating region has not been identified. |
+| **Measured / refuted within stated conditions** | A declared experiment produced evidence against the claim under its recorded conditions. |
+| **Validated within bounded conditions** | The mechanism is implemented and covered by explicit tests or reproducible evidence for a precisely bounded claim. |
+
+Negative results are retained. An approach that fails under a pinned fixture, calibration, provider, or representation remains useful evidence and must not be silently converted into a success claim.
+
+Read the complete matrix in [`docs/claims-audit.md`](docs/claims-audit.md).
+
+---
+
+## Capability, proof, demonstration, and boundary
+
+The core repository is the source of truth for implementation and evidence. The demos repository explains and presents the work, but must not strengthen a claim beyond the evidence recorded here.
+
+| Major capability | Current bounded result | Proof | Demonstration | Boundary |
+|---|---|---|---|---|
+| **VPM artifact kernel** | Deterministic artifacts preserve scored values, stable row/metric IDs, layout, source mapping, provenance, and identity. | [`packages/core/README.md`](packages/core/README.md) · [`docs/claims-audit.md`](docs/claims-audit.md) | [Visual Policy Map Lookup programme](https://github.com/ernanhughes/zeromodel-demos/blob/main/catalog.yaml) | Identity and mapping do not prove semantic correctness or authorship. |
+| **Dense multi-view analysis** | One scored source can produce multiple deterministic policy views while preserving source identity and mappings. | [`docs/examples/view-profiles.md`](docs/examples/view-profiles.md) · [`docs/research/dense-multiview-representation.md`](docs/research/dense-multiview-representation.md) | [Policy Profiles](https://github.com/ernanhughes/zeromodel-demos) | No current human-study evidence proves faster or better inspection. |
+| **Compiled policy lookup** | A finite policy can be compiled into a VPM and read by stable state address without a model call during lookup. | [`docs/examples/sign-reader.md`](docs/examples/sign-reader.md) | [State Chooses the Pixel](https://github.com/ernanhughes/zeromodel-demos) | Closed enumerable states only; no unseen-state generalization. |
+| **Finite policy verification** | Named row-level properties can be checked exhaustively and materialized as linked verification artifacts with exact counterexamples. | [`docs/examples/criticality-verification.md`](docs/examples/criticality-verification.md) · [`docs/research/viper-policy-compilation.md`](docs/research/viper-policy-compilation.md) | [Test the Transition](https://github.com/ernanhughes/zeromodel-demos) | Not temporal, continuous-state, or universal formal verification. |
+| **Provider-neutral observation contracts** | Observations, provider identity, calibration, replay semantics, acceptance, and rejection evidence share a governed seam independent of policy identity. | [`packages/observation/README.md`](packages/observation/README.md) | [Provenance and Replay](https://github.com/ernanhughes/zeromodel-demos) | The contract governs evidence; it does not validate provider accuracy. |
+| **Deterministic visual addressing** | The committed bounded arcade codebook recovers all canonical feature codewords, rows, and actions, including all 2,401 four-target waves. | [`docs/research/visual-sign-reader.md`](docs/research/visual-sign-reader.md) · [`packages/vision/README.md`](packages/vision/README.md) | [Visual Policy Map Lookup programme](https://github.com/ernanhughes/zeromodel-demos/blob/main/catalog.yaml) | Exact closed-world addressing, not general computer vision or accepted non-exact recognition. |
+| **Visual transition evidence** | In the deterministic arcade benchmark, declared fields and contracts improve visible changed-component attribution over the committed raw-pixel baseline. | [`examples/visual_transition_benchmark/`](examples/visual_transition_benchmark/) · [`docs/claims-audit.md`](docs/claims-audit.md) | [Transition Inspector](https://github.com/ernanhughes/zeromodel-demos/tree/main/apps/transition-inspector) | Visible component attribution is not perfect fault attribution or causal diagnosis. |
+| **Value and relation contracts** | Typed values and selected relations detect bounded wrong-direction, wrong-magnitude, and wrong-value faults that component-presence evidence cannot express. | [`docs/research/value-aware-transition-contracts.md`](docs/research/value-aware-transition-contracts.md) | [Numeric State Contract and Relation Contract programme](https://github.com/ernanhughes/zeromodel-demos/blob/main/catalog.yaml) | Hidden target identity and visually absent events remain unresolved. |
+| **Cross-domain contract replication** | Component attribution and one relation contract replicated across independently rendered arcade and warehouse domains under the frozen benchmark. | [`docs/research/cross-domain-visual-contract-replication.md`](docs/research/cross-domain-visual-contract-replication.md) | [Cross-Domain Contract Replication](https://github.com/ernanhughes/zeromodel-demos/blob/main/catalog.yaml) | Two small deterministic domains do not establish open-world generalization. |
+| **Evidence Contract Compiler** | A bounded deterministic search compiled an evidence-preserving representation for 11 of 12 declared requirements and identified one insufficient-observability case. | [`docs/research/evidence-contract-representation-compiler.md`](docs/research/evidence-contract-representation-compiler.md) | [Evidence Contract Compiler](https://github.com/ernanhughes/zeromodel-demos/blob/main/catalog.yaml) | Requirements remain human-declared; the compiler searches a fixed bounded candidate family. |
+| **Temporal policy and provider evaluation** | Immutable provider-evaluation aggregates distinguish exact-state, action-equivalent, action-changing, and rejected outcomes while binding provider, observation, policy, and evidence identities. | [`docs/architecture/provider-evaluation-rmdto.md`](docs/architecture/provider-evaluation-rmdto.md) · [`packages/video/README.md`](packages/video/README.md) | [Observe the Consequence](https://github.com/ernanhughes/zeromodel-demos) | Evidence accounting does not prove provider quality or calibrated confidence. |
+| **SQLite persistence** | DTO-only video and observation aggregates persist through explicit SQLAlchemy/SQLite stores with reload, parity, rollback, and tamper checks. | [`packages/sqlalchemy/README.md`](packages/sqlalchemy/README.md) | [Durable Activation Across Restart programme](https://github.com/ernanhughes/zeromodel-demos/blob/main/catalog.yaml) | Reference persistence is not distributed coordination or production availability. |
+| **Perception promotion and rollback** | The bounded reference path records candidate validation, review, materialization, activation, durable receipts, exact inverse plans, and rollback across SQLite restart. | [`packages/perception/README.md`](packages/perception/README.md) · [`packages/perception/docs/p18h-durable-activation-and-rollback.md`](packages/perception/docs/p18h-durable-activation-and-rollback.md) | [Governed Exact-State Rollback programme](https://github.com/ernanhughes/zeromodel-demos/blob/main/catalog.yaml) | Rollback restores stored state; it does not prove semantic safety or enterprise authorization. |
+| **Artifact storage and identity** | Canonical references and content-addressed storage preserve artifact identity independently of presentation. | [`packages/artifacts/README.md`](packages/artifacts/README.md) | [Provenance and Replay](https://github.com/ernanhughes/zeromodel-demos) | Content identity is not authenticity or approval. |
+| **Trust contracts** | Signature envelopes, trust receipts, revocation, and deployment-scope contracts can bind decisions to identified artifacts. | [`packages/trust/README.md`](packages/trust/README.md) | [Provenance and Replay](https://github.com/ernanhughes/zeromodel-demos) | Trust DTOs and signatures do not constitute organizational authorization by themselves. |
+| **Finite artifact navigation** | Identified artifact corpora can be compiled into deterministic finite hierarchies and traversed. | [`packages/navigation/README.md`](packages/navigation/README.md) | [Representation and provenance labs](https://github.com/ernanhughes/zeromodel-demos) | Search, planet-scale traversal, and constant-time navigation are not validated claims. |
+| **Observer application layer** | Transition inspection can combine policy expectation, visual evidence, representation boundaries, contract results, and provenance metadata. | [`packages/observer/README.md`](packages/observer/README.md) | [Transition Inspector](https://github.com/ernanhughes/zeromodel-demos/tree/main/apps/transition-inspector) | The browser reconstruction is not yet the production compiler, ledger, or replay runtime. |
+
+---
+
+## Package system
+
+ZeroModel 1.2.0 is coordinated across eleven namespace-package distributions:
+
+| Distribution | Import namespace | Purpose |
+|---|---|---|
+| `zeromodel` | `zeromodel.core` | Immutable artifact kernel, views, rendering, bounded policy lookup, Lua export. |
+| `zeromodel-analysis` | `zeromodel.analysis` | Composition, diagnostics, verification, optimization, patterns, manifolds, learning and training artifacts. |
+| `zeromodel-observation` | `zeromodel.observation` | Observation identity and provider-neutral visual-address contracts. |
+| `zeromodel-vision` | `zeromodel.vision` | Deterministic closed-world visual indexing and policy addressing. |
+| `zeromodel-perception` | `zeromodel.perception` | Fields, evidence, conformance, transition discovery, validation, promotion, activation, and rollback. |
+| `zeromodel-observer` | `zeromodel.observer` | Demonstration/application layer for transition evidence and artifact lineage. |
+| `zeromodel-video` | `zeromodel.video` | Temporal policy and video action-set DTO/store contracts. |
+| `zeromodel-sqlalchemy` | `zeromodel.persistence.sqlalchemy` | Explicit SQLAlchemy and SQLite persistence. |
+| `zeromodel-artifacts` | `zeromodel.artifacts` | Artifact references, resolution, and content-addressed storage. |
+| `zeromodel-trust` | `zeromodel.trust` | Authenticity, trust receipts, revocation, and deployment scope. |
+| `zeromodel-navigation` | `zeromodel.navigation` | Finite artifact hierarchy compilation and traversal. |
+
+The legacy root compatibility surface that re-exported every capability from `zeromodel/__init__.py` has been removed. Import from the owning package namespace directly.
+
+---
+
+## Install from a local clone
+
+The coordinated 1.2.0 packages are not assumed to be available from a package index until the release process records publication.
 
 ```bash
 git clone https://github.com/ernanhughes/zeromodel.git
@@ -30,9 +174,9 @@ cd zeromodel
 python -m pip install -r requirements-dev.txt
 ```
 
-`requirements-dev.txt` installs all nine packages in editable mode plus the
-development toolchain (pytest, ruff, mypy, build, twine). For a non-editable
-install of only the packages you need, after cloning:
+`requirements-dev.txt` installs all eleven packages in editable mode plus the development toolchain.
+
+For a non-editable local installation:
 
 ```bash
 python -m pip install \
@@ -40,6 +184,8 @@ python -m pip install \
   ./packages/analysis \
   ./packages/observation \
   ./packages/vision \
+  ./packages/perception \
+  ./packages/observer \
   ./packages/video \
   ./packages/sqlalchemy \
   ./packages/artifacts \
@@ -47,309 +193,112 @@ python -m pip install \
   ./packages/navigation
 ```
 
-Then verify the checkout:
+Verify the checkout:
 
 ```bash
 python scripts/run_fast_tests.py
 ```
 
-`scripts/validate_release_candidate.py` builds every wheel/sdist into a clean
-virtual environment and runs the full test-layer suite; see
-[`docs/release.md`](docs/release.md) before running it, since it is a heavier,
-release-gating command rather than a routine development check.
+Run the heavier coordinated release gate only when preparing a release candidate:
 
-## Core artifact
+```bash
+python scripts/validate_release_candidate.py
+```
+
+See [`docs/release.md`](docs/release.md).
+
+---
+
+## Minimal artifact example
 
 ```python
 from zeromodel.core import LayoutRecipe, ScoreTable, build_vpm
 
-score_table = ScoreTable(
-    values=[[0.9, 0.2], [0.4, 0.8]],
+source = ScoreTable(
+    values=[[0.90, 0.20], [0.40, 0.80]],
     row_ids=["candidate-a", "candidate-b"],
     metric_ids=["quality", "uncertainty"],
 )
 
-recipe = LayoutRecipe.from_dict({
-    "version": "vpm-layout/0",
-    "name": "quality-first",
-    "row_order": {
-        "kind": "lexicographic",
-        "keys": [{"metric_id": "quality", "direction": "desc"}],
-        "tie_break": "row_id",
-    },
-    "column_order": {"kind": "source"},
-    "normalization": {"kind": "per_metric_minmax", "clip": True},
-})
-
-artifact = build_vpm(score_table, recipe)
-cell = artifact.cell(view_row=0, view_column=0)
-region = artifact.region(rows=slice(0, 1), columns=slice(0, 2))
-```
-
-## Capability surface
-
-| Capability | Module |
-|---|---|
-| Immutable artifact kernel | `zeromodel.core` |
-| Analysis, views, spatial/manifold, policy diagnostics | `zeromodel.analysis` |
-| Observation DTOs and visual address contracts | `zeromodel.observation` |
-| Deterministic visual index and visual policy reader | `zeromodel.vision` |
-| Video policy, arcade fixture, video action-set DTOs/stores, provider evaluation aggregate | `zeromodel.video` |
-| Explicit SQLAlchemy persistence runtime | `zeromodel.persistence.sqlalchemy` |
-| Content-addressed artifact storage and reference identity | `zeromodel.artifacts` |
-| Signature envelopes, trust receipts, revocation | `zeromodel.trust` |
-| Artifact navigation (Search remains unimplemented) | `zeromodel.navigation` |
-
-## Policy lookup: signs, not directions
-
-`VPMPolicyLookup` is the small 1.0 consumer behind the blog phrase “signs, not directions.” Rows are discretized runtime states, metric columns are candidate actions, and the consumer returns the winning action plus the exact VPM cell that produced it.
-
-```python
-from zeromodel.core import LayoutRecipe, ScoreTable, VPMPolicyLookup, build_vpm
-
-source = ScoreTable(
-    values=[
-        [1.0, 0.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0, 1.0],
-    ],
-    row_ids=["state:left", "state:right", "state:aligned"],
-    metric_ids=["LEFT", "RIGHT", "STAY", "FIRE"],
+recipe = LayoutRecipe.from_dict(
+    {
+        "version": "vpm-layout/0",
+        "name": "quality-first",
+        "row_order": {
+            "kind": "lexicographic",
+            "keys": [{"metric_id": "quality", "direction": "desc"}],
+            "tie_break": "row_id",
+        },
+        "column_order": {"kind": "source"},
+        "normalization": {"kind": "per_metric_minmax", "clip": True},
+    }
 )
-recipe = LayoutRecipe.from_dict({
-    "version": "vpm-layout/0",
-    "name": "policy-source-order",
-    "row_order": {"kind": "source", "tie_break": "row_id"},
-    "column_order": {"kind": "source"},
-    "normalization": {"kind": "per_metric_minmax", "clip": True},
-})
 
 artifact = build_vpm(source, recipe)
-decision = VPMPolicyLookup(artifact).read("state:aligned")
+cell = artifact.cell(view_row=0, view_column=0)
 
-assert decision.action == "FIRE"
-assert decision.artifact_id == artifact.artifact_id
+print(artifact.artifact_id)
+print(cell.row_id, cell.metric_id, cell.raw_value)
 ```
 
-The demo is a tiny arcade shooter:
+A policy artifact can then be read as a bounded sign:
 
-```bash
-python examples/arcade_shooter_policy.py
+```python
+from zeromodel.core import VPMPolicyLookup
+
+reader = VPMPolicyLookup(artifact, action_metric_ids=("quality", "uncertainty"))
+decision = reader.read("candidate-a")
+
+print(decision.action, decision.value, decision.artifact_id)
 ```
 
-It compiles a closed-world shooter policy into one VPM artifact, then replays by reading state signs from that artifact. Tests assert wave clear, random-baseline comparison, and deterministic action trace replay.
+---
 
-See [`docs/examples/sign-reader.md`](docs/examples/sign-reader.md).
+## The coordinated project
 
-## Criticality-aware verification
+| Repository | Responsibility |
+|---|---|
+| [`ernanhughes/zeromodel`](https://github.com/ernanhughes/zeromodel) | Implementation, packages, tests, benchmarks, evidence, claim boundaries, and releases. |
+| [`ernanhughes/zeromodel-demos`](https://github.com/ernanhughes/zeromodel-demos) | Reproducible demonstrations, browser applications, showcases, labs, and bounded experiments. |
+| [`ernanhughes/zeromodel.org`](https://github.com/ernanhughes/zeromodel.org) | Hugo source for the public product, documentation, research, release, and business website. |
+| [`ernanhughes/zeromodel.github.io`](https://github.com/ernanhughes/zeromodel.github.io) | Public static deployment target. |
 
-ZeroModel 1.0.11 can add two separate evidence metrics to a Q-bearing policy surface:
+The flow is:
 
 ```text
-criticality     = best action value - worst action value
-decision margin = best action value - second-best action value
+core implementation and evidence
+            ↓
+reproducible demonstrations
+            ↓
+interactive public explanation
+            ↓
+commercial platform and applications
 ```
 
-Criticality estimates how consequential a poor choice could be. Decision margin measures how decisively the winner beats its nearest alternative. Describe the first metric as VIPER-style criticality only when the source values are Q-values or an equivalent consequence-bearing teacher signal.
+Claims may be simplified as they move outward, but they must never be silently strengthened.
 
-```python
-from zeromodel.analysis import (
-    PolicyPropertyChecker,
-    PolicyPropertySpec,
-    with_q_diagnostics,
-)
-from zeromodel.core import VPMPolicyLookup, build_vpm
+---
 
-ACTIONS = ("LEFT", "RIGHT", "STAY", "FIRE")
+## Current boundary
 
-enriched = with_q_diagnostics(
-    source,
-    action_metric_ids=ACTIONS,
-)
-artifact = build_vpm(enriched, recipe)
+ZeroModel has validated substantial foundations for Visual AI Computing. It has not yet validated general Visual AI.
 
-# Diagnostic metadata lets the reader safely separate actions from evidence.
-reader = VPMPolicyLookup(artifact)
-```
+The central open problem is trustworthy observation-to-evidence compilation in less constrained environments. Current work must continue to distinguish:
 
-Evidence metrics are returned with the decision but never participate in action selection.
+- evidence that exists but is lost by the representation;
+- evidence that can be recovered by a bounded representation compiler;
+- evidence that was never present in the permitted observation;
+- state errors that preserve the same policy action;
+- action-changing errors;
+- provider confidence from independently calibrated evidence;
+- artifact identity from authenticity and authorization.
 
-A finite policy property is declarative and versioned:
+That boundary is a design requirement, not a disclaimer added after the result.
 
-```python
-fire_requires_alignment = PolicyPropertySpec.from_dict({
-    "id": "fire_requires_alignment",
-    "version": "1",
-    "assert": {
-        "implies": [
-            {"eq": [{"var": "winner"}, "FIRE"]},
-            {"all": [
-                {"eq": [{"var": "state.tank"}, {"var": "state.target"}]},
-                {"eq": [{"var": "state.cooldown"}, 0]},
-            ]},
-        ]
-    },
-})
+Read [`docs/claims-audit.md`](docs/claims-audit.md) before making public capability claims.
 
-report = PolicyPropertyChecker(
-    artifact,
-    action_metric_ids=ACTIONS,
-    evidence_metric_ids=("criticality", "decision_margin"),
-).check([fire_requires_alignment])
+---
 
-verification_artifact = report.to_vpm()
-```
+## License
 
-The verification artifact points back to the exact checked policy through a provenance parent with relation `verifies`. Failed checks retain exact counterexample rows, candidates, evidence, and source/view coordinates.
-
-Run the full counterexample, repair, and re-verification fixture:
-
-```bash
-python examples/criticality_verification.py \
-  --output-dir docs/assets/criticality-verification
-```
-
-See [`docs/examples/criticality-verification.md`](docs/examples/criticality-verification.md) and [`docs/research/viper-policy-compilation.md`](docs/research/viper-policy-compilation.md).
-
-## Dense view profiles
-
-A source table can contain many signals at once. A view profile is a policy lens over that dense table: turn up one set of metrics and the matching rows/columns become salient without changing the source evidence.
-
-```python
-from zeromodel.core import ScoreTable, ViewProfile, build_view
-
-source = ScoreTable(
-    values=[
-        [0.10, 0.96, 0.05, 0.72, 0.20],
-        [0.94, 0.12, 0.08, 0.18, 0.35],
-        [0.24, 0.07, 0.97, 0.08, 0.78],
-        [0.07, 0.18, 0.04, 0.98, 0.10],
-    ],
-    row_ids=["forest", "crowd", "traffic", "meadow"],
-    metric_ids=["people", "trees", "cars", "grass", "risk"],
-)
-
-people_view = build_view(source, ViewProfile.from_metric("people", name="people"))
-tree_view = build_view(source, ViewProfile.from_metric("trees", name="trees"))
-risk_view = build_view(source, ViewProfile.from_metric("risk", name="risk"))
-
-assert people_view.source.digest == tree_view.source.digest == risk_view.source.digest
-print(people_view.cell(0, 0).row_id)  # crowd
-print(tree_view.cell(0, 0).row_id)    # forest
-print(risk_view.cell(0, 0).row_id)    # traffic
-```
-
-Positive weights make high values salient. Negative weights make low values salient.
-
-See [`docs/examples/view-profiles.md`](docs/examples/view-profiles.md) and [`docs/research/dense-multiview-representation.md`](docs/research/dense-multiview-representation.md).
-
-## Spatial optimizer
-
-The spatial optimizer derives a `ViewProfile` for one explicit geometric objective: concentrate high-signal mass in the top-left inspection region.
-
-```python
-from zeromodel.analysis import SpatialOptimizer, build_optimized_view, optimize_view_profile
-from zeromodel.core import ScoreTable
-
-source = ScoreTable(
-    values=[
-        [0.10, 0.50, 0.20],
-        [0.95, 0.50, 0.25],
-        [0.90, 0.50, 0.15],
-        [0.05, 0.50, 0.20],
-    ],
-    row_ids=["background", "target_a", "target_b", "flat"],
-    metric_ids=["target", "constant", "weak"],
-)
-
-optimizer = SpatialOptimizer(Kc=2, Kr=2, alpha=0.95, max_evals=40)
-result = optimize_view_profile(source, name="optimized-target", optimizer=optimizer)
-view = build_optimized_view(source, name="optimized-target", optimizer=optimizer)
-
-print(result.baseline_mass, result.optimized_mass)
-print(view.cell(0, 0).row_id, view.cell(0, 0).metric_id)
-```
-
-This does not claim the optimizer learns the correct semantic view for every task. It proves a deterministic top-left mass objective can emit a normal `ViewProfile` while preserving source mapping.
-
-See [`docs/examples/spatial-optimizer.md`](docs/examples/spatial-optimizer.md) and [`docs/research/spatial-calculus.md`](docs/research/spatial-calculus.md).
-
-## Decision manifold
-
-A decision manifold turns a sequence of dense scored panels into optimized VPM frames, then surfaces where the spatial view changes most.
-
-```python
-from zeromodel.analysis import SpatialOptimizer, build_decision_manifold
-from zeromodel.core import ScoreTable
-
-panels = [
-    ScoreTable(
-        values=[[0.20, 0.60, 0.10], [1.00, 0.10, 0.10], [0.10, 0.20, 0.30]],
-        row_ids=["forest", "crowd", "traffic"],
-        metric_ids=["people", "trees", "risk"],
-    ),
-    ScoreTable(
-        values=[[0.15, 0.55, 0.14], [0.25, 0.10, 0.30], [0.10, 0.18, 1.00]],
-        row_ids=["forest", "crowd", "traffic"],
-        metric_ids=["people", "trees", "risk"],
-    ),
-]
-
-summary = build_decision_manifold(
-    panels,
-    optimizer=SpatialOptimizer(Kc=1, Kr=1),
-    name="scene-shift",
-    inflection_top_k=1,
-)
-
-print(summary.inflection_indices)
-print(summary.mass_series)
-print(summary.curvature_series)
-```
-
-This does not claim semantic cause or universal change-point discovery. It provides deterministic temporal geometry over scored panels.
-
-See [`docs/examples/decision-manifold.md`](docs/examples/decision-manifold.md) and [`docs/research/temporal-spatial-calculus.md`](docs/research/temporal-spatial-calculus.md).
-
-## PHOS and edge usage
-
-```python
-from zeromodel.analysis import TopLeftGate, guarded_pack_artifact
-from zeromodel.core import write_png
-
-packed = guarded_pack_artifact(artifact)
-write_png(packed.packed, "artifact_phos.png")
-result = TopLeftGate(threshold=0.75).evaluate(packed.packed)
-print(result.accepted, result.score)
-```
-
-## Learning trace usage
-
-Tracking means a score moved. Learning means a feedback-driven change improves corrected work, transfers to held-out work, and avoids unacceptable regression.
-
-```python
-from zeromodel.analysis import LearningObservation, build_learning_vpm
-
-assessment = build_learning_vpm([
-    LearningObservation("claim-support", before=0.42, after=0.72, split="train"),
-    LearningObservation("related-claim", before=0.50, after=0.63, split="heldout"),
-    LearningObservation("summary-quality", before=0.82, after=0.81, split="regression"),
-])
-
-print(assessment.learned)
-learning_artifact = assessment.artifact
-```
-
-## Local vision-model provider evaluation
-
-A local vision-language model can act as an external observation provider for
-a compiled ZeroModel policy: it perceives a rendered frame, ZeroModel
-validates and addresses the observation, and an independently compiled VPM
-policy selects the action. Every case is persisted through a dedicated
-provider-evaluation aggregate that separates exact-state correctness from
-policy-action correctness.
-
-See [`docs/examples/local_model_zero_arcade_test.md`](docs/examples/local_model_zero_arcade_test.md),
-[`docs/architecture/provider-evaluation-rmdto.md`](docs/architecture/provider-evaluation-rmdto.md),
-and the controlled PNG-representation benchmark built on that aggregate,
-[`docs/research/controlled-png-representation-benchmark.md`](docs/research/controlled-png-representation-benchmark.md).
+MIT. See [`LICENSE`](LICENSE).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,224 +1,133 @@
 # Release process
 
-## Current: v1.1.0 release-candidate validation preparation
+## Current: ZeroModel 1.2.0
 
-P18H closes the in-memory durability gap left by P18G for the perception package.
-The bounded claim is an in-process SQLite reference implementation that preserves
-admitted active state, activation receipts, rollback plans, rollback admissions,
-and rollback receipts across restart, and executes exact stored inverse rollback
-plans atomically only when the current active state still matches the activated
-state named by the plan.
+ZeroModel 1.2.0 is a coordinated eleven-distribution release of the Visual AI Computing foundation.
 
-This does not create distributed activation, multi-step historical rewind,
-production authorization, semantic safety recovery, or a production uptime/scale
-claim.
+The release includes:
 
-Before tagging or publishing `v1.1.0`, run the release-candidate gates below and
-record any unrelated failures separately:
-
-```powershell
-python scripts/validate_release_candidate.py
-python scripts/run_fast_tests.py
-python scripts/check_quality.py
-```
-
-## Historical: 1.0.13 nine-package release-candidate validation
-
-ZeroModel 1.0.13 uses a nine-distribution release-candidate workflow before any
-publish, tag, or GitHub release action:
-
-```powershell
-python scripts/validate_release_candidate.py
-python scripts/run_fast_tests.py
-python scripts/check_quality.py
-```
-
-The validator builds and checks all nine packages declared in
-`package-boundaries.toml` (the authoritative package configuration; the
-validator fails if its own package list drifts from that file):
-
-- `zeromodel` (core)
+- `zeromodel`
 - `zeromodel-analysis`
 - `zeromodel-observation`
 - `zeromodel-vision`
+- `zeromodel-perception`
+- `zeromodel-observer`
 - `zeromodel-video`
 - `zeromodel-sqlalchemy`
 - `zeromodel-artifacts`
 - `zeromodel-trust`
 - `zeromodel-navigation`
 
-It writes `docs/architecture/package-release-artifacts-1.0.13.json` and
-`docs/architecture/package-public-api-1.0.13.csv`. It does not upload to
-TestPyPI or PyPI, create tags, or create a GitHub release. No publication of
-the 1.0.13 nine-package release has occurred as of this writing; the workflow
-below (Phase 1/Phase 2, `scripts/create-release.ps1`) has not been adapted to
-drive a nine-package publish and should not be run against 1.0.13 without
-that work first — see "Historical: 1.0.12 single-package workflow" below.
+[`package-boundaries.toml`](../package-boundaries.toml) is the machine-readable authority for distribution names, namespaces, source roots, internal dependency edges, publication eligibility, and the coordinated release version.
 
-## Historical: 1.0.12 single-package workflow
+The exact release claim and boundaries are recorded in [`docs/releases/1.2.0.md`](releases/1.2.0.md). The authoritative public evidence posture remains [`docs/claims-audit.md`](claims-audit.md).
 
-The following two-phase PowerShell workflow published ZeroModel 1.0.12, when
-the repository still shipped one monolithic `zeromodel` distribution. It is
-recorded here as history and as a starting point for a future nine-package
-publish orchestrator, not as a currently runnable process:
-`scripts/create-release.ps1` still reads and rewrites `zeromodel\__init__.py`
-and a single root `pyproject.toml` version, both of which no longer exist in
-this checkout (each of the nine packages now carries its own
-`packages/*/pyproject.toml` and version). Do not run this script against the
-current tree until it is updated for the nine-package layout.
+## Required validation
+
+Before tagging or publishing `v1.2.0`, run from a clean checkout:
+
+```powershell
+python scripts/validate_release_candidate.py
+python scripts/run_fast_tests.py
+python scripts/check_quality.py
+```
+
+The coordinated validator must verify:
+
+- every package declares version `1.2.0`;
+- all internal dependencies use the coordinated `1.2.0` pin;
+- package metadata agrees with `package-boundaries.toml`;
+- bounded fast tests pass;
+- package-local tests pass;
+- cross-package integration tests pass;
+- visual-transition regression tests pass;
+- all wheels and source distributions build;
+- `twine check` passes;
+- clean-environment installation succeeds;
+- public API imports succeed;
+- release evidence is generated for the exact commit.
+
+The validator writes versioned package manifests and a release-candidate report under:
 
 ```text
-Prepare
-    ↓
-release pull request
-    ↓
-review + CI + merge
-    ↓
-Publish
-    ↓
-final integration validation
-    ↓
-PyPI upload
-    ↓
-Git tag
-    ↓
-GitHub release
+docs/architecture/package-release-artifacts-1.2.0.json
+docs/architecture/package-public-api-1.2.0.csv
+docs/architecture/package-release-test-layers-1.2.0.json
+docs/results/release-candidate-1.2.0/
 ```
 
-The workflow is implemented by:
+Generated evidence must not be copied from an older release line.
 
-```text
-scripts/create-release.ps1
-```
+## Release preparation
 
-The existing `scripts/publish-pypi.ps1` remains the low-level production PyPI uploader. The release orchestrator calls it only after the merged release commit and all release gates have been validated.
+The release pull request should contain only deliberate release and positioning changes:
 
-## Prerequisites
+1. coordinated package versions;
+2. coordinated internal dependency pins;
+3. `package-boundaries.toml` release version;
+4. release-validator version and generated paths;
+5. root and package README version references;
+6. changelog entry;
+7. release notes;
+8. generated release-candidate evidence after validation.
 
-Run releases from a clean Windows checkout with:
-
-- Git;
-- Python 3.10 or later;
-- GitHub CLI (`gh`) authenticated for `ernanhughes/zeromodel`;
-- permission to push release branches and tags;
-- a production PyPI token in `PYPI_API_TOKEN`, or available for secure interactive entry;
-- the intended release-notes file already committed on `main`.
-
-Check GitHub authentication with:
-
-```powershell
-gh auth status
-```
-
-## Phase 1: prepare the release pull request
-
-For ZeroModel 1.0.12:
-
-```powershell
-.\scripts\create-release.ps1 `
-    -Mode Prepare `
-    -Version 1.0.12
-```
-
-The prepare phase requires a clean, synchronized `main` branch. It then:
-
-1. creates `release/1.0.12`;
-2. updates `pyproject.toml`;
-3. updates `zeromodel\__init__.py`;
-4. updates the README production install pin;
-5. adds the release section to `CHANGELOG.md`;
-6. verifies the committed release-notes file;
-7. installs release dependencies;
-8. runs the repository quality gate;
-9. runs the bounded fast suite;
-10. runs the release demos;
-11. builds the source distribution and wheel;
-12. runs `twine check`;
-13. commits and pushes the release branch;
-14. opens the release pull request.
-
-The prepare phase does not upload to PyPI, create a tag, or create a GitHub release.
-
-### Dry-run preflight
-
-```powershell
-.\scripts\create-release.ps1 `
-    -Mode Prepare `
-    -Version 1.0.12 `
-    -DryRun
-```
-
-A dry run verifies the repository, branch, synchronization state, commands, and release-notes path without changing anything.
+The preparation PR must not upload to PyPI, create a tag, or create a GitHub release.
 
 ## Review and merge
 
-Review the generated release PR and require the normal `Python package` workflow to pass.
+Before merge:
 
-The release PR should contain only release metadata changes:
+- inspect the complete diff;
+- confirm historical `1.0.13` and `1.1.0` evidence records were not rewritten as if they belonged to 1.2.0;
+- confirm every public claim links to a proof and a boundary;
+- require the package and repository quality workflows to pass;
+- preserve failed or unsupported benchmark results;
+- verify all generated reports identify the exact release commit.
 
-- canonical version declarations;
-- README install pin;
-- changelog entry;
-- release notes.
+## Publish
 
-Merge the PR before starting the publish phase.
+After the release pull request is merged:
 
-## Phase 2: publish the merged release
+1. return to a clean, synchronized `main` checkout;
+2. rerun the complete release gate against the merged commit;
+3. confirm the built metadata declares `1.2.0` for all eleven distributions;
+4. publish the distributions in dependency order;
+5. install the published packages into a clean environment;
+6. run the public API and bounded smoke checks;
+7. create annotated tag `v1.2.0` at the exact validated commit;
+8. create the GitHub release and attach the built artifacts and release evidence.
 
-Return to `main`, pull the merged release commit, and run:
-
-```powershell
-.\scripts\create-release.ps1 `
-    -Mode Publish `
-    -Version 1.0.12
-```
-
-The publish phase requires the merged source tree to already declare `1.0.12`. It then:
-
-1. re-runs the local release gates;
-2. runs the bounded video-finalization integration validation against the exact merged commit;
-3. confirms `main` is synchronized with `origin/main`;
-4. pushes the merged commit if necessary;
-5. waits for the GitHub package workflow for that commit;
-6. checks whether `zeromodel==1.0.12` already exists on PyPI;
-7. invokes `scripts/publish-pypi.ps1` when upload is still required;
-8. performs the clean-environment PyPI smoke test;
-9. creates and pushes annotated tag `v1.0.12`;
-10. creates the GitHub release and attaches the built distributions.
-
-Before the irreversible step, the operator must type:
+Recommended dependency-aware publication order:
 
 ```text
-RELEASE 1.0.12
+zeromodel
+    ↓
+zeromodel-analysis
+zeromodel-observation
+zeromodel-artifacts
+    ↓
+zeromodel-vision
+zeromodel-perception
+zeromodel-video
+zeromodel-trust
+zeromodel-navigation
+    ↓
+zeromodel-observer
+zeromodel-sqlalchemy
 ```
 
-Use `-Yes` only in a controlled non-interactive release environment.
+Parallel publication inside the same level is acceptable only when the package index and automation handle dependency availability reliably.
 
 ## Recovery and repeatability
 
-The publish phase is designed to be safely repeatable after a partial failure:
+A partially completed publish must be recoverable without reusing immutable versions:
 
-- an existing PyPI version is detected and not uploaded again;
-- an existing tag is accepted only when it resolves to the expected release commit;
-- a conflicting local or remote tag is rejected;
-- an existing GitHub release is detected and not recreated.
-
-Do not delete or move a published tag. PyPI versions are immutable and cannot be reused.
-
-## Optional skips
-
-The script exposes narrowly scoped recovery switches:
-
-```text
--SkipQuality
--SkipTests
--SkipDemos
--SkipFinalizationIntegration
--SkipPyPI
--SkipGitHubRelease
-```
-
-These switches are not normal release posture. Use them only when the skipped gate has already passed for the exact release commit or when recovering a partially completed release.
+- do not delete or move a published tag;
+- do not upload different bytes under an existing package version;
+- verify an existing tag resolves to the expected release commit;
+- verify an existing GitHub release belongs to the expected tag;
+- record publication failures separately from package-validation failures;
+- rerun clean-environment installation after recovery.
 
 ## Claims boundary
 
@@ -226,21 +135,24 @@ A successful release proves package construction, installation, bounded runtime 
 
 It does not establish:
 
-- open-world visual recognition;
+- general or open-world visual recognition;
+- arbitrary image understanding;
 - scientific provider validity;
 - general formal verification;
+- semantic safety certification;
+- production authorization;
 - arbitrary image-transform survival;
 - planet-scale traversal;
 - constrained-device performance without named hardware measurements.
 
-`docs/claims-audit.md` remains the source of truth for public capability wording.
+## Historical release records
 
-## Next development version
+Historical records remain evidence for their original release lines and should not be renamed:
 
-The nine-package split described above is not future work: it is the current
-state of `main` at release-candidate version 1.0.13, and the removal of the
-legacy root compatibility import surface is already in effect in this
-checkout. There is no pending `2.0.0.dev0` package-architecture line still to
-begin. Any future major-version bump should be driven by a new breaking
-change identified after the 1.0.13 nine-package release candidate is
-published, not by the split itself.
+- [`docs/releases/1.1.0.md`](releases/1.1.0.md)
+- [`docs/architecture/package-system-1.1.0.md`](architecture/package-system-1.1.0.md)
+- [`docs/results/release-candidate-1.1.0/`](results/release-candidate-1.1.0/)
+- the unpublished 1.0.13 package-split evidence under `docs/architecture/`
+- [`docs/releases/1.0.12.md`](releases/1.0.12.md)
+
+The old single-package `scripts/create-release.ps1` workflow is historical and must not be used to publish the coordinated eleven-package system unless it is explicitly rewritten and validated for that topology.

--- a/docs/releases/1.2.0.md
+++ b/docs/releases/1.2.0.md
@@ -1,0 +1,123 @@
+# ZeroModel 1.2.0 — Visual AI Computing Foundation
+
+**Status:** release preparation
+
+ZeroModel 1.2.0 establishes the coordinated foundation for Visual AI Computing.
+
+> **ZeroModel 1.2.0 turns scored state, visual evidence, and bounded decision logic into deterministic, inspectable, identity-bearing artifacts that can be addressed, compared, verified, persisted, trusted, navigated, and consumed through explicit package contracts.**
+
+This is the exact headline claim for the release. The phrase **foundation for Visual AI Computing** describes the integrated architecture and research direction; it is not a claim that general open-world Visual AI has been solved.
+
+## Why 1.2.0
+
+The 1.1.0 release established the package architecture and the first integrated perception, promotion, persistence, and rollback contracts. Subsequent work added the observer application layer, expanded the evidence-contract programme, strengthened cross-domain transition evidence, and clarified the relationship between the core repository, the demonstrations repository, and the public website.
+
+Version 1.2.0 makes that system explicit:
+
+- one coordinated eleven-distribution package graph;
+- one system-level Visual AI Computing architecture;
+- one evidence ladder for public claims;
+- one capability ledger linking proof, demonstration, and boundary;
+- one outward flow from implementation to demos to the public website.
+
+## Coordinated distributions
+
+- `zeromodel`
+- `zeromodel-analysis`
+- `zeromodel-observation`
+- `zeromodel-vision`
+- `zeromodel-perception`
+- `zeromodel-observer`
+- `zeromodel-video`
+- `zeromodel-sqlalchemy`
+- `zeromodel-artifacts`
+- `zeromodel-trust`
+- `zeromodel-navigation`
+
+The authoritative dependency and ownership graph is [`package-boundaries.toml`](../../package-boundaries.toml).
+
+## System result
+
+The coordinated system now contains bounded mechanisms for:
+
+1. deterministic VPM artifact construction and exact source mapping;
+2. multiple deterministic views over shared scored evidence;
+3. compiled finite-policy lookup without a model call during lookup;
+4. exact canonical visual codeword addressing in a closed enumerable fixture;
+5. provider-neutral observation and visual-address contracts;
+6. visual field extraction, transition evidence, conformance, and discovery;
+7. typed value and selected relation contracts;
+8. bounded evidence-preserving representation compilation;
+9. finite policy property checking and counterexample artifacts;
+10. temporal policy and closure-validated provider-evaluation aggregates;
+11. explicit SQLite/SQLAlchemy persistence;
+12. content-addressed artifact references;
+13. signatures, trust receipts, revocation, and deployment-scope contracts;
+14. finite artifact hierarchy compilation and traversal;
+15. an observer application layer for transition evidence and lineage.
+
+## Evidence ladder
+
+Every public capability must use one of the statuses defined by the claims audit:
+
+| Status | Meaning |
+|---|---|
+| **Not implemented** | The claimed mechanism is absent. |
+| **Implemented / unmeasured** | Code exists, but no committed evidence package measures the claim. |
+| **Measured / unsupported** | Measurement exists but does not support the stronger claim or a useful operating region. |
+| **Measured / refuted within stated conditions** | The recorded experiment produced evidence against the claim under its declared conditions. |
+| **Validated within bounded conditions** | Explicit tests or reproducible evidence support a precisely bounded claim. |
+
+Qualifiers and operating conditions are part of the status. Negative results remain first-class release evidence.
+
+## Validated centre
+
+The strongest supported centre of ZeroModel remains:
+
+> ZeroModel turns scored data into deterministic, inspectable Visual Policy Map artifacts.
+
+The integrated 1.2.0 system extends that centre with bounded policy lookup, observation contracts, transition evidence, representation compilation, verification, persistence, trust, navigation, and governed operational records.
+
+## Boundaries
+
+ZeroModel 1.2.0 does not establish:
+
+- general artificial intelligence;
+- general or open-world Visual AI;
+- arbitrary image understanding;
+- universal causal diagnosis;
+- reliable recovery of evidence absent from the permitted observation;
+- universal transformation invariance;
+- general formal verification;
+- semantic safety certification;
+- production enterprise authorization;
+- distributed activation or rollback;
+- high-availability persistence;
+- planet-scale or constant-time navigation;
+- constrained-device performance without named hardware measurements;
+- improved human inspection without a task study.
+
+The authoritative wording is [`docs/claims-audit.md`](../claims-audit.md).
+
+## Repository system
+
+| Repository | Role |
+|---|---|
+| [`zeromodel`](https://github.com/ernanhughes/zeromodel) | implementation, packages, tests, evidence, claims, releases |
+| [`zeromodel-demos`](https://github.com/ernanhughes/zeromodel-demos) | demos, applications, showcases, labs, experiments |
+| [`zeromodel.org`](https://github.com/ernanhughes/zeromodel.org) | Hugo source for product, documentation, research, and business positioning |
+| [`zeromodel.github.io`](https://github.com/ernanhughes/zeromodel.github.io) | static deployment target |
+
+The core repository proves bounded mechanisms. The demos repository teaches and presents them. The website turns the coordinated result into an interactive public product. Claims may be simplified outward but may not be strengthened without new evidence.
+
+## Release validation
+
+Before tagging or publishing 1.2.0, run:
+
+```powershell
+python scripts/validate_release_candidate.py
+python scripts/run_fast_tests.py
+python scripts/check_quality.py
+```
+
+The release is not complete until the generated release-candidate evidence, package artifacts, clean-environment installation, public API checks, cross-package integration tests, and visual-transition regression gates pass for the exact release commit.

--- a/package-boundaries.toml
+++ b/package-boundaries.toml
@@ -1,5 +1,5 @@
 schema_version = 1
-release_version = "1.1.0"
+release_version = "1.2.0"
 forbidden_roots = ["zeromodel"]
 research_root = "research"
 examples_root = "examples"

--- a/packages/analysis/README.md
+++ b/packages/analysis/README.md
@@ -1,17 +1,13 @@
 # zeromodel-analysis
 
-`zeromodel-analysis` contains deterministic analysis utilities for ZeroModel
-Visual Policy Map artifacts. It is the second package in the ZeroModel 1.0.13
-split and exposes its API through `zeromodel.analysis`.
+`zeromodel-analysis` contains deterministic analysis utilities for ZeroModel Visual Policy Map artifacts. It is part of the coordinated ZeroModel 1.2.0 Visual AI Computing package system and exposes its API through `zeromodel.analysis`.
 
-The package depends on the validated core distribution, `zeromodel==1.0.13`.
-Core data objects such as `ScoreTable`, `LayoutRecipe`, and `VPMArtifact` should
-be imported from `zeromodel.core`, not re-exported from this package.
+The package depends on the validated core distribution, `zeromodel==1.2.0`. Core data objects such as `ScoreTable`, `LayoutRecipe`, and `VPMArtifact` should be imported from `zeromodel.core`, not re-exported from this package.
 
 ## Install
 
 ```powershell
-python -m pip install zeromodel==1.0.13 zeromodel-analysis==1.0.13
+python -m pip install zeromodel==1.2.0 zeromodel-analysis==1.2.0
 ```
 
 ## Includes
@@ -28,14 +24,9 @@ python -m pip install zeromodel==1.0.13 zeromodel-analysis==1.0.13
 
 ## Excludes
 
-`zeromodel-analysis` deliberately excludes observation capture, vision encoders,
-video runtime/instrumentation, SQLAlchemy persistence, research orchestration,
-examples, Torch, TorchVision, Transformers, Pillow, and database runtimes.
+`zeromodel-analysis` deliberately excludes observation capture, vision encoders, perception contracts, video runtime/instrumentation, SQLAlchemy persistence, research orchestration, examples, Torch, TorchVision, Transformers, Pillow, and database runtimes.
 
-Analysis functions operate over numeric artifacts and bounded finite policies.
-They do not claim semantic reasoning, causal detection, continuous formal
-verification, or benchmark adjudication beyond the explicit deterministic
-contracts documented by each API.
+Analysis functions operate over numeric artifacts and bounded finite policies. They do not claim semantic reasoning, causal detection, continuous formal verification, or benchmark adjudication beyond the explicit deterministic contracts documented by each API.
 
 ## Minimal Comparison
 
@@ -105,3 +96,5 @@ report = PolicyPropertyChecker(artifact, action_metric_ids=("WAIT", "ACT")).chec
     [spec]
 )
 ```
+
+See the [system README](../../README.md) and [claims audit](../../docs/claims-audit.md) for the validated capability boundary.

--- a/packages/analysis/pyproject.toml
+++ b/packages/analysis/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-analysis"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel analysis package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,13 +31,13 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23",
-    "zeromodel==1.1.0",
+    "zeromodel==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/artifacts/pyproject.toml
+++ b/packages/artifacts/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-artifacts"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel canonical artifact reference, resolution, and content-addressed storage"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,13 +31,13 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23",
-    "zeromodel==1.1.0",
+    "zeromodel==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,15 +1,15 @@
 # ZeroModel Core
 
-`zeromodel` is the lightweight core distribution for ZeroModel 1.0.13. It owns the `zeromodel.core` import namespace.
+`zeromodel` is the lightweight core distribution for ZeroModel 1.2.0. It owns the `zeromodel.core` import namespace and provides the deterministic artifact kernel beneath the Visual AI Computing package system.
 
 Core includes deterministic VPM artifact construction, stable artifact and matrix identities, basic views, `.vpm` bundle serialization, lightweight PNG/SVG rendering, exact bounded policy lookup, and Lua export for compiled policy plans.
 
-Core deliberately excludes analysis, observation contracts, vision providers, video domains, SQLAlchemy persistence, benchmarks, and research evidence tooling. Those live in separate distributions.
+Core deliberately excludes analysis, observation contracts, vision providers, perception, observer applications, video domains, SQLAlchemy persistence, artifact stores, trust, navigation, benchmarks, and research evidence tooling. Those live in separate distributions.
 
 ## Install
 
 ```powershell
-pip install zeromodel
+pip install zeromodel==1.2.0
 ```
 
 Runtime dependency: NumPy.
@@ -51,4 +51,17 @@ decision = reader.read("candidate-a")
 print(decision.action, decision.value)
 ```
 
-Use `zeromodel.analysis`, `zeromodel.observation`, `zeromodel.vision`, `zeromodel.video`, and `zeromodel.persistence.sqlalchemy` for the higher-level packages.
+Use the owning namespaces directly for higher-level capabilities:
+
+- `zeromodel.analysis`
+- `zeromodel.observation`
+- `zeromodel.vision`
+- `zeromodel.perception`
+- `zeromodel.observer`
+- `zeromodel.video`
+- `zeromodel.persistence.sqlalchemy`
+- `zeromodel.artifacts`
+- `zeromodel.trust`
+- `zeromodel.navigation`
+
+See the [system README](../../README.md) and [claims audit](../../docs/claims-audit.md).

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel core package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,7 +31,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/ernanhughes/zeromodel"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
 Documentation = "https://zeromodel.org/"
 

--- a/packages/navigation/pyproject.toml
+++ b/packages/navigation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-navigation"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel finite, deterministic artifact-corpus hierarchy compiler and traversal engine"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -32,14 +32,14 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23",
-    "zeromodel==1.1.0",
-    "zeromodel-artifacts==1.1.0",
+    "zeromodel==1.2.0",
+    "zeromodel-artifacts==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/observation/README.md
+++ b/packages/observation/README.md
@@ -1,41 +1,26 @@
 # zeromodel-observation
 
-`zeromodel-observation` defines provider-neutral observation contracts for
-ZeroModel. It is the boundary between raw observations and deterministic policy
-addressing, exposed through `zeromodel.observation`.
+`zeromodel-observation` defines provider-neutral observation contracts for ZeroModel. It is the boundary between raw observations and deterministic policy addressing, exposed through `zeromodel.observation`.
 
-The package depends on the validated core distribution, `zeromodel==1.0.13`, and
-uses NumPy for immutable image-array contracts. It does not implement perception,
-visual recognition, video policy behavior, model inference, or persistence.
+The package depends on the validated 1.2.0 core distribution, `zeromodel==1.2.0`, and uses NumPy for immutable image-array contracts. It does not implement perception, visual recognition, video policy behavior, model inference, or persistence.
 
 ## Install
 
 ```powershell
-python -m pip install zeromodel==1.0.13 zeromodel-observation==1.0.13
+python -m pip install zeromodel==1.2.0 zeromodel-observation==1.2.0
 ```
 
 ## Provider-Neutral Contracts
 
-`ImageObservation` stores an owned, read-only `uint8` image array plus source,
-timestamp, and metadata. It accepts `HxW`, `HxWx3`, and `HxWx4` arrays and
-derives a deterministic raw digest from the canonical shape and bytes.
+`ImageObservation` stores an owned, read-only `uint8` image array plus source, timestamp, and metadata. It accepts `HxW`, `HxWx3`, and `HxWx4` arrays and derives a deterministic raw digest from the canonical shape and bytes.
 
-`VisualAddressContract` describes what a provider promises before inference:
-provider identity, score polarity, replay semantics, representation identity,
-calibration identity, policy identity, and source scope.
+`VisualAddressContract` describes what a provider promises before inference: provider identity, score polarity, replay semantics, representation identity, calibration identity, policy identity, and source scope.
 
-`VisualAddressDecision` records an accepted address or evidence-bearing
-rejection. It links the observation, representation, provider, address artifact,
-calibration artifact, and policy artifact without depending on any concrete
-vision implementation.
+`VisualAddressDecision` records an accepted address or evidence-bearing rejection. It links the observation, representation, provider, address artifact, calibration artifact, and policy artifact without depending on any concrete vision implementation.
 
-`VisualAddressManifest` and `PrototypeBinding` bind representation rows to
-policy row IDs and link those rows to a content-addressed matrix blob. The
-manifest is an address contract artifact, not a visual reader.
+`VisualAddressManifest` and `PrototypeBinding` bind representation rows to policy row IDs and link those rows to a content-addressed matrix blob. The manifest is an address contract artifact, not a visual reader.
 
-`DeploymentBinding` records an approved pairing of policy, address artifact,
-calibration, source scope, and optional encoder identity. It is not a
-cryptographic signature or authorization system.
+`DeploymentBinding` records an approved pairing of policy, address artifact, calibration, source scope, and optional encoder identity. It is not a cryptographic signature or authorization system.
 
 ## Minimal Provider
 
@@ -94,9 +79,8 @@ decision = provider.read(ImageObservation(np.zeros((2, 2), dtype=np.uint8)))
 
 ## Exclusions
 
-Concrete deterministic visual addressing belongs to `zeromodel-vision`.
-Temporal policy and video-domain behavior belong to `zeromodel-video`.
-Durable SQL persistence belongs to `zeromodel-sqlalchemy`.
+Concrete deterministic visual addressing belongs to `zeromodel-vision`. Visual evidence and transition contracts belong to `zeromodel-perception`. Temporal policy and video-domain behavior belong to `zeromodel-video`. Durable SQL persistence belongs to `zeromodel-sqlalchemy`.
 
-This package does not import or require `zeromodel-analysis`, `zeromodel-vision`,
-`zeromodel-video`, SQLAlchemy, Torch, TorchVision, Transformers, or Pillow.
+This package does not import or require `zeromodel-analysis`, `zeromodel-vision`, `zeromodel-perception`, `zeromodel-video`, SQLAlchemy, Torch, TorchVision, Transformers, or Pillow.
+
+See the [system README](../../README.md) and [claims audit](../../docs/claims-audit.md).

--- a/packages/observation/pyproject.toml
+++ b/packages/observation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-observation"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel observation package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,13 +31,13 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23",
-    "zeromodel==1.1.0",
+    "zeromodel==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/observer/pyproject.toml
+++ b/packages/observer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-observer"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel Observer demonstration package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,15 +31,15 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "zeromodel==1.1.0",
-    "zeromodel-observation==1.1.0",
-    "zeromodel-perception==1.1.0",
+    "zeromodel==1.2.0",
+    "zeromodel-observation==1.2.0",
+    "zeromodel-perception==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/perception/pyproject.toml
+++ b/packages/perception/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-perception"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel perception package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -33,14 +33,14 @@ classifiers = [
 dependencies = [
     "numpy>=1.23",
     "pillow>=9.0",
-    "zeromodel==1.1.0",
-    "zeromodel-observation==1.1.0",
+    "zeromodel==1.2.0",
+    "zeromodel-observation==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/perception/src/zeromodel/perception/__init__.py
+++ b/packages/perception/src/zeromodel/perception/__init__.py
@@ -211,7 +211,7 @@ from .transition_evidence import (  # noqa: F401
     build_transition_evidence_vpm,
 )
 
-PERCEPTION_PACKAGE_VERSION = "1.1.0"
+PERCEPTION_PACKAGE_VERSION = "1.2.0"
 PERCEPTION_STAGE = "P18H"
 
 __all__ = [

--- a/packages/perception/tests/test_public_api.py
+++ b/packages/perception/tests/test_public_api.py
@@ -6,6 +6,7 @@ from zeromodel.perception import (
     COEFFICIENT_SEMANTICS,
     DIFFERENCE_SURFACE_SEMANTICS,
     FIELD_RELEVANCE_SEMANTICS,
+    PERCEPTION_PACKAGE_VERSION,
     PROMOTED_INFERENCE_SEMANTICS,
     PROMOTED_TEST_EVALUATION_SEMANTICS,
     PROMOTION_SEMANTICS,
@@ -33,7 +34,7 @@ from zeromodel.perception import (
 
 
 def test_public_contract_through_promoted_inference() -> None:
-    # assert PERCEPTION_PACKAGE_VERSION == "1.1.0"
+    assert PERCEPTION_PACKAGE_VERSION == "1.2.0"
     assert FIELD_RELEVANCE_SEMANTICS == "eta_squared_of_field_mean_by_action"
     assert WEIGHTED_DISTANCE_SEMANTICS == (
         "field_relevance_weighted_normalized_mean_absolute_distance"

--- a/packages/sqlalchemy/README.md
+++ b/packages/sqlalchemy/README.md
@@ -1,25 +1,16 @@
-# zeromodel-sqlalchemy 1.0.13
+# zeromodel-sqlalchemy 1.2.0
 
-`zeromodel-sqlalchemy` owns the SQLAlchemy and SQLite persistence adapter for
-the validated video action-set domain. Its import namespace is
-`zeromodel.persistence.sqlalchemy`.
+`zeromodel-sqlalchemy` owns the SQLAlchemy and SQLite persistence adapter for the validated video action-set domain. Its import namespace is `zeromodel.persistence.sqlalchemy`.
 
-The package depends on `zeromodel==1.0.13`, `zeromodel-video==1.0.13`, NumPy,
-and SQLAlchemy 2.x. It does not depend on analysis, vision, research fixtures,
-examples, Torch, TorchVision, Transformers, or Pillow.
+The package depends on `zeromodel==1.2.0`, `zeromodel-video==1.2.0`, NumPy, and SQLAlchemy 2.x. It does not depend on analysis, vision, perception, research fixtures, examples, Torch, TorchVision, Transformers, or Pillow.
 
 ## Boundary
 
-Video owns DTOs, domain services, runtime protocols, and the in-memory Store.
-This package owns SQLAlchemy engines, sessions, ORM rows, schema creation, and
-SQL Store implementations. Store methods accept and return video DTOs; ORM
-objects remain internal to `zeromodel.persistence.sqlalchemy.db.orm` and
-`zeromodel.persistence.sqlalchemy.db.stores`.
+Video owns DTOs, domain services, runtime protocols, and the in-memory Store. This package owns SQLAlchemy engines, sessions, ORM rows, schema creation, and SQL Store implementations. Store methods accept and return video DTOs; ORM objects remain internal to `zeromodel.persistence.sqlalchemy.db.orm` and `zeromodel.persistence.sqlalchemy.db.stores`.
 
 ## Schema Initialization
 
-Database creation is explicit. Importing `zeromodel.persistence.sqlalchemy`
-does not create files, tables, engines, or sessions.
+Database creation is explicit. Importing `zeromodel.persistence.sqlalchemy` does not create files, tables, engines, or sessions.
 
 ```python
 from pathlib import Path
@@ -47,8 +38,8 @@ runtime = build_sqlite_runtime("sqlite:///video.sqlite", initialize_schema=True)
 
 ## Validation
 
-Package-local tests cover import isolation, explicit schema creation, SQLite
-foreign keys, in-memory Store parity for identity and episode plans,
-transaction rollback on batch conflicts, MatrixBlob deduplication/conflict
-handling, observation operation filters, database reopen behavior, tamper
-detection, and runtime composition.
+Package-local tests cover import isolation, explicit schema creation, SQLite foreign keys, in-memory Store parity for identity and episode plans, transaction rollback on batch conflicts, MatrixBlob deduplication/conflict handling, observation operation filters, database reopen behavior, tamper detection, and runtime composition.
+
+This is an explicit bounded persistence adapter. It does not claim distributed coordination, high availability, or production authorization.
+
+See the [system README](../../README.md) and [claims audit](../../docs/claims-audit.md).

--- a/packages/sqlalchemy/pyproject.toml
+++ b/packages/sqlalchemy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-sqlalchemy"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel SQLAlchemy and SQLite persistence adapter"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,9 +12,14 @@ license = {text = "MIT"}
 dependencies = [
     "numpy>=1.23",
     "SQLAlchemy>=2.0,<3",
-    "zeromodel==1.1.0",
-    "zeromodel-video==1.1.0",
+    "zeromodel==1.2.0",
+    "zeromodel-video==1.2.0",
 ]
+
+[project.urls]
+Homepage = "https://zeromodel.org/"
+Repository = "https://github.com/ernanhughes/zeromodel"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/trust/pyproject.toml
+++ b/packages/trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-trust"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel artifact trust, authenticity, and deployment-scope authorization kernel"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -33,14 +33,14 @@ classifiers = [
 dependencies = [
     "numpy>=1.23",
     "cryptography>=41",
-    "zeromodel==1.1.0",
-    "zeromodel-artifacts==1.1.0",
+    "zeromodel==1.2.0",
+    "zeromodel-artifacts==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/video/README.md
+++ b/packages/video/README.md
@@ -1,36 +1,27 @@
 # zeromodel-video
 
-`zeromodel-video` provides ZeroModel's deterministic video runtime contracts,
-provider-neutral temporal policy reader, and video action-set domain DTO/Store
-architecture.
+`zeromodel-video` provides ZeroModel's deterministic video runtime contracts, provider-neutral temporal policy reader, and video action-set domain DTO/Store architecture.
 
 It depends on:
 
-- `zeromodel==1.0.13`
-- `zeromodel-observation==1.0.13`
+- `zeromodel==1.2.0`
+- `zeromodel-observation==1.2.0`
 - `numpy>=1.23`
 
-It does not depend on `zeromodel-analysis`, `zeromodel-vision`,
-`zeromodel-sqlalchemy`, SQLAlchemy, Torch, TorchVision, Transformers, Pillow,
-research modules, examples, or the repository root.
+It does not depend on `zeromodel-analysis`, `zeromodel-vision`, `zeromodel-perception`, `zeromodel-sqlalchemy`, SQLAlchemy, Torch, TorchVision, Transformers, Pillow, research modules, examples, or the repository root.
 
 ## Install
 
 ```powershell
-python -m pip install zeromodel==1.0.13 zeromodel-observation==1.0.13 zeromodel-video==1.0.13
+python -m pip install zeromodel==1.2.0 zeromodel-observation==1.2.0 zeromodel-video==1.2.0
 ```
 
 ## Includes
 
-- `VideoFrame`, `VideoFrameSource`, `InMemoryVideoFrameSource`, and
-  `VideoClipManifest` for immutable frame and clip identity.
-- `VideoPolicyReader`, `TemporalEvidence`, `VideoPolicyDecision`, and
-  `VideoPolicyTrace` for temporal policy over observation-owned visual address
-  contracts.
-- Video action-set DTOs for benchmark identity, episode plans, sealed final
-  split plans, observation ledgers, provider descriptors, and operation chains.
-- `VideoActionSetStore` and `InMemoryVideoActionSetStore` for DTO-only Store
-  semantics.
+- `VideoFrame`, `VideoFrameSource`, `InMemoryVideoFrameSource`, and `VideoClipManifest` for immutable frame and clip identity.
+- `VideoPolicyReader`, `TemporalEvidence`, `VideoPolicyDecision`, and `VideoPolicyTrace` for temporal policy over observation-owned visual address contracts.
+- Video action-set DTOs for benchmark identity, episode plans, sealed final split plans, observation ledgers, provider descriptors, and operation chains.
+- `VideoActionSetStore` and `InMemoryVideoActionSetStore` for DTO-only Store semantics.
 - `build_runtime()` for default in-memory runtime composition.
 
 ## Temporal Policy Example
@@ -95,13 +86,10 @@ assert runtime.video_action_set.get_identity(identity.seed_digest) == identity
 
 ## Exclusions
 
-Concrete visual providers are injected by callers. This package consumes
-provider-neutral observation contracts and does not import `zeromodel.vision`.
+Concrete visual providers are injected by callers. This package consumes provider-neutral observation contracts and does not import `zeromodel.vision` or `zeromodel.perception`.
 
-SQL persistence belongs to `zeromodel-sqlalchemy`. This package provides Store
-protocols and in-memory implementations only.
+SQL persistence belongs to `zeromodel-sqlalchemy`. This package provides Store protocols and in-memory implementations only.
 
-Research benchmark orchestration, provider comparison, evidence generation,
-large sweeps, committed-result reconstruction, and final cross-package
-integration remain outside this package.
+Research benchmark orchestration, provider comparison, evidence generation, large sweeps, committed-result reconstruction, and final cross-package integration remain outside this package.
 
+See the [system README](../../README.md), [provider-evaluation architecture](../../docs/architecture/provider-evaluation-rmdto.md), and [claims audit](../../docs/claims-audit.md).

--- a/packages/video/pyproject.toml
+++ b/packages/video/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-video"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel video package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,14 +31,14 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23",
-    "zeromodel==1.1.0",
-    "zeromodel-observation==1.1.0",
+    "zeromodel==1.2.0",
+    "zeromodel-observation==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/vision/README.md
+++ b/packages/vision/README.md
@@ -1,34 +1,23 @@
 # zeromodel-vision
 
-`zeromodel-vision` provides the deterministic bounded visual-address runtime for
-ZeroModel. It implements the provider-neutral contracts from
-`zeromodel-observation` and uses the core artifact and policy lookup primitives
-from `zeromodel`.
+`zeromodel-vision` provides the deterministic bounded visual-address runtime for ZeroModel 1.2.0. It implements the provider-neutral contracts from `zeromodel-observation` and uses the core artifact and policy lookup primitives from `zeromodel`.
 
-The supported production path is closed-world and codebook-based: a bounded
-`ImageObservation` is converted into deterministic integer features, matched
-against a calibrated visual index, and optionally passed through core bounded
-policy lookup.
+The supported production path is closed-world and codebook-based: a bounded `ImageObservation` is converted into deterministic integer features, matched against a calibrated visual index, and optionally passed through core bounded policy lookup.
 
 ## Install
 
 ```powershell
-python -m pip install zeromodel==1.0.13 zeromodel-observation==1.0.13 zeromodel-vision==1.0.13
+python -m pip install zeromodel==1.2.0 zeromodel-observation==1.2.0 zeromodel-vision==1.2.0
 ```
 
 ## Includes
 
-- `VisualFeatureSpec` for the exact image shape, pooling, grayscale conversion,
-  and quantization contract.
-- `extract_visual_features`, `visual_input_digest`, and
-  `visual_feature_digest`.
-- `build_visual_index` and `VisualIndexCalibration` for deterministic codebook
-  construction and rejection thresholds.
+- `VisualFeatureSpec` for the exact image shape, pooling, grayscale conversion, and quantization contract.
+- `extract_visual_features`, `visual_input_digest`, and `visual_feature_digest`.
+- `build_visual_index` and `VisualIndexCalibration` for deterministic codebook construction and rejection thresholds.
 - `VisualSignReader` for exact visual address recovery or rejection evidence.
-- `DeterministicVisualAddressProvider` for the observation-owned
-  `VisualAddressProvider` protocol.
-- `VisualPolicyReader` and `VisualPolicyDecision` for bridging an accepted
-  visual address to core `VPMPolicyLookup`.
+- `DeterministicVisualAddressProvider` for the observation-owned `VisualAddressProvider` protocol.
+- `VisualPolicyReader` and `VisualPolicyDecision` for bridging an accepted visual address to core `VPMPolicyLookup`.
 
 ## Minimal Example
 
@@ -86,16 +75,10 @@ assert decision.action == "B"
 
 ## Limitations
 
-This package does not claim general computer vision, object recognition, semantic
-perception, learned embedding quality, or benchmark superiority. It validates a
-closed-world deterministic codebook and bounded rejection rules.
+This package does not claim general computer vision, object recognition, semantic perception, learned embedding quality, or benchmark superiority. It validates a closed-world deterministic codebook and bounded rejection rules.
 
-Learned and approximate provider families, DINOv2/Hugging Face encoders, linear
-probes, registration experiments, corruption sweeps, local-correlation
-providers, discriminative evidence providers, benchmark calibration, and
-architecture-selection systems remain research or later package concerns.
+Learned and approximate provider families, DINOv2/Hugging Face encoders, linear probes, registration experiments, corruption sweeps, local-correlation providers, discriminative evidence providers, benchmark calibration, and architecture-selection systems remain research or later package concerns.
 
-Temporal video behavior belongs to `zeromodel-video`. SQL persistence belongs to
-`zeromodel-sqlalchemy`. This package does not import SQLAlchemy, Torch,
-TorchVision, Transformers, Pillow, model weights, datasets, examples, or
-research results.
+Visual evidence, fields, transitions, and representation compilation belong to `zeromodel-perception`. Temporal video behavior belongs to `zeromodel-video`. SQL persistence belongs to `zeromodel-sqlalchemy`.
+
+See the [system README](../../README.md), [Visual Sign Reader research note](../../docs/research/visual-sign-reader.md), and [claims audit](../../docs/claims-audit.md).

--- a/packages/vision/pyproject.toml
+++ b/packages/vision/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zeromodel-vision"
-version = "1.1.0"
+version = "1.2.0"
 description = "ZeroModel vision package"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,14 +31,14 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23",
-    "zeromodel==1.1.0",
-    "zeromodel-observation==1.1.0",
+    "zeromodel==1.2.0",
+    "zeromodel-observation==1.2.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/ernanhughes/zeromodel"
+Homepage = "https://zeromodel.org/"
 Repository = "https://github.com/ernanhughes/zeromodel"
-Documentation = "https://ernanhughes.github.io/zeromodel/"
+Documentation = "https://zeromodel.org/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/validate_release_candidate.py
+++ b/scripts/validate_release_candidate.py
@@ -56,7 +56,11 @@ globals()["RELEASE_CANDIDATE_REPORT_DIR"] = (
 
 for package in globals()["PACKAGES"].values():
     package["requires"] = {
-        requirement.replace("==1.1.0", f"=={_RELEASE_VERSION}")
+        (
+            f"{requirement.split('==', 1)[0]}=={_RELEASE_VERSION}"
+            if requirement.startswith("zeromodel") and "==" in requirement
+            else requirement
+        )
         for requirement in package["requires"]
     }
 

--- a/scripts/validate_release_candidate.py
+++ b/scripts/validate_release_candidate.py
@@ -3,10 +3,19 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
 _IMPLEMENTATION_PATH = Path(__file__).with_name("_validate_release_candidate_impl.py")
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PACKAGE_BOUNDARIES_PATH = _REPO_ROOT / "package-boundaries.toml"
 _ORIGINAL_MODULE_NAME = __name__
 _IMPLEMENTATION_MODULE_NAME = "_zeromodel_validate_release_candidate_impl"
-_RELEASE_VERSION = "1.2.0"
+_RELEASE_VERSION = str(
+    tomllib.loads(_PACKAGE_BOUNDARIES_PATH.read_text(encoding="utf-8"))["release_version"]
+)
 
 _CURRENT_MODULE = sys.modules[_ORIGINAL_MODULE_NAME]
 sys.modules[_IMPLEMENTATION_MODULE_NAME] = _CURRENT_MODULE
@@ -26,8 +35,8 @@ finally:
     sys.modules.pop(_IMPLEMENTATION_MODULE_NAME, None)
 
 # The implementation remains the large stable release harness. The coordinated
-# release line is declared here so a release preparation changes one small
-# wrapper rather than rewriting the complete validator implementation.
+# release line comes from package-boundaries.toml, the package-system authority,
+# so release preparation does not require rewriting the complete implementation.
 globals()["VERSION"] = _RELEASE_VERSION
 globals()["PACKAGE_RELEASE_ARTIFACTS_PATH"] = globals()["ARCHITECTURE_REPORT_DIR"] / (
     f"package-release-artifacts-{_RELEASE_VERSION}.json"

--- a/scripts/validate_release_candidate.py
+++ b/scripts/validate_release_candidate.py
@@ -6,6 +6,7 @@ from pathlib import Path
 _IMPLEMENTATION_PATH = Path(__file__).with_name("_validate_release_candidate_impl.py")
 _ORIGINAL_MODULE_NAME = __name__
 _IMPLEMENTATION_MODULE_NAME = "_zeromodel_validate_release_candidate_impl"
+_RELEASE_VERSION = "1.2.0"
 
 _CURRENT_MODULE = sys.modules[_ORIGINAL_MODULE_NAME]
 sys.modules[_IMPLEMENTATION_MODULE_NAME] = _CURRENT_MODULE
@@ -24,20 +25,31 @@ finally:
     globals()["__name__"] = _ORIGINAL_MODULE_NAME
     sys.modules.pop(_IMPLEMENTATION_MODULE_NAME, None)
 
-_VERSION = globals()["VERSION"]
-globals()["PACKAGES"]["perception"] = {
-    "path": Path("packages/perception"),
-    "distribution": "zeromodel-perception",
-    "wheel_stem": "zeromodel_perception",
-    "namespace": "zeromodel.perception",
-    "requires": {
-        "numpy>=1.23",
-        "pillow>=9.0",
-        f"zeromodel=={_VERSION}",
-        f"zeromodel-observation=={_VERSION}",
-    },
-    "depends_on": ("core", "observation"),
-}
+# The implementation remains the large stable release harness. The coordinated
+# release line is declared here so a release preparation changes one small
+# wrapper rather than rewriting the complete validator implementation.
+globals()["VERSION"] = _RELEASE_VERSION
+globals()["PACKAGE_RELEASE_ARTIFACTS_PATH"] = globals()["ARCHITECTURE_REPORT_DIR"] / (
+    f"package-release-artifacts-{_RELEASE_VERSION}.json"
+)
+globals()["PACKAGE_PUBLIC_API_PATH"] = globals()["ARCHITECTURE_REPORT_DIR"] / (
+    f"package-public-api-{_RELEASE_VERSION}.csv"
+)
+globals()["PACKAGE_RELEASE_TEST_LAYERS_PATH"] = globals()[
+    "ARCHITECTURE_REPORT_DIR"
+] / f"package-release-test-layers-{_RELEASE_VERSION}.json"
+globals()["RELEASE_CANDIDATE_REPORT_DIR"] = (
+    globals()["REPO_ROOT"]
+    / "docs"
+    / "results"
+    / f"release-candidate-{_RELEASE_VERSION}"
+)
+
+for package in globals()["PACKAGES"].values():
+    package["requires"] = {
+        requirement.replace("==1.1.0", f"=={_RELEASE_VERSION}")
+        for requirement in package["requires"]
+    }
 
 if _ORIGINAL_MODULE_NAME == "__main__":
     raise SystemExit(globals()["main"]())


### PR DESCRIPTION
## What changed

- rewrites the root README around **Visual AI Computing**
- defines the exact bounded ZeroModel 1.2.0 headline claim
- adds the system-wide package and repository architecture map
- introduces the five-state evidence ladder prominently
- links major capabilities to implementation proof, demo programme, and explicit boundary
- coordinates all eleven package distributions and internal dependency pins at `1.2.0`
- adds `zeromodel-observer` to the explicit coordinated system and install surface
- updates package documentation URLs to `https://zeromodel.org/`
- adds 1.2.0 release posture and rewrites the current coordinated release process
- makes the release validator read the coordinated version from `package-boundaries.toml`
- exposes and tests `PERCEPTION_PACKAGE_VERSION == "1.2.0"`

## Why

ZeroModel has moved beyond the unpublished nine-package 1.0.13 split described by the old README. The repository now contains eleven coordinated distributions and a much broader evidence-backed system spanning deterministic artifacts, bounded policy, observation, perception, transition contracts, representation compilation, persistence, trust, navigation, and the observer application layer.

This PR establishes the repository as the technical source of truth for the wider business and public system:

```text
zeromodel -> zeromodel-demos -> zeromodel.org -> static deployment
```

The positioning is ambitious, but the evidence boundary remains explicit: 1.2.0 establishes the **foundation for Visual AI Computing**; it does not claim general open-world Visual AI.

## Validation

This branch was reviewed through the GitHub compare API for file scope and coordinated version metadata. Full local package, quality, release-candidate, and visual-transition gates were not available in the current execution environment and must run in GitHub Actions / a normal development checkout:

```powershell
python scripts/validate_release_candidate.py
python scripts/run_fast_tests.py
python scripts/check_quality.py
```

Historical 1.0.13 and 1.1.0 evidence records remain under their original names and are not presented as 1.2.0 evidence.