### PR TITLE
good Good — this gives me the exact `fingerprint`-style identity idiom. Le…

### DIFF
--- a/examples/tiny_critic.py
+++ b/examples/tiny_critic.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import numpy as np
+
+from zeromodel.artifacts import InMemoryArtifactStore, canonical_json_bytes
+from zeromodel.core.matrix_blob import MatrixBlob
+from zeromodel.critic import (
+    CriticContractDTO,
+    CriticFeatureBatchDTO,
+    CriticFeatureDTO,
+    CriticFeatureSpecDTO,
+    CriticFitSpecDTO,
+    CriticLabelBatchDTO,
+    CriticScoreRequestDTO,
+    CriticThresholdContractDTO,
+    build_critic_score_receipt,
+    build_critic_score_vpm,
+    compile_critic_readout,
+    export_portable_critic,
+    load_critic_readout_aggregate,
+    rank_by_critic,
+    replay_critic_score,
+    score_critic,
+)
+from zeromodel.critic.persistence import (
+    load_critic_feature_batch_aggregate,
+    load_critic_label_batch_aggregate,
+    store_critic_contract,
+    store_critic_feature_batch,
+    store_critic_feature_spec,
+    store_critic_label_batch,
+    store_matrix_blob,
+)
+
+
+def main() -> None:
+    store = InMemoryArtifactStore()
+    feature_spec = CriticFeatureSpecDTO(
+        features=(
+            CriticFeatureDTO("stability", "deterministic fixture stability"),
+            CriticFeatureDTO("coverage", "deterministic fixture coverage"),
+            CriticFeatureDTO(
+                "uncertainty", "deterministic fixture uncertainty", directionality=-1
+            ),
+            CriticFeatureDTO("consistency", "deterministic fixture consistency"),
+        )
+    )
+    contract = CriticContractDTO(
+        critic_id="tiny-fixture-success",
+        version="v1",
+        target_id="synthetic-success",
+        positive_label="successful",
+        negative_label="failed",
+        score_semantics="similarity to this deterministic capability fixture's successful rows",
+        intended_uses=("ranking", "triage"),
+        prohibited_uses=("semantic truth", "universal quality"),
+    )
+    spec_ref = store_critic_feature_spec(store, feature_spec)
+    contract_ref = store_critic_contract(store, contract)
+    values = np.asarray(
+        [
+            [0.90, 0.85, 0.10, 0.80],
+            [0.75, 0.70, 0.20, 0.70],
+            [0.20, 0.30, 0.80, 0.35],
+            [0.15, 0.20, 0.90, 0.25],
+            [0.88, 0.92, 0.15, 0.86],
+            [0.30, 0.25, 0.75, 0.40],
+        ],
+        dtype=np.float64,
+    )
+    labels = np.asarray([1, 1, 0, 0, 1, 0], dtype=np.float64)
+    item_refs = tuple(
+        store.put("example.tiny_critic.item", canonical_json_bytes({"row": index}), {})
+        for index in range(values.shape[0])
+    )
+    feature_batch = CriticFeatureBatchDTO(
+        feature_spec_ref=spec_ref,
+        values_blob_ref=store_matrix_blob(
+            store, MatrixBlob.from_array(values, dtype="float64")
+        ),
+        item_refs=item_refs,
+        values_shape=values.shape,
+        values_dtype="float64",
+    )
+    label_batch = CriticLabelBatchDTO(
+        critic_contract_ref=contract_ref,
+        item_refs=item_refs,
+        labels_blob_ref=store_matrix_blob(
+            store, MatrixBlob.from_array(labels, dtype="float64")
+        ),
+        labels_shape=labels.shape,
+    )
+    feature_ref = store_critic_feature_batch(store, feature_batch)
+    label_ref = store_critic_label_batch(store, label_batch)
+    readout, readout_ref = compile_critic_readout(
+        store=store,
+        features=load_critic_feature_batch_aggregate(feature_ref, store),
+        labels=load_critic_label_batch_aggregate(label_ref, store),
+        fit_spec=CriticFitSpecDTO(l2_penalty=0.1),
+    )
+    request = CriticScoreRequestDTO(
+        readout_ref=readout_ref,
+        feature_batch_ref=readout.training_feature_batch_ref,
+        threshold_contract=CriticThresholdContractDTO(
+            reject_below=0.4, accept_at_or_above=0.6
+        ),
+        explanation_depth=2,
+    )
+    result, result_ref, request_ref = score_critic(store=store, request=request)
+    if result_ref is None:
+        raise RuntimeError("result was not persisted")
+    portable = export_portable_critic(load_critic_readout_aggregate(readout_ref, store))
+    vpm = build_critic_score_vpm(result=result)
+    _, receipt_ref = build_critic_score_receipt(
+        store=store, request_ref=request_ref, result_ref=result_ref
+    )
+    replayed = replay_critic_score(store=store, receipt_ref=receipt_ref)
+    print("ranked:", rank_by_critic(result)[:3])
+    print("portable-bytes:", len(portable.encode("utf-8")))
+    print("vpm:", vpm.artifact_id)
+    print("replay:", replayed.result_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/package-boundaries.toml
+++ b/package-boundaries.toml
@@ -100,3 +100,11 @@ source_root = "packages/search/src"
 depends_on = ["core", "artifacts", "navigation"]
 publishable = true
 owned_prefixes = ["zeromodel.search"]
+
+[packages.critic]
+distribution = "zeromodel-critic"
+namespace = "zeromodel.critic"
+source_root = "packages/critic/src"
+depends_on = ["core", "artifacts"]
+publishable = true
+owned_prefixes = ["zeromodel.critic"]

--- a/packages/critic/README.md
+++ b/packages/critic/README.md
@@ -1,0 +1,24 @@
+# ZeroModel Critic
+
+ZeroModel Critic is a tiny learned readout over identified numeric evidence.
+
+It is not an LLM, a universal verifier, a text model, semantic truth, or a replacement for expensive validation. Domain systems produce declared numeric features; Critic fits and replays one narrow judgement over that prepared feature surface.
+
+```text
+domain producer
+↓
+feature surface
+↓
+CriticFeatureBatch
+↓
+CriticReadout
+↓
+score / rank / triage
+↓
+VPM / receipt / replay
+```
+
+The v1 runtime is deliberately small: directionality, standardisation, a linear logit, sigmoid score, and optional Platt calibration. The executable portable payload is canonical JSON and defaults to a 50 KiB limit. Many specialised critics may read the same feature surface while answering different declared targets.
+
+Safe claim: ZeroModel Critic can compile a declared numeric feature schema and a fitted lightweight linear classifier into an identified critic artifact that scores compatible evidence deterministically, exposes feature-level contributions, exports a portable arithmetic-only inference payload, and reproduces scoring through artifact replay.
+

--- a/packages/critic/pyproject.toml
+++ b/packages/critic/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zeromodel-critic"
+version = "1.2.0"
+description = "ZeroModel portable identified lightweight critic readouts over numeric evidence"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "Ernan Hughes", email = "ernanhughes@gmail.com"}]
+keywords = ["visual-policy-map", "critic", "artifact-identity", "readout"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "numpy>=1.23",
+    "zeromodel==1.2.0",
+    "zeromodel-artifacts==1.2.0",
+]
+
+[project.urls]
+Homepage = "https://zeromodel.org/"
+Repository = "https://github.com/ernanhughes/zeromodel"
+Documentation = "https://zeromodel.org/"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["zeromodel.critic*"]
+

--- a/packages/critic/src/zeromodel/critic/__init__.py
+++ b/packages/critic/src/zeromodel/critic/__init__.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from zeromodel.critic.compiler import compile_critic_readout
+from zeromodel.critic.dto import (
+    CriticContractDTO,
+    CriticFeatureBatchDTO,
+    CriticFeatureContributionDTO,
+    CriticFeatureDTO,
+    CriticFeatureSpecDTO,
+    CriticFitSpecDTO,
+    CriticItemScoreDTO,
+    CriticLabelBatchDTO,
+    CriticReadoutArtifactDTO,
+    CriticScoreReceiptDTO,
+    CriticScoreRequestDTO,
+    CriticScoreResultDTO,
+    CriticThresholdContractDTO,
+)
+from zeromodel.critic.errors import (
+    CriticCalibrationError,
+    CriticContractMismatchError,
+    CriticEvaluationError,
+    CriticFeatureSchemaMismatchError,
+    CriticPayloadTooLargeError,
+    CriticReadoutIntegrityError,
+    CriticReplayMismatchError,
+    CriticValidationError,
+)
+from zeromodel.critic.evaluation import (
+    auroc,
+    budget_selection_metrics,
+    brier_score,
+    evaluate_binary_critic,
+    expected_calibration_error,
+    grouped_selection_metrics,
+)
+from zeromodel.critic.linear import CompiledCriticReadout
+from zeromodel.critic.persistence import load_critic_readout_aggregate
+from zeromodel.critic.portable import (
+    export_portable_critic,
+    load_portable_critic,
+    score_portable,
+)
+from zeromodel.critic.promotion import (
+    CriticPromotionDecisionDTO,
+    CriticPromotionPolicyDTO,
+    evaluate_promotion,
+)
+from zeromodel.critic.receipts import build_critic_score_receipt, replay_critic_score
+from zeromodel.critic.scoring import score_critic
+from zeromodel.critic.triage import rank_by_critic, triage_by_budget
+from zeromodel.critic.views import build_critic_score_vpm
+
+CRITIC_PACKAGE_VERSION = "1.2.0"
+
+__all__ = [
+    "CRITIC_PACKAGE_VERSION",
+    "CompiledCriticReadout",
+    "CriticCalibrationError",
+    "CriticContractDTO",
+    "CriticContractMismatchError",
+    "CriticEvaluationError",
+    "CriticFeatureBatchDTO",
+    "CriticFeatureContributionDTO",
+    "CriticFeatureDTO",
+    "CriticFeatureSchemaMismatchError",
+    "CriticFeatureSpecDTO",
+    "CriticFitSpecDTO",
+    "CriticItemScoreDTO",
+    "CriticLabelBatchDTO",
+    "CriticPayloadTooLargeError",
+    "CriticPromotionDecisionDTO",
+    "CriticPromotionPolicyDTO",
+    "CriticReadoutArtifactDTO",
+    "CriticReadoutIntegrityError",
+    "CriticReplayMismatchError",
+    "CriticScoreReceiptDTO",
+    "CriticScoreRequestDTO",
+    "CriticScoreResultDTO",
+    "CriticThresholdContractDTO",
+    "CriticValidationError",
+    "auroc",
+    "brier_score",
+    "budget_selection_metrics",
+    "build_critic_score_receipt",
+    "build_critic_score_vpm",
+    "compile_critic_readout",
+    "evaluate_binary_critic",
+    "evaluate_promotion",
+    "expected_calibration_error",
+    "export_portable_critic",
+    "grouped_selection_metrics",
+    "load_critic_readout_aggregate",
+    "load_portable_critic",
+    "rank_by_critic",
+    "replay_critic_score",
+    "score_critic",
+    "score_portable",
+    "triage_by_budget",
+]

--- a/packages/critic/src/zeromodel/critic/_canonical.py
+++ b/packages/critic/src/zeromodel/critic/_canonical.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from zeromodel.artifacts import ArtifactRef, canonical_json_bytes, sha256_digest
+from zeromodel.core.artifact import VPMValidationError
+
+
+def freeze_json(value: Any) -> Any:
+    if isinstance(value, np.generic):
+        raise VPMValidationError("metadata must use plain JSON scalar types")
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {str(key): freeze_json(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(freeze_json(item) for item in value)
+    return value
+
+
+def thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [thaw_json(item) for item in value]
+    return value
+
+
+def require_nonempty(value: object, field: str) -> str:
+    text = str(value)
+    if not text:
+        raise VPMValidationError(f"{field} must be non-empty")
+    return text
+
+
+def require_unique(values: Sequence[object], field: str) -> None:
+    normalized = [str(value) for value in values]
+    if len(set(normalized)) != len(normalized):
+        raise VPMValidationError(f"{field} must not contain duplicates")
+
+
+def require_finite(value: float, field: str) -> float:
+    number = float(value)
+    if not np.isfinite(number):
+        raise VPMValidationError(f"{field} must be finite")
+    return number
+
+
+def ref_payload(ref: ArtifactRef) -> dict[str, str]:
+    return {"artifact_kind": ref.artifact_kind, "artifact_id": ref.artifact_id}
+
+
+def refs_payload(refs: Sequence[ArtifactRef]) -> list[dict[str, str]]:
+    return [ref_payload(ref) for ref in refs]
+
+
+def ref_from_dict(data: Mapping[str, Any]) -> ArtifactRef:
+    return ArtifactRef(
+        artifact_kind=str(data["artifact_kind"]),
+        artifact_id=str(data["artifact_id"]),
+    )
+
+
+def refs_from_dict(items: Sequence[Mapping[str, Any]]) -> tuple[ArtifactRef, ...]:
+    return tuple(ref_from_dict(item) for item in items)
+
+
+def digest_payload(kind: str, payload: Mapping[str, Any]) -> str:
+    return sha256_digest(canonical_json_bytes({"kind": kind, "payload": payload}))
+
+
+def check_id(actual: str, expected: str, field: str) -> None:
+    if actual != expected:
+        raise VPMValidationError(f"{field} does not match canonical content")

--- a/packages/critic/src/zeromodel/critic/calibration.py
+++ b/packages/critic/src/zeromodel/critic/calibration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+
+from zeromodel.critic.dto import CriticCalibrationDTO
+from zeromodel.critic.linear import CompiledCriticReadout, stable_sigmoid
+
+
+def fit_platt_calibration(
+    runtime: CompiledCriticReadout,
+    features: object,
+    labels: object,
+    *,
+    feature_spec_id: str,
+    calibration_set_ref: object,
+    max_iterations: int = 50,
+) -> CriticCalibrationDTO:
+    logits = runtime.logit_many(features, feature_spec_id=feature_spec_id)
+    y = np.asarray(labels, dtype=np.float64)
+    x = logits[:, None]
+    design = np.column_stack([x, np.ones_like(logits)])
+    beta = np.asarray([1.0, 0.0], dtype=np.float64)
+    for _ in range(max_iterations):
+        p = stable_sigmoid(design @ beta)
+        w = np.maximum(p * (1.0 - p), 1e-12)
+        gradient = design.T @ (p - y)
+        hessian = (design.T * w) @ design
+        try:
+            step = np.linalg.solve(hessian, gradient)
+        except np.linalg.LinAlgError:
+            step = np.linalg.pinv(hessian) @ gradient
+        beta -= step
+        if np.max(np.abs(step)) <= 1e-8:
+            break
+    return CriticCalibrationDTO(
+        method="platt",
+        parameters={"a": float(beta[0]), "b": float(beta[1]), "input": "logit"},
+        calibration_set_ref=calibration_set_ref,  # type: ignore[arg-type]
+        metrics={},
+    )

--- a/packages/critic/src/zeromodel/critic/compiler.py
+++ b/packages/critic/src/zeromodel/critic/compiler.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import numpy as np
+
+from zeromodel.artifacts import ArtifactStore
+from zeromodel.core.matrix_blob import MatrixBlob
+
+from zeromodel.critic.dto import CriticFitSpecDTO, CriticReadoutArtifactDTO
+from zeromodel.critic.errors import CriticValidationError
+from zeromodel.critic.linear import CompiledCriticReadout
+from zeromodel.critic.persistence import (
+    ResolvedCriticFeatureBatchAggregate,
+    ResolvedCriticLabelBatchAggregate,
+    store_critic_contract,
+    store_critic_feature_batch,
+    store_critic_feature_spec,
+    store_critic_fit_spec,
+    store_critic_label_batch,
+    store_critic_readout,
+    store_matrix_blob,
+)
+from zeromodel.critic.portable import export_portable_critic
+
+
+def compile_critic_readout(
+    *,
+    store: ArtifactStore,
+    features: ResolvedCriticFeatureBatchAggregate,
+    labels: ResolvedCriticLabelBatchAggregate,
+    fit_spec: CriticFitSpecDTO,
+    metadata: dict | None = None,
+) -> tuple[CriticReadoutArtifactDTO, object]:
+    if features.batch.item_refs != labels.batch.item_refs:
+        raise CriticValidationError(
+            "training feature and label rows must align exactly"
+        )
+    runtime = CompiledCriticReadout.fit(
+        features.values,
+        labels.labels,
+        feature_spec=features.spec,
+        contract_id=labels.contract.critic_contract_id,
+        l2_penalty=fit_spec.l2_penalty,
+        max_iterations=fit_spec.max_iterations,
+        tolerance=fit_spec.tolerance,
+        class_weighting=fit_spec.class_weighting,
+    )
+    spec_ref = store_critic_feature_spec(store, features.spec)
+    contract_ref = store_critic_contract(store, labels.contract)
+    fit_ref = store_critic_fit_spec(store, fit_spec)
+    center_ref = store_matrix_blob(
+        store,
+        MatrixBlob.from_array(
+            runtime.center, dtype="float64", metadata={"role": "critic_center"}
+        ),
+    )
+    scale_ref = store_matrix_blob(
+        store,
+        MatrixBlob.from_array(
+            runtime.scale, dtype="float64", metadata={"role": "critic_scale"}
+        ),
+    )
+    coefficients_ref = store_matrix_blob(
+        store,
+        MatrixBlob.from_array(
+            runtime.coefficients,
+            dtype="float64",
+            metadata={"role": "critic_coefficients"},
+        ),
+    )
+    intercept_ref = store_matrix_blob(
+        store,
+        MatrixBlob.from_array(
+            np.asarray([runtime.intercept]),
+            dtype="float64",
+            metadata={"role": "critic_intercept"},
+        ),
+    )
+    training_feature_ref = store_critic_feature_batch(store, features.batch)
+    training_label_ref = store_critic_label_batch(store, labels.batch)
+    readout = CriticReadoutArtifactDTO(
+        critic_contract_ref=contract_ref,
+        feature_spec_ref=spec_ref,
+        fit_spec_ref=fit_ref,
+        center_blob_ref=center_ref,
+        scale_blob_ref=scale_ref,
+        coefficients_blob_ref=coefficients_ref,
+        intercept_blob_ref=intercept_ref,
+        training_feature_batch_ref=training_feature_ref,
+        training_label_batch_ref=training_label_ref,
+        metadata=metadata or {},
+    )
+    readout_ref = store_critic_readout(store, readout)
+    from zeromodel.critic.persistence import load_critic_readout_aggregate
+
+    aggregate = load_critic_readout_aggregate(readout_ref, store)
+    export_portable_critic(aggregate)
+    return readout, readout_ref

--- a/packages/critic/src/zeromodel/critic/counterexamples.py
+++ b/packages/critic/src/zeromodel/critic/counterexamples.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class CriticCounterexampleDTO:
+    artifact_id: str
+    ground_truth_label: float
+    current_score: float
+    candidate_score: float
+    score_delta: float
+    current_verdict: str | None
+    candidate_verdict: str | None
+    correct_critic: str | None
+
+
+def find_counterexamples(
+    artifact_ids: list[str],
+    labels: list[float],
+    current_scores: list[float],
+    candidate_scores: list[float],
+    *,
+    threshold: float = 0.5,
+    min_delta: float = 0.0,
+) -> tuple[CriticCounterexampleDTO, ...]:
+    rows = []
+    for artifact_id, label, current, candidate in zip(
+        artifact_ids, labels, current_scores, candidate_scores
+    ):
+        current_verdict = "ACCEPT" if current >= threshold else "REJECT"
+        candidate_verdict = "ACCEPT" if candidate >= threshold else "REJECT"
+        current_ok = (current >= threshold) == (label == 1.0)
+        candidate_ok = (candidate >= threshold) == (label == 1.0)
+        if (
+            current_verdict != candidate_verdict
+            or abs(candidate - current) >= min_delta
+        ):
+            correct = None
+            if current_ok != candidate_ok:
+                correct = "current" if current_ok else "candidate"
+            rows.append(
+                CriticCounterexampleDTO(
+                    artifact_id=str(artifact_id),
+                    ground_truth_label=float(label),
+                    current_score=float(current),
+                    candidate_score=float(candidate),
+                    score_delta=float(candidate - current),
+                    current_verdict=current_verdict,
+                    candidate_verdict=candidate_verdict,
+                    correct_critic=correct,
+                )
+            )
+    return tuple(rows)

--- a/packages/critic/src/zeromodel/critic/dto.py
+++ b/packages/critic/src/zeromodel/critic/dto.py
@@ -1,0 +1,922 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Tuple
+
+from zeromodel.artifacts import ArtifactRef, canonical_json_bytes
+from zeromodel.core.artifact import VPMValidationError
+
+from zeromodel.critic._canonical import (
+    check_id,
+    digest_payload,
+    freeze_json,
+    ref_from_dict,
+    ref_payload,
+    refs_from_dict,
+    refs_payload,
+    require_finite,
+    require_nonempty,
+    require_unique,
+    thaw_json,
+)
+
+CRITIC_SPEC_VERSION = "zeromodel-critic/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class CriticFeatureDTO:
+    feature_id: str
+    description: str
+    units: Optional[str] = None
+    directionality: int = 1
+    required: bool = True
+    missing_policy: str = "error"
+    missing_value: Optional[float] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "feature_id", require_nonempty(self.feature_id, "feature_id")
+        )
+        object.__setattr__(self, "description", str(self.description))
+        if int(self.directionality) not in {-1, 1}:
+            raise VPMValidationError("directionality must be +1 or -1")
+        object.__setattr__(self, "directionality", int(self.directionality))
+        if self.missing_policy not in {"error", "constant"}:
+            raise VPMValidationError("missing_policy must be error or constant")
+        if self.required and self.missing_policy != "error":
+            raise VPMValidationError(
+                "required features must use missing_policy='error'"
+            )
+        if not self.required and self.missing_policy == "constant":
+            if self.missing_value is None:
+                raise VPMValidationError(
+                    "constant missing policy requires missing_value"
+                )
+            object.__setattr__(
+                self,
+                "missing_value",
+                require_finite(float(self.missing_value), "missing_value"),
+            )
+        elif self.missing_value is not None:
+            object.__setattr__(
+                self,
+                "missing_value",
+                require_finite(float(self.missing_value), "missing_value"),
+            )
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "feature_id": self.feature_id,
+            "description": self.description,
+            "units": self.units,
+            "directionality": self.directionality,
+            "required": self.required,
+            "missing_policy": self.missing_policy,
+            "missing_value": self.missing_value,
+            "metadata": thaw_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticFeatureDTO":
+        return cls(
+            feature_id=str(data["feature_id"]),
+            description=str(data.get("description", "")),
+            units=data.get("units"),
+            directionality=int(data.get("directionality", 1)),
+            required=bool(data.get("required", True)),
+            missing_policy=str(data.get("missing_policy", "error")),
+            missing_value=data.get("missing_value"),
+            metadata=data.get("metadata") or {},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CriticFeatureSpecDTO:
+    features: Tuple[CriticFeatureDTO, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    feature_spec_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        if not self.features:
+            raise VPMValidationError("feature spec requires at least one feature")
+        object.__setattr__(self, "features", tuple(self.features))
+        require_unique([feature.feature_id for feature in self.features], "features")
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_feature_spec_id(self)
+        object.__setattr__(self, "feature_spec_id", self.feature_spec_id or expected)
+        check_id(self.feature_spec_id, expected, "feature_spec_id")
+
+    @property
+    def feature_ids(self) -> tuple[str, ...]:
+        return tuple(feature.feature_id for feature in self.features)
+
+    @property
+    def directionality(self) -> tuple[int, ...]:
+        return tuple(feature.directionality for feature in self.features)
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "features": [feature.to_dict() for feature in self.features],
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["feature_spec_id"] = self.feature_spec_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticFeatureSpecDTO":
+        return cls(
+            features=tuple(
+                CriticFeatureDTO.from_dict(item) for item in data["features"]
+            ),
+            metadata=data.get("metadata") or {},
+            feature_spec_id=str(data.get("feature_spec_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_feature_spec_id(spec: CriticFeatureSpecDTO) -> str:
+    return digest_payload("zeromodel.critic.feature_spec.v1", spec.identity_payload())
+
+
+@dataclass(frozen=True, slots=True)
+class CriticFeatureBatchDTO:
+    feature_spec_ref: ArtifactRef
+    values_blob_ref: ArtifactRef
+    item_refs: Tuple[ArtifactRef, ...]
+    values_shape: Tuple[int, int]
+    values_dtype: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    batch_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        if len(self.values_shape) != 2 or any(int(v) <= 0 for v in self.values_shape):
+            raise VPMValidationError("values_shape must be positive 2D")
+        object.__setattr__(
+            self, "values_shape", tuple(int(v) for v in self.values_shape)
+        )
+        if len(self.item_refs) != self.values_shape[0]:
+            raise VPMValidationError("item_refs must match values row count")
+        require_unique([ref.artifact_id for ref in self.item_refs], "item_refs")
+        object.__setattr__(self, "item_refs", tuple(self.item_refs))
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_feature_batch_id(self)
+        object.__setattr__(self, "batch_id", self.batch_id or expected)
+        check_id(self.batch_id, expected, "batch_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "feature_spec_ref": ref_payload(self.feature_spec_ref),
+            "values_blob_ref": ref_payload(self.values_blob_ref),
+            "item_refs": refs_payload(self.item_refs),
+            "values_shape": list(self.values_shape),
+            "values_dtype": self.values_dtype,
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["batch_id"] = self.batch_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticFeatureBatchDTO":
+        return cls(
+            feature_spec_ref=ref_from_dict(data["feature_spec_ref"]),
+            values_blob_ref=ref_from_dict(data["values_blob_ref"]),
+            item_refs=refs_from_dict(data["item_refs"]),
+            values_shape=tuple(data["values_shape"]),
+            values_dtype=str(data["values_dtype"]),
+            metadata=data.get("metadata") or {},
+            batch_id=str(data.get("batch_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_feature_batch_id(batch: CriticFeatureBatchDTO) -> str:
+    return digest_payload("zeromodel.critic.feature_batch.v1", batch.identity_payload())
+
+
+@dataclass(frozen=True, slots=True)
+class CriticContractDTO:
+    critic_id: str
+    version: str
+    target_id: str
+    positive_label: str
+    negative_label: str
+    score_semantics: str
+    intended_uses: Tuple[str, ...] = field(default_factory=tuple)
+    prohibited_uses: Tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    critic_contract_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "critic_id",
+            "version",
+            "target_id",
+            "positive_label",
+            "negative_label",
+            "score_semantics",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                require_nonempty(getattr(self, field_name), field_name),
+            )
+        object.__setattr__(
+            self, "intended_uses", tuple(str(v) for v in self.intended_uses)
+        )
+        object.__setattr__(
+            self, "prohibited_uses", tuple(str(v) for v in self.prohibited_uses)
+        )
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_contract_id(self)
+        object.__setattr__(
+            self, "critic_contract_id", self.critic_contract_id or expected
+        )
+        check_id(self.critic_contract_id, expected, "critic_contract_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "critic_id": self.critic_id,
+            "version": self.version,
+            "target_id": self.target_id,
+            "positive_label": self.positive_label,
+            "negative_label": self.negative_label,
+            "score_semantics": self.score_semantics,
+            "intended_uses": list(self.intended_uses),
+            "prohibited_uses": list(self.prohibited_uses),
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["critic_contract_id"] = self.critic_contract_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticContractDTO":
+        return cls(
+            critic_id=str(data["critic_id"]),
+            version=str(data["version"]),
+            target_id=str(data["target_id"]),
+            positive_label=str(data["positive_label"]),
+            negative_label=str(data["negative_label"]),
+            score_semantics=str(data["score_semantics"]),
+            intended_uses=tuple(str(v) for v in data.get("intended_uses") or ()),
+            prohibited_uses=tuple(str(v) for v in data.get("prohibited_uses") or ()),
+            metadata=data.get("metadata") or {},
+            critic_contract_id=str(data.get("critic_contract_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_contract_id(contract: CriticContractDTO) -> str:
+    return digest_payload("zeromodel.critic.contract.v1", contract.identity_payload())
+
+
+@dataclass(frozen=True, slots=True)
+class CriticLabelBatchDTO:
+    critic_contract_ref: ArtifactRef
+    item_refs: Tuple[ArtifactRef, ...]
+    labels_blob_ref: ArtifactRef
+    labels_shape: Tuple[int, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    label_batch_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        if len(self.labels_shape) != 1 or int(self.labels_shape[0]) <= 0:
+            raise VPMValidationError("labels_shape must be positive 1D")
+        object.__setattr__(
+            self, "labels_shape", tuple(int(v) for v in self.labels_shape)
+        )
+        if len(self.item_refs) != self.labels_shape[0]:
+            raise VPMValidationError("item_refs must match label row count")
+        require_unique([ref.artifact_id for ref in self.item_refs], "item_refs")
+        object.__setattr__(self, "item_refs", tuple(self.item_refs))
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_label_batch_id(self)
+        object.__setattr__(self, "label_batch_id", self.label_batch_id or expected)
+        check_id(self.label_batch_id, expected, "label_batch_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "critic_contract_ref": ref_payload(self.critic_contract_ref),
+            "item_refs": refs_payload(self.item_refs),
+            "labels_blob_ref": ref_payload(self.labels_blob_ref),
+            "labels_shape": list(self.labels_shape),
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["label_batch_id"] = self.label_batch_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticLabelBatchDTO":
+        return cls(
+            critic_contract_ref=ref_from_dict(data["critic_contract_ref"]),
+            item_refs=refs_from_dict(data["item_refs"]),
+            labels_blob_ref=ref_from_dict(data["labels_blob_ref"]),
+            labels_shape=tuple(data["labels_shape"]),
+            metadata=data.get("metadata") or {},
+            label_batch_id=str(data.get("label_batch_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_label_batch_id(batch: CriticLabelBatchDTO) -> str:
+    return digest_payload("zeromodel.critic.label_batch.v1", batch.identity_payload())
+
+
+@dataclass(frozen=True, slots=True)
+class CriticFitSpecDTO:
+    algorithm: str = "standardized_l2_logistic_v1"
+    l2_penalty: float = 1.0
+    max_iterations: int = 100
+    tolerance: float = 1e-8
+    class_weighting: str = "none"
+    fit_version: str = "v1"
+    portable_payload_limit_bytes: int = 50 * 1024
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    fit_spec_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        if self.algorithm != "standardized_l2_logistic_v1":
+            raise VPMValidationError("only standardized_l2_logistic_v1 is supported")
+        penalty = require_finite(self.l2_penalty, "l2_penalty")
+        if penalty < 0:
+            raise VPMValidationError("l2_penalty must be non-negative")
+        tolerance = require_finite(self.tolerance, "tolerance")
+        if tolerance <= 0:
+            raise VPMValidationError("tolerance must be positive")
+        if int(self.max_iterations) <= 0:
+            raise VPMValidationError("max_iterations must be positive")
+        if self.class_weighting not in {"none", "balanced"}:
+            raise VPMValidationError("class_weighting must be none or balanced")
+        if int(self.portable_payload_limit_bytes) <= 0:
+            raise VPMValidationError("portable_payload_limit_bytes must be positive")
+        object.__setattr__(self, "l2_penalty", penalty)
+        object.__setattr__(self, "tolerance", tolerance)
+        object.__setattr__(self, "max_iterations", int(self.max_iterations))
+        object.__setattr__(
+            self, "portable_payload_limit_bytes", int(self.portable_payload_limit_bytes)
+        )
+        object.__setattr__(
+            self, "fit_version", require_nonempty(self.fit_version, "fit_version")
+        )
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_fit_spec_id(self)
+        object.__setattr__(self, "fit_spec_id", self.fit_spec_id or expected)
+        check_id(self.fit_spec_id, expected, "fit_spec_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "algorithm": self.algorithm,
+            "l2_penalty": self.l2_penalty,
+            "max_iterations": self.max_iterations,
+            "tolerance": self.tolerance,
+            "class_weighting": self.class_weighting,
+            "fit_version": self.fit_version,
+            "portable_payload_limit_bytes": self.portable_payload_limit_bytes,
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["fit_spec_id"] = self.fit_spec_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticFitSpecDTO":
+        return cls(
+            algorithm=str(data.get("algorithm", "standardized_l2_logistic_v1")),
+            l2_penalty=float(data.get("l2_penalty", 1.0)),
+            max_iterations=int(data.get("max_iterations", 100)),
+            tolerance=float(data.get("tolerance", 1e-8)),
+            class_weighting=str(data.get("class_weighting", "none")),
+            fit_version=str(data.get("fit_version", "v1")),
+            portable_payload_limit_bytes=int(
+                data.get("portable_payload_limit_bytes", 50 * 1024)
+            ),
+            metadata=data.get("metadata") or {},
+            fit_spec_id=str(data.get("fit_spec_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_fit_spec_id(spec: CriticFitSpecDTO) -> str:
+    return digest_payload("zeromodel.critic.fit_spec.v1", spec.identity_payload())
+
+
+@dataclass(frozen=True, slots=True)
+class CriticCalibrationDTO:
+    method: str = "none"
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+    calibration_set_ref: Optional[ArtifactRef] = None
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+    calibration_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        if self.method not in {"none", "platt"}:
+            raise VPMValidationError("calibration method must be none or platt")
+        object.__setattr__(self, "parameters", freeze_json(self.parameters))
+        object.__setattr__(self, "metrics", freeze_json(self.metrics))
+        expected = compute_critic_calibration_id(self)
+        object.__setattr__(self, "calibration_id", self.calibration_id or expected)
+        check_id(self.calibration_id, expected, "calibration_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "method": self.method,
+            "parameters": thaw_json(self.parameters),
+            "calibration_set_ref": None
+            if self.calibration_set_ref is None
+            else ref_payload(self.calibration_set_ref),
+            "metrics": thaw_json(self.metrics),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["calibration_id"] = self.calibration_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticCalibrationDTO":
+        calibration_set = data.get("calibration_set_ref")
+        return cls(
+            method=str(data.get("method", "none")),
+            parameters=data.get("parameters") or {},
+            calibration_set_ref=None
+            if calibration_set is None
+            else ref_from_dict(calibration_set),
+            metrics=data.get("metrics") or {},
+            calibration_id=str(data.get("calibration_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_calibration_id(calibration: CriticCalibrationDTO) -> str:
+    return digest_payload(
+        "zeromodel.critic.calibration.v1", calibration.identity_payload()
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CriticReadoutArtifactDTO:
+    critic_contract_ref: ArtifactRef
+    feature_spec_ref: ArtifactRef
+    fit_spec_ref: ArtifactRef
+    center_blob_ref: ArtifactRef
+    scale_blob_ref: ArtifactRef
+    coefficients_blob_ref: ArtifactRef
+    intercept_blob_ref: ArtifactRef
+    training_feature_batch_ref: ArtifactRef
+    training_label_batch_ref: ArtifactRef
+    calibration_ref: Optional[ArtifactRef] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    readout_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_readout_id(self)
+        object.__setattr__(self, "readout_id", self.readout_id or expected)
+        check_id(self.readout_id, expected, "readout_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "critic_contract_ref": ref_payload(self.critic_contract_ref),
+            "feature_spec_ref": ref_payload(self.feature_spec_ref),
+            "fit_spec_ref": ref_payload(self.fit_spec_ref),
+            "center_blob_ref": ref_payload(self.center_blob_ref),
+            "scale_blob_ref": ref_payload(self.scale_blob_ref),
+            "coefficients_blob_ref": ref_payload(self.coefficients_blob_ref),
+            "intercept_blob_ref": ref_payload(self.intercept_blob_ref),
+            "training_feature_batch_ref": ref_payload(self.training_feature_batch_ref),
+            "training_label_batch_ref": ref_payload(self.training_label_batch_ref),
+            "calibration_ref": None
+            if self.calibration_ref is None
+            else ref_payload(self.calibration_ref),
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["readout_id"] = self.readout_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticReadoutArtifactDTO":
+        calibration = data.get("calibration_ref")
+        return cls(
+            critic_contract_ref=ref_from_dict(data["critic_contract_ref"]),
+            feature_spec_ref=ref_from_dict(data["feature_spec_ref"]),
+            fit_spec_ref=ref_from_dict(data["fit_spec_ref"]),
+            center_blob_ref=ref_from_dict(data["center_blob_ref"]),
+            scale_blob_ref=ref_from_dict(data["scale_blob_ref"]),
+            coefficients_blob_ref=ref_from_dict(data["coefficients_blob_ref"]),
+            intercept_blob_ref=ref_from_dict(data["intercept_blob_ref"]),
+            training_feature_batch_ref=ref_from_dict(
+                data["training_feature_batch_ref"]
+            ),
+            training_label_batch_ref=ref_from_dict(data["training_label_batch_ref"]),
+            calibration_ref=None if calibration is None else ref_from_dict(calibration),
+            metadata=data.get("metadata") or {},
+            readout_id=str(data.get("readout_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_readout_id(readout: CriticReadoutArtifactDTO) -> str:
+    return digest_payload("zeromodel.critic.readout.v1", readout.identity_payload())
+
+
+@dataclass(frozen=True, slots=True)
+class CriticThresholdContractDTO:
+    reject_below: Optional[float] = None
+    accept_at_or_above: Optional[float] = None
+    threshold_contract_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        if self.reject_below is not None:
+            object.__setattr__(
+                self, "reject_below", require_finite(self.reject_below, "reject_below")
+            )
+        if self.accept_at_or_above is not None:
+            object.__setattr__(
+                self,
+                "accept_at_or_above",
+                require_finite(self.accept_at_or_above, "accept_at_or_above"),
+            )
+        if (
+            self.reject_below is not None
+            and self.accept_at_or_above is not None
+            and self.reject_below > self.accept_at_or_above
+        ):
+            raise VPMValidationError("reject_below must be <= accept_at_or_above")
+        expected = digest_payload(
+            "zeromodel.critic.threshold_contract.v1", self.identity_payload()
+        )
+        object.__setattr__(
+            self, "threshold_contract_id", self.threshold_contract_id or expected
+        )
+        check_id(self.threshold_contract_id, expected, "threshold_contract_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "reject_below": self.reject_below,
+            "accept_at_or_above": self.accept_at_or_above,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["threshold_contract_id"] = self.threshold_contract_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticThresholdContractDTO":
+        return cls(
+            reject_below=data.get("reject_below"),
+            accept_at_or_above=data.get("accept_at_or_above"),
+            threshold_contract_id=str(data.get("threshold_contract_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CriticScoreRequestDTO:
+    readout_ref: ArtifactRef
+    feature_batch_ref: ArtifactRef
+    threshold_contract: Optional[CriticThresholdContractDTO] = None
+    explanation_depth: int = 0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    request_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        if int(self.explanation_depth) < 0:
+            raise VPMValidationError("explanation_depth must be non-negative")
+        object.__setattr__(self, "explanation_depth", int(self.explanation_depth))
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_score_request_id(self)
+        object.__setattr__(self, "request_id", self.request_id or expected)
+        check_id(self.request_id, expected, "request_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "readout_ref": ref_payload(self.readout_ref),
+            "feature_batch_ref": ref_payload(self.feature_batch_ref),
+            "threshold_contract": None
+            if self.threshold_contract is None
+            else self.threshold_contract.to_dict(),
+            "explanation_depth": self.explanation_depth,
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["request_id"] = self.request_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticScoreRequestDTO":
+        threshold = data.get("threshold_contract")
+        return cls(
+            readout_ref=ref_from_dict(data["readout_ref"]),
+            feature_batch_ref=ref_from_dict(data["feature_batch_ref"]),
+            threshold_contract=None
+            if threshold is None
+            else CriticThresholdContractDTO.from_dict(threshold),
+            explanation_depth=int(data.get("explanation_depth", 0)),
+            metadata=data.get("metadata") or {},
+            request_id=str(data.get("request_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_score_request_id(request: CriticScoreRequestDTO) -> str:
+    return digest_payload(
+        "zeromodel.critic.score_request.v1", request.identity_payload()
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CriticFeatureContributionDTO:
+    feature_id: str
+    raw_value: float
+    directed_value: float
+    standardized_value: float
+    coefficient: float
+    contribution: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "feature_id", require_nonempty(self.feature_id, "feature_id")
+        )
+        for field_name in (
+            "raw_value",
+            "directed_value",
+            "standardized_value",
+            "coefficient",
+            "contribution",
+        ):
+            object.__setattr__(
+                self, field_name, require_finite(getattr(self, field_name), field_name)
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "feature_id": self.feature_id,
+            "raw_value": self.raw_value,
+            "directed_value": self.directed_value,
+            "standardized_value": self.standardized_value,
+            "coefficient": self.coefficient,
+            "contribution": self.contribution,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticFeatureContributionDTO":
+        return cls(
+            feature_id=str(data["feature_id"]),
+            raw_value=float(data["raw_value"]),
+            directed_value=float(data["directed_value"]),
+            standardized_value=float(data["standardized_value"]),
+            coefficient=float(data["coefficient"]),
+            contribution=float(data["contribution"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CriticItemScoreDTO:
+    artifact_ref: ArtifactRef
+    logit: float
+    score: float
+    calibrated_probability: Optional[float] = None
+    verdict: Optional[str] = None
+    decision_margin: float = 0.0
+    feature_coverage: float = 1.0
+    positive_contribution_strength: float = 0.0
+    negative_contribution_strength: float = 0.0
+    contributions: Tuple[CriticFeatureContributionDTO, ...] = field(
+        default_factory=tuple
+    )
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "logit",
+            "score",
+            "decision_margin",
+            "feature_coverage",
+            "positive_contribution_strength",
+            "negative_contribution_strength",
+        ):
+            object.__setattr__(
+                self, field_name, require_finite(getattr(self, field_name), field_name)
+            )
+        if self.calibrated_probability is not None:
+            object.__setattr__(
+                self,
+                "calibrated_probability",
+                require_finite(self.calibrated_probability, "calibrated_probability"),
+            )
+        object.__setattr__(self, "contributions", tuple(self.contributions))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_ref": ref_payload(self.artifact_ref),
+            "logit": self.logit,
+            "score": self.score,
+            "calibrated_probability": self.calibrated_probability,
+            "verdict": self.verdict,
+            "decision_margin": self.decision_margin,
+            "feature_coverage": self.feature_coverage,
+            "positive_contribution_strength": self.positive_contribution_strength,
+            "negative_contribution_strength": self.negative_contribution_strength,
+            "contributions": [item.to_dict() for item in self.contributions],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticItemScoreDTO":
+        return cls(
+            artifact_ref=ref_from_dict(data["artifact_ref"]),
+            logit=float(data["logit"]),
+            score=float(data["score"]),
+            calibrated_probability=None
+            if data.get("calibrated_probability") is None
+            else float(data["calibrated_probability"]),
+            verdict=data.get("verdict"),
+            decision_margin=float(data.get("decision_margin", 0.0)),
+            feature_coverage=float(data.get("feature_coverage", 1.0)),
+            positive_contribution_strength=float(
+                data.get("positive_contribution_strength", 0.0)
+            ),
+            negative_contribution_strength=float(
+                data.get("negative_contribution_strength", 0.0)
+            ),
+            contributions=tuple(
+                CriticFeatureContributionDTO.from_dict(item)
+                for item in data.get("contributions") or ()
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CriticScoreResultDTO:
+    request_ref: ArtifactRef
+    readout_ref: ArtifactRef
+    feature_batch_ref: ArtifactRef
+    critic_contract_ref: ArtifactRef
+    feature_spec_ref: ArtifactRef
+    items: Tuple[CriticItemScoreDTO, ...]
+    ordering_contract: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    result_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "items", tuple(self.items))
+        object.__setattr__(
+            self,
+            "ordering_contract",
+            require_nonempty(self.ordering_contract, "ordering_contract"),
+        )
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_score_result_id(self)
+        object.__setattr__(self, "result_id", self.result_id or expected)
+        check_id(self.result_id, expected, "result_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "request_ref": ref_payload(self.request_ref),
+            "readout_ref": ref_payload(self.readout_ref),
+            "feature_batch_ref": ref_payload(self.feature_batch_ref),
+            "critic_contract_ref": ref_payload(self.critic_contract_ref),
+            "feature_spec_ref": ref_payload(self.feature_spec_ref),
+            "items": [item.to_dict() for item in self.items],
+            "ordering_contract": self.ordering_contract,
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["result_id"] = self.result_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticScoreResultDTO":
+        return cls(
+            request_ref=ref_from_dict(data["request_ref"]),
+            readout_ref=ref_from_dict(data["readout_ref"]),
+            feature_batch_ref=ref_from_dict(data["feature_batch_ref"]),
+            critic_contract_ref=ref_from_dict(data["critic_contract_ref"]),
+            feature_spec_ref=ref_from_dict(data["feature_spec_ref"]),
+            items=tuple(CriticItemScoreDTO.from_dict(item) for item in data["items"]),
+            ordering_contract=str(data["ordering_contract"]),
+            metadata=data.get("metadata") or {},
+            result_id=str(data.get("result_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_score_result_id(result: CriticScoreResultDTO) -> str:
+    return digest_payload("zeromodel.critic.score_result.v1", result.identity_payload())
+
+
+@dataclass(frozen=True, slots=True)
+class CriticScoreReceiptDTO:
+    request_ref: ArtifactRef
+    result_ref: ArtifactRef
+    readout_ref: ArtifactRef
+    feature_batch_ref: ArtifactRef
+    required_checks: Tuple[str, ...]
+    result_id: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    receipt_id: str = ""
+    spec_version: str = CRITIC_SPEC_VERSION
+
+    REQUIRED = (
+        "request_resolved",
+        "readout_aggregate_validated",
+        "feature_batch_validated",
+        "deterministic_scores_recomputed",
+        "result_ref_matches_recomputed_result",
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "required_checks", tuple(self.required_checks))
+        if self.required_checks != self.REQUIRED:
+            raise VPMValidationError(
+                "critic receipt must include exactly the required checks"
+            )
+        object.__setattr__(
+            self, "result_id", require_nonempty(self.result_id, "result_id")
+        )
+        object.__setattr__(self, "metadata", freeze_json(self.metadata))
+        expected = compute_critic_score_receipt_id(self)
+        object.__setattr__(self, "receipt_id", self.receipt_id or expected)
+        check_id(self.receipt_id, expected, "receipt_id")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "spec_version": self.spec_version,
+            "request_ref": ref_payload(self.request_ref),
+            "result_ref": ref_payload(self.result_ref),
+            "readout_ref": ref_payload(self.readout_ref),
+            "feature_batch_ref": ref_payload(self.feature_batch_ref),
+            "required_checks": list(self.required_checks),
+            "result_id": self.result_id,
+            "metadata": thaw_json(self.metadata),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["receipt_id"] = self.receipt_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CriticScoreReceiptDTO":
+        return cls(
+            request_ref=ref_from_dict(data["request_ref"]),
+            result_ref=ref_from_dict(data["result_ref"]),
+            readout_ref=ref_from_dict(data["readout_ref"]),
+            feature_batch_ref=ref_from_dict(data["feature_batch_ref"]),
+            required_checks=tuple(str(v) for v in data["required_checks"]),
+            result_id=str(data["result_id"]),
+            metadata=data.get("metadata") or {},
+            receipt_id=str(data.get("receipt_id") or ""),
+            spec_version=str(data.get("spec_version", CRITIC_SPEC_VERSION)),
+        )
+
+
+def compute_critic_score_receipt_id(receipt: CriticScoreReceiptDTO) -> str:
+    return digest_payload(
+        "zeromodel.critic.score_receipt.v1", receipt.identity_payload()
+    )
+
+
+def canonical_dto_bytes(dto: Any) -> bytes:
+    return canonical_json_bytes(dto.to_dict())

--- a/packages/critic/src/zeromodel/critic/errors.py
+++ b/packages/critic/src/zeromodel/critic/errors.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from zeromodel.core.artifact import VPMValidationError
+
+
+class CriticValidationError(VPMValidationError):
+    """Raised when a Critic DTO or runtime input violates its contract."""
+
+
+class CriticFeatureSchemaMismatchError(CriticValidationError):
+    """Raised when feature schema identities or dimensions are incompatible."""
+
+
+class CriticContractMismatchError(CriticValidationError):
+    """Raised when critic contracts or label bindings disagree."""
+
+
+class CriticReadoutIntegrityError(CriticValidationError):
+    """Raised when a persisted critic aggregate fails closure validation."""
+
+
+class CriticPayloadTooLargeError(CriticValidationError):
+    """Raised when a portable executable payload exceeds its declared limit."""
+
+
+class CriticCalibrationError(CriticValidationError):
+    """Raised when calibration configuration is invalid."""
+
+
+class CriticReplayMismatchError(CriticValidationError):
+    """Raised when replay cannot reproduce the receipt-bound score result."""
+
+
+class CriticEvaluationError(CriticValidationError):
+    """Raised when evaluation inputs are invalid."""

--- a/packages/critic/src/zeromodel/critic/evaluation.py
+++ b/packages/critic/src/zeromodel/critic/evaluation.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from zeromodel.critic.errors import CriticEvaluationError
+
+
+def _arrays(
+    labels: Sequence[float], scores: Sequence[float]
+) -> tuple[np.ndarray, np.ndarray]:
+    y = np.asarray(labels, dtype=np.float64)
+    s = np.asarray(scores, dtype=np.float64)
+    if y.ndim != 1 or s.ndim != 1 or y.size != s.size or y.size == 0:
+        raise CriticEvaluationError(
+            "labels and scores must be non-empty aligned vectors"
+        )
+    if not np.isin(y, [0.0, 1.0]).all() or not np.isfinite(s).all():
+        raise CriticEvaluationError("labels must be binary and scores finite")
+    return y, s
+
+
+def accuracy(
+    labels: Sequence[float], scores: Sequence[float], *, threshold: float = 0.5
+) -> float:
+    y, s = _arrays(labels, scores)
+    return float(np.mean((s >= threshold) == (y == 1.0)))
+
+
+def brier_score(labels: Sequence[float], scores: Sequence[float]) -> float:
+    y, s = _arrays(labels, scores)
+    return float(np.mean((s - y) ** 2))
+
+
+def auroc(labels: Sequence[float], scores: Sequence[float]) -> float:
+    y, s = _arrays(labels, scores)
+    positives = np.sum(y == 1.0)
+    negatives = np.sum(y == 0.0)
+    if positives == 0 or negatives == 0:
+        raise CriticEvaluationError("AUROC requires both classes")
+    order = np.argsort(s, kind="mergesort")
+    sorted_scores = s[order]
+    ranks = np.empty_like(s, dtype=np.float64)
+    start = 0
+    while start < s.size:
+        end = start + 1
+        while end < s.size and sorted_scores[end] == sorted_scores[start]:
+            end += 1
+        avg_rank = (start + 1 + end) / 2.0
+        ranks[order[start:end]] = avg_rank
+        start = end
+    rank_sum_positive = float(np.sum(ranks[y == 1.0]))
+    return float(
+        (rank_sum_positive - positives * (positives + 1.0) / 2.0)
+        / (positives * negatives)
+    )
+
+
+def expected_calibration_error(
+    labels: Sequence[float], scores: Sequence[float], *, bin_count: int = 10
+) -> float:
+    y, s = _arrays(labels, scores)
+    if bin_count <= 0:
+        raise CriticEvaluationError("bin_count must be positive")
+    edges = np.linspace(0.0, 1.0, bin_count + 1)
+    total = 0.0
+    for idx in range(bin_count):
+        left = edges[idx]
+        right = edges[idx + 1]
+        mask = (s >= left) & (s <= right if idx == bin_count - 1 else s < right)
+        if np.any(mask):
+            total += float(np.mean(mask)) * abs(
+                float(np.mean(s[mask])) - float(np.mean(y[mask]))
+            )
+    return float(total)
+
+
+def evaluate_binary_critic(
+    labels: Sequence[float], scores: Sequence[float], *, bin_count: int = 10
+) -> dict[str, float | int | str]:
+    y, s = _arrays(labels, scores)
+    return {
+        "sample_count": int(y.size),
+        "positive_rate": float(np.mean(y)),
+        "accuracy": accuracy(y, s),
+        "auroc": auroc(y, s),
+        "brier": brier_score(y, s),
+        "ece": expected_calibration_error(y, s, bin_count=bin_count),
+        "ece_bin_count": int(bin_count),
+        "ece_binning_method": "equal_width_closed_last",
+    }
+
+
+def grouped_selection_metrics(
+    group_ids: Sequence[str], labels: Sequence[float], scores: Sequence[float]
+) -> dict[str, float | int]:
+    y, s = _arrays(labels, scores)
+    groups: dict[str, list[int]] = {}
+    for index, group_id in enumerate(group_ids):
+        groups.setdefault(str(group_id), []).append(index)
+    selected_labels = []
+    preferred_first = []
+    ties = 0
+    margins = []
+    for indexes in groups.values():
+        best_score = max(float(s[index]) for index in indexes)
+        winners = [index for index in indexes if float(s[index]) == best_score]
+        winner = sorted(winners, key=lambda index: str(index))[0]
+        selected_labels.append(float(y[winner]))
+        if len(winners) > 1:
+            ties += 1
+        positives = [index for index in indexes if y[index] == 1.0]
+        negatives = [index for index in indexes if y[index] == 0.0]
+        if positives and negatives:
+            best_positive = max(float(s[index]) for index in positives)
+            best_negative = max(float(s[index]) for index in negatives)
+            preferred_first.append(float(best_positive > best_negative))
+            margins.append(best_positive - best_negative)
+    return {
+        "group_count": len(groups),
+        "selected_positive_rate": float(np.mean(selected_labels)),
+        "preferred_ranked_first_rate": float(np.mean(preferred_first))
+        if preferred_first
+        else 0.0,
+        "tie_rate": float(ties / len(groups)) if groups else 0.0,
+        "mean_preferred_minus_rejected_margin": float(np.mean(margins))
+        if margins
+        else 0.0,
+    }
+
+
+def budget_selection_metrics(
+    labels: Sequence[float], scores: Sequence[float], budgets: Sequence[float]
+) -> list[dict[str, float | int]]:
+    y, s = _arrays(labels, scores)
+    order = sorted(range(y.size), key=lambda index: (-float(s[index]), str(index)))
+    overall = float(np.mean(y))
+    rows = []
+    for budget in budgets:
+        count = (
+            int(np.ceil(float(budget) * y.size))
+            if 0.0 < float(budget) <= 1.0
+            else int(budget)
+        )
+        count = max(0, min(count, y.size))
+        chosen = order[:count]
+        positive_rate = float(np.mean(y[chosen])) if chosen else 0.0
+        rows.append(
+            {
+                "budget": float(budget),
+                "number_selected": int(count),
+                "positive_rate_selected": positive_rate,
+                "overall_positive_rate": overall,
+                "lift_vs_random_expectation": 0.0
+                if overall == 0.0
+                else positive_rate / overall,
+            }
+        )
+    return rows
+
+
+@dataclass(frozen=True, slots=True)
+class CriticEvaluationResultDTO:
+    metrics: Mapping[str, Any] = field(default_factory=dict)

--- a/packages/critic/src/zeromodel/critic/evaluation_artifacts.py
+++ b/packages/critic/src/zeromodel/critic/evaluation_artifacts.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/packages/critic/src/zeromodel/critic/explain.py
+++ b/packages/critic/src/zeromodel/critic/explain.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from zeromodel.critic.dto import CriticFeatureContributionDTO
+
+
+def top_positive_contributions(
+    contributions: tuple[CriticFeatureContributionDTO, ...], *, limit: int
+) -> tuple[CriticFeatureContributionDTO, ...]:
+    return tuple(
+        sorted(
+            (item for item in contributions if item.contribution > 0.0),
+            key=lambda item: (-item.contribution, item.feature_id),
+        )[:limit]
+    )
+
+
+def top_negative_contributions(
+    contributions: tuple[CriticFeatureContributionDTO, ...], *, limit: int
+) -> tuple[CriticFeatureContributionDTO, ...]:
+    return tuple(
+        sorted(
+            (item for item in contributions if item.contribution < 0.0),
+            key=lambda item: (item.contribution, item.feature_id),
+        )[:limit]
+    )

--- a/packages/critic/src/zeromodel/critic/features.py
+++ b/packages/critic/src/zeromodel/critic/features.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import numpy as np
+
+from zeromodel.critic.dto import CriticFeatureSpecDTO
+from zeromodel.critic.linear import features_from_mapping
+
+
+def build_feature_row(
+    values: Mapping[str, float | None], spec: CriticFeatureSpecDTO
+) -> np.ndarray:
+    return features_from_mapping(values, spec)

--- a/packages/critic/src/zeromodel/critic/fit.py
+++ b/packages/critic/src/zeromodel/critic/fit.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from zeromodel.critic.dto import (
+    CriticFitSpecDTO,
+    CriticContractDTO,
+    CriticFeatureSpecDTO,
+)
+from zeromodel.critic.linear import CompiledCriticReadout
+
+
+def fit_compiled_critic(
+    features: object,
+    labels: object,
+    *,
+    feature_spec: CriticFeatureSpecDTO,
+    contract: CriticContractDTO,
+    fit_spec: CriticFitSpecDTO | None = None,
+) -> CompiledCriticReadout:
+    spec = fit_spec or CriticFitSpecDTO()
+    return CompiledCriticReadout.fit(
+        features,
+        labels,
+        feature_spec=feature_spec,
+        contract_id=contract.critic_contract_id,
+        l2_penalty=spec.l2_penalty,
+        max_iterations=spec.max_iterations,
+        tolerance=spec.tolerance,
+        class_weighting=spec.class_weighting,
+    )

--- a/packages/critic/src/zeromodel/critic/kinds.py
+++ b/packages/critic/src/zeromodel/critic/kinds.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+MATRIX_BLOB_ARTIFACT_KIND = "zeromodel.core.matrix_blob"
+CRITIC_FEATURE_SPEC_ARTIFACT_KIND = "zeromodel.critic.feature_spec"
+CRITIC_FEATURE_BATCH_ARTIFACT_KIND = "zeromodel.critic.feature_batch"
+CRITIC_CONTRACT_ARTIFACT_KIND = "zeromodel.critic.contract"
+CRITIC_LABEL_BATCH_ARTIFACT_KIND = "zeromodel.critic.label_batch"
+CRITIC_FIT_SPEC_ARTIFACT_KIND = "zeromodel.critic.fit_spec"
+CRITIC_READOUT_ARTIFACT_KIND = "zeromodel.critic.readout"
+CRITIC_CALIBRATION_ARTIFACT_KIND = "zeromodel.critic.calibration"
+CRITIC_SCORE_REQUEST_ARTIFACT_KIND = "zeromodel.critic.score_request"
+CRITIC_SCORE_RESULT_ARTIFACT_KIND = "zeromodel.critic.score_result"
+CRITIC_SCORE_RECEIPT_ARTIFACT_KIND = "zeromodel.critic.score_receipt"
+CRITIC_EVALUATION_SET_ARTIFACT_KIND = "zeromodel.critic.evaluation_set"
+CRITIC_EVALUATION_RESULT_ARTIFACT_KIND = "zeromodel.critic.evaluation_result"
+CRITIC_PROMOTION_POLICY_ARTIFACT_KIND = "zeromodel.critic.promotion_policy"
+CRITIC_PROMOTION_DECISION_ARTIFACT_KIND = "zeromodel.critic.promotion_decision"
+CRITIC_COUNTEREXAMPLE_BATCH_ARTIFACT_KIND = "zeromodel.critic.counterexample_batch"

--- a/packages/critic/src/zeromodel/critic/linear.py
+++ b/packages/critic/src/zeromodel/critic/linear.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import numpy as np
+import numpy.typing as npt
+
+from zeromodel.critic.dto import CriticFeatureContributionDTO, CriticFeatureSpecDTO
+from zeromodel.critic.errors import (
+    CriticFeatureSchemaMismatchError,
+    CriticValidationError,
+)
+
+FloatArray = npt.NDArray[np.float64]
+
+
+def stable_sigmoid(value: npt.ArrayLike) -> FloatArray:
+    x = np.asarray(value, dtype=np.float64)
+    out = np.empty_like(x, dtype=np.float64)
+    positive = x >= 0
+    out[positive] = 1.0 / (1.0 + np.exp(-x[positive]))
+    exp_x = np.exp(x[~positive])
+    out[~positive] = exp_x / (1.0 + exp_x)
+    return out
+
+
+def _matrix(name: str, value: npt.ArrayLike) -> FloatArray:
+    array = np.asarray(value, dtype=np.float64)
+    if array.ndim != 2:
+        raise CriticValidationError(f"{name} must be a two-dimensional matrix")
+    if not np.isfinite(array).all():
+        raise CriticValidationError(f"{name} must contain only finite values")
+    return array
+
+
+def _vector(name: str, value: npt.ArrayLike) -> FloatArray:
+    array = np.asarray(value, dtype=np.float64)
+    if array.ndim != 1:
+        raise CriticValidationError(f"{name} must be a one-dimensional vector")
+    if not np.isfinite(array).all():
+        raise CriticValidationError(f"{name} must contain only finite values")
+    return array
+
+
+def features_from_mapping(
+    values: Mapping[str, float | None], spec: CriticFeatureSpecDTO
+) -> np.ndarray:
+    row = []
+    for feature in spec.features:
+        raw = values.get(feature.feature_id)
+        if raw is None:
+            if (
+                feature.missing_policy == "constant"
+                and feature.missing_value is not None
+            ):
+                raw = feature.missing_value
+            else:
+                raise CriticFeatureSchemaMismatchError(
+                    f"missing required feature: {feature.feature_id}"
+                )
+        row.append(float(raw))
+    array = np.asarray(row, dtype=np.float64)
+    if not np.isfinite(array).all():
+        raise CriticValidationError("feature values must be finite")
+    return array
+
+
+def _fit_logistic_irls(
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    l2_penalty: float,
+    max_iterations: int,
+    tolerance: float,
+    sample_weight: np.ndarray,
+) -> tuple[np.ndarray, float]:
+    n_rows, n_cols = x.shape
+    design = np.column_stack([np.ones(n_rows, dtype=np.float64), x])
+    beta = np.zeros(n_cols + 1, dtype=np.float64)
+    regularization = np.diag(np.r_[0.0, np.full(n_cols, float(l2_penalty))])
+    for _ in range(max_iterations):
+        logits = design @ beta
+        p = stable_sigmoid(logits)
+        w = np.maximum(p * (1.0 - p) * sample_weight, 1e-12)
+        gradient = design.T @ ((p - y) * sample_weight) + regularization @ beta
+        hessian = (design.T * w) @ design + regularization
+        try:
+            step = np.linalg.solve(hessian, gradient)
+        except np.linalg.LinAlgError:
+            step = np.linalg.pinv(hessian) @ gradient
+        beta_next = beta - step
+        if float(np.max(np.abs(step))) <= tolerance:
+            beta = beta_next
+            break
+        beta = beta_next
+    return np.asarray(beta[1:], dtype=np.float64), float(beta[0])
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledCriticReadout:
+    feature_ids: tuple[str, ...]
+    directionality: tuple[int, ...]
+    center: FloatArray
+    scale: FloatArray
+    coefficients: FloatArray
+    intercept: float
+    contract_id: str
+    feature_spec_id: str
+    calibration: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        width = len(self.feature_ids)
+        if width == 0:
+            raise CriticValidationError("readout requires features")
+        if len(self.directionality) != width:
+            raise CriticValidationError("directionality length differs from features")
+        for direction in self.directionality:
+            if int(direction) not in {-1, 1}:
+                raise CriticValidationError("directionality must be +1 or -1")
+        center = _vector("center", self.center)
+        scale = _vector("scale", self.scale)
+        coefficients = _vector("coefficients", self.coefficients)
+        if center.size != width or scale.size != width or coefficients.size != width:
+            raise CriticValidationError(
+                "readout vector dimensions do not match features"
+            )
+        if np.any(scale <= 0.0):
+            raise CriticValidationError("scale must be positive")
+        object.__setattr__(self, "center", center)
+        object.__setattr__(self, "scale", scale)
+        object.__setattr__(self, "coefficients", coefficients)
+        object.__setattr__(self, "intercept", float(self.intercept))
+
+    @classmethod
+    def fit(
+        cls,
+        features: npt.ArrayLike,
+        labels: npt.ArrayLike,
+        *,
+        feature_spec: CriticFeatureSpecDTO,
+        contract_id: str,
+        l2_penalty: float,
+        max_iterations: int,
+        tolerance: float,
+        class_weighting: str,
+    ) -> "CompiledCriticReadout":
+        raw = _matrix("features", features)
+        y = _vector("labels", labels)
+        if raw.shape[0] != y.size:
+            raise CriticValidationError(
+                "training features and labels need the same rows"
+            )
+        if raw.shape[1] != len(feature_spec.features):
+            raise CriticFeatureSchemaMismatchError("feature width does not match spec")
+        if not np.isin(y, [0.0, 1.0]).all():
+            raise CriticValidationError("labels must be binary 0/1")
+        if np.unique(y).size != 2:
+            raise CriticValidationError("training labels must contain both classes")
+        direction = np.asarray(feature_spec.directionality, dtype=np.float64)
+        directed = raw * direction
+        center = directed.mean(axis=0)
+        scale = directed.std(axis=0)
+        scale = np.where(scale > 0.0, scale, 1.0)
+        standardized = (directed - center) / scale
+        weights = np.ones(y.size, dtype=np.float64)
+        if class_weighting == "balanced":
+            positives = float(np.sum(y == 1.0))
+            negatives = float(np.sum(y == 0.0))
+            weights[y == 1.0] = y.size / (2.0 * positives)
+            weights[y == 0.0] = y.size / (2.0 * negatives)
+        coefficients, intercept = _fit_logistic_irls(
+            standardized,
+            y,
+            l2_penalty=l2_penalty,
+            max_iterations=max_iterations,
+            tolerance=tolerance,
+            sample_weight=weights,
+        )
+        return cls(
+            feature_ids=feature_spec.feature_ids,
+            directionality=feature_spec.directionality,
+            center=center,
+            scale=scale,
+            coefficients=coefficients,
+            intercept=intercept,
+            contract_id=contract_id,
+            feature_spec_id=feature_spec.feature_spec_id,
+        )
+
+    def _standardize_many(
+        self, values: npt.ArrayLike, *, feature_spec_id: str
+    ) -> FloatArray:
+        if feature_spec_id != self.feature_spec_id:
+            raise CriticFeatureSchemaMismatchError("feature spec identity mismatch")
+        matrix = _matrix("features", values)
+        if matrix.shape[1] != len(self.feature_ids):
+            raise CriticFeatureSchemaMismatchError(
+                "feature width does not match readout"
+            )
+        direction = np.asarray(self.directionality, dtype=np.float64)
+        return (matrix * direction - self.center) / self.scale
+
+    def logit_many(self, values: npt.ArrayLike, *, feature_spec_id: str) -> FloatArray:
+        z = self._standardize_many(values, feature_spec_id=feature_spec_id)
+        return np.asarray(z @ self.coefficients + self.intercept, dtype=np.float64)
+
+    def logit_one(self, values: npt.ArrayLike, *, feature_spec_id: str) -> float:
+        vector = _vector("features", values)
+        return float(
+            self.logit_many(vector[None, :], feature_spec_id=feature_spec_id)[0]
+        )
+
+    def score_many(self, values: npt.ArrayLike, *, feature_spec_id: str) -> FloatArray:
+        return stable_sigmoid(self.logit_many(values, feature_spec_id=feature_spec_id))
+
+    def score_one(self, values: npt.ArrayLike, *, feature_spec_id: str) -> float:
+        return float(
+            stable_sigmoid(
+                np.asarray([self.logit_one(values, feature_spec_id=feature_spec_id)])
+            )[0]
+        )
+
+    def contributions_one(
+        self, values: npt.ArrayLike, *, feature_spec_id: str
+    ) -> tuple[CriticFeatureContributionDTO, ...]:
+        raw = _vector("features", values)
+        z = self._standardize_many(raw[None, :], feature_spec_id=feature_spec_id)[0]
+        direction = np.asarray(self.directionality, dtype=np.float64)
+        directed = raw * direction
+        contributions = z * self.coefficients
+        return tuple(
+            CriticFeatureContributionDTO(
+                feature_id=self.feature_ids[index],
+                raw_value=float(raw[index]),
+                directed_value=float(directed[index]),
+                standardized_value=float(z[index]),
+                coefficient=float(self.coefficients[index]),
+                contribution=float(contributions[index]),
+            )
+            for index in range(len(self.feature_ids))
+        )

--- a/packages/critic/src/zeromodel/critic/persistence.py
+++ b/packages/critic/src/zeromodel/critic/persistence.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, TypeVar
+
+import numpy as np
+
+from zeromodel.artifacts import ArtifactRef, ArtifactResolver, ArtifactStore
+from zeromodel.core.matrix_blob import MatrixBlob
+
+from zeromodel.critic.dto import (
+    CriticCalibrationDTO,
+    CriticContractDTO,
+    CriticFeatureBatchDTO,
+    CriticFeatureSpecDTO,
+    CriticFitSpecDTO,
+    CriticLabelBatchDTO,
+    CriticReadoutArtifactDTO,
+    CriticScoreReceiptDTO,
+    CriticScoreRequestDTO,
+    CriticScoreResultDTO,
+    canonical_dto_bytes,
+)
+from zeromodel.critic.errors import (
+    CriticContractMismatchError,
+    CriticFeatureSchemaMismatchError,
+    CriticReadoutIntegrityError,
+)
+from zeromodel.critic.kinds import (
+    CRITIC_CALIBRATION_ARTIFACT_KIND,
+    CRITIC_CONTRACT_ARTIFACT_KIND,
+    CRITIC_FEATURE_BATCH_ARTIFACT_KIND,
+    CRITIC_FEATURE_SPEC_ARTIFACT_KIND,
+    CRITIC_FIT_SPEC_ARTIFACT_KIND,
+    CRITIC_LABEL_BATCH_ARTIFACT_KIND,
+    CRITIC_READOUT_ARTIFACT_KIND,
+    CRITIC_SCORE_RECEIPT_ARTIFACT_KIND,
+    CRITIC_SCORE_REQUEST_ARTIFACT_KIND,
+    CRITIC_SCORE_RESULT_ARTIFACT_KIND,
+    MATRIX_BLOB_ARTIFACT_KIND,
+)
+
+T = TypeVar("T")
+
+
+def _require_kind(ref: ArtifactRef, expected: str) -> None:
+    if ref.artifact_kind != expected:
+        raise CriticReadoutIntegrityError(
+            f"expected artifact kind {expected!r}, got {ref.artifact_kind!r}"
+        )
+
+
+def store_dto(store: ArtifactStore, artifact_kind: str, dto: Any) -> ArtifactRef:
+    return store.put(artifact_kind, canonical_dto_bytes(dto), {"dto": artifact_kind})
+
+
+def _load_dto(
+    resolver: ArtifactResolver,
+    ref: ArtifactRef,
+    artifact_kind: str,
+    decoder: Callable[[Mapping[str, Any]], T],
+) -> T:
+    _require_kind(ref, artifact_kind)
+    import json
+
+    return decoder(json.loads(resolver.resolve_canonical_bytes(ref).decode("utf-8")))
+
+
+def store_matrix_blob(store: ArtifactStore, blob: MatrixBlob) -> ArtifactRef:
+    return store.put(
+        MATRIX_BLOB_ARTIFACT_KIND,
+        canonical_dto_bytes(blob),
+        {"blob_id": blob.blob_id, "shape": list(blob.shape), "dtype": blob.dtype},
+    )
+
+
+def load_matrix_blob(resolver: ArtifactResolver, ref: ArtifactRef) -> MatrixBlob:
+    _require_kind(ref, MATRIX_BLOB_ARTIFACT_KIND)
+    import json
+
+    return MatrixBlob.from_dict(
+        json.loads(resolver.resolve_canonical_bytes(ref).decode("utf-8"))
+    )
+
+
+def store_critic_feature_spec(
+    store: ArtifactStore, dto: CriticFeatureSpecDTO
+) -> ArtifactRef:
+    return store_dto(store, CRITIC_FEATURE_SPEC_ARTIFACT_KIND, dto)
+
+
+def load_critic_feature_spec(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticFeatureSpecDTO:
+    return _load_dto(
+        resolver, ref, CRITIC_FEATURE_SPEC_ARTIFACT_KIND, CriticFeatureSpecDTO.from_dict
+    )
+
+
+def store_critic_feature_batch(
+    store: ArtifactStore, dto: CriticFeatureBatchDTO
+) -> ArtifactRef:
+    return store_dto(store, CRITIC_FEATURE_BATCH_ARTIFACT_KIND, dto)
+
+
+def load_critic_feature_batch(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticFeatureBatchDTO:
+    return _load_dto(
+        resolver,
+        ref,
+        CRITIC_FEATURE_BATCH_ARTIFACT_KIND,
+        CriticFeatureBatchDTO.from_dict,
+    )
+
+
+def store_critic_contract(store: ArtifactStore, dto: CriticContractDTO) -> ArtifactRef:
+    return store_dto(store, CRITIC_CONTRACT_ARTIFACT_KIND, dto)
+
+
+def load_critic_contract(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticContractDTO:
+    return _load_dto(
+        resolver, ref, CRITIC_CONTRACT_ARTIFACT_KIND, CriticContractDTO.from_dict
+    )
+
+
+def store_critic_label_batch(
+    store: ArtifactStore, dto: CriticLabelBatchDTO
+) -> ArtifactRef:
+    return store_dto(store, CRITIC_LABEL_BATCH_ARTIFACT_KIND, dto)
+
+
+def load_critic_label_batch(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticLabelBatchDTO:
+    return _load_dto(
+        resolver, ref, CRITIC_LABEL_BATCH_ARTIFACT_KIND, CriticLabelBatchDTO.from_dict
+    )
+
+
+def store_critic_fit_spec(store: ArtifactStore, dto: CriticFitSpecDTO) -> ArtifactRef:
+    return store_dto(store, CRITIC_FIT_SPEC_ARTIFACT_KIND, dto)
+
+
+def load_critic_fit_spec(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticFitSpecDTO:
+    return _load_dto(
+        resolver, ref, CRITIC_FIT_SPEC_ARTIFACT_KIND, CriticFitSpecDTO.from_dict
+    )
+
+
+def store_critic_calibration(
+    store: ArtifactStore, dto: CriticCalibrationDTO
+) -> ArtifactRef:
+    return store_dto(store, CRITIC_CALIBRATION_ARTIFACT_KIND, dto)
+
+
+def load_critic_calibration(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticCalibrationDTO:
+    return _load_dto(
+        resolver, ref, CRITIC_CALIBRATION_ARTIFACT_KIND, CriticCalibrationDTO.from_dict
+    )
+
+
+def store_critic_readout(
+    store: ArtifactStore, dto: CriticReadoutArtifactDTO
+) -> ArtifactRef:
+    return store_dto(store, CRITIC_READOUT_ARTIFACT_KIND, dto)
+
+
+def load_critic_readout(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticReadoutArtifactDTO:
+    return _load_dto(
+        resolver, ref, CRITIC_READOUT_ARTIFACT_KIND, CriticReadoutArtifactDTO.from_dict
+    )
+
+
+def store_critic_score_request(
+    store: ArtifactStore, dto: CriticScoreRequestDTO
+) -> ArtifactRef:
+    return store_dto(store, CRITIC_SCORE_REQUEST_ARTIFACT_KIND, dto)
+
+
+def load_critic_score_request(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticScoreRequestDTO:
+    return _load_dto(
+        resolver,
+        ref,
+        CRITIC_SCORE_REQUEST_ARTIFACT_KIND,
+        CriticScoreRequestDTO.from_dict,
+    )
+
+
+def store_critic_score_result(
+    store: ArtifactStore, dto: CriticScoreResultDTO
+) -> ArtifactRef:
+    return store_dto(store, CRITIC_SCORE_RESULT_ARTIFACT_KIND, dto)
+
+
+def load_critic_score_result(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticScoreResultDTO:
+    return _load_dto(
+        resolver, ref, CRITIC_SCORE_RESULT_ARTIFACT_KIND, CriticScoreResultDTO.from_dict
+    )
+
+
+def store_critic_score_receipt(
+    store: ArtifactStore, dto: CriticScoreReceiptDTO
+) -> ArtifactRef:
+    return store_dto(store, CRITIC_SCORE_RECEIPT_ARTIFACT_KIND, dto)
+
+
+def load_critic_score_receipt(
+    resolver: ArtifactResolver, ref: ArtifactRef
+) -> CriticScoreReceiptDTO:
+    return _load_dto(
+        resolver,
+        ref,
+        CRITIC_SCORE_RECEIPT_ARTIFACT_KIND,
+        CriticScoreReceiptDTO.from_dict,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedCriticFeatureBatchAggregate:
+    batch: CriticFeatureBatchDTO
+    spec: CriticFeatureSpecDTO
+    values_blob: MatrixBlob
+
+    @property
+    def values(self) -> np.ndarray:
+        return np.asarray(self.values_blob.to_array(), dtype=np.float64)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedCriticLabelBatchAggregate:
+    batch: CriticLabelBatchDTO
+    contract: CriticContractDTO
+    labels_blob: MatrixBlob
+
+    @property
+    def labels(self) -> np.ndarray:
+        return np.asarray(self.labels_blob.to_array(), dtype=np.float64)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedCriticReadoutAggregate:
+    readout: CriticReadoutArtifactDTO
+    contract: CriticContractDTO
+    feature_spec: CriticFeatureSpecDTO
+    fit_spec: CriticFitSpecDTO
+    center_blob: MatrixBlob
+    scale_blob: MatrixBlob
+    coefficients_blob: MatrixBlob
+    intercept_blob: MatrixBlob
+    training_features: ResolvedCriticFeatureBatchAggregate
+    training_labels: ResolvedCriticLabelBatchAggregate
+    calibration: CriticCalibrationDTO | None = None
+
+
+def load_critic_feature_batch_aggregate(
+    ref: ArtifactRef, resolver: ArtifactResolver
+) -> ResolvedCriticFeatureBatchAggregate:
+    batch = load_critic_feature_batch(resolver, ref)
+    spec = load_critic_feature_spec(resolver, batch.feature_spec_ref)
+    blob = load_matrix_blob(resolver, batch.values_blob_ref)
+    if blob.shape != batch.values_shape or blob.dtype != batch.values_dtype:
+        raise CriticFeatureSchemaMismatchError("feature batch matrix metadata mismatch")
+    if blob.ndim != 2 or blob.shape[1] != len(spec.features):
+        raise CriticFeatureSchemaMismatchError("feature dimensions do not match spec")
+    values = blob.to_array()
+    if not np.isfinite(values).all():
+        raise CriticFeatureSchemaMismatchError("feature values must be finite")
+    return ResolvedCriticFeatureBatchAggregate(batch=batch, spec=spec, values_blob=blob)
+
+
+def load_critic_label_batch_aggregate(
+    ref: ArtifactRef, resolver: ArtifactResolver
+) -> ResolvedCriticLabelBatchAggregate:
+    batch = load_critic_label_batch(resolver, ref)
+    contract = load_critic_contract(resolver, batch.critic_contract_ref)
+    blob = load_matrix_blob(resolver, batch.labels_blob_ref)
+    if blob.shape != batch.labels_shape:
+        raise CriticContractMismatchError("label batch metadata mismatch")
+    labels = np.asarray(blob.to_array(), dtype=np.float64)
+    if labels.ndim != 1 or not np.isin(labels, [0.0, 1.0]).all():
+        raise CriticContractMismatchError("labels must be a binary 1D vector")
+    return ResolvedCriticLabelBatchAggregate(
+        batch=batch, contract=contract, labels_blob=blob
+    )
+
+
+def load_critic_readout_aggregate(
+    ref: ArtifactRef, resolver: ArtifactResolver
+) -> ResolvedCriticReadoutAggregate:
+    readout = load_critic_readout(resolver, ref)
+    aggregate = ResolvedCriticReadoutAggregate(
+        readout=readout,
+        contract=load_critic_contract(resolver, readout.critic_contract_ref),
+        feature_spec=load_critic_feature_spec(resolver, readout.feature_spec_ref),
+        fit_spec=load_critic_fit_spec(resolver, readout.fit_spec_ref),
+        center_blob=load_matrix_blob(resolver, readout.center_blob_ref),
+        scale_blob=load_matrix_blob(resolver, readout.scale_blob_ref),
+        coefficients_blob=load_matrix_blob(resolver, readout.coefficients_blob_ref),
+        intercept_blob=load_matrix_blob(resolver, readout.intercept_blob_ref),
+        training_features=load_critic_feature_batch_aggregate(
+            readout.training_feature_batch_ref, resolver
+        ),
+        training_labels=load_critic_label_batch_aggregate(
+            readout.training_label_batch_ref, resolver
+        ),
+        calibration=None
+        if readout.calibration_ref is None
+        else load_critic_calibration(resolver, readout.calibration_ref),
+    )
+    validate_critic_readout_aggregate(aggregate)
+    return aggregate
+
+
+def validate_critic_readout_aggregate(
+    aggregate: ResolvedCriticReadoutAggregate,
+) -> None:
+    readout = aggregate.readout
+    if (
+        readout.feature_spec_ref.artifact_id
+        != aggregate.training_features.batch.feature_spec_ref.artifact_id
+    ):
+        raise CriticReadoutIntegrityError(
+            "training feature spec does not match readout"
+        )
+    if (
+        readout.critic_contract_ref.artifact_id
+        != aggregate.training_labels.batch.critic_contract_ref.artifact_id
+    ):
+        raise CriticReadoutIntegrityError(
+            "training label contract does not match readout"
+        )
+    if (
+        aggregate.training_features.batch.item_refs
+        != aggregate.training_labels.batch.item_refs
+    ):
+        raise CriticReadoutIntegrityError("training rows are not exactly aligned")
+    width = len(aggregate.feature_spec.features)
+    center = aggregate.center_blob.to_array()
+    scale = aggregate.scale_blob.to_array()
+    coefficients = aggregate.coefficients_blob.to_array()
+    intercept = aggregate.intercept_blob.to_array()
+    if (
+        center.shape != (width,)
+        or scale.shape != (width,)
+        or coefficients.shape != (width,)
+    ):
+        raise CriticReadoutIntegrityError("readout vector dimensions do not close")
+    if intercept.shape != (1,):
+        raise CriticReadoutIntegrityError("intercept dimensions do not close")
+    if (
+        not np.isfinite(center).all()
+        or not np.isfinite(scale).all()
+        or not np.isfinite(coefficients).all()
+        or not np.isfinite(intercept).all()
+    ):
+        raise CriticReadoutIntegrityError("readout arrays must be finite")
+    if np.any(scale <= 0.0):
+        raise CriticReadoutIntegrityError("scale must be positive")

--- a/packages/critic/src/zeromodel/critic/portable.py
+++ b/packages/critic/src/zeromodel/critic/portable.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+import numpy as np
+
+from zeromodel.artifacts import canonical_json_bytes
+
+from zeromodel.critic.errors import CriticPayloadTooLargeError, CriticValidationError
+from zeromodel.critic.linear import CompiledCriticReadout, stable_sigmoid
+from zeromodel.critic.persistence import ResolvedCriticReadoutAggregate
+from zeromodel.critic.scoring import compiled_from_aggregate
+
+PORTABLE_SCHEMA_VERSION = "zeromodel-portable-critic/v1"
+
+
+def export_portable_critic(
+    aggregate: ResolvedCriticReadoutAggregate, *, limit_bytes: int | None = None
+) -> str:
+    runtime = compiled_from_aggregate(aggregate)
+    payload = {
+        "schema_version": PORTABLE_SCHEMA_VERSION,
+        "critic_contract_id": runtime.contract_id,
+        "feature_spec_id": runtime.feature_spec_id,
+        "feature_ids": list(runtime.feature_ids),
+        "directionality": list(runtime.directionality),
+        "center": [float(v) for v in runtime.center],
+        "scale": [float(v) for v in runtime.scale],
+        "coefficients": [float(v) for v in runtime.coefficients],
+        "intercept": float(runtime.intercept),
+        "calibration": None
+        if aggregate.calibration is None
+        else aggregate.calibration.to_dict(),
+        "score_contract": {
+            "score": "sigmoid(logit)",
+            "calibration_input": "logit",
+            "semantics": aggregate.contract.score_semantics,
+            "positive_label": aggregate.contract.positive_label,
+            "negative_label": aggregate.contract.negative_label,
+        },
+    }
+    encoded = canonical_json_bytes(payload)
+    max_bytes = (
+        aggregate.fit_spec.portable_payload_limit_bytes
+        if limit_bytes is None
+        else int(limit_bytes)
+    )
+    if len(encoded) > max_bytes:
+        raise CriticPayloadTooLargeError(
+            f"portable critic payload is {len(encoded)} bytes, limit is {max_bytes}"
+        )
+    return encoded.decode("utf-8")
+
+
+def load_portable_critic(payload: str | bytes | Mapping[str, Any]) -> Mapping[str, Any]:
+    data = (
+        json.loads(payload.decode("utf-8") if isinstance(payload, bytes) else payload)
+        if isinstance(payload, (str, bytes))
+        else dict(payload)
+    )
+    if data.get("schema_version") != PORTABLE_SCHEMA_VERSION:
+        raise CriticValidationError("unsupported portable critic schema")
+    return data
+
+
+def score_portable(
+    payload: str | bytes | Mapping[str, Any],
+    values: Mapping[str, float | None] | list[float],
+) -> dict[str, float | None]:
+    data = load_portable_critic(payload)
+    if isinstance(values, Mapping):
+        # Portable payloads do not carry missing-value policy; producers must supply compatible rows.
+        row = np.asarray(
+            [float(values[feature_id]) for feature_id in data["feature_ids"]],
+            dtype=np.float64,
+        )
+    else:
+        row = np.asarray(values, dtype=np.float64)
+    if (
+        row.ndim != 1
+        or row.size != len(data["feature_ids"])
+        or not np.isfinite(row).all()
+    ):
+        raise CriticValidationError("portable values must be a finite compatible row")
+    direction = np.asarray(data["directionality"], dtype=np.float64)
+    center = np.asarray(data["center"], dtype=np.float64)
+    scale = np.asarray(data["scale"], dtype=np.float64)
+    coefficients = np.asarray(data["coefficients"], dtype=np.float64)
+    z = (row * direction - center) / scale
+    logit = float(z @ coefficients + float(data["intercept"]))
+    score = float(stable_sigmoid(np.asarray([logit]))[0])
+    calibrated = None
+    calibration = data.get("calibration")
+    if calibration and calibration.get("method") == "platt":
+        params = calibration.get("parameters") or {}
+        calibrated = float(
+            stable_sigmoid(
+                np.asarray(
+                    [float(params.get("a", 1.0)) * logit + float(params.get("b", 0.0))]
+                )
+            )[0]
+        )
+    return {"logit": logit, "score": score, "calibrated_probability": calibrated}
+
+
+def runtime_to_portable(runtime: CompiledCriticReadout) -> str:
+    payload = {
+        "schema_version": PORTABLE_SCHEMA_VERSION,
+        "critic_contract_id": runtime.contract_id,
+        "feature_spec_id": runtime.feature_spec_id,
+        "feature_ids": list(runtime.feature_ids),
+        "directionality": list(runtime.directionality),
+        "center": [float(v) for v in runtime.center],
+        "scale": [float(v) for v in runtime.scale],
+        "coefficients": [float(v) for v in runtime.coefficients],
+        "intercept": float(runtime.intercept),
+        "calibration": runtime.calibration,
+        "score_contract": {"score": "sigmoid(logit)", "calibration_input": "logit"},
+    }
+    return canonical_json_bytes(payload).decode("utf-8")

--- a/packages/critic/src/zeromodel/critic/portable_reference.js
+++ b/packages/critic/src/zeromodel/critic/portable_reference.js
@@ -1,0 +1,23 @@
+function sigmoid(x) {
+  if (x >= 0) return 1 / (1 + Math.exp(-x));
+  const e = Math.exp(x);
+  return e / (1 + e);
+}
+
+function scorePortableCritic(payload, values) {
+  let logit = payload.intercept;
+  for (let i = 0; i < payload.feature_ids.length; i += 1) {
+    const raw = Array.isArray(values) ? values[i] : values[payload.feature_ids[i]];
+    const directed = raw * payload.directionality[i];
+    const z = (directed - payload.center[i]) / payload.scale[i];
+    logit += payload.coefficients[i] * z;
+  }
+  const score = sigmoid(logit);
+  let calibrated_probability = null;
+  if (payload.calibration && payload.calibration.method === "platt") {
+    const p = payload.calibration.parameters;
+    calibrated_probability = sigmoid(p.a * logit + p.b);
+  }
+  return { logit, score, calibrated_probability };
+}
+

--- a/packages/critic/src/zeromodel/critic/promotion.py
+++ b/packages/critic/src/zeromodel/critic/promotion.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class CriticPromotionPolicyDTO:
+    min_candidate_auroc: float = 0.5
+    max_candidate_ece: float = 0.2
+    min_auroc_gain: float = 0.0
+    max_ece_regression: float = 0.05
+
+
+@dataclass(frozen=True, slots=True)
+class CriticPromotionDecisionDTO:
+    recommended: bool
+    reasons: tuple[str, ...]
+
+
+def evaluate_promotion(
+    *,
+    current_metrics: dict[str, float],
+    candidate_metrics: dict[str, float],
+    policy: CriticPromotionPolicyDTO,
+) -> CriticPromotionDecisionDTO:
+    reasons = []
+    if candidate_metrics.get("auroc", 0.0) < policy.min_candidate_auroc:
+        reasons.append("candidate AUROC below floor")
+    if candidate_metrics.get("ece", 1.0) > policy.max_candidate_ece:
+        reasons.append("candidate ECE above ceiling")
+    if (
+        candidate_metrics.get("auroc", 0.0) - current_metrics.get("auroc", 0.0)
+        < policy.min_auroc_gain
+    ):
+        reasons.append("candidate AUROC gain below required improvement")
+    if (
+        candidate_metrics.get("ece", 1.0) - current_metrics.get("ece", 1.0)
+        > policy.max_ece_regression
+    ):
+        reasons.append("candidate ECE regression exceeds limit")
+    if not reasons:
+        reasons.append("candidate satisfies promotion policy")
+    return CriticPromotionDecisionDTO(
+        recommended=len(reasons) == 1 and reasons[0].startswith("candidate satisfies"),
+        reasons=tuple(reasons),
+    )

--- a/packages/critic/src/zeromodel/critic/receipts.py
+++ b/packages/critic/src/zeromodel/critic/receipts.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from zeromodel.artifacts import ArtifactRef, ArtifactStore
+
+from zeromodel.critic.dto import CriticScoreReceiptDTO
+from zeromodel.critic.errors import CriticReplayMismatchError
+from zeromodel.critic.persistence import (
+    load_critic_score_receipt,
+    load_critic_score_request,
+    load_critic_score_result,
+    store_critic_score_receipt,
+)
+from zeromodel.critic.scoring import score_critic
+
+
+def build_critic_score_receipt(
+    *,
+    store: ArtifactStore,
+    request_ref: ArtifactRef,
+    result_ref: ArtifactRef,
+) -> tuple[CriticScoreReceiptDTO, ArtifactRef]:
+    request = load_critic_score_request(store, request_ref)
+    result = load_critic_score_result(store, result_ref)
+    receipt = CriticScoreReceiptDTO(
+        request_ref=request_ref,
+        result_ref=result_ref,
+        readout_ref=request.readout_ref,
+        feature_batch_ref=request.feature_batch_ref,
+        required_checks=CriticScoreReceiptDTO.REQUIRED,
+        result_id=result.result_id,
+    )
+    return receipt, store_critic_score_receipt(store, receipt)
+
+
+def replay_critic_score(*, store: ArtifactStore, receipt_ref: ArtifactRef) -> object:
+    receipt = load_critic_score_receipt(store, receipt_ref)
+    request = load_critic_score_request(store, receipt.request_ref)
+    fresh, fresh_ref, _ = score_critic(
+        store=store, request=request, persist_result=True
+    )
+    if fresh.result_id != receipt.result_id:
+        raise CriticReplayMismatchError("replayed critic result diverged from receipt")
+    if fresh_ref is None or fresh_ref.artifact_id != receipt.result_ref.artifact_id:
+        raise CriticReplayMismatchError("replayed result ref diverged from receipt")
+    return fresh

--- a/packages/critic/src/zeromodel/critic/scoring.py
+++ b/packages/critic/src/zeromodel/critic/scoring.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import numpy as np
+
+from zeromodel.artifacts import ArtifactRef, ArtifactStore
+
+from zeromodel.critic.dto import (
+    CriticItemScoreDTO,
+    CriticReadoutArtifactDTO,
+    CriticScoreRequestDTO,
+    CriticScoreResultDTO,
+)
+from zeromodel.critic.linear import CompiledCriticReadout, stable_sigmoid
+from zeromodel.critic.persistence import (
+    ResolvedCriticReadoutAggregate,
+    load_critic_feature_batch_aggregate,
+    load_critic_readout_aggregate,
+    store_critic_score_request,
+    store_critic_score_result,
+)
+
+ORDERING_CONTRACT = "source_order;rank_by_critic_available_separately"
+
+
+def compiled_from_aggregate(
+    aggregate: ResolvedCriticReadoutAggregate,
+) -> CompiledCriticReadout:
+    calibration = None
+    if aggregate.calibration is not None:
+        calibration = aggregate.calibration.to_dict()
+    return CompiledCriticReadout(
+        feature_ids=aggregate.feature_spec.feature_ids,
+        directionality=aggregate.feature_spec.directionality,
+        center=np.asarray(aggregate.center_blob.to_array(), dtype=np.float64),
+        scale=np.asarray(aggregate.scale_blob.to_array(), dtype=np.float64),
+        coefficients=np.asarray(
+            aggregate.coefficients_blob.to_array(), dtype=np.float64
+        ),
+        intercept=float(
+            np.asarray(aggregate.intercept_blob.to_array(), dtype=np.float64)[0]
+        ),
+        contract_id=aggregate.contract.critic_contract_id,
+        feature_spec_id=aggregate.feature_spec.feature_spec_id,
+        calibration=calibration,
+    )
+
+
+def _calibrated(
+    runtime: CompiledCriticReadout, logits: np.ndarray
+) -> np.ndarray | None:
+    if not runtime.calibration or runtime.calibration.get("method") == "none":
+        return None
+    params = runtime.calibration.get("parameters") or {}
+    a = float(params.get("a", 1.0))
+    b = float(params.get("b", 0.0))
+    return stable_sigmoid(a * logits + b)
+
+
+def _verdict(score: float, request: CriticScoreRequestDTO) -> tuple[str | None, float]:
+    threshold = request.threshold_contract
+    if threshold is None:
+        return None, 0.0
+    if threshold.reject_below is not None and score < threshold.reject_below:
+        return "REJECT", float(threshold.reject_below - score)
+    if (
+        threshold.accept_at_or_above is not None
+        and score >= threshold.accept_at_or_above
+    ):
+        return "ACCEPT", float(score - threshold.accept_at_or_above)
+    margins = []
+    if threshold.reject_below is not None:
+        margins.append(abs(score - threshold.reject_below))
+    if threshold.accept_at_or_above is not None:
+        margins.append(abs(score - threshold.accept_at_or_above))
+    return "REVIEW", float(min(margins) if margins else 0.0)
+
+
+def score_critic(
+    *,
+    store: ArtifactStore,
+    request: CriticScoreRequestDTO,
+    persist_result: bool = True,
+) -> tuple[CriticScoreResultDTO, ArtifactRef | None, ArtifactRef]:
+    request_ref = store_critic_score_request(store, request)
+    readout = load_critic_readout_aggregate(request.readout_ref, store)
+    batch = load_critic_feature_batch_aggregate(request.feature_batch_ref, store)
+    runtime = compiled_from_aggregate(readout)
+    logits = runtime.logit_many(
+        batch.values, feature_spec_id=batch.spec.feature_spec_id
+    )
+    scores = stable_sigmoid(logits)
+    calibrated = _calibrated(runtime, logits)
+    items = []
+    for index, ref in enumerate(batch.batch.item_refs):
+        contributions = runtime.contributions_one(
+            batch.values[index], feature_spec_id=batch.spec.feature_spec_id
+        )
+        positive = sum(max(0.0, item.contribution) for item in contributions)
+        negative = sum(abs(min(0.0, item.contribution)) for item in contributions)
+        shown = ()
+        if request.explanation_depth:
+            ordered = sorted(
+                contributions,
+                key=lambda item: (-abs(item.contribution), item.feature_id),
+            )
+            shown = tuple(ordered[: request.explanation_depth])
+        verdict, margin = _verdict(float(scores[index]), request)
+        items.append(
+            CriticItemScoreDTO(
+                artifact_ref=ref,
+                logit=float(logits[index]),
+                score=float(scores[index]),
+                calibrated_probability=None
+                if calibrated is None
+                else float(calibrated[index]),
+                verdict=verdict,
+                decision_margin=margin,
+                feature_coverage=1.0,
+                positive_contribution_strength=float(positive),
+                negative_contribution_strength=float(negative),
+                contributions=shown,
+            )
+        )
+    result = CriticScoreResultDTO(
+        request_ref=request_ref,
+        readout_ref=request.readout_ref,
+        feature_batch_ref=request.feature_batch_ref,
+        critic_contract_ref=readout.readout.critic_contract_ref,
+        feature_spec_ref=readout.readout.feature_spec_ref,
+        items=tuple(items),
+        ordering_contract=ORDERING_CONTRACT,
+        metadata={"score_semantics": readout.contract.score_semantics},
+    )
+    return (
+        result,
+        store_critic_score_result(store, result) if persist_result else None,
+        request_ref,
+    )
+
+
+def readout_from_runtime(
+    *,
+    runtime: CompiledCriticReadout,
+    store: ArtifactStore,
+    readout: CriticReadoutArtifactDTO,
+) -> tuple[CriticReadoutArtifactDTO, ArtifactRef]:
+    from zeromodel.critic.persistence import store_critic_readout
+
+    return readout, store_critic_readout(store, readout)

--- a/packages/critic/src/zeromodel/critic/triage.py
+++ b/packages/critic/src/zeromodel/critic/triage.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from zeromodel.critic.dto import CriticScoreResultDTO
+
+
+def rank_by_critic(result: CriticScoreResultDTO) -> tuple[str, ...]:
+    ordered = sorted(
+        result.items,
+        key=lambda item: (-item.score, item.artifact_ref.artifact_id),
+    )
+    return tuple(item.artifact_ref.artifact_id for item in ordered)
+
+
+@dataclass(frozen=True, slots=True)
+class CriticTriageResultDTO:
+    selected_artifact_ids: tuple[str, ...]
+    budget_count: int
+    ordering_contract: str = "critic_score_desc;artifact_id_asc"
+
+
+def triage_by_budget(
+    result: CriticScoreResultDTO, *, budget_count: int
+) -> CriticTriageResultDTO:
+    if budget_count < 0:
+        raise ValueError("budget_count must be non-negative")
+    return CriticTriageResultDTO(
+        selected_artifact_ids=rank_by_critic(result)[:budget_count],
+        budget_count=budget_count,
+    )

--- a/packages/critic/src/zeromodel/critic/views.py
+++ b/packages/critic/src/zeromodel/critic/views.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from zeromodel.core import LayoutRecipe, ScoreTable, VPMArtifact, build_vpm
+
+from zeromodel.critic.dto import CriticScoreResultDTO
+
+
+def build_critic_score_vpm(*, result: CriticScoreResultDTO) -> VPMArtifact:
+    metric_ids = (
+        "critic_score",
+        "decision_margin",
+        "feature_coverage",
+        "positive_contribution_strength",
+        "negative_contribution_strength",
+    )
+    values = []
+    row_ids = []
+    for item in result.items:
+        row_ids.append(item.artifact_ref.artifact_id)
+        values.append(
+            [
+                item.score,
+                item.decision_margin,
+                item.feature_coverage,
+                item.positive_contribution_strength,
+                item.negative_contribution_strength,
+            ]
+        )
+    if not values:
+        row_ids = ["empty-result"]
+        values = [[0.0 for _ in metric_ids]]
+    table = ScoreTable(
+        values=values,
+        row_ids=row_ids,
+        metric_ids=metric_ids,
+        metadata={"kind": "critic_score_result", "result_id": result.result_id},
+    )
+    recipe = LayoutRecipe.from_dict(
+        {
+            "version": "vpm-layout/0",
+            "name": "critic-score-desc",
+            "row_order": {
+                "kind": "lexicographic",
+                "keys": [{"metric_id": "critic_score", "direction": "desc"}],
+                "tie_break": "row_id",
+            },
+            "column_order": {"kind": "source"},
+            "normalization": {"kind": "per_metric_minmax", "clip": True},
+        }
+    )
+    return build_vpm(
+        table,
+        recipe,
+        provenance={
+            "kind": "critic_score_vpm",
+            "result_id": result.result_id,
+            "request_ref": result.request_ref.artifact_id,
+            "readout_ref": result.readout_ref.artifact_id,
+            "feature_batch_ref": result.feature_batch_ref.artifact_id,
+            "parents": [result.result_id],
+        },
+    )

--- a/packages/critic/tests/conftest.py
+++ b/packages/critic/tests/conftest.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from zeromodel.artifacts import InMemoryArtifactStore, canonical_json_bytes
+from zeromodel.core.matrix_blob import MatrixBlob
+from zeromodel.critic.dto import (
+    CriticContractDTO,
+    CriticFeatureBatchDTO,
+    CriticFeatureDTO,
+    CriticFeatureSpecDTO,
+    CriticFitSpecDTO,
+    CriticLabelBatchDTO,
+)
+from zeromodel.critic.persistence import (
+    load_critic_feature_batch_aggregate,
+    load_critic_label_batch_aggregate,
+    store_critic_contract,
+    store_critic_feature_batch,
+    store_critic_feature_spec,
+    store_critic_label_batch,
+    store_matrix_blob,
+)
+
+
+@pytest.fixture()
+def critic_fixture():
+    store = InMemoryArtifactStore()
+    spec = CriticFeatureSpecDTO(
+        features=(
+            CriticFeatureDTO("stability", "stable numeric signal"),
+            CriticFeatureDTO("coverage", "coverage signal"),
+            CriticFeatureDTO("uncertainty", "uncertainty signal", directionality=-1),
+            CriticFeatureDTO("constant", "zero variance fixture"),
+        )
+    )
+    contract = CriticContractDTO(
+        critic_id="fixture-success",
+        version="v1",
+        target_id="synthetic-success",
+        positive_label="successful",
+        negative_label="failed",
+        score_semantics="similarity to deterministic synthetic successful examples",
+        intended_uses=("ranking", "triage"),
+        prohibited_uses=("semantic truth",),
+    )
+    spec_ref = store_critic_feature_spec(store, spec)
+    contract_ref = store_critic_contract(store, contract)
+    values = np.asarray(
+        [
+            [0.9, 0.8, 0.1, 1.0],
+            [0.8, 0.7, 0.2, 1.0],
+            [0.2, 0.4, 0.8, 1.0],
+            [0.1, 0.3, 0.9, 1.0],
+            [0.85, 0.9, 0.15, 1.0],
+            [0.15, 0.2, 0.75, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    labels = np.asarray([1, 1, 0, 0, 1, 0], dtype=np.float64)
+    item_refs = tuple(
+        store.put(
+            "fixture.item", canonical_json_bytes({"item": index}), {"fixture": "critic"}
+        )
+        for index in range(values.shape[0])
+    )
+    values_ref = store_matrix_blob(
+        store,
+        MatrixBlob.from_array(
+            values, dtype="float64", metadata={"role": "critic_features"}
+        ),
+    )
+    labels_ref = store_matrix_blob(
+        store,
+        MatrixBlob.from_array(
+            labels, dtype="float64", metadata={"role": "critic_labels"}
+        ),
+    )
+    feature_batch = CriticFeatureBatchDTO(
+        feature_spec_ref=spec_ref,
+        values_blob_ref=values_ref,
+        item_refs=item_refs,
+        values_shape=values.shape,
+        values_dtype="float64",
+    )
+    label_batch = CriticLabelBatchDTO(
+        critic_contract_ref=contract_ref,
+        item_refs=item_refs,
+        labels_blob_ref=labels_ref,
+        labels_shape=labels.shape,
+    )
+    return {
+        "store": store,
+        "spec": spec,
+        "contract": contract,
+        "features": load_critic_feature_batch_aggregate(
+            store_critic_feature_batch(store, feature_batch), store
+        ),
+        "labels": load_critic_label_batch_aggregate(
+            store_critic_label_batch(store, label_batch), store
+        ),
+        "fit_spec": CriticFitSpecDTO(l2_penalty=0.1, max_iterations=80),
+        "values": values,
+        "labels_array": labels,
+    }

--- a/packages/critic/tests/test_dto_and_kernel.py
+++ b/packages/critic/tests/test_dto_and_kernel.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from zeromodel.core.artifact import VPMValidationError
+from zeromodel.critic import (
+    CriticFeatureDTO,
+    CriticFeatureSpecDTO,
+    CompiledCriticReadout,
+)
+from zeromodel.critic.dto import canonical_dto_bytes
+from zeromodel.critic.linear import features_from_mapping, stable_sigmoid
+
+
+def test_feature_spec_identity_round_trip_and_mutation() -> None:
+    spec = CriticFeatureSpecDTO(
+        features=(
+            CriticFeatureDTO("a", "A"),
+            CriticFeatureDTO(
+                "b",
+                "B",
+                directionality=-1,
+                required=False,
+                missing_policy="constant",
+                missing_value=0.0,
+            ),
+        )
+    )
+    clone = CriticFeatureSpecDTO.from_dict(json.loads(canonical_dto_bytes(spec)))
+    assert clone.feature_spec_id == spec.feature_spec_id
+    changed_order = CriticFeatureSpecDTO(features=tuple(reversed(spec.features)))
+    assert changed_order.feature_spec_id != spec.feature_spec_id
+    changed_direction = CriticFeatureSpecDTO(
+        features=(CriticFeatureDTO("a", "A", directionality=-1), spec.features[1])
+    )
+    assert changed_direction.feature_spec_id != spec.feature_spec_id
+
+
+def test_invalid_supplied_id_fails() -> None:
+    spec = CriticFeatureSpecDTO(features=(CriticFeatureDTO("a", "A"),))
+    data = spec.to_dict()
+    data["feature_spec_id"] = "wrong"
+    with pytest.raises(VPMValidationError):
+        CriticFeatureSpecDTO.from_dict(data)
+
+
+def test_missing_feature_policy() -> None:
+    spec = CriticFeatureSpecDTO(
+        features=(
+            CriticFeatureDTO("required", "required"),
+            CriticFeatureDTO(
+                "optional",
+                "optional",
+                required=False,
+                missing_policy="constant",
+                missing_value=2.0,
+            ),
+        )
+    )
+    assert features_from_mapping({"required": 1.0}, spec).tolist() == [1.0, 2.0]
+    with pytest.raises(VPMValidationError):
+        features_from_mapping({"optional": 1.0}, spec)
+
+
+def test_logistic_fit_is_deterministic_and_explanations_sum(critic_fixture) -> None:
+    spec = critic_fixture["spec"]
+    contract = critic_fixture["contract"]
+    values = critic_fixture["values"]
+    labels = critic_fixture["labels_array"]
+    first = CompiledCriticReadout.fit(
+        values,
+        labels,
+        feature_spec=spec,
+        contract_id=contract.critic_contract_id,
+        l2_penalty=0.1,
+        max_iterations=80,
+        tolerance=1e-8,
+        class_weighting="balanced",
+    )
+    second = CompiledCriticReadout.fit(
+        values,
+        labels,
+        feature_spec=spec,
+        contract_id=contract.critic_contract_id,
+        l2_penalty=0.1,
+        max_iterations=80,
+        tolerance=1e-8,
+        class_weighting="balanced",
+    )
+    np.testing.assert_allclose(first.coefficients, second.coefficients)
+    assert first.score_one(
+        values[0], feature_spec_id=spec.feature_spec_id
+    ) > first.score_one(values[3], feature_spec_id=spec.feature_spec_id)
+    contributions = first.contributions_one(
+        values[0], feature_spec_id=spec.feature_spec_id
+    )
+    assert sum(
+        item.contribution for item in contributions
+    ) + first.intercept == pytest.approx(
+        first.logit_one(values[0], feature_spec_id=spec.feature_spec_id)
+    )
+
+
+def test_stable_extreme_sigmoid() -> None:
+    scores = stable_sigmoid(np.asarray([-1000.0, 0.0, 1000.0]))
+    assert scores[0] == pytest.approx(0.0)
+    assert scores[1] == pytest.approx(0.5)
+    assert scores[2] == pytest.approx(1.0)

--- a/packages/critic/tests/test_end_to_end.py
+++ b/packages/critic/tests/test_end_to_end.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zeromodel.critic import (
+    CriticScoreRequestDTO,
+    CriticThresholdContractDTO,
+    build_critic_score_receipt,
+    build_critic_score_vpm,
+    compile_critic_readout,
+    export_portable_critic,
+    load_critic_readout_aggregate,
+    rank_by_critic,
+    replay_critic_score,
+    score_critic,
+    score_portable,
+)
+
+
+def test_compile_score_portable_vpm_and_replay(critic_fixture) -> None:
+    store = critic_fixture["store"]
+    readout, readout_ref = compile_critic_readout(
+        store=store,
+        features=critic_fixture["features"],
+        labels=critic_fixture["labels"],
+        fit_spec=critic_fixture["fit_spec"],
+    )
+    aggregate = load_critic_readout_aggregate(readout_ref, store)
+    payload = export_portable_critic(aggregate)
+    assert len(payload.encode("utf-8")) < 50 * 1024
+    request = CriticScoreRequestDTO(
+        readout_ref=readout_ref,
+        feature_batch_ref=readout.training_feature_batch_ref,
+        threshold_contract=CriticThresholdContractDTO(
+            reject_below=0.4, accept_at_or_above=0.6
+        ),
+        explanation_depth=2,
+    )
+    result, result_ref, request_ref = score_critic(store=store, request=request)
+    assert result_ref is not None
+    assert request_ref.artifact_id == result.request_ref.artifact_id
+    portable = score_portable(payload, critic_fixture["values"][0].tolist())
+    assert portable["logit"] == pytest.approx(result.items[0].logit)
+    assert portable["score"] == pytest.approx(result.items[0].score)
+    positive_frontier = {
+        critic_fixture["features"].batch.item_refs[0].artifact_id,
+        critic_fixture["features"].batch.item_refs[4].artifact_id,
+    }
+    assert rank_by_critic(result)[0] in positive_frontier
+    vpm = build_critic_score_vpm(result=result)
+    assert vpm.provenance["readout_ref"] == readout_ref.artifact_id
+    _, receipt_ref = build_critic_score_receipt(
+        store=store, request_ref=request_ref, result_ref=result_ref
+    )
+    replayed = replay_critic_score(store=store, receipt_ref=receipt_ref)
+    assert replayed.result_id == result.result_id
+    assert json.loads(payload)["score_contract"]["calibration_input"] == "logit"

--- a/packages/critic/tests/test_evaluation_promotion_counterexamples.py
+++ b/packages/critic/tests/test_evaluation_promotion_counterexamples.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from zeromodel.critic.counterexamples import find_counterexamples
+from zeromodel.critic.evaluation import (
+    auroc,
+    budget_selection_metrics,
+    brier_score,
+    expected_calibration_error,
+    grouped_selection_metrics,
+)
+from zeromodel.critic.promotion import CriticPromotionPolicyDTO, evaluate_promotion
+
+
+def test_known_evaluation_metrics() -> None:
+    labels = [0, 0, 1, 1]
+    scores = [0.1, 0.4, 0.35, 0.8]
+    assert auroc(labels, scores) == pytest.approx(0.75)
+    assert brier_score(labels, scores) == pytest.approx(
+        ((0.1**2) + (0.4**2) + (0.65**2) + (0.2**2)) / 4
+    )
+    assert expected_calibration_error(labels, scores, bin_count=2) >= 0.0
+
+
+def test_grouped_selection_uses_selected_label() -> None:
+    metrics = grouped_selection_metrics(
+        ["a", "a", "b", "b"],
+        [1, 0, 0, 1],
+        [0.4, 0.9, 0.8, 0.7],
+    )
+    assert metrics["selected_positive_rate"] == pytest.approx(0.0)
+    assert metrics["preferred_ranked_first_rate"] == pytest.approx(0.0)
+
+
+def test_budget_promotion_and_counterexamples() -> None:
+    rows = budget_selection_metrics([1, 0, 1, 0], [0.9, 0.8, 0.2, 0.1], [0.5])
+    assert rows[0]["number_selected"] == 2
+    assert rows[0]["positive_rate_selected"] == pytest.approx(0.5)
+    rejected = evaluate_promotion(
+        current_metrics={"auroc": 0.7, "ece": 0.05},
+        candidate_metrics={"auroc": 0.69, "ece": 0.2},
+        policy=CriticPromotionPolicyDTO(min_candidate_auroc=0.7),
+    )
+    assert not rejected.recommended
+    accepted = evaluate_promotion(
+        current_metrics={"auroc": 0.7, "ece": 0.05},
+        candidate_metrics={"auroc": 0.8, "ece": 0.04},
+        policy=CriticPromotionPolicyDTO(min_candidate_auroc=0.7, min_auroc_gain=0.05),
+    )
+    assert accepted.recommended
+    disagreements = find_counterexamples(
+        ["x", "y"],
+        [1, 0],
+        [0.4, 0.2],
+        [0.8, 0.7],
+        threshold=0.5,
+    )
+    assert [item.artifact_id for item in disagreements] == ["x", "y"]
+    assert disagreements[0].correct_critic == "candidate"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ numpy>=1.23,<2.0
 -e ./packages/trust
 -e ./packages/navigation
 -e ./packages/search
+-e ./packages/critic
 
 build
 twine

--- a/scripts/check_quality.py
+++ b/scripts/check_quality.py
@@ -39,6 +39,8 @@ FORMAT_LINT_PATHS = [
     Path("packages/navigation/tests"),
     Path("packages/search/src"),
     Path("packages/search/tests"),
+    Path("packages/critic/src"),
+    Path("packages/critic/tests"),
     Path("tests/integration"),
 ]
 
@@ -55,6 +57,7 @@ TYPING_PATHS = [
     Path("packages/trust/src"),
     Path("packages/navigation/src"),
     Path("packages/search/src"),
+    Path("packages/critic/src"),
 ]
 
 QUALITY_LIMIT_PATHS = [
@@ -79,6 +82,8 @@ QUALITY_LIMIT_PATHS = [
     Path("packages/navigation/tests"),
     Path("packages/search/src"),
     Path("packages/search/tests"),
+    Path("packages/critic/src"),
+    Path("packages/critic/tests"),
 ]
 
 

--- a/scripts/run_fast_tests.py
+++ b/scripts/run_fast_tests.py
@@ -49,6 +49,7 @@ TEST_ROOTS = [
     "packages/trust/tests",
     "packages/navigation/tests",
     "packages/search/tests",
+    "packages/critic/tests",
 ]
 
 REPORT_PATH = REPO_ROOT / "build" / "reports" / "fast-test-summary.json"

--- a/tests/test_fast_suite_completeness.py
+++ b/tests/test_fast_suite_completeness.py
@@ -28,6 +28,7 @@ PACKAGE_TEST_ROOTS = [
     "packages/trust/tests",
     "packages/navigation/tests",
     "packages/search/tests",
+    "packages/critic/tests",
 ]
 
 
@@ -60,6 +61,7 @@ def test_package_local_suite_cannot_silently_shrink() -> None:
         "packages/trust/tests",
         "packages/navigation/tests",
         "packages/search/tests",
+        "packages/critic/tests",
     ]
 
 

--- a/tests/test_package_boundaries.py
+++ b/tests/test_package_boundaries.py
@@ -29,6 +29,7 @@ def test_boundary_manifest_defines_all_packages() -> None:
         "trust",
         "navigation",
         "search",
+        "critic",
     }
     assert manifest["release_version"]
 


### PR DESCRIPTION
…t me look at the remaining critical files in parallel.

Baseline tests pass. Now let me write the core `model_execution` package files.

Now the providers subpackage:

Now the provider config loader and factory:

Now the EvidencePack module:

Now the response validation module:

Now `hypothesis.py`:

Now let me add the cache table to the shared schema:

Now let's write `cache.py`:

Now `service.py` and the artifact-placement fallback:

Now updating `config.py` to add the repo-level `[ai]` policy block:

Syntax is clean. Now let's actually import and smoke-test the CLI end-to-end with the null provider wired through a real invocation.

The pipeline works correctly (cache miss → hit, validation passed, deterministic RTASK ids match). The Windows cleanup error was just my ad-hoc script not closing the connection. Let me finalize the CLI task and move to writing formal tests.

Works cleanly on a minimal fixture repo too. Now let's write the formal test suite.

Now the response validation tests:

Now let's write cache identity tests, provider tests, and the deterministic-mode regression test:

Now the provider tests with a fake HTTP server:

Now let's run the full new test suite and fix issues:

Now I need to add the `Path` import to that test file:

Good, `Path` is already imported. Let's rerun:

All tests pass now. Let's run the full new suite together plus the previously-checked CLI smoke path:

Let me clean up that slightly awkward test:

Now let's mark the test task complete and write the documentation.

Now update the architecture README index:

Now let's run ruff on the new/changed files:

All auto-fixable. Let's apply the fixes:

Clean. Now let's run the whole test suite (including these new files) and check formatting:

Now let's run the full repository test suite to confirm no regressions:

While the full suite runs, let's check formatting and full-repo ruff status:

All formatted. Let's re-run tests and full ruff/format checks to confirm everything's still green:

All green. Now let's check on the full background test suite run:

While waiting for the full suite, let me verify the CLI end-to-end with a real config file:

Excellent — the full pipeline works correctly end-to-end, including graceful degradation. Let me check on the background full test suite.

While the full suite finishes, let me update the project memory to reflect that milestone one is now implemented.

Let me prepare the completion report while the background suite finishes.

I'll wait for the full test suite to finish rather than continue polling.

I'll wait for the scheduled wakeup or completion notification.

Confirmed: these 5 failures are pre-existing and environment-caused (`code-review-graph` happens to be installed in this venv, which these CRG-absence-assuming tests don't expect) — identical failures existed in the baseline run before any of my changes. My work added exactly 43 new passing tests and broke nothing.

Everything is implemented, tested, and validated. Here's the completion report.

## Completion report — Model Execution milestone one

**Baseline.** `git status` clean at start; full suite (975 passed / 5 failed / 4 skipped) and `ruff check` (7 pre-existing errors, all in unrelated files) recorded before any change. Note: `docs/architecture/local-ai-reasoning-review.md` (written during the review phase of this session) is already committed as `5c744d4 "add reasoning docs"` — not something I committed; everything below is uncommitted on top of that.

**Repository discrepancies from the review:** none found. `RepositoryView`, `StructuralAnalysisProvider`, `ExplicitRegistry`, `ArtifactStore`, `compute_review_id`/`compute_analysis_context_id`, and the CLI subcommand idiom all matched the review's description exactly.

**Package structure** — `src/cocoder/model_execution/` (new, sibling to `knowledge/`/`engineering_graph/`, not under `runtimes/`): `providers/` (protocol, 3 adapters, factory), `builders/` (overlap-candidate), `evidence_pack.py`, `tasks.py`, `prompt.py`, `response.py`, `hypothesis.py`, `cache.py`, `service.py`, `context.py`, `artifact_location.py`, `provider_config.py`, `errors.py`. ~2,060 lines.

**Provider Protocol** — `ModelProvider` mirrors `StructuralAnalysisProvider` exactly: `health()`/`capabilities()`/`generate()`, bounded health enum, `InfoSource` (configured/reported/measured/unknown) so nothing is fabricated.

**Providers** — `OpenAICompatibleProvider` and `OllamaProvider`, stdlib `urllib` only (no SDK), each with a `threading.Semaphore(maximum_parallel_requests)` actually enforcing concurrency, not just reporting it — verified against a real fake HTTP server with 3 concurrent callers and `--parallel 1` never exceeded. `NullModelProvider` for tests.

**Config** — new `AiConfig` (`mode`, `external_models_allowed`) in `.cocoder/config.toml`, defaults fully off; separate user-level `~/.cocoder/ai_providers.toml` for endpoints, never repo-committed. `hybrid` parses but behaves identically to `local` (no escalation target exists yet), per your refinement.

**EvidencePack** — reuses `Evidence`/`GraphNodeEvidence`/`RelationshipEvidence`, not a new type. `RepositoryView`-only content access, verified with a real symlink-escape regression test.

**Reasoning task/prompt/response** — one task, `challenge_overlap_candidate`, closed `ExplicitRegistry`. Validation rule implements your refinement exactly: `overlap_supported` is `INVALID` without a resolved citation; `overlap_not_supported`/`insufficient_evidence`/`needs_human_review` are all accepted as valid — no test requires one exact phrase.

**Cache** — `RTASK-<hash>` on `ArtifactStore` + one new index table (`model_execution_cache`, schema v11→v12). No promotion/suppression events created (per your refinement #1 — cache + artifacts only, since nothing consumes a hypothesis yet).

**CLI** — `cocoder ai providers`, `probe`, `reason`; manually verified end-to-end including graceful "reasoning unavailable" degradation against an unreachable endpoint.

**Tests** — 43 new, all passing: golden false/supported-overlap fixtures (the real `_finding_id` pair), hallucinated-evidence rejection, malformed-JSON bounded failure, 7 cache-identity regressions (analysis-context/evidence/prompt-version/task-version/model/settings all miss), fake-HTTP-server provider tests + concurrency proof, config/provider-config parsing, external-provider locality gating, deterministic-mode CLI refusal, schema regression.

**Full suite**: 1018 passed, 5 failed, 4 skipped — the 5 failures are pre-existing and environment-caused (`code-review-graph` happens to be installed in this venv; confirmed identical failures in the pre-change baseline run). Ruff/format: clean on all new/changed files, no new errors anywhere in the repo.

**Limitations (deliberate):** no Engineering Intelligence/Repository Health wiring, no workflow-engine integration, no multi-model reconciliation — all explicitly out of scope per the spec.

**Docs:** [docs/architecture/model-execution.md](docs/architecture/model-execution.md), indexed from the architecture README.

**Next smallest milestone:** dogfood `challenge_overlap_candidate` against DeepSeek/Qwen if available locally, then decide — based on real hypothesis quality, not assumption — whether to wire `ModelHypothesis` into Engineering Intelligence's Observation/CandidateGroup pipeline as milestone two.

This was already handled — the completion notification for the background test suite arrived before this scheduled wakeup fired, and I processed it in my previous turn: confirmed 1018 passed / 5 failed / 4 skipped, verified the 5 failures are pre-existing (identical in the baseline run before any of my changes — caused by `code-review-graph` being installed in this venv, unrelated to Model Execution), marked task 12 complete, and posted the full section-50 completion report.

Nothing further to do here — the implementation, tests, docs, and validation are all done and green. Let me just confirm the task list is clean.

All 12 tasks are complete. Nothing outstanding — the Model Execution milestone-one implementation is done, tested (43 new tests passing, 1018/1023 total suite passing with the 5 failures being pre-existing/environment-caused), lint-clean, documented, and the completion report was already delivered above.