### PR TITLE
Fix version-neutral wheel isolation tests

### DIFF
--- a/packages/core/tests/test_core_api_isolation_wheel.py
+++ b/packages/core/tests/test_core_api_isolation_wheel.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import inspect
-from importlib.metadata import version
 import json
 import os
-from pathlib import Path
 import subprocess
 import sys
 import zipfile
+from importlib.metadata import version
+from pathlib import Path
 
 import zeromodel.core as core
 

--- a/packages/core/tests/test_core_api_isolation_wheel.py
+++ b/packages/core/tests/test_core_api_isolation_wheel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+from importlib.metadata import version
 import json
 import os
 from pathlib import Path
@@ -100,7 +101,10 @@ def test_core_wheel_contains_only_core_namespace_when_wheel_path_is_provided() -
         for prefix in forbidden_prefixes
         if name == prefix or name.startswith(prefix)
     ]
+    distribution_version = version("zeromodel")
+    dist_info_prefix = f"zeromodel-{distribution_version}.dist-info/"
+
     assert offenders == []
     assert "zeromodel/core/artifact.py" in names
     assert "zeromodel/core/policy_lookup.py" in names
-    assert any(name.startswith("zeromodel-1.0.13.dist-info/") for name in names)
+    assert any(name.startswith(dist_info_prefix) for name in names)

--- a/packages/video/tests/test_import_isolation_and_wheel.py
+++ b/packages/video/tests/test_import_isolation_and_wheel.py
@@ -62,8 +62,7 @@ def test_video_wheel_contains_only_video_namespace_when_path_is_provided() -> No
     assert "zeromodel/video/__init__.py" in names
     assert "zeromodel/__init__.py" not in names
     assert all(
-        name.startswith("zeromodel/video/")
-        or name.startswith(dist_info_prefix)
+        name.startswith("zeromodel/video/") or name.startswith(dist_info_prefix)
         for name in names
     )
     assert not any(

--- a/packages/video/tests/test_import_isolation_and_wheel.py
+++ b/packages/video/tests/test_import_isolation_and_wheel.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from importlib.metadata import version
 import os
 import subprocess
 import sys
 import zipfile
+from importlib.metadata import version
 
 
 FORBIDDEN = {

--- a/packages/video/tests/test_import_isolation_and_wheel.py
+++ b/packages/video/tests/test_import_isolation_and_wheel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib.metadata import version
 import os
 import subprocess
 import sys
@@ -55,11 +56,14 @@ def test_video_wheel_contains_only_video_namespace_when_path_is_provided() -> No
     with zipfile.ZipFile(wheel) as archive:
         names = set(archive.namelist())
 
+    distribution_version = version("zeromodel-video")
+    dist_info_prefix = f"zeromodel_video-{distribution_version}.dist-info/"
+
     assert "zeromodel/video/__init__.py" in names
     assert "zeromodel/__init__.py" not in names
     assert all(
         name.startswith("zeromodel/video/")
-        or name.startswith("zeromodel_video-1.0.13.dist-info/")
+        or name.startswith(dist_info_prefix)
         for name in names
     )
     assert not any(


### PR DESCRIPTION
Audit-Exempt: internal release-version test repair; no empirical capability claim changed.

## Root cause

The core and video wheels built and installed correctly at version 1.2.0, but their wheel-isolation tests still asserted literal `1.0.13.dist-info` directory names.

## Changes

- derive the installed `zeromodel` distribution version with `importlib.metadata.version`
- derive the installed `zeromodel-video` distribution version the same way
- construct the expected `.dist-info/` prefix dynamically
- preserve all existing namespace-isolation assertions

## Result

These tests now validate package ownership and metadata layout without embedding a release number, so future coordinated upgrades do not require editing them.

## Validation

GitHub Actions should rerun the focused Core package and video-package clean-wheel tests. The prior failures were:

- `packages/core/tests/test_core_api_isolation_wheel.py::test_core_wheel_contains_only_core_namespace_when_wheel_path_is_provided`
- `packages/video/tests/test_import_isolation_and_wheel.py::test_video_wheel_contains_only_video_namespace_when_path_is_provided`

No historical 1.0.13 evidence documents were changed.